### PR TITLE
 fix: get correct return code with podman

### DIFF
--- a/vulnscout.sh
+++ b/vulnscout.sh
@@ -501,10 +501,10 @@ start_vulnscout(){
     $DOCKER_COMPOSE -f "$YAML_FILE" up
 
     # Retrieve container exit code directly from Docker
-    docker_exit_code=$(docker inspect vulnscout --format '{{.State.ExitCode}}' 2>/dev/null || echo 1)
+    docker_exit_code=$($CONTAINER_ENGINE inspect vulnscout --format '{{.State.ExitCode}}' 2>/dev/null || echo 1)
 
     # Retrieve container logs
-    docker_result=$(docker logs vulnscout 2>/dev/null || echo "")
+    docker_result=$($CONTAINER_ENGINE logs vulnscout 2>/dev/null || echo "")
 
     if [ "$docker_exit_code" -eq 2 ]; then
         echo "---------------- Vulnscout triggered fail condition ----------------"


### PR DESCRIPTION
When using Podman, the vulnscount.sh shell script did not exit with the correct return code since it relied on hardcoded docker commands.

### Changes proposed in this pull request:

* Now using the CONTAINER_ENGINE variable instead of hardcoded `docker`.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

- `bash vulnscout_CI_test.sh` on a system with Podman installed and not Docker
- The whole test should work.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [ ] Added necessary reviewers


