### PR TITLE
Using environment variables in report templates

### DIFF
--- a/doc/WRITING_TEMPLATES.adoc
+++ b/doc/WRITING_TEMPLATES.adoc
@@ -25,6 +25,14 @@ All templates can be run from the graphical interface, using the export button i
 * `scan_date`: string in form `<date> at <time> (timezone)` or `unknown date` if scan date is not known.
 * `client_name`: string which may be undefined, empty or contain the company name of the customer.
 
+=== Environment variables available in templates
+
+* `env(name, default="")`: Access host environment variables in your templates.
+For example, to fetch the value of the `DISTRO` environment variable from the host, you can use one of the following:
+* `{{ env("DISTRO") }}` 
+* `{{ env("DISTRO", "unknown") }}`
+VulnnScout will automatically scan your templates for `env("...")` patterns and passes the corresponding environment variable values from host system.
+
 When exporting, user can add filters to export only some vulnerabilites. If you want to access all vulnerabilities and bypassing these filters,
 you can use `unfiltered_vulnerabilities` instead of `vulnerabilities` and `unfiltered_assessments` instead of `assessments`.
 This can be a valid use-case when you want to produce a summary, or to show the number of filtered-out vulnerabilities for example.

--- a/src/views/templates.py
+++ b/src/views/templates.py
@@ -37,6 +37,7 @@ class Templates:
             ]),
             autoescape=False
         )
+        self.env.globals['env'] = TemplatesExtensions.get_env_var
         self.extensions = TemplatesExtensions(self.env)
 
     def render(self, template_name, **kwargs):
@@ -190,6 +191,14 @@ class TemplatesExtensions:
         jinjaEnv.filters["print_iso8601"] = TemplatesExtensions.print_iso8601
         jinjaEnv.filters["sort_by_last_modified"] = TemplatesExtensions.sort_by_last_modified
         jinjaEnv.filters["last_assessment_date"] = TemplatesExtensions.filter_last_assessment_date
+
+    @staticmethod
+    def get_env_var(key: str, default: str = "") -> str:
+        """Get an environment variable, looking up VULNSCOUT_TPL_<key> prefix first."""
+        prefixed = os.getenv(f"VULNSCOUT_TPL_{key}")
+        if prefixed is not None:
+            return prefixed
+        return default
 
     @staticmethod
     def filter_status(value: list, status: str | list[str]) -> list:

--- a/tests/unit_tests/test_template_extensions.py
+++ b/tests/unit_tests/test_template_extensions.py
@@ -10,6 +10,7 @@ from src.views.templates import TemplatesExtensions
 class MockEnv:
     def __init__(self):
         self.filters = {}
+        self.globals = {}
 
 
 @pytest.fixture

--- a/vulnscout.sh
+++ b/vulnscout.sh
@@ -413,6 +413,23 @@ EOF
     if [ "$VULNSCOUT_CVE_EXCLUDE_PATCHED" == "true" ]; then
         echo "      - CVE_CHECK_EXCLUDE_PATCHED=true" >> "$YAML_FILE"
     fi
+
+    # Scan the provided report template for env("VAR") usage and pass those host env vars to container
+    if [ ! -z "$VULNSCOUT_TEMPLATE" ] && [ -f "$VULNSCOUT_PATH/templates/$VULNSCOUT_TEMPLATE" ]; then
+        # Extract all env("...") and env('...') variable names from the template
+        template_env_vars=$(grep -hoE 'env\s*\(\s*["\x27]([^"\x27]+)["\x27]' "$VULNSCOUT_PATH/templates/$VULNSCOUT_TEMPLATE" 2>/dev/null | \
+            sed -E "s/env\s*\(\s*[\"']([^\"']+)[\"']/\1/" | \
+            sort -u || true)
+        
+        for var_name in $template_env_vars; do
+            # Get the value from host environment
+            var_value="${!var_name:-}"
+            if [ ! -z "$var_value" ]; then
+                echo "      - VULNSCOUT_TPL_${var_name}=${var_value}" >> "$YAML_FILE"
+            fi
+        done
+    fi
+
     echo "Vulnscout Succeed: Docker Compose file set at $YAML_FILE"
 }
 


### PR DESCRIPTION
### Changes proposed in this pull request:

* Using environment variables in report templates

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Create a template under .`vulnscout/templates/env-example.adoc` with any environment variable set in your host:

```
Report of vulnerabilities

Report author: {{ env("USER") }}

...
```

2. Run vulnscout.sh with the appropriate template file:

```
./vulnscout.sh --name demo-env-template \
--no_webui --dev \
--report-template env-example.adoc
```


## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


