### PR TITLE
add SELinux support

### DIFF
--- a/.vulnscout/example/docker-example.yml
+++ b/.vulnscout/example/docker-example.yml
@@ -11,13 +11,13 @@ services:
       # Put .cdx.json and .cdx.xml files in /scan/inputs/cdx
       # Put .json generated from yocto cve-check in /scan/inputs/yocto_cve_check
       # Also accepted .tar, .tar.gz, .tar.zst for all inputs
-      - ../../src:/scan/src # Mount the source code on actual source code path. Only needed for development if you want to test changes in the source code.
-      - ../cache:/cache/vulnscout # Cache directory for VulnScout to store the DB EPSS and NVD
-      - ./output:/scan/outputs
+      - ../../src:/scan/src:Z # Mount the source code on actual source code path. Only needed for development if you want to test changes in the source code.
+      - ../cache:/cache/vulnscout:Z # Cache directory for VulnScout to store the DB EPSS and NVD
+      - ./output:/scan/outputs:Z
       # - ./tmp:/scan/tmp # Debug only
-      - ./input/cve-yocto.json:/scan/inputs/yocto_cve_check/cve-yocto.json:ro
-      - ./input/example.rootfs.spdx.tar.zst:/scan/inputs/spdx/example.rootfs.spdx.tar.zst:ro
-      - ./input/cyclonedx-export:/scan/inputs/cdx:ro
+      - ./input/cve-yocto.json:/scan/inputs/yocto_cve_check/cve-yocto.json:ro,Z
+      - ./input/example.rootfs.spdx.tar.zst:/scan/inputs/spdx/example.rootfs.spdx.tar.zst:ro,Z
+      - ./input/cyclonedx-export:/scan/inputs/cdx:ro,Z
     environment:
       - FLASK_RUN_PORT=7275
       - FLASK_RUN_HOST=0.0.0.0


### PR DESCRIPTION
Modified the docker run and the docker-compose template to add the Z option to the volume mounts.

Based on the opened : https://github.com/savoirfairelinux/vulnscout/pull/20

(now we should use forks and not branch so can't push on the top of old PR)