### PR TITLE
Add silent execution mode to start-example.sh

### DIFF
--- a/start-example.sh
+++ b/start-example.sh
@@ -4,11 +4,13 @@
 set -e
 
 show_help() {
-  echo "Usage: ./start-example.sh [--dev] [--spdx3] [--help]"
+  echo "Usage: ./start-example.sh [OPTION]"
   echo ""
   echo "Options:"
   echo "  --dev         Start frontend in development mode (npm run dev) and mount volume on src/ for the backend"
   echo "  --spdx3       Use the SPDX-3 example instead of SPDX-2"
+  echo "  --detach      Start docker services in detached mode"
+  echo "  --stop        Stop running example"
   echo "  --help        Show this help message and exit"
   echo ""
   echo "Default mode:"
@@ -17,6 +19,7 @@ show_help() {
 
 # Function to set up frontend - Only required for development
 setup_devtools() {
+  local is_detached=$1
 
   # Check if npm is installed
   if ! command -v npm &> /dev/null; then
@@ -41,14 +44,22 @@ setup_devtools() {
   npm_pid=$!
   echo "Frontend dev server started (PID $npm_pid)"
 
-  # Function to cleanup background process on exit (Ctrl+C)
-  cleanup() {
-      echo -e "\n Stopping frontend dev server (PID $npm_pid)..."
-      kill -- -$(ps -o pgid= $npm_pid | grep -o '[0-9]*') 2>/dev/null
-      wait $npm_pid 2>/dev/null
-      exit 0
-  }
-  trap cleanup SIGINT SIGTERM EXIT
+  # Store PID for later cleanup
+  echo "$npm_pid" > .vulnscout-npm.pid
+
+  if [ "$is_detached" == "false" ]; then
+    # Function to cleanup background process on exit (Ctrl+C)
+    cleanup() {
+        echo -e "\n Stopping frontend dev server (PID $npm_pid)..."
+        kill -- -$(ps -o pgid= $npm_pid | grep -o '[0-9]*') 2>/dev/null
+        wait $npm_pid 2>/dev/null
+        rm -f .vulnscout-npm.pid
+        exit 0
+    }
+    trap cleanup SIGINT SIGTERM EXIT
+  else
+    echo "Frontend dev server running in detached mode. Use './start-example.sh --stop' to stop it."
+  fi
 
   sleep 1
 
@@ -60,6 +71,8 @@ setup_devtools() {
 NPM_MODE="none"
 DOCKER_COMPOSE_FILE=".vulnscout/example/docker-example.yml"
 DOCKER_EXTRA_VOLUMES=""
+DETACH_MODE="false"
+STOP_MODE="false"
 
 # Parse arguments
 for arg in "$@"; do
@@ -69,6 +82,12 @@ for arg in "$@"; do
       ;;
     --spdx3)
       DOCKER_COMPOSE_FILE=".vulnscout/example-spdx3/docker-example-spdx3.yml"
+      ;;
+    -d|--detach)
+      DETACH_MODE="true"
+      ;;
+    --stop)
+      STOP_MODE="true"
       ;;
     --help|-h)
       show_help
@@ -82,15 +101,6 @@ for arg in "$@"; do
   esac
 done
 
-## Check for required docker compose command
-if ! command -v docker &> /dev/null; then
-  echo "Error: Docker is not installed or not in PATH."
-  exit 1
-fi
-
-if [ "$NPM_MODE" == "dev" ]; then
-  setup_devtools
-fi
 
 if docker compose version &> /dev/null; then
   DOCKER_COMPOSE="docker compose"
@@ -103,7 +113,31 @@ fi
 
 echo "Docker Compose command found: $DOCKER_COMPOSE"
 
-## Backend Development Environment Setup Script
+if [ "$STOP_MODE" == "true" ]; then
+  echo "Stopping running example..."
+  
+  # Stop frontend dev server if running
+  if [ -f .vulnscout-npm.pid ]; then
+    npm_pid=$(cat .vulnscout-npm.pid)
+    if ps -p "$npm_pid" > /dev/null 2>&1; then
+      echo "Stopping frontend dev server (PID $npm_pid)..."
+      kill -- -$(ps -o pgid= "$npm_pid" | grep -o '[0-9]*') 2>/dev/null || kill "$npm_pid" 2>/dev/null || true
+    fi
+    rm -f .vulnscout-npm.pid
+  fi
+  
+  $DOCKER_COMPOSE -f "$DOCKER_COMPOSE_FILE" down 2>/dev/null || true
+  docker rm -f vulnscout 2>/dev/null || true
+  
+  echo "Example stopped."
+  exit 0
+fi
+
+if [ "$NPM_MODE" == "dev" ]; then
+  setup_devtools "$DETACH_MODE"
+fi
+
+echo "Docker Compose command found: $DOCKER_COMPOSE"
 
 # Update the docker image if necessary
 docker pull sflinux/vulnscout:latest
@@ -111,5 +145,15 @@ docker pull sflinux/vulnscout:latest
 # Close any existing docker-compose processes
 docker rm -f vulnscout 2>/dev/null || true
 
-# Start docker services
-$DOCKER_COMPOSE -f "$DOCKER_COMPOSE_FILE" $DOCKER_EXTRA_VOLUMES up
+# Start Docker services
+if [ "$DETACH_MODE" == "true" ]; then
+  $DOCKER_COMPOSE -f "$DOCKER_COMPOSE_FILE" $DOCKER_EXTRA_VOLUMES up -d
+  if [ "$NPM_MODE" == "dev" ]; then
+      echo "Frontend dev server is available at http://localhost:5173"
+      echo "Backend dev server is available at http://localhost:7275"
+  else
+      echo "Vulnscout is available at http://localhost:7275"
+  fi
+else
+  $DOCKER_COMPOSE -f "$DOCKER_COMPOSE_FILE" $DOCKER_EXTRA_VOLUMES up
+fi


### PR DESCRIPTION
### Changes proposed in this pull request:

* Adding a --detach mode to hide logs and free the terminal prompt when running VS .

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Use the following commands:
* Start in silent mode:
`./start-example.sh --spdx3  --detach`
* Stop the VS instance
` ./start-example.sh --spdx3 --stop`

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


