### PR TITLE
Fix search code bug

### DIFF
--- a/frontend/src/components/TableGeneric.tsx
+++ b/frontend/src/components/TableGeneric.tsx
@@ -42,8 +42,6 @@ function TableGeneric<DataType> ({
             useExtendedSearch: true,
             shouldSort: true,
             minMatchCharLength: 2,
-            useExtendedSearch: true,
-            ignoreLocation: true
         });
     }, [fuseKeys, data]);
 


### PR DESCRIPTION
A bug in TableGeneric prevented the frontend from being built when the user starts VulnScout in build mode

### Changes proposed in this pull request:

* Remove redundant code


### Status

- [X ] READY
- [ ] HOLD
- [] WIP (Work-In-Progress)

### How to verify this change

Run ./start-example.sh


