### PR TITLE
Add support for caching

### DIFF
--- a/scan.sh
+++ b/scan.sh
@@ -126,8 +126,8 @@ function full_scan_steps() {
 
     set_status "5" "Scanning CDX with OSV (WIP)"
     if [[ -f "$TMP_PATH/merged.cdx.json" ]]; then
-        osv-scanner --sbom="$TMP_PATH/merged.cdx.json" --format json --output "$TMP_PATH/vulns-cdx.osv.json" || true
-        osv-scanner --sbom="$TMP_PATH/merged.cdx.json" --format sarif --output "$TMP_PATH/vulns-cdx.osv.sarif.json" || true
+        osv-scanner --offline-vulnerabilities --download-offline-databases /cache/vulnscout/osv/ --sbom="$TMP_PATH/merged.cdx.json" --format json --output "$TMP_PATH/vulns-cdx.osv.json" || true
+        osv-scanner --offline-vulnerabilities --download-offline-databases /cache/vulnscout/osv/ --sbom="$TMP_PATH/merged.cdx.json" --format sarif --output "$TMP_PATH/vulns-cdx.osv.sarif.json" || trueyyy
     fi
 
     if [[ -e "$YOCTO_CVE_INPUTS_PATH" ]]; then

--- a/src/bin/epss_db_builder.py
+++ b/src/bin/epss_db_builder.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import os
+from ..controllers.epss_db import EPSS_DB
+
+
+def fetch_epss_updates():
+    epss_db_path = os.getenv("EPSS_DB_PATH", "/cache/vulnscout/epss.db")
+    epss_db = EPSS_DB(epss_db_path)
+
+    if epss_db.needs_update():
+        print(f"EPSS DB outdated or missing: updating now...", flush=True)
+        epss_db.update_epss()
+        print("EPSS DB update complete!", flush=True)
+    else:
+        print("EPSS DB is up to date, skipping synccing", flush=True)
+        
+if __name__ == "__main__":
+    fetch_epss_updates()
+    print("EPSS DB is now synced")

--- a/src/controllers/epss_db.py
+++ b/src/controllers/epss_db.py
@@ -1,0 +1,71 @@
+import sqlite3
+import csv
+import urllib.request
+import gzip
+from datetime import datetime
+
+EPSS_URL = "https://epss.empiricalsecurity.com/epss_scores-current.csv.gz"
+
+class EPSS_DB:
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self.conn = sqlite3.connect(db_path)
+        self.cursor = self.conn.cursor()
+        self._init_db()
+
+    def _init_db(self):
+        self.cursor.execute("""
+            CREATE TABLE IF NOT EXISTS epss_scores (
+                cve TEXT PRIMARY KEY NOT NULL,
+                epss REAL,
+                percentile REAL
+            )
+        """)
+        self.cursor.execute("""
+            CREATE TABLE IF NOT EXISTS epss_metadata (
+                key TEXT PRIMARY KEY NOT NULL,
+                value TEXT
+            )
+        """)
+        self.conn.commit()
+
+    def update_epss(self):
+        tmp_gz = "/tmp/epss.csv.gz"
+        urllib.request.urlretrieve(EPSS_URL, tmp_gz)
+
+        with gzip.open(tmp_gz, "rt") as f:
+            next(f)
+            reader = csv.DictReader(f)
+            rows = [(row['cve'], float(row['epss']), float(row['percentile'])) for row in reader if row['cve'].startswith("CVE")]
+
+        self.cursor.execute("DELETE FROM epss_scores")
+        self.cursor.executemany(
+            "INSERT OR REPLACE INTO epss_scores (cve, epss, percentile) VALUES (?, ?, ?);",
+            rows
+        )
+        self.cursor.execute(
+            "INSERT OR REPLACE INTO epss_metadata (key, value) VALUES ('last_updated', ?);",
+            (datetime.utcnow().isoformat(),)
+        )
+        self.conn.commit()
+
+    def get_score(self, cve_id: str):
+        row = self.cursor.execute(
+            "SELECT epss, percentile FROM epss_scores WHERE cve = ?;",
+            (cve_id,)
+        ).fetchone()
+        if row:
+            return {"score": row[0], "percentile": row[1]}
+        return None
+
+    def needs_update(self, days: int = 1) -> bool:
+        res = self.cursor.execute(  
+            "SELECT value FROM epss_metadata WHERE key = 'last_updated';"
+        ).fetchone()
+        if not res:
+            return True
+        try:
+            last_updated = datetime.fromisoformat(res[0])
+            return (datetime.utcnow() - last_updated).days >= days
+        except Exception:
+            return True

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 from ..models.vulnerability import Vulnerability
-from ..controllers.packages import PackagesController
-import http.client
+from ..                                                                                                                                                          controllers.packages import PackagesController
 import json
 import time
 import re
 from typing import Optional
+from ..controllers.epss_db import EPSS_DB
 
 
 class VulnerabilitiesController:
@@ -27,6 +27,7 @@ class VulnerabilitiesController:
         self.vulnerabilities: dict[str, Vulnerability] = {}
         """A dictionary of vulnerabilities, indexed by their id."""
         self.alias_registered: dict[str, str] = {}
+        self.epss_db = EPSS_DB("/cache/vulnscout/epss.db")
 
     def get(self, vuln_id: str):
         """Return a vulnerability by id (str) or None if not found. Also look for aliases."""
@@ -85,45 +86,19 @@ class VulnerabilitiesController:
             return True
         return False
 
-    def _fetch_epss_for_cves(self, conn, cve_ids: list[str]):
-        cve_ids = [re.sub(self.safe_url_regex, '', s) for s in cve_ids]
-        conn.request('GET', '/data/v1/epss?envelope=false&cve=' + ','.join(cve_ids))
-        resp = conn.getresponse()
-        data = json.loads(resp.read())
-        for epss in data:
-            if 'cve' in epss and epss['cve'] in self.vulnerabilities:
-                self.vulnerabilities[epss['cve']].epss = {
-                    "score": epss['epss'],
-                    "percentile": epss['percentile']
-                }
-
     def fetch_epss_scores(self):
-        """
-        Fetch the EPS Scores for all vulnerabilities in the list.
-        This method must be called after all vulnerabilities have been added.
-        It make API call with chunks of 80 CVE ID per call to improve network performance.
-        """
         start_time = time.time()
-        nb_of_chuncks = 0
-        conn = http.client.HTTPSConnection('api.first.org', 443)
-        cve_ids = []
-        for vuln in self.vulnerabilities.values():
-            cve_ids.append(vuln.id)
-            if len(cve_ids) >= 80:
-                try:
-                    self._fetch_epss_for_cves(conn, cve_ids)
-                    nb_of_chuncks += 1
-                except Exception as e:
-                    print(e)
-                cve_ids = []
-        if len(cve_ids) > 0:
-            try:
-                self._fetch_epss_for_cves(conn, cve_ids)
-            except Exception as e:
-                print(e)
-        nb_vuln = nb_of_chuncks * 80 + len(cve_ids)
-        print(f"Fetched EPSS data for {nb_vuln} vulnerabilities in {time.time() - start_time} seconds.")
+        nb_vuln = 0
 
+        for vuln in self.vulnerabilities.values():
+            result = self.epss_db.get_score(vuln.id)
+            if result:
+                vuln.epss_score = result['score']
+                vuln.epss_percentile = result['percentile']
+                nb_vuln += 1
+
+        print(f"Fetched EPSS data for {nb_vuln} vulnerabilities from local DB in {time.time() - start_time} seconds.")
+ 
     def to_dict(self) -> dict:
         """Export the list of vulnerabilities as a dictionary of dictionaries."""
         return {k: v.to_dict() for k, v in self.vulnerabilities.items()}


### PR DESCRIPTION
The goal is to reduce scanning time by saching databases and online resources used by VulnScout and its dependancies, this includes:
* NVD: Already cached onto nvd.db
* EPSS: added epss.db with daily update
* Grype: Already cached onto /.cache/grype
* osv-scanner: added offline scan with database update onto /cache/.vulnscout/osv