### PR TITLE
vulnscout.sh: update over https

### DIFF
--- a/bin/vulnscout.sh
+++ b/bin/vulnscout.sh
@@ -18,7 +18,7 @@ set -euo pipefail # Enable error checking
 # Configuration are changed automatically by bin/release_tag.sh
 VULNSCOUT_VERSION="v0.6.0"
 DOCKER_IMAGE="sflinux/vulnscout:$VULNSCOUT_VERSION"
-VULNSCOUT_GIT_URI="git@github.com:savoirfairelinux/vulnscout.git"
+VULNSCOUT_GIT_URI="https://github.com/savoirfairelinux/vulnscout.git"
 INTERACTIVE_MODE="true"
 FAIL_CONDITION=""
 QUIET_MODE="false"


### PR DESCRIPTION
VulnScout git URI is only used to fetch latest script version from vulnscout public repo. There is no need to use SSH protocol for this.

Using HTTPS protocol makes it simpler to use since it does not requires any github account nor any SSH keys.