### PR TITLE
Add Package indicator to the Vulns table

### DIFF
--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -12,6 +12,8 @@ import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
 import ToggleSwitch from "../components/ToggleSwitch";
 import MessageBanner from "../components/MessageBanner";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 type Props = {
     vulnerabilities: Vulnerability[];
@@ -384,6 +386,21 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 setSelected={handleStatusChange}
             />
 
+            {/* Package indicator (no dropdown, just display) */}
+            {selectedPackages.length > 0 && (
+                <div className="flex items-center gap-1 bg-sky-900 px-2 py-1 rounded text-white border border-sky-700">
+                    <span className="font-semibold">Package:</span>
+                    <span>{selectedPackages.join(', ')}</span>
+                    <button
+                        className="ml-1 text-white hover:text-red-400"
+                        title="Clear package filter"
+                        onClick={() => setSelectedPackages([])}
+                    >
+                        <FontAwesomeIcon icon={faTimes} />
+                    </button>
+                </div>
+            )}
+
             <ToggleSwitch
                 enabled={hideFixed}
                 setEnabled={handleHideFixedToggle}
@@ -397,7 +414,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 Reset Filters
             </button>
         </div>
-
 
         <MultiEditBar
             vulnerabilities={vulnerabilities}


### PR DESCRIPTION
### Changes proposed in this pull request:

* Add Package indicator to the Vulns table

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

Open VS web dashboard and select a package from the Packages table, notice that there is a new Package indicator in the blue bar, you can remove it to show vulns for all packages.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


