### PR TITLE
vulnscout: add new variable to bypass grype scan

### DIFF
--- a/src/scan.sh
+++ b/src/scan.sh
@@ -29,6 +29,7 @@ DOCUMENT_URL=${DOCUMENT_URL-"https://spdx.org/spdxdocs/${PRODUCT_NAME}-${PRODUCT
 INTERACTIVE_MODE=${INTERACTIVE_MODE-"true"}
 VERBOSE_MODE=${VERBOSE_MODE-"false"}
 VULNSCOUT_VERSION=${VULNSCOUT_VERSION-"unknown"}
+SKIP_GRYPE_SCAN=${SKIP_GRYPE_SCAN-"false"}
 
 echo "VulnScout $VULNSCOUT_VERSION"
 
@@ -151,13 +152,19 @@ function full_scan_steps() {
         fi
     fi
 
-    if [[ -f "$TMP_PATH/merged.spdx.json" ]]; then
-        set_status "5" "Scanning SPDX with Grype"
-        grype --add-cpes-if-none "sbom:$TMP_PATH/merged.spdx.json" -o json > "$TMP_PATH/vulns-spdx.grype.json"
-    fi
-    if [[ -f "$TMP_PATH/merged.cdx.json" ]]; then
-        set_status "5" "Scanning CDX with Grype"
-        grype --add-cpes-if-none "sbom:$TMP_PATH/merged.cdx.json" -o json > "$TMP_PATH/vulns-cdx.grype.json"
+    # 5. Scan SPDX and CDX with Grype
+    if [[ "${SKIP_GRYPE_SCAN}" == "true" ]]; then
+        set_status "5" "Skipping Grype scan"
+    else
+        if [[ -f "$TMP_PATH/merged.spdx.json" ]]; then
+            set_status "5" "Scanning SPDX with Grype"
+            grype --add-cpes-if-none "sbom:$TMP_PATH/merged.spdx.json" -o json > "$TMP_PATH/vulns-spdx.grype.json"
+        fi
+
+        if [[ -f "$TMP_PATH/merged.cdx.json" ]]; then
+            set_status "5" "Scanning CDX with Grype"
+            grype --add-cpes-if-none "sbom:$TMP_PATH/merged.cdx.json" -o json > "$TMP_PATH/vulns-cdx.grype.json"
+        fi
     fi
 
     set_status "6" "Scanning CDX with OSV (WIP)"

--- a/vulnscout.sh
+++ b/vulnscout.sh
@@ -54,6 +54,7 @@ show_help() {
   echo "  --document_url <url>        Document URL"
   echo ""
   echo "Other options:"
+  echo "  --skip-grype-scan Skip the Grype scan which can detect new vulnerabilities"
   echo "  --help, -h        Show this help message and exit"
   echo "  --dev             Use the development version of VulnScout"
 }
@@ -83,6 +84,7 @@ VULNSCOUT_HTTP_PROXY=""
 VULNSCOUT_HTTPS_PROXY=""
 VULNSCOUT_NO_PROXY="localhost,127.0.0.1"
 VULNSCOUT_CVE_EXCLUDE_PATCHED="false"
+VULNSCOUT_SKIP_GRYPE_SCAN="false"
 
 # Build version string
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
@@ -246,6 +248,10 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       ;;
+    --skip-grype-scan)
+      VULNSCOUT_SKIP_GRYPE_SCAN="true"
+      shift
+      ;;
     --dev)
       VULNSCOUT_DEV_MODE="true"
       shift
@@ -402,6 +408,9 @@ EOF
     fi
     if [ ! -z "$VULNSCOUT_DOCUMENT_URL" ]; then
         echo "      - DOCUMENT_URL=$VULNSCOUT_DOCUMENT_URL" >> "$YAML_FILE"
+    fi
+    if [ "$VULNSCOUT_SKIP_GRYPE_SCAN" == "true" ]; then
+        echo "      - SKIP_GRYPE_SCAN=true" >> "$YAML_FILE"
     fi
     if [ ! -z "$VULNSCOUT_NVD_API_KEY" ]; then
         echo "      - NVD_API_KEY=$VULNSCOUT_NVD_API_KEY" >> "$YAML_FILE"


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The Grype scan was mandatory, which is not very convenient to get a deterministic set of CVEs.

Add a new argument to vulnscout.sh with `--skip-grype-scan` option to remove the grype scan.

It will modify the YAML file to add `- SKIP_GRYPE_SCAN=true`

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

```
./vulnscout.sh --name demo --spdx $(pwd)/.vulnscout/example/spdx3/core-image-minimal-qemux86-64.rootfs.spdx.json --cve-check $(pwd)/.vulnscout/example/spdx3/core-image-minimal-qemux86-64.rootfs.json --skip_grype_scan --dev
```

The (5/8) step should be skipped