### PR TITLE
Add "Reset filters" to Packages view

### DIFF
--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -96,6 +96,14 @@ function TablePackages({ packages }: Readonly<Props>) {
         return Array.from(statuses);
     }, [packages]);
 
+    const resetFilters = () => {
+        setSearch('');
+        setSelectedSources([]);
+        setSelectedStatuses([]);
+        setSelectedLicences([]);
+        setShowSeverity(false);
+    }
+
     const hide_filter = useMemo(() => {
         return statusOptions.filter(status => selectedStatuses.includes(status))
     }, [selectedStatuses])
@@ -202,6 +210,13 @@ function TablePackages({ packages }: Readonly<Props>) {
                     label="Severity"
                 />
             </div>
+
+            <button
+                onClick={resetFilters}
+                className="ml-auto bg-sky-900 hover:bg-sky-950 px-3 py-1 rounded text-white border border-sky-700"
+            >
+                Reset Filters
+            </button>
         </div>
 
         <div ref={tableRef}>


### PR DESCRIPTION
### Changes proposed in this pull request:

* Add "Reset filters" button to the Packages view

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

Open the VS web dashboard, go to the Packages tab, set a few filters then click on "Reset filters". Notice that the table shows all the original unfiltered data.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


