### PR TITLE
Fix/NPM issue with default Ubuntu version provided with pip install + NPM should NOT be mandotry for testing

### DIFF
--- a/.vulnscout/docker-npm-override.yml
+++ b/.vulnscout/docker-npm-override.yml
@@ -1,0 +1,6 @@
+# ONLY development with NPM
+services:
+  vulnscout:
+    volumes:
+      # You need to mount the source code on actual source code path with "../../src:/scan/src:Z"
+      - ../../src:/scan/src:Z

--- a/.vulnscout/example-spdx3/docker-example-spdx3.yml
+++ b/.vulnscout/example-spdx3/docker-example-spdx3.yml
@@ -10,7 +10,6 @@ services:
       # Put .spdx.json files in /scan/inputs/spdx
       # Put .cdx.json and .cdx.xml files in /scan/inputs/cdx
       # Put .json generated from yocto cve-check in /scan/inputs/yocto_cve_check
-      - ../../src:/scan/src:Z # Mount the source code on actual source code path. Only needed for development if you want to test changes in the source code.
       - ../cache:/cache/vulnscout:Z # Cache directory for VulnScout to store the DB EPSS and NVD
       - ./output:/scan/outputs:Z
       - ./input/core-image-minimal-qemux86-64.rootfs.json:/scan/inputs/yocto_cve_check/core-image-minimal-qemux86-64.rootfs.json:ro,Z

--- a/.vulnscout/example/docker-example.yml
+++ b/.vulnscout/example/docker-example.yml
@@ -11,10 +11,8 @@ services:
       # Put .cdx.json and .cdx.xml files in /scan/inputs/cdx
       # Put .json generated from yocto cve-check in /scan/inputs/yocto_cve_check
       # Also accepted .tar, .tar.gz, .tar.zst for all inputs
-      - ../../src:/scan/src:Z # Mount the source code on actual source code path. Only needed for development if you want to test changes in the source code.
       - ../cache:/cache/vulnscout:Z # Cache directory for VulnScout to store the DB EPSS and NVD
       - ./output:/scan/outputs:Z
-      # - ./tmp:/scan/tmp # Debug only
       - ./input/example.rootfs.json:/scan/inputs/yocto_cve_check/example.rootfs.json:ro,Z
       - ./input/example.rootfs.spdx.tar.zst:/scan/inputs/spdx/example.rootfs.spdx.tar.zst:ro,Z
       - ./input/cyclonedx-export:/scan/inputs/cdx:ro,Z

--- a/README_DEV.adoc
+++ b/README_DEV.adoc
@@ -2,6 +2,17 @@
 
 This document provides guidelines for developers working on the vulnscout project, including setup, testing, and code quality practices.
 
+== Requirements
+
+NVM 22 is required to develop on vulnscout without any issues. 
+Installation guide for NVM : https://github.com/nvm-sh/nvm
+
+[source,bash]
+----
+nvm install 22
+nvm use 22
+----
+
 == Modify the frontend
 
 To modify the frontend, you will need to run vulnscout in development mode.
@@ -9,7 +20,7 @@ To do so, you can run the following command:
 
 [source,bash]
 ----
-./start-example.sh --dev
+./start-example.sh --npm-dev
 ----
 
 == Testing the project

--- a/start-example.sh
+++ b/start-example.sh
@@ -4,26 +4,90 @@
 set -e
 
 show_help() {
-  echo "Usage: ./start-example.sh [--dev | --help]"
+  echo "Usage: ./start-example.sh [--npm-build | --npm-dev] [--spdx3] [--help]"
   echo ""
   echo "Options:"
-  echo "  --dev      Start frontend in development mode (npm run dev) and backend with Docker Compose"
-  echo "  --spdx3    Use the SPDX-3 example instead of SPDX-2"
-  echo "  --help     Show this help message and exit"
+  echo "  --npm-build   Build frontend (npm run build) before starting backend"
+  echo "  --npm-dev     Start frontend in development mode (npm run dev) and backend with Docker Compose"
+  echo "  --spdx3       Use the SPDX-3 example instead of SPDX-2"
+  echo "  --help        Show this help message and exit"
   echo ""
   echo "Default mode:"
-  echo "  If no arguments are passed, frontend will be built (npm run build) for SPDX2."
+  echo "  If no option is passed, the example will be started for SPDX2."
+}
+
+# Function to set up frontend - Only required for development
+setup_frontend_devtools() {
+  local mode=$1
+
+  if [[ "$mode" != "dev" && "$mode" != "build" ]]; then
+    echo "Error: setup_frontend_devtools requires an argument: \"dev\" or \"build\""
+    exit 1
+  fi
+
+  if ! command -v npm &> /dev/null; then
+    echo "Error: npm is not installed or not in PATH."
+    exit 1
+  fi
+
+  # Create the .env file in frontend if it doesn't exist
+  if [ ! -f frontend/.env ]; then
+    echo 'VITE_API_URL="http://localhost:7275"' > frontend/.env
+  fi
+
+  # Check if node_modules exists in frontend; if not, run npm install
+  if [ ! -d frontend/node_modules ]; then
+    echo "node_modules not found. Running npm install first..."
+    (cd frontend && npm install)
+  fi
+
+  # Start frontend dev server from within the frontend folder
+  # Run frontend
+  if [ "$mode" == "dev" ]; then
+    echo "Starting frontend in development mode..."
+    (cd frontend && npm run dev) &
+    npm_pid=$!
+    echo "Frontend dev server started (PID $npm_pid)"
+
+    # Function to cleanup background process on exit (Ctrl+C)
+    # Only needed in dev mode because we run npm in the background in dev mode
+    # In build mode, we just run npm build and exit
+    cleanup() {
+        echo -e "\n Stopping frontend dev server (PID $npm_pid)..."
+        kill -- -$(ps -o pgid= $npm_pid | grep -o '[0-9]*') 2>/dev/null
+        wait $npm_pid 2>/dev/null
+        exit 0
+    }
+    trap cleanup SIGINT SIGTERM EXIT
+
+    sleep 1
+  else
+    echo "Building frontend..."
+    (cd frontend && npm run build)
+  fi
 }
 
 # Default settings
