### PR TITLE
Move "new assessment" above history in VulnModal

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -366,6 +366,16 @@ const dt_options: Intl.DateTimeFormatOptions = {
 
                         <h3 className="font-bold">Assessments</h3>
                         <ol className="relative border-s border-gray-800">
+                            <li className="ms-4 text-white pb-8">
+                                <div className="absolute w-3 h-3 bg-gray-200 rounded-full mt-1.5 -start-1.5 border border-sky-500 bg-sky-500"></div>
+                                <time className="mb-1 text-sm font-normal leading-none text-gray-400">Add a new assessment</time>
+                                <StatusEditor 
+                                    onAddAssessment={(data) => addAssessment(data)} 
+                                    clearFields={clearAssessmentFields}
+                                    onFieldsChange={setHasAssessmentChanges} 
+                                    triggerBanner={showMessage}
+                                />
+                            </li>
 
                             {groupedAssessments.map(group => {
                                 const dt = new Date(group.timestamp);
@@ -394,17 +404,6 @@ const dt_options: Intl.DateTimeFormatOptions = {
                                     </li>
                                 );
                             })}
-
-                            <li className="ms-4 text-white">
-                                <div className="absolute w-3 h-3 bg-gray-200 rounded-full mt-1.5 -start-1.5 border border-sky-500 bg-sky-500"></div>
-                                <time className="mb-1 text-sm font-normal leading-none text-gray-400">Add a new assessment</time>
-                                <StatusEditor 
-                                    onAddAssessment={(data) => addAssessment(data)} 
-                                    clearFields={clearAssessmentFields}
-                                    onFieldsChange={setHasAssessmentChanges} 
-                                    triggerBanner={showMessage}
-                                />
-                            </li>
                         </ol>
                     </div>
 


### PR DESCRIPTION
### Changes proposed in this pull request:

* Move "new assessment" above history in VulnModal

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open the web dashboard and pick a vulnerability from the Vulnerabilities tab, observe that the New assessment section moved to be at the top of the assessments history

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


