### PR TITLE
Update the Dockerfile used for vulnscout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,13 @@ RUN curl -L "https://github.com/google/osv-scanner/releases/download/$OSV_SCANNE
     && chmod +x /usr/local/bin/osv-scanner
 
 # Install CycloneDX
-ARG CYCLONEDX_VERSION=v0.25.1
+ARG CYCLONEDX_VERSION=v0.29.1
 RUN curl -sSfL "https://github.com/CycloneDX/cyclonedx-cli/releases/download/$CYCLONEDX_VERSION/cyclonedx-linux-musl-x64" -o cyclonedx-cli && \
     chmod +x cyclonedx-cli && \
     mv cyclonedx-cli /usr/local/bin/
 
 # Install Grype
-ARG GRYPE_VERSION=v0.78.0
+ARG GRYPE_VERSION=v0.97.2
 RUN curl -sSfL "https://raw.githubusercontent.com/anchore/grype/$GRYPE_VERSION/install.sh" | sh -s -- -b /usr/local/bin
 
 # Install dependencies for python backend


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Changed OSV scanner installation method from pip to a curl on the official repo. The pip command faced an issue with a wrong experimental version on OSV scanner used
* Increased the version used of Grype and CycloneDX

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Rebuild a test version with: docker build -t sflinux/vulnscout:test .
Then modify .vulnscout/example/docker-example.yml to use "image: sflinux/vulnscout:test"