-NPM_MODE="build"
+NPM_MODE="none"
 DOCKER_COMPOSE_FILE=".vulnscout/example/docker-example.yml"
+DOCKER_EXTRA_VOLUMES=""
 
 # Parse arguments
 for arg in "$@"; do
   case "$arg" in
-    --dev)
+    --npm-build)
+      NPM_MODE="build"
+      if [ "$NPM_MODE" == "dev" ]; then
+        echo "Error: Cannot use --npm-build and --npm-dev at the same time."
+        exit 1
+      fi
+      ;;
+    --npm-dev)
       NPM_MODE="dev"
+      if [ "$NPM_MODE" == "build" ]; then
+        echo "Error: Cannot use --npm-build and --npm-dev at the same time."
+        exit 1
+      fi
       ;;
     --spdx3)
       DOCKER_COMPOSE_FILE=".vulnscout/example-spdx3/docker-example-spdx3.yml"
@@ -40,15 +104,18 @@ for arg in "$@"; do
   esac
 done
 
-## Check for required tools
-if ! command -v npm &> /dev/null; then
-  echo "Error: npm is not installed or not in PATH."
-  exit 1
-fi
-
+## Check for required docker compose command
 if ! command -v docker &> /dev/null; then
   echo "Error: Docker is not installed or not in PATH."
   exit 1
+fi
+
+if [ "$NPM_MODE" == "dev" ]; then
+  setup_frontend_devtools dev
+  DOCKER_EXTRA_VOLUMES="-f .vulnscout/docker-npm-override.yml"
+elif [ "$NPM_MODE" == "build" ]; then
+  setup_frontend_devtools build
+  DOCKER_EXTRA_VOLUMES="-f .vulnscout/docker-npm-override.yml"
 fi
 
 if docker compose version &> /dev/null; then
@@ -62,53 +129,9 @@ fi
 
 echo "Docker Compose command found: $DOCKER_COMPOSE"
 
-## Frontend Development Environment Setup Script
-
-# Create the .env file in frontend if it doesn't exist
-if [ ! -f frontend/.env ]; then
-  echo 'VITE_API_URL="http://localhost:7275"' > frontend/.env
-fi
-
-# Check if node_modules exists in frontend; if not, run npm install
-if [ ! -d frontend/node_modules ]; then
-  echo "node_modules not found. Running npm install first..."
-  (cd frontend && npm install)
-fi
-
-# Start frontend dev server from within the frontend folder
-
-# Run frontend
-if [ "$NPM_MODE" == "dev" ]; then
-  echo "Starting frontend in development mode..."
-  (cd frontend && npm run dev) &
-  npm_pid=$!
-  echo "Frontend dev server started (PID $npm_pid)"
-
-  # Function to cleanup background process on exit (Ctrl+C)
-  # Only needed in dev mode because we run npm in the background in dev mode
-  # In build mode, we just run npm build and exit
-  cleanup() {
-      echo -e "\n Stopping frontend dev server (PID $npm_pid)..."
-      kill -- -$(ps -o pgid= $npm_pid | grep -o '[0-9]*') 2>/dev/null
-      wait $npm_pid 2>/dev/null
-      exit 0
-  }
-  trap cleanup SIGINT SIGTERM EXIT
-
-  sleep 1
-else
-  echo "Building frontend..."
-  (cd frontend && npm run build)
-fi
-
 ## Backend Development Environment Setup Script
 # Close any existing docker-compose processes
-docker rm -f vulnscout 2>/dev/null
+docker rm -f vulnscout 2>/dev/null || true
 
 # Start docker services
-$DOCKER_COMPOSE -f "$DOCKER_COMPOSE_FILE" up
-
-# When docker-compose finishes (or script ends), cleanup npm too if dev mode
-if [ "$NPM_MODE" == "dev" ]; then
-  cleanup
-fi
+$DOCKER_COMPOSE -f "$DOCKER_COMPOSE_FILE" $DOCKER_EXTRA_VOLUMES up


### PR DESCRIPTION
## Fixes # by Valentin Boudevin based on NPM issue with default Ubuntu version provided with pip install + NPM should NOT be mandotry for testing #59

### Changes proposed in this pull request:

start-example: Running Vulnscout as a user should not require NPM on the host

NPM is only required for devleopment! A user don't need it to run vulnscout.

*Changed start-example to start VS with examples with only docker-compose 
*Changed the yaml examples to not mount the source code (required with NPM) if NPM is not used 
*Added "docker-npm-overrde.yaml" to mount the source code for NPM dev use. Handled by start-example.sh with "npm-dev" or "npm-build"

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

./start-example works without NPM on your device
./start-example --npm-dev run correctly the dev session

