### PR TITLE
docker: add entrypoint to manage permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,19 @@ FROM alpine:3.20
 RUN mkdir -p /scan/inputs /scan/tmp /scan/outputs /cache/vulnscout
 WORKDIR /scan
 
-RUN apk add --no-cache bash curl git zstd icu python3 py3-pip asciidoctor ruby && \
-    gem install asciidoctor-pdf --version 2.3.15
+RUN apk add --no-cache \
+    asciidoctor \
+    bash \
+    curl \
+    git \
+    icu \
+    python3 \
+    py3-pip \
+    ruby \
+    shadow \
+    sudo \
+    zstd \
+    && gem install asciidoctor-pdf --version 2.3.15
 
 # Install OSV Scanner
 ARG OSV_SCANNER_VERSION=v2.2.1
@@ -45,6 +56,7 @@ RUN pip3 install --no-cache-dir -r base.txt --break-system-packages
 RUN mkdir -p src
 COPY src ./src
 RUN chmod +x src/scan.sh
+RUN chmod +x src/entrypoint.sh
 COPY --from=buildfront /src/static ./src/static
 
 RUN rm -rf /tmp/patches
@@ -53,5 +65,7 @@ LABEL org.opencontainers.image.title="VulnScout"
 LABEL org.opencontainers.image.description="SFL Vulnerability Scanner"
 LABEL org.opencontainers.image.authors="Savoir-faire Linux, Inc."
 LABEL org.opencontainers.image.version="v0.7.0-beta.2"
+
+ENTRYPOINT ["/scan/src/entrypoint.sh"]
 
 CMD ["/scan/src/scan.sh"]

--- a/README.adoc
+++ b/README.adoc
@@ -127,6 +127,13 @@ To configure your `yaml` file, you can look at the example provided here _.vulns
 - To ignore parsing errors for malformed SBOMs, set: `IGNORE_PARSING_ERRORS=true`
 ====
 
+List of environment variables and their purpose:
+
+* `USER_UID`: This variable sets the UID of the user in the container, allowing
+  Vulnscout to create output files with correct permissions
+* `USER_GID`: This variable sets the GID of the user in the container, allowing
+  Vulnscout to create output files with correct permissions
+
 ===== HTTP Proxy Configuration
 
 If you want to run VulnScout with an HTTP proxy, simply add the standard http_proxy environment variables to the docker-compose file. These variables are respected by all traffic in the container:

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# create container user to match expected environment
+
+if [ -z "$USER_UID" ] || [ -z "$USER_GID" ]; then
+    exec sh -c "$1"
+fi
+
+USER_NAME="builder"
+GROUP_NAME="builders"
+USER_HOME="/builder"
+
+# Add the host's user and group to the container, and adjust ownership
+groupadd -og "$USER_GID" -f "$GROUP_NAME"
+useradd -s "/bin/sh" -oN -u "$USER_UID" -g "$USER_GID" -d "$USER_HOME" "$USER_NAME"
+mkdir -p "$USER_HOME"
+chown "$USER_UID:$USER_GID" "$USER_HOME"
+chown -Rf "$USER_UID:$USER_GID" "/scan"
+
+# Drop the root privileges and run provided script using sudo
+exec sudo --preserve-env --set-home -u "#$USER_UID" sh -c "$1"

--- a/vulnscout.sh
+++ b/vulnscout.sh
@@ -374,6 +374,11 @@ EOF
       - VULNSCOUT_VERSION=$VULNSCOUT_VERSION
 EOF
 
+    if [ -n "$UID" ]; then
+        echo "      - USER_UID=$UID" >> "$YAML_FILE"
+        echo "      - USER_GID=${GID:-$UID}" >> "$YAML_FILE"
+    fi
+
     if [ ! -z "$VULNSCOUT_FAIL_CONDITION" ]; then
         echo "      - INTERACTIVE_MODE=false" >> "$YAML_FILE"
         echo "      - FAIL_CONDITION=$VULNSCOUT_FAIL_CONDITION" >> "$YAML_FILE"


### PR DESCRIPTION
Specifying the variables USER_UID and USER_GID to the vulnscout container will make it run as the specified user, and so the files created by vulnscout in the output folder will have the correct permissions associated with the current user

### Changes proposed in this pull request:

* This PR allows to set an UID and GID to the container so the container creates output files with permissions corresponding to the current user instead of creating files as `root`

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

To verify this change, build the new docker image, create a new project using vulnscout.sh, then run it and verify that the files in the `output` folder have the permissions corresponding to your user

```sh
docker build -t "sflinux/vulnscout:save-file-user" -f "Dockerfile" "."
./vulnscout.sh --name test1 --cve-check /mnt/data/src/sfl/vulnscout/.vulnscout/example-spdx3/input/core-image-minimal-qemux86-64.rootfs.json --sbom /mnt/data/src/sfl/vulnscout/.vulnscout/example-spdx3/input/core-image-minimal-qemux86-64.rootfs.spdx.json --dev
```
Then Ctrl+C

Then edit `.vulnscout/test1/docker-test1.yml` and change the image version from `latest` to `save-file-user`.

Then run:

```sh
docker compose -f docker-test1.yml up
```


### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [X] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


