### PR TITLE
Add SPDX3 support 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,6 @@ RUN rm -rf /tmp/patches
 LABEL org.opencontainers.image.title="VulnScout"
 LABEL org.opencontainers.image.description="SFL Vulnerability Scanner"
 LABEL org.opencontainers.image.authors="Savoir-faire Linux, Inc."
-LABEL org.opencontainers.image.version="v0.6.0"
+LABEL org.opencontainers.image.version="v0.7.0-beta.1"
 
 CMD ./scan.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,6 @@ RUN rm -rf /tmp/patches
 LABEL org.opencontainers.image.title="VulnScout"
 LABEL org.opencontainers.image.description="SFL Vulnerability Scanner"
 LABEL org.opencontainers.image.authors="Savoir-faire Linux, Inc."
-LABEL org.opencontainers.image.version="v0.7.0-beta.1"
+LABEL org.opencontainers.image.version="v0.7.0-beta.2"
 
 CMD ./scan.sh

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = VulnScout
 Savoir-faire Linux
-v0.6.0, {docdate}: developement builds
+v0.7.0-beta.1, {docdate}: developement builds
 :url-repo: https://github.com/savoirfairelinux/vulnscout
 :source-highlighter: highlight.js
 :toc:

--- a/README.adoc
+++ b/README.adoc
@@ -71,7 +71,7 @@ More information on <<Authentification>> section.
 `BUILD_TAG="local-build" cqfd -b docker_build run`
 
 2. Then, copy `bin/vulnscout.sh` into root of your project repository. Create a `.vulnscout` folder also at root. +
