### PR TITLE
vulnscout_CI_test.sh: Fixed Tests_CI

### DIFF
--- a/tests/CI_tests/vulnscout_CI_test.sh
+++ b/tests/CI_tests/vulnscout_CI_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 BASE_DIR=$PWD/../../
 VULNSCOUT_DIR=.vulnscout/test_ci/output
-OUPUT_CI_FILES=("time_estimates.csv" "time_estimates.json" "openvex.json" "sbom.cdx.json" "sbom.spdx.json" "summary.adoc")
+OUPUT_CI_FILES=("time_estimates.csv" "time_estimates.json" "openvex.json" "sbom.cdx.json" "sbom.spdx.json" "summary.adoc" "sbom.spdx3.json")
 OUPUT_CI_FILES_SORT=($(printf '%s\n' "${OUPUT_CI_FILES[@]}" | sort))
 
 cd $BASE_DIR


### PR DESCRIPTION

### Changes proposed in this pull request:

The Tests_CI was failing because vulnscout now create a sbom.spdx3.json file in ouput when the CI do not fail with a condition.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Check the Test_CI does not fail anymore on GitHub or launch manually the test with the command `cqfd -b test_ci`

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


