### PR TITLE
entrypoint: chown also the cache folder

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -15,6 +15,7 @@ useradd -s "/bin/sh" -oN -u "$USER_UID" -g "$USER_GID" -d "$USER_HOME" "$USER_NA
 mkdir -p "$USER_HOME"
 chown "$USER_UID:$USER_GID" "$USER_HOME"
 chown -Rf "$USER_UID:$USER_GID" "/scan"
+chown -Rf "$USER_UID:$USER_GID" "/cache"
 
 # Drop the root privileges and run provided script using sudo
 exec sudo --preserve-env --set-home -u "#$USER_UID" sh -c "$1"


### PR DESCRIPTION
If the cache folder was created as root, then it will cause issue if afterwards the docker container is run as the current user. So we should also chown the /cache folder and not only /scan

### Changes proposed in this pull request:

* In the entrypoint.sh script, also set the permissions for the `cache` folder so the current user can access it even if it was previously created as root

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

To verify this change, first build the new docker-image. Go to the vulnscout source folder:

```
docker build -t "sflinux/vulnscout:set-cache-permissions" -f "Dockerfile" "."
./vulnscout.sh --name test1 --cve-check ./.vulnscout/example-spdx3/input/core-image-minimal-qemux86-64.rootfs.json --spdx ./.vulnscout/example-spdx3/input/core-image-minimal-qemux86-64.rootfs.spdx.json --dev
```

Then Ctrl+C

Then edit `.vulnscout/test1/docker-test1.yml` and change the image version from `latest` to `set-cache-permissions`, and remove the lines with `USER_UID` and `USER_GID`.

Then run:

```
docker compose -f .vulnscout/test1/docker-test1.yml up
```

Then Ctrl+C (after 10seconds) and:

```
ls -l .vulnscout
```

And check that the `cache` folder is owned by root.

Now edit again `.vulnscout/test1/docker-test1.yml` and re-add the `USER_UID` and `USER_GID` variables with the values they had initially (usually `1000`), and run:

```
docker compose -f .vulnscout/test1/docker-test1.yml up
```

and:

```
ls -l .vulnscout
```

Verify that the `cache` folder is owned by your user.

### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


