### PR TITLE
bugfix: Fix cve_check CVE version issue

### DIFF
--- a/src/models/package.py
+++ b/src/models/package.py
@@ -27,7 +27,7 @@ class Package:
         cpe, purl and licences are optional lists of identifiers.
         """
         self.name = name
-        self.version = version.split("+git")[0]
+        self.version = str(version).strip().split("+git")[0]
         cpes = cpe or []
         purls = purl or []
         lics = licences or ""


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

    bugfix: Fix cve_check CVE version issue
    
    A package may have a complex version number (e.g. "89.0.4389.72").
    
    In this rare scenario, cve_check failed with the following error:
    
    vulnscout  | Traceback (most recent call last):
    vulnscout  |   File "<frozen runpy>", line 198, in _run_module_as_main
    vulnscout  |   File "<frozen runpy>", line 88, in _run_code
    vulnscout  |   File "/scan/src/bin/merger_ci.py", line 367, in <module>
    vulnscout  |     main()
    vulnscout  |   File "/scan/src/bin/merger_ci.py", line 349, in main
    vulnscout  |     files = read_inputs(controllers)
    vulnscout  |             ^^^^^^^^^^^^^^^^^^^^^^^^
    vulnscout  |   File "/scan/src/bin/merger_ci.py", line 261, in read_inputs
    vulnscout  |     scanYocto.load_from_dict(json.loads(f.read()))
    vulnscout  |   File "/scan/src/views/yocto_vulns.py", line 28, in load_from_dict
    vulnscout  |     package = Package(pkg["name"], pkg["version"], [], [])
    vulnscout  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    vulnscout  |   File "/scan/src/models/package.py", line 30, in __init__
    vulnscout  |     self.version = version.split("+git")[0]
    vulnscout  |                    ^^^^^^^^^^^^^
    vulnscout  | AttributeError: 'float' object has no attribute 'split'
    
    I fixed version version.split() to handle version correctly.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Modify a cve_check file package version to a complex version like: 99.0.2222.11

Now no error will raise. 

