### PR TITLE
Pass filtering criteria from pie charts

### DIFF
--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -24,7 +24,8 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
     const [vulns, setVulns] = useState<Vulnerability[]>([]);
     const [patchInfo, setPatchInfo] = useState<PackageVulnerabilities>({});
     const [patchDbReady, setPatchDbReady] = useState<boolean>(false);
-    const [filteredVulns, setFilteredVulns] = useState<Vulnerability[] | null>(null);
+    const [filterLabel, setFilterLabel] = useState<"Source" | "Severity" | "Status" | undefined>(undefined);
+    const [filterValue, setFilterValue] = useState<string | undefined>(undefined);
 
     useEffect(() => {
         Promise.allSettled([
@@ -99,16 +100,26 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         }));
     }
 
-    function goToVulnsTabWithFilter(filtered: Vulnerability[]) {
-        setFilteredVulns(filtered);
+    function goToVulnsTabWithFilter(filterType: "Source" | "Severity" | "Status", value: string) {
+        setFilterLabel(filterType);
+        setFilterValue(value);
         setTab('vulnerabilities');
     }
 
     const [tab, setTab] = useState("metrics");
 
+    // This function ensures vulns get reset when switching outside filtering context
+    function handleTabChange(newTab: string) {
+        if (newTab === 'vulnerabilities' && tab !== 'vulnerabilities') {
+            setFilterLabel(undefined);
+            setFilterValue(undefined);
+        }
+        setTab(newTab);
+    }
+
     return (
         <div className="w-screen h-screen bg-gray-200 dark:bg-neutral-800 dark:text-[#eee] flex flex-col overflow-hidden">
-            <NavigationBar tab={tab} changeTab={setTab} darkMode={darkMode} setDarkMode={setDarkMode} />
+            <NavigationBar tab={tab} changeTab={handleTabChange} darkMode={darkMode} setDarkMode={setDarkMode} />
 
             <div className="p-8 flex-1 overflow-auto">
                 {tab === 'metrics' &&
@@ -128,7 +139,8 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     appendCVSS={appendCVSS}
                     patchVuln={patchVuln}
                     vulnerabilities={vulns}
-                    {...(filteredVulns && { filteredVulns: filteredVulns })}
+                    filterLabel={filterLabel}
+                    filterValue={filterValue}
                 />}
                 {tab == 'patch-finder' && <PatchFinder vulnerabilities={vulns} packages={pkgs} patchData={patchInfo} db_ready={patchDbReady} />}
                 {tab == 'exports' && <Exports />}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -2,7 +2,7 @@ import type { Vulnerability } from "../handlers/vulnerabilities";
 import type { CVSS } from "../handlers/vulnerabilities";
 import type { Assessment } from "../handlers/assessments";
 import { createColumnHelper, SortingFn, RowSelectionState, Row, Table } from '@tanstack/react-table'
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import SeverityTag from "../components/SeverityTag";
 import { SEVERITY_ORDER } from "../handlers/vulnerabilities";
 import TableGeneric from "../components/TableGeneric";
@@ -13,10 +13,11 @@ import FilterOption from "../components/FilterOption";
 
 type Props = {
     vulnerabilities: Vulnerability[];
-    filteredVulns?: Vulnerability[];
     appendAssessment: (added: Assessment) => void;
     appendCVSS: (vulnId: string, vector: string) => CVSS | null;
     patchVuln: (vulnId: string, replace_vuln: Vulnerability) => void;
+    filterLabel?: "Source" | "Severity" | "Status";
+    filterValue?: string;
 };
 
 const sortSeverityFn: SortingFn<Vulnerability> = (rowA, rowB) => {
@@ -46,15 +47,21 @@ const sortAttackVectorFn: SortingFn<Vulnerability> = (rowA, rowB) => {
 
 const fuseKeys = ['id', 'aliases', 'related_vulnerabilities', 'packages', 'simplified_status', 'status', 'texts.content']
 
-function TableVulnerabilities ({ vulnerabilities, filteredVulns, appendAssessment, appendCVSS, patchVuln }: Readonly<Props>) {
+function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln }: Readonly<Props>) {
 
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);
     const [search, setSearch] = useState<string>('');
     const [selectedSeverities, setSelectedSeverities] = useState<string[]>([]);
     const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
-    const [selectedRows, setSelectedRows] = useState<RowSelectionState>({})
-    const [useFilteredProp, setUseFilteredProp] = useState(true);
+    const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
+
+    useEffect(() => {
+        if (!filterLabel || !filterValue) return;
+        if (filterLabel === "Source") setSelectedSources([filterValue]);
+        if (filterLabel === "Severity") setSelectedSeverities([filterValue]);
+        if (filterLabel === "Status") setSelectedStatuses([filterValue]);
+    }, [filterLabel, filterValue]);
 
     const updateSearch = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
         if (event.target.value.length < 2) {
@@ -179,16 +186,14 @@ function TableVulnerabilities ({ vulnerabilities, filteredVulns, appendAssessmen
         ]
     }, []);
 
-    const baseData = useFilteredProp && filteredVulns ? filteredVulns : vulnerabilities;
-
     const dataToDisplay = useMemo(() => {
-        return baseData.filter((el) => {
+        return vulnerabilities.filter((el) => {
             if (selectedSeverities.length && !selectedSeverities.includes(el.severity.severity)) return false;
             if (selectedStatuses.length && !selectedStatuses.includes(el.simplified_status)) return false;
             if (selectedSources.length && !selectedSources.some(src => el.found_by.includes(src))) return false;
             return true;
         });
-    }, [baseData, selectedSeverities, selectedStatuses, selectedSources]);
+    }, [vulnerabilities, selectedSeverities, selectedStatuses, selectedSources]);
 
     const selectedVulns = useMemo(() => {
         return Object.entries(selectedRows).flatMap(([id, selected]) => selected ? [id] : [])
@@ -200,7 +205,6 @@ function TableVulnerabilities ({ vulnerabilities, filteredVulns, appendAssessmen
         setSelectedSeverities([]);
         setSelectedStatuses([]);
         setSelectedRows({});
-        setUseFilteredProp(false);
     }
 
     return (<>


### PR DESCRIPTION
### Changes proposed in this pull request:

* Pass the filter label and values to the vulnerabilities table, so the user can see the  criteria inside the filter options
* Refactor filtering mechanism to process all filtering in the vulnerabilities view in order to reduce data volume

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open the VS web dashboard, click on an element of the pie chart, you will be directed to the Vulnerabilities table.
Click on a filtering option (severity or status), notice that the selected item from the pie chart is indeed checked

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers