### PR TITLE
Add background when hobering rows

### DIFF
--- a/frontend/src/components/TableGeneric.tsx
+++ b/frontend/src/components/TableGeneric.tsx
@@ -189,7 +189,8 @@ function TableGeneric<DataType> ({
                                 key={row.id}
                                 className={[
                                     "flex absolute w-full row-with-hover-effect",
-                                    row.getIsSelected() ? 'selected bg-gray-700' : 'bg-slate-600'
+                                    row.getIsSelected() ? 'selected bg-gray-700' : 'bg-slate-600',
+                                    "hover:bg-slate-800"
                                 ].join(' ')}
                                 onClick={(e) => ctrl_click(e, row)}
                                 style={{
@@ -213,7 +214,7 @@ function TableGeneric<DataType> ({
                                     })}
                                 </tr>,
                                 hoverField != undefined && <tr
-                                    className="show-on-row-hover absolute z-30 overflow-visible w-full px-8 xl:px-32 2xl:px-64 text-center"
+                                    className="show-on-row-hover absolute z-30 overflow-visible w-full px-8 xl:px-32 2xl:px-64 text-center pointer-events-none"
                                     key={`${row.id}_hoverpanel`}
                                     style={{
                                         transform: virtualRow.start > 150 ?  //this should always be a `style` as it changes on scroll


### PR DESCRIPTION
### Changes proposed in this pull request:

In tables (e.g vulnerabilities / packages), user needs to kmow which row he is hovering. Passing the mouse changes background color of the row in addition to showing the description bubble.

* Change row background color when user hovers a line
* Solve issue of description bubble overlay

### Status

- [x ] READY

### How to verify this change

Go to any table, hover any row. It will change background color and a description bubble

