### PR TITLE
vulnscout_CI_test.sh: Add automatic test for CI mode

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -17,3 +17,18 @@ RUN mkdir -p /cache/vulnscout && chmod -R 777 /cache
 
 RUN pip install --no-cache-dir -r /tmp/dev.txt \
     && rm -rf /tmp/dev.txt
+
+# Install Docker CLI only (no daemon)
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl gnupg lsb-release && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | \
+        gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) \
+        signed-by=/etc/apt/keyrings/docker.gpg] \
+        https://download.docker.com/linux/debian \
+        $(lsb_release -cs) stable" \
+        > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y docker-ce-cli && \
+    rm -rf /var/lib/apt/lists/*

--- a/.cqfdrc
+++ b/.cqfdrc
@@ -15,3 +15,7 @@ command="make -C tests test_backend"
 
 [test_frontend]
 command="make -C tests test_frontend"
+
+[test_ci]
+command="make -C tests test_ci"
+docker_run_args="-v /run/docker.sock:/run/docker.sock"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [Backend, Frontend, Docker]
+        target: [Backend, Frontend, CI, Docker]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -32,6 +32,10 @@ jobs:
       - name: Run Frontend Tests in the container
         if: matrix.target == 'Frontend'
         run: cqfd -b test_frontend
+
+      - name: Run CI Tests in the container
+        if: matrix.target == 'CI'
+        run: cqfd -b test_ci
 
       - name: Docker Build
         if: matrix.target == 'Docker'

--- a/tests/CI_tests/vulnscout_CI_test.sh
+++ b/tests/CI_tests/vulnscout_CI_test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+BASE_DIR=$PWD/../../
+VULNSCOUT_DIR=.vulnscout/test_ci/output
+OUPUT_CI_FILES=("time_estimates.csv" "time_estimates.json" "openvex.json" "sbom.cdx.json" "sbom.spdx.json" "summary.adoc")
+OUPUT_CI_FILES_SORT=($(printf '%s\n' "${OUPUT_CI_FILES[@]}" | sort))
+
+cd $BASE_DIR
+# Launching VulnScout CI script with a fail condition that must be triggered
+./vulnscout.sh --name test_ci --sbom $(pwd)/.vulnscout/example-spdx3/input/core-image-minimal-qemux86-64.rootfs.spdx.json \
+	--cve-check $(pwd)/.vulnscout/example-spdx3/input/core-image-minimal-qemux86-64.rootfs.json \
+	--fail_condition "cvss >= 8.0 or (cvss >= 7.0 and epss >= 50%)"
+if [ $? -eq 2 ]; then
+	echo "**Vulnscout condition fail correctly triggered**"
+else
+	echo "**VulnScout condition fail should have been triggered**"
+	exit 1
+fi
+# Launching VulnScout CI script with fail condition that must not be triggered
+./vulnscout.sh --name test_ci --sbom $(pwd)/.vulnscout/example-spdx3/input/core-image-minimal-qemux86-64.rootfs.spdx.json \
+	--cve-check $(pwd)/.vulnscout/example-spdx3/input/core-image-minimal-qemux86-64.rootfs.json \
+	--fail_condition "cvss >= 11.0"
+if [ $? -eq 0 ]; then
+	echo "**Checking output files**"
+	check_output_files=( $(find $VULNSCOUT_DIR -type f | cut -d'/' -f4) )
+	output_files_sort=($(printf '%s\n' "${check_output_files[@]}" | sort))
+	if [ "${output_files_sort[*]}" == "${OUPUT_CI_FILES_SORT[*]}" ]; then
+		echo "**Output files correctly created**"
+	else
+		echo "**Ouput files incorrect:**"
+		echo "**${check_output_files[@]}**"
+		exit 1
+	fi
+else
+	echo "**VulnScout condition fail should not have been triggered**"
+	exit 1
+fi

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,9 @@
 MAKEFILE_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 SRC_DIR := $(MAKEFILE_DIR)../src
 FRONTEND_DIR := $(MAKEFILE_DIR)../frontend
+CI_DIR := $(MAKEFILE_DIR)/CI_tests
 
-test: test_backend test_frontend
+test: test_backend test_frontend test_ci
 
 test_backend:
 	flake8 $(SRC_DIR)
@@ -19,6 +20,10 @@ test_frontend:
 		echo "Running frontend tests with full coverage reporters"; \
 		npm test -- --coverage; \
 	fi
+
+test_ci:
+	cd $(CI_DIR) && \
+	bash ./vulnscout_CI_test.sh
 
 docker_build:
 	@if [ -z "${BUILD_TAG}" ]; then echo "BUILD_TAG is not set"; exit 1; fi

--- a/vulnscout.sh
+++ b/vulnscout.sh
@@ -307,6 +307,7 @@ start_vulnscout(){
     if [ "$docker_exit_code" -eq 2 ]; then
         echo "---------------- Vulnscout triggered fail condition ----------------"
         echo "--- Vulnscout exited with code 2 with fail condition: $VULNSCOUT_FAIL_CONDITION ---"
+        exit 2
     else
         echo "---------------- Vulnscout scanning success ----------------"
         if [ -n "$VULNSCOUT_FAIL_CONDITION" ]; then


### PR DESCRIPTION
### Changes proposed in this pull request:
Create a vulnscout_CI_test.sh to test the CI mode with cqfd. It test if the fail condition is correctly working and if the output files are correctly created when the fail condition was not triggered. To make it work, it was needed to install docker in the cqfd for DinD context.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change
You can launch manually the test with the command: `cqfd -b test_ci` in the vulnscout directory.

### Additional notes

*If applicable, explain the rationale behind your change.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [x] Added necessary reviewers


