### PR TITLE
Solve fixed Version line in Patch-Finder

### DIFF
--- a/frontend/src/components/VersionsLine.tsx
+++ b/frontend/src/components/VersionsLine.tsx
@@ -21,18 +21,18 @@ function VersionsLine ({ versions, reduce_size=false }: Readonly<Props>) {
             {versions.map((version, index) => [
                 (index > 0 || version.left_color) && <div key={'color_'+version.title} className={["min-h-0.5 flex-1", version.left_color ?? "bg-gray-900"].join(' ')}></div>,
                 <div key={version.title} className={[
-                    "flex-none rounded-full bg-slate-100 text-center",
+                    "flex-none rounded-full bg-slate-100 text-center relative",
                     width_sizes[index] ?? 'w-7', height_sizes[index] ?? 'h-7'
                 ].join(' ')}>
                     <div className={[
-                        "absolute text-white -translate-y-8 -translate-x-[calc(50%-0.825rem)] font-mono",
+                        "absolute text-white -top-8 left-1/2 -translate-x-1/2 font-mono whitespace-nowrap",
                         reduce_size ? 'text-sm' : 'text-lg'
                     ].join(' ')}>
                         {version.title}
                     </div>
                     {(version.details || version.highlight) && <div
                         className={[
-                            "absolute text-sm text-slate-300 translate-y-8 -translate-x-[calc(50%-0.825rem)]",
+                            "absolute text-slate-300 top-8 left-1/2 -translate-x-1/2 whitespace-nowrap",
                             reduce_size ? 'text-xs' : 'text-sm'
                     ].join(' ')}>
                         {version.highlight && <span className="font-mono">{version.highlight}</span>}


### PR DESCRIPTION
### Changes proposed in this pull request:

* Fix the version line that wasn't scrolling with the rest of Patch-Finder content

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Launch VS and open the web dashboard, go to the Patch-Finder tab and scroll through the page, notice that the version lines are moving along the rest of the content

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


