### PR TITLE
Add workflow to publish on tag

### DIFF
--- a/.github/workflows/publish-image-on-tag.yml
+++ b/.github/workflows/publish-image-on-tag.yml
@@ -1,0 +1,55 @@
+name: Publish Docker Hub image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Git tag to build from
+        required: true
+        type: string
+      publish_latest:
+        description: Also push :latest
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: sflinux/vulnscout
+  IMAGE_TAG: ${{ inputs.tag }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Docker login
+        run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Build image from Dockerfile
+        run: docker build -f Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .
+
+      - name: Push image tag
+        run: docker push ${IMAGE_NAME}:${IMAGE_TAG}
+
+      - name: Tag and push latest (optional)
+        if: ${{ inputs.publish_latest }}
+        run: |
+          docker tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:latest
+          docker push ${IMAGE_NAME}:latest
+
+        description: Git tag to build from
+        required: true
+        type: string
+      publish_latest:
+        description: Also push :latest
+        required: false
+        default: false
+        type: boolean


### PR DESCRIPTION
## Added workflow to push Image Tag

### Changes proposed in this pull request:

* Added workflow to push image using tag version
* Added option to push latest tag 
* The workflow is trigger manually for now 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

The workflow will run on main, it creates a new image on docker hub with the new tag.
To test it you need to run it in your local fork, and push test tags, however it requires Docker hub user and password
For the moment we could merge and test the docker images generated afterward and improve upon it 

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [X] The code compiles and passes all tests
- [X] All new and existing tests are passing
- [X] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [X] Linked relevant issues (if any)
- [X] Added necessary reviewers


