### PR TITLE
release: publish release v0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,6 @@ RUN rm -rf /tmp/patches
 LABEL org.opencontainers.image.title="VulnScout"
 LABEL org.opencontainers.image.description="SFL Vulnerability Scanner"
 LABEL org.opencontainers.image.authors="Savoir-faire Linux, Inc."
-LABEL org.opencontainers.image.version="v0.5.0"
+LABEL org.opencontainers.image.version="v0.6.0"
 
 CMD ./scan.sh

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = VulnScout
 Savoir-faire Linux
-0.5.0, {docdate}: developement builds
+v0.6.0, {docdate}: developement builds
 :url-repo: https://github.com/savoirfairelinux/vulnscout
 :source-highlighter: highlight.js
 :toc:

--- a/WRITING_CI_CONDITIONS.adoc
+++ b/WRITING_CI_CONDITIONS.adoc
@@ -1,6 +1,6 @@
 = vulnscout-ci(1)
 Savoir-faire Linux
-v0.5.0
+v0.6.0
 :doctype: manpage
 :manmanual: VULNSCOUT
 :mansource: VULNSCOUT

--- a/WRITING_TEMPLATES.adoc
+++ b/WRITING_TEMPLATES.adoc
@@ -1,6 +1,6 @@
 = VulnScout - Writing guide for creating templates
 Savoir-faire Linux
-0.5.0, {docdate}
+v0.6.0, {docdate}
 :url-repo: https://github.com/savoirfairelinux/vulnscout
 :source-highlighter: highlight.js
 :toc:

--- a/bin/vulnscout.sh
+++ b/bin/vulnscout.sh
@@ -16,7 +16,7 @@
 set -euo pipefail # Enable error checking
 
 # Configuration are changed automatically by bin/release_tag.sh
-VULNSCOUT_VERSION="v0.5.0"
+VULNSCOUT_VERSION="v0.6.0"
 DOCKER_IMAGE="sflinux/vulnscout:$VULNSCOUT_VERSION"
 VULNSCOUT_GIT_URI="git@github.com:savoirfairelinux/vulnscout.git"
 INTERACTIVE_MODE="true"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "v0.5.0",
+  "version": "v0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
* Jenkinsfile: Makefile: use correct image name
* remove references to old docker registry
* README.adoc: README_DEV.adoc: remove references to old gerrit repo
* QUICKSTART_YOCTO.adoc: bin/.vulnscout-example: add template example
* replace gerrit URLs by github URLs
* nvd_db: close connection to NVD after request
* nvd_db_builder: fix use of NVD_API_KEY
* affix GPLv3-only license