-Copy one of the `.rc` conf file from `bin/.vulnscout-example` into your `.vulnscout` folder.l`.
+Copy one of the `.rc` conf file from `bin/.vulnscout-example` into your `.vulnscout` folder.
 
 3. In your new copied file, customize variables to bind the correct paths. +
 Replace the `DOCKER_IMAGE` value by your image name like `vulnscout:local-build`.

--- a/README.adoc
+++ b/README.adoc
@@ -88,6 +88,12 @@ Now, after each build, you can run `./vulnscout.sh scan` to run a new scan and o
 
 == Specific configuration
 
+=== Environment variables
+
+The following environment variables may be used to configure the scanner:
+
+* `NVD_API_KEY`: An API key for NVD. This is required to properly use the NVD datasource.
+
 === Configuration for Yocto projects
 
 After having setup one of the <<Deployment>> tutorial, you have some steps needed make Yocto output necessary files.

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = VulnScout
 Savoir-faire Linux
-v0.7.0-beta.1, {docdate}: developement builds
+v0.7.0-beta.2, {docdate}: developement builds
 :url-repo: https://github.com/savoirfairelinux/vulnscout
 :source-highlighter: highlight.js
 :toc:

--- a/WRITING_CI_CONDITIONS.adoc
+++ b/WRITING_CI_CONDITIONS.adoc
@@ -1,6 +1,6 @@
 = vulnscout-ci(1)
 Savoir-faire Linux
-v0.6.0
+v0.7.0-beta.1
 :doctype: manpage
 :manmanual: VULNSCOUT
 :mansource: VULNSCOUT

--- a/WRITING_CI_CONDITIONS.adoc
+++ b/WRITING_CI_CONDITIONS.adoc
@@ -1,6 +1,6 @@
 = vulnscout-ci(1)
 Savoir-faire Linux
-v0.7.0-beta.1
+v0.7.0-beta.2
 :doctype: manpage
 :manmanual: VULNSCOUT
 :mansource: VULNSCOUT

--- a/WRITING_TEMPLATES.adoc
+++ b/WRITING_TEMPLATES.adoc
@@ -1,6 +1,6 @@
 = VulnScout - Writing guide for creating templates
 Savoir-faire Linux
-v0.7.0-beta.1, {docdate}
+v0.7.0-beta.2, {docdate}
 :url-repo: https://github.com/savoirfairelinux/vulnscout
 :source-highlighter: highlight.js
 :toc:

--- a/WRITING_TEMPLATES.adoc
+++ b/WRITING_TEMPLATES.adoc
@@ -1,6 +1,6 @@
 = VulnScout - Writing guide for creating templates
 Savoir-faire Linux
-v0.6.0, {docdate}
+v0.7.0-beta.1, {docdate}
 :url-repo: https://github.com/savoirfairelinux/vulnscout
 :source-highlighter: highlight.js
 :toc:

--- a/bin/vulnscout.sh
+++ b/bin/vulnscout.sh
@@ -16,7 +16,7 @@
 set -euo pipefail # Enable error checking
 
 # Configuration are changed automatically by bin/release_tag.sh
-VULNSCOUT_VERSION="v0.6.0"
+VULNSCOUT_VERSION="v0.7.0-beta.1"
 DOCKER_IMAGE="sflinux/vulnscout:$VULNSCOUT_VERSION"
 VULNSCOUT_GIT_URI="https://github.com/savoirfairelinux/vulnscout.git"
 INTERACTIVE_MODE="true"

--- a/bin/vulnscout.sh
+++ b/bin/vulnscout.sh
@@ -158,6 +158,7 @@ function scan() {
 	if [[ -n "${COMPANY_NAME-}" ]]; then docker_args+=" -e COMPANY_NAME=${COMPANY_NAME}"; fi
 	if [[ -n "${CONTACT_EMAIL-}" ]]; then docker_args+=" -e CONTACT_EMAIL=${CONTACT_EMAIL}"; fi
 	if [[ -n "${DOCUMENT_URL-}" ]]; then docker_args+=" -e DOCUMENT_URL=${DOCUMENT_URL}"; fi
+	if [[ -n "${NVD_API_KEY-}" ]]; then docker_args+=" -e NVD_API_KEY=${NVD_API_KEY}"; fi
 
 	if [[ -n "${SPDX_SOURCES-}" ]]; then
 		for source in "${SPDX_SOURCES[@]}"; do

--- a/bin/vulnscout.sh
+++ b/bin/vulnscout.sh
@@ -16,7 +16,7 @@
 set -euo pipefail # Enable error checking
 
 # Configuration are changed automatically by bin/release_tag.sh
-VULNSCOUT_VERSION="v0.7.0-beta.1"
+VULNSCOUT_VERSION="v0.7.0-beta.2"
 DOCKER_IMAGE="sflinux/vulnscout:$VULNSCOUT_VERSION"
 VULNSCOUT_GIT_URI="https://github.com/savoirfairelinux/vulnscout.git"
 INTERACTIVE_MODE="true"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "v0.6.0",
+  "version": "v0.7.0-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "v0.7.0-beta.1",
+  "version": "v0.7.0-beta.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/bin/spdx_merge.py
+++ b/src/bin/spdx_merge.py
@@ -61,7 +61,7 @@ def output_results(controllers):
 
     verbose(f"spdx_merge: Writing {os.getenv('OUTPUT_SPDX_FILE', OUTPUT_SPDX_FILE)}")
     with open(os.getenv("OUTPUT_SPDX_FILE", OUTPUT_SPDX_FILE), "w") as f:
-        f.write(spdx.output_as_json())
+        f.write(spdx.output_as_json(with_cpe=True))
 
 
 def main():

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -54,7 +54,7 @@ class Package:
 
     def generate_generic_cpe(self) -> str:
         """Build a generic cpe string for the package, add it to the cpe list and return it."""
-        item = f"cpe:2.3:*:*:{self.name}:{self.version}:*:*:*:*:*:*:*"
+        item = f"cpe:2.3:*:*:{self.name or '*'}:{self.version or '*'}:*:*:*:*:*:*:*"
         self.add_cpe(item)
         return item
 

--- a/src/views/fast_spdx3.py
+++ b/src/views/fast_spdx3.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+from typing import Dict, List, Optional, Any
+import logging
+from ..models.package import Package
+from ..models.vulnerability import Vulnerability
+from ..models.assessment import VulnAssessment
+
+
+class FastSPDX3:
+    """
+    FastSPDX3 class to handle SPDX 3.0 SBOM and parse it.
+    Uses a lightweight approach similar to FastSPDX for parsing SPDX 3.0 files.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    # Types of VEX assessment relationships in SPDX 3.0
+    ASSESSMENT_TYPES = {
+        'security_VexNotAffectedVulnAssessmentRelationship',
+        'security_VexAffectedVulnAssessmentRelationship',
+        'security_VexFixedVulnAssessmentRelationship',
+    }
+
+    # Map from SPDX VEX justification types to internal representation
+    JUSTIFICATION_MAP = {
+        "vulnerableCodeNotPresent": "vulnerable_code_not_present",
+        "componentNotPresent": "component_not_present",
+        "vulnerableCodeNotInExecutePath": "vulnerable_code_not_in_execute_path",
+        "vulnerableCodeCannotBeControlledByAdversary": "vulnerable_code_cannot_be_controlled_by_adversary",
+        "inlineMitigationsAlreadyExist": "inline_mitigations_already_exist",
+    }
+
+    def __init__(self, controllers: Dict[str, Any]):
+        """
+        Initialize the FastSPDX3 parser with controllers for packages, vulnerabilities, and assessments.
+
+        Args:
+            controllers: Dictionary containing controllers for packages, vulnerabilities, and assessments
+        """
+        self.packagesCtrl = controllers["packages"]
+        self.vulnerabilitiesCtrl = controllers["vulnerabilities"]
+        self.assessmentsCtrl = controllers["assessments"]
+        self.uri_to_package: Dict[str, str] = {}
+
+    def find_spdx_version(self, spdx: Dict[str, Any]) -> Optional[str]:
+        """
+        Find the SPDX version from the document.
+        """
+        for item in spdx.get("@graph", []):
+            if item.get("@type") == "CreationInfo" or item.get("type") == "CreationInfo":
+                version = item.get("specVersion")
+                if version:
+                    return version
+
+        return None
+
+    def could_parse_spdx(self, spdx: Dict[str, Any]) -> bool:
+        """
+        Check if this parser can handle the SPDX document (version 3.x).
+
+        Args:
+            spdx: SPDX document dictionary
+
+        Returns:
+            True if the document version starts with "3", False otherwise
+        """
+        version = self.find_spdx_version(spdx)
+        return bool(version and version.startswith("3"))
+
+    def merge_components_into_controller(self, components_dict: Dict[str, Any]):
+        """
+        Extract package information from components objects and create Package objects.
+        """
+        graph = components_dict.get("@graph", [])
+        if not graph:
+            self.logger.warning("No @graph found in SPDX document")
+            return
+
+        for component in graph:
+            if component.get('type') != 'software_Package':
+                continue
+            primary_purpose = component.get('software_primaryPurpose', '').lower()
+            if primary_purpose in {'source', 'development', 'documentation'}:
+                continue
+
+            package = self._convert_to_package(component)
+            if not package:
+                continue
+
+            # Store mapping from URI to package ID
+            spdx_id = component.get('spdxId')
+            if spdx_id:
+                self.uri_to_package[spdx_id] = package.id
+
+            self.packagesCtrl.add(package)
+
+    def _convert_to_package(self, pkg_element: Dict[str, Any]) -> Optional[Package]:
+        """
+        Convert an SPDX 3.0 package dictionary to a VulnScout Package object.
+        """
+
+        def extract_value(fields: List[str]) -> Optional[str]:
+            for f in fields:
+                value = pkg_element.get(f)
+                if isinstance(value, str):
+                    return value
+            return None
+
+        name = extract_value(["name", "Name", "packageName", "PackageName"])
+        version = extract_value(["versionInfo", "version", "software_packageVersion", "packageVersion"])
+
+        if not name or not version:
+            return None
+
+        pkg = Package(name, version, [], [])
+
+        cpes = self.extract_cpes(pkg_element)
+        for cpe in cpes:
+            pkg.add_cpe(cpe)
+        pkg.generate_generic_cpe()
+
+        purl = self.extract_purl(pkg_element)
+        if purl:
+            pkg.add_purl(purl)
+        pkg.generate_generic_purl()
+
+        return pkg
+
+    def extract_purl(self, element: Dict[str, Any]) -> Optional[str]:
+        """
+        Extract Package URL (PURL) from SPDX element.
+        """
+        if 'packageUrl' in element:
+            return element['packageUrl']
+
+        if 'software_packageUrl' in element:
+            return element['software_packageUrl']
+        return None
+
+    def extract_cpes(self, element: Dict[str, Any]) -> List[str]:
+        """
+        Extract CPE identifiers from an SPDX element.
+        """
+        external_identifiers = element.get('externalIdentifier')
+        if not isinstance(external_identifiers, list):
+            return []
+
+        cpe_identifiers = []
+
+        for ext_id in external_identifiers:
+            ext_id_type = ext_id.get('externalIdentifierType', '')
+            if ext_id_type == 'cpe23' or ext_id_type == 'cpe22':
+                cpe_id = ext_id.get('identifier')
+                if cpe_id:
+                    cpe_identifiers.append(cpe_id)
+
+        return cpe_identifiers
+
+    def merge_vulnerabilities_into_controller(self, vuln_dict: Dict[str, Any]):
+        """
+        Extract Vulnerability objects from SPDX graph elements.
+        """
+        graph = vuln_dict.get("@graph", [])
+        if not graph:
+            return
+
+        self._extract_explicit_vulnerabilities(graph)
+
+        self._process_package_vulnerability_relationships(graph)
+
+        self._remove_vulnerabilities_without_packages()
+
+    def _remove_vulnerabilities_without_packages(self):
+        """
+        Remove vulnerabilities that don't have any packages.
+        """
+        vulnerabilities_to_remove = []
+
+        for vuln in self.vulnerabilitiesCtrl.vulnerabilities.values():
+            if not vuln.packages:
+                vulnerabilities_to_remove.append(vuln.id)
+
+        for vuln_id in vulnerabilities_to_remove:
+            self.vulnerabilitiesCtrl.remove(vuln_id)
+
+    def _extract_explicit_vulnerabilities(self, graph: List[Dict]):
+        """
+        Extract vulnerabilities explicitly defined as security_Vulnerability elements.
+
+        Structure example:
+        {
+            "type": "security_Vulnerability",
+            "externalIdentifier": [
+                {
+                    "externalIdentifierType": "cve",
+                    "identifier": "CVE-2023-XXXX",
+                    "identifierLocator": ["https://..."]
+                }
+            ]
+        }
+        """
+        for element in graph:
+            if element.get('type') != 'security_Vulnerability':
+                continue
+
+            ext_ids = element.get('externalIdentifier', [])
+            for ext_id in ext_ids:
+                if ext_id.get('externalIdentifierType') != 'cve':
+                    continue
+
+                cve_id = ext_id.get('identifier')
+                if not cve_id:
+                    continue
+
+                locators = ext_id.get('identifierLocator', [])
+                datasource = locators[0] if locators else "unknown"
+
+                vulnerability = Vulnerability(cve_id, ["yocto"], datasource, "unknown")
+
+                # Add remaining locators as URLs
+                for locator in locators[1:]:
+                    vulnerability.add_url(locator)
+
+                self.vulnerabilitiesCtrl.add(vulnerability)
+
+    def _process_package_vulnerability_relationships(self, graph: List[Dict]):
+        """
+        Process relationships that link packages to vulnerabilities, to update the Vulnerability objects.
+
+        Example structure:
+        {
+            "type": "Relationship",
+            "spdxId": "...",
+            "from": "package_uri",
+            "relationshipType": "hasAssociatedVulnerability",
+            "to": ["vulnerability_uri1", "vulnerability_uri2"]
+        }
+        """
+        for element in graph:
+            if element.get('type') != 'Relationship':
+                continue
+
+            if element.get('relationshipType') != 'hasAssociatedVulnerability':
+                continue
+
+            package_uri = element.get('from')
+            if not package_uri:
+                continue
+
+            vulnerability_uris = element.get('to', [])
+            if not vulnerability_uris:
+                continue
+
+            # Get package ID from URI mapping
+            package_id = self.uri_to_package.get(package_uri)
+            if not package_id:
+                self.logger.warning(f"Package URI {package_uri} not found in package mapping")
+                continue
+
+            for vuln_uri in vulnerability_uris:
+                cve_id = self._extract_cve_id(vuln_uri)
+                if not cve_id:
+                    continue
+
+                vulnerability = self.vulnerabilitiesCtrl.get(cve_id)
+                if vulnerability:
+                    vulnerability.add_package(package_id)
+
+    def _extract_cve_id(self, text: str) -> Optional[str]:
+        """Extract CVE ID from text string if present."""
+        if not text:
+            return None
+
+        parts = text.split('/')
+        for part in parts:
+            if part.startswith('CVE-'):
+                return part
+
+        return None
+
+    def is_vex_relationship(self, rel: Dict[str, Any]) -> bool:
+        """
+        Check if a relationship element is a VEX relationship.
+        """
+        rel_type = rel.get("type", "")
+        return rel_type in self.ASSESSMENT_TYPES
+
+    def process_vex_relationships(self, spdx_dict: Dict[str, Any]):
+        """
+        Process VEX relationships from the SPDX document to create vulnerability assessments.
+        """
+        graph = spdx_dict.get("@graph", [])
+        if not graph:
+            return
+
+        for rel in graph:
+            if not self.is_vex_relationship(rel):
+                continue
+
+            assessment = self._parse_vex_relationship(rel)
+            if assessment:
+                self.assessmentsCtrl.add(assessment)
+
+    def _parse_vex_relationship(self, element: Dict[str, Any]) -> Optional[VulnAssessment]:
+        """
+        Extract relevant information from VulnAssessmentRelationship element.
+        """
+        if 'from' not in element or 'to' not in element:
+            return None
+
+        from_value = element.get('from', '')  # package uri
+        to_values = element.get('to', [])     # vulnerabilities uri
+        vuln_id = self._extract_cve_id(from_value)
+        package_uri = to_values[0] if to_values else None
+
+        if not vuln_id or not package_uri:
+            return None
+
+        package_id = self.uri_to_package.get(package_uri)
+        if not package_id:
+            self.logger.warning(f"Package URI {package_uri} not found in package mapping for assessment")
+            return None
+
+        assessment = VulnAssessment(vuln_id, [package_id])
+
+        # Set status based on relationship type
+        relationship_type = element.get('relationshipType', '')
+        if relationship_type == 'doesNotAffect':
+            assessment.set_status('not_affected')
+        elif relationship_type == 'affects':
+            assessment.set_status('affected')
+        elif relationship_type == "fixedIn":
+            assessment.set_status('fixed')
+
+        raw_justification = element.get('security_justificationType')
+        if raw_justification and raw_justification in self.JUSTIFICATION_MAP:
+            assessment.set_justification(self.JUSTIFICATION_MAP[raw_justification])
+
+        if element.get('security_impactStatement'):
+            assessment.impact_statement = element.get("security_impactStatement", "")
+
+        return assessment
+
+    def _remove_vulnerabilities_without_assessments(self):
+        """
+        Remove vulnerabilities that don't have any assessments.
+        Because report generation fails for vulnerabilities without assessments.
+        """
+        vulnerabilities_to_remove = []
+
+        for vuln in self.vulnerabilitiesCtrl.vulnerabilities.values():
+            assessments = self.assessmentsCtrl.gets_by_vuln(vuln.id)
+            if not assessments:
+                vulnerabilities_to_remove.append(vuln.id)
+
+        for vuln_id in vulnerabilities_to_remove:
+            self.vulnerabilitiesCtrl.remove(vuln_id)
+
+    def parse_all_from_dict(self, spdx: Dict[str, Any]):
+        """
+        Parse all packages, vulnerabilities, and VEX relationships from SPDX document.
+        """
+        self.merge_components_into_controller(spdx)
+        self.merge_vulnerabilities_into_controller(spdx)
+        self.process_vex_relationships(spdx)
+        self._remove_vulnerabilities_without_assessments()
+
+    def parse_controllers_from_dict(self, spdx: Dict[str, Any]):
+        """
+        Parse only packages from SPDX document.
+        """
+        self.merge_components_into_controller(spdx)
+
+    def parse_from_dict(self, spdx: Dict[str, Any]):
+        """
+        Read data from SPDX JSON parsed format and populate controllers.
+        """
+        self.parse_all_from_dict(spdx)

--- a/src/views/templates/vulnerability_summary.txt
+++ b/src/views/templates/vulnerability_summary.txt
@@ -1,0 +1,79 @@
+Vulnerability Status Report
+=========================
+
+Author: {{ author }}
+Export Date: {{ export_date }}
+{% if scan_date is defined %}
+Scan Date: {{ scan_date }}
+{% endif %}
+
+
+Overview
+--------
+This report provides a summary of all vulnerabilities, organized by their current status and severity, with lists of affected packages.
+{% set active_statuses = ['under_investigation', 'in_triage', 'affected', 'exploitable'] %}
+{% set inactive_statuses = ['fixed', 'resolved', 'resolved_with_pedigree', 'not_affected', 'false_positive'] %}
+{% set severity_order = ['critical', 'high', 'medium', 'low', 'none', 'unknown'] %}
+
+{% macro render_vulnerability_section(vulns, section_title) -%}
+{{ section_title }} ({{ vulns | length }})
+============================================================
+
+{% for severity in severity_order -%}
+{% set severity_vulns = vulns | selectattr('severity.severity', 'equalto', severity) | list -%}
+{% if severity_vulns | length > 0 -%}
+{{ severity | title }} Severity ({{ severity_vulns | length }})
+------------------------------------------------------------
+
+{% for vuln in severity_vulns -%}
+CVE: {{ vuln.id }}
+  Status: {{ vuln.status | title }}
+  Affected Packages ({{ vuln.packages | length }}):
+  {% for pkg in vuln.packages %}  - {{ pkg }}
+  {% endfor -%}
+  CVSS Scores:
+  {% if vuln.severity.cvss -%}
+  {% for cvss in vuln.severity.cvss %}  - CVSS v{{ cvss.version }}: {{ cvss.base_score }} ({{ cvss.vector_string }})
+    Exploitability Score: {{ cvss.exploitability_score }}
+    Impact Score: {{ cvss.impact_score }}
+    Source: {{ cvss.author }}
+  {% endfor -%}
+  {% else %}  - No CVSS scores available
+  {% endif -%}
+  EPSS Score: {{ vuln.epss.score | default("None") }}
+
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+{% endmacro -%}
+
+Vulnerability Summary by Status
+------------------------------
+
+
+{{ render_vulnerability_section(
+    vulnerabilities | as_list | selectattr('status', 'in', active_statuses) | list,
+    "Active Vulnerabilities"
+) }}
+
+{{ render_vulnerability_section(
+    vulnerabilities | as_list | selectattr('status', 'in', inactive_statuses) | list,
+    "Inactive Vulnerabilities"
+) }}
+
+Summary Statistics
+-----------------
+Total Vulnerabilities: {{ vulnerabilities | length }}
+
+By Status:
+----------
+{% for status in vulnerabilities | as_list | map(attribute='status') | unique -%}
+- {{ status | title }}: {{ vulnerabilities | as_list | selectattr('status', 'equalto', status) | list | length }}
+{% endfor %}
+
+
+By Severity:
+-----------
+{% for severity in vulnerabilities | as_list | map(attribute='severity.severity') | unique -%}
+- {{ severity | title }}: {{ vulnerabilities | as_list | selectattr('severity.severity', 'equalto', severity) | list | length }}
+{% endfor -%}

--- a/tests/integration_tests/test_spdx3_parsing.py
+++ b/tests/integration_tests/test_spdx3_parsing.py
@@ -1,0 +1,427 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import pytest
+from src.views.fast_spdx3 import FastSPDX3
+from src.controllers.packages import PackagesController
+from src.controllers.vulnerabilities import VulnerabilitiesController
+from src.controllers.assessments import AssessmentsController
+
+
+@pytest.fixture
+def spdx3_parser():
+    controllers = {}
+    controllers["packages"] = PackagesController()
+    controllers["vulnerabilities"] = VulnerabilitiesController(controllers["packages"])
+    controllers["assessments"] = AssessmentsController(controllers["packages"], controllers["vulnerabilities"])
+    return FastSPDX3(controllers)
+
+
+def test_parse_empty_json(spdx3_parser):
+    spdx3_parser.parse_from_dict({
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "specVersion": "3.0.1",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "SBOM-SPDX3-test",
+        "creationInfo": {
+            "created": "2024-03-20T00:00:00Z",
+            "creators": ["Tool: VulnScout"],
+            "specVersion": "3.0.1"
+        },
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://spdx.org/spdxdocs/test",
+        "@graph": []
+    })
+
+    assert len(spdx3_parser.packagesCtrl) == 0
+    assert len(spdx3_parser.vulnerabilitiesCtrl) == 0
+    assert len(spdx3_parser.assessmentsCtrl) == 0
+
+
+def test_parse_packages(spdx3_parser):
+    spdx3_parser.parse_from_dict({
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "specVersion": "3.0.1",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "@graph": [
+            {
+                "type": "CreationInfo",
+                "@id": "_:CreationInfo1",
+                "created": "2025-04-08T13:09:06Z",
+                "createdBy": [
+                    "http://spdx.org/spdxdocs/bitbake-5ae3-87c2-0c3a1a5812ba/bitbake/agent/OpenEmbedded"
+                ],
+                "createdUsing": [
+                    "http://spdx.org/spdxdocs/bitbake-5ae3-87c2-0c3a1a5812ba/bitbake/tool/oe-spdx-creator_1_0"
+                ],
+                "specVersion": "3.0.1"
+            },
+            {
+                "type": "software_Package",
+                "spdxId": "http://spdx.org/spdxdocs/binutils-test/package/binutils",
+                "creationInfo": "_:CreationInfo1",
+                "description": "GNU binutils",
+                "externalIdentifier": [
+                    {
+                        "type": "ExternalIdentifier",
+                        "externalIdentifierType": "cpe23Type",
+                        "identifier": "cpe:2.3:a:gnu:binutils:2.38:*:*:*:*:*:*:*"
+                    }
+                ],
+                "name": "binutils",
+                "summary": "GNU binary utilities",
+                "software_primaryPurpose": "application",
+                "software_homePage": "https://www.gnu.org/software/binutils/",
+                "software_packageVersion": "2.38"
+            },
+            {
+                "type": "software_Package",
+                "spdxId": "http://spdx.org/spdxdocs/linux-test/package/linux",
+                "creationInfo": "_:CreationInfo1",
+                "description": "Linux kernel",
+                "externalIdentifier": [
+                    {
+                        "type": "ExternalIdentifier",
+                        "externalIdentifierType": "cpe23Type",
+                        "identifier": "cpe:2.3:o:linux:linux:6.8.0:*:*:*:*:*:*:*"
+                    }
+                ],
+                "name": "linux",
+                "summary": "Linux kernel",
+                "software_primaryPurpose": "operating-system",
+                "software_homePage": "https://www.kernel.org/",
+                "software_packageVersion": "6.8.0"
+            }
+        ]
+    })
+
+    assert len(spdx3_parser.packagesCtrl) == 2
+    assert "binutils@2.38" in spdx3_parser.packagesCtrl
+    assert "linux@6.8.0" in spdx3_parser.packagesCtrl
+
+    binutils = spdx3_parser.packagesCtrl.get("binutils@2.38")
+    assert len(binutils.cpe) > 0
+    assert "binutils" in binutils.cpe[0]
+    assert "2.38" in binutils.cpe[0]
+
+    linux = spdx3_parser.packagesCtrl.get("linux@6.8.0")
+    assert len(linux.cpe) > 0
+    assert "linux" in linux.cpe[0]
+    assert "6.8.0" in linux.cpe[0]
+
+
+def test_parse_assessments(spdx3_parser):
+    """Test parsing SPDX files with assessments."""
+    spdx3_parser.parse_from_dict({
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "specVersion": "3.0.1",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "@graph": [
+            {
+                "type": "CreationInfo",
+                "@id": "_:CreationInfo1",
+                "created": "2025-04-08T13:09:06Z",
+                "createdBy": [
+                    "http://spdx.org/spdxdocs/bitbake-agent/OpenEmbedded"
+                ],
+                "createdUsing": [
+                    "http://spdx.org/spdxdocs/bitbake-tool/oe-spdx-creator_1_0"
+                ],
+                "specVersion": "3.0.1"
+            },
+            {
+                "type": "software_Package",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/package/kernel",
+                "creationInfo": "_:CreationInfo1",
+                "description": "Linux kernel",
+                "externalIdentifier": [
+                    {
+                        "type": "ExternalIdentifier",
+                        "externalIdentifierType": "cpe23Type",
+                        "identifier": "cpe:2.3:o:linux:linux:6.12.22:*:*:*:*:*:*:*"
+                    }
+                ],
+                "name": "kernel",
+                "summary": "Linux kernel",
+                "software_primaryPurpose": "operating-system",
+                "software_homePage": "https://www.kernel.org/",
+                "software_packageVersion": "6.12.22+git"
+            },
+            {
+                "type": "security_VexNotAffectedVulnAssessmentRelationship",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/vex-not-affected/1",
+                "from": "http://spdxdocs.org/openembedded-alias/linux-yocto/vulnerability/CVE-2023-1234",
+                "to": ["http://spdx.org/spdxdocs/linux-yocto/package/kernel"],
+                "relationshipType": "doesNotAffect",
+                "security_vexVersion": "1.0.0",
+                "security_justificationType": "vulnerableCodeNotPresent",
+                "security_impactStatement": "The vulnerable code is not present in this package"
+            },
+            {
+                "type": "security_VexAffectedVulnAssessmentRelationship",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/vex-affected/2",
+                "from": "http://spdxdocs.org/openembedded-alias/linux-yocto/vulnerability/CVE-2023-5678",
+                "to": ["http://spdx.org/spdxdocs/linux-yocto/package/kernel"],
+                "relationshipType": "affects",
+                "security_vexVersion": "1.0.0",
+                "security_justificationType": "exploitabilityConfirmed",
+                "security_impactStatement": "This vulnerability affects the kernel"
+            },
+            {
+                "type": "security_VexFixedVulnAssessmentRelationship",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/vex-fixed/67890",
+                "from": "http://spdxdocs.org/openembedded-alias/linux-yocto/vulnerability/CVE-2024-1234",
+                "to": ["http://spdx.org/spdxdocs/linux-yocto/package/kernel"],
+                "relationshipType": "fixedIn",
+                "security_vexVersion": "1.0.0",
+                "security_impactStatement": "This vulnerability has been fixed in this package"
+            }
+        ]
+    })
+
+    assert len(spdx3_parser.packagesCtrl) == 1
+    assert "kernel@6.12.22" in spdx3_parser.packagesCtrl
+
+    assert len(spdx3_parser.assessmentsCtrl) == 3
+
+    not_affected = spdx3_parser.assessmentsCtrl.gets_by_vuln("CVE-2023-1234")[0]
+    assert not_affected.status == "not_affected"
+    assert len(not_affected.packages) == 1
+    assert not_affected.justification == "vulnerable_code_not_present"
+    assert "The vulnerable code is not present in this package" in not_affected.impact_statement
+
+    affected = spdx3_parser.assessmentsCtrl.gets_by_vuln("CVE-2023-5678")[0]
+    assert affected.status == "affected"
+    assert len(affected.packages) == 1
+    # exploitabilityConfirmed is not in the JUSTIFICATION_MAP, so it should not be set
+    assert affected.justification == ""
+    assert "This vulnerability affects the kernel" in affected.impact_statement
+
+    fixed = spdx3_parser.assessmentsCtrl.gets_by_vuln("CVE-2024-1234")[0]
+    assert fixed.status == "fixed"
+    assert len(fixed.packages) == 1
+    assert "This vulnerability has been fixed in this package" in fixed.impact_statement
+
+
+def test_extract_vulnerabilities(spdx3_parser):
+    """Test extracting vulnerabilities"""
+
+    spdx_data = {
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "specVersion": "3.0.1",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "@graph": [
+            {
+                "type": "CreationInfo",
+                "@id": "_:CreationInfo1",
+                "created": "2025-04-08T13:09:06Z",
+                "createdBy": [
+                    "http://spdx.org/spdxdocs/bitbake-agent/OpenEmbedded"
+                ],
+                "createdUsing": [
+                    "http://spdx.org/spdxdocs/bitbake-tool/oe-spdx-creator_1_0"
+                ],
+                "specVersion": "3.0.1"
+            },
+            {
+                "type": "software_Package",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/package/kernel",
+                "name": "kernel",
+                "software_packageVersion": "6.12.22",
+                "creationInfo": "_:CreationInfo1",
+                "description": "Linux kernel",
+                "externalIdentifier": [
+                    {
+                        "type": "ExternalIdentifier",
+                        "externalIdentifierType": "cpe23Type",
+                        "identifier": "cpe:2.3:o:linux:linux:6.12.22:*:*:*:*:*:*:*"
+                    }
+                ],
+                "summary": "Linux kernel",
+                "software_primaryPurpose": "operating-system",
+                "software_homePage": "https://www.kernel.org/"
+            },
+            {
+                "type": "security_Vulnerability",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/vulnerability/CVE-2023-1234",
+                "externalIdentifier": [
+                    {
+                        "type": "ExternalIdentifier",
+                        "externalIdentifierType": "cve",
+                        "identifier": "CVE-2023-1234",
+                        "identifierLocator": [
+                            "https://cveawg.mitre.org/api/cve/CVE-2023-1234",
+                            "https://www.cve.org/CVERecord?id=CVE-2023-1234"
+                        ]
+                    }
+                ]
+            },
+            {
+                "type": "Relationship",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/relationship/1",
+                "creationInfo": "_:CreationInfo1",
+                "from": "http://spdx.org/spdxdocs/linux-yocto/package/kernel",
+                "relationshipType": "hasAssociatedVulnerability",
+                "to": ["http://spdx.org/spdxdocs/linux-yocto/vulnerability/CVE-2023-1234"]
+            },
+            {
+                "type": "security_VexNotAffectedVulnAssessmentRelationship",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/vex-not-affected/1",
+                "from": "http://spdx.org/spdxdocs/linux-yocto/vulnerability/CVE-2023-1234",
+                "to": ["http://spdx.org/spdxdocs/linux-yocto/package/kernel"],
+                "relationshipType": "doesNotAffect"
+            }
+        ]
+    }
+
+    spdx3_parser.parse_from_dict(spdx_data)
+
+    assert len(spdx3_parser.vulnerabilitiesCtrl) == 1
+    assert "CVE-2023-1234" in spdx3_parser.vulnerabilitiesCtrl
+
+    vuln = spdx3_parser.vulnerabilitiesCtrl.get("CVE-2023-1234")
+    assert vuln.id == "CVE-2023-1234"
+    assert "https://cveawg.mitre.org/api/cve/CVE-2023-1234" == vuln.datasource
+    assert vuln.namespace == "unknown"
+    assert "https://www.cve.org/CVERecord?id=CVE-2023-1234" in vuln.urls
+
+
+def test_package_vulnerability_relationships(spdx3_parser):
+    """Test parsing SPDX files with package-vulnerability relationships."""
+    spdx3_parser.parse_from_dict({
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "specVersion": "3.0.1",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "@graph": [
+            {
+                "type": "CreationInfo",
+                "@id": "_:CreationInfo1",
+                "created": "2025-04-08T13:09:06Z",
+                "createdBy": ["http://spdx.org/spdxdocs/bitbake-agent/OpenEmbedded"],
+                "createdUsing": ["http://spdx.org/spdxdocs/bitbake-tool/oe-spdx-creator_1_0"],
+                "specVersion": "3.0.1"
+            },
+            {
+                "type": "software_Package",
+                "spdxId": "http://spdx.org/spdxdocs/glibc/package/libc6",
+                "creationInfo": "_:CreationInfo1",
+                "description": "GNU C Library",
+                "externalIdentifier": [
+                    {
+                        "type": "ExternalIdentifier",
+                        "externalIdentifierType": "cpe23Type",
+                        "identifier": "cpe:2.3:a:gnu:glibc:2.38:*:*:*:*:*:*:*"
+                    }
+                ],
+                "name": "libc6",
+                "summary": "GNU C Library",
+                "software_primaryPurpose": "library",
+                "software_homePage": "https://www.gnu.org/software/libc/",
+                "software_packageVersion": "2.38"
+            },
+            {
+                "type": "security_Vulnerability",
+                "spdxId": "http://spdx.org/spdxdocs/glibc/vulnerability/CVE-2019-1010022",
+                "externalIdentifier": [
+                    {
+                        "type": "ExternalIdentifier",
+                        "externalIdentifierType": "cve",
+                        "identifier": "CVE-2019-1010022",
+                        "identifierLocator": ["https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1010022"]
+                    }
+                ]
+            },
+            {
+                "type": "Relationship",
+                "spdxId": "http://spdx.org/spdxdocs/glibc/relationship/1",
+                "creationInfo": "_:CreationInfo1",
+                "from": "http://spdx.org/spdxdocs/glibc/package/libc6",
+                "relationshipType": "hasAssociatedVulnerability",
+                "to": [
+                    "http://spdx.org/spdxdocs/glibc/vulnerability/CVE-2019-1010022"
+                ]
+            },
+            {
+                "type": "security_VexNotAffectedVulnAssessmentRelationship",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/vex-not-affected/1",
+                "from": "http://spdx.org/spdxdocs/glibc/vulnerability/CVE-2019-1010022",
+                "to": ["http://spdx.org/spdxdocs/glibc/package/libc6"],
+                "relationshipType": "doesNotAffect"
+            }
+        ]
+    })
+
+    assert len(spdx3_parser.packagesCtrl) == 1
+    assert "libc6@2.38" in spdx3_parser.packagesCtrl
+
+    assert len(spdx3_parser.vulnerabilitiesCtrl) == 1
+    assert "CVE-2019-1010022" in spdx3_parser.vulnerabilitiesCtrl
+
+    vuln = spdx3_parser.vulnerabilitiesCtrl.get("CVE-2019-1010022")
+    assert vuln.id == "CVE-2019-1010022"
+    assert len(vuln.packages) == 1
+    assert "libc6@2.38" in vuln.packages
+
+
+def test_vulnerability_without_relationship(spdx3_parser):
+    """Test that vulnerabilities without hasAssociatedVulnerability relationship are not added."""
+    spdx_data = {
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "specVersion": "3.0.1",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "@graph": [
+            {
+                "type": "CreationInfo",
+                "@id": "_:CreationInfo1",
+                "created": "2025-04-08T13:09:06Z",
+                "createdBy": [
+                    "http://spdx.org/spdxdocs/bitbake-agent/OpenEmbedded"
+                ],
+                "createdUsing": [
+                    "http://spdx.org/spdxdocs/bitbake-tool/oe-spdx-creator_1_0"
+                ],
+                "specVersion": "3.0.1"
+            },
+            {
+                "type": "software_Package",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/package/kernel",
+                "name": "kernel",
+                "software_packageVersion": "6.12.22",
+                "creationInfo": "_:CreationInfo1",
+                "description": "Linux kernel",
+                "externalIdentifier": [
+                    {
+                        "type": "ExternalIdentifier",
+                        "externalIdentifierType": "cpe23Type",
+                        "identifier": "cpe:2.3:o:linux:linux:6.12.22:*:*:*:*:*:*:*"
+                    }
+                ],
+                "summary": "Linux kernel",
+                "software_primaryPurpose": "operating-system",
+                "software_homePage": "https://www.kernel.org/"
+            },
+            {
+                "type": "security_Vulnerability",
+                "spdxId": "http://spdx.org/spdxdocs/linux-yocto/vulnerability/CVE-2023-1234",
+                "externalIdentifier": [
+                    {
+                        "type": "ExternalIdentifier",
+                        "externalIdentifierType": "cve",
+                        "identifier": "CVE-2023-1234",
+                        "identifierLocator": [
+                            "https://cveawg.mitre.org/api/cve/CVE-2023-1234",
+                            "https://www.cve.org/CVERecord?id=CVE-2023-1234"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    spdx3_parser.parse_from_dict(spdx_data)
+
+    # Verify that the vulnerability was not added since there's no hasAssociatedVulnerability relationship
+    assert len(spdx3_parser.vulnerabilitiesCtrl) == 0
+    assert "CVE-2023-1234" not in spdx3_parser.vulnerabilitiesCtrl


### PR DESCRIPTION
This pull request introduces:
- A parser for Yocto SBOMs in SPDX 3.0.1 format
- A new vulnerability_summary.txt report showing vulnerability data
- Use regex for CVE detection
- Fix misplaced 'from' and 'to' in VEX relationship
- Add more tests