### PR TITLE
Add border indication for active filter options in FilterOption component

### DIFF
--- a/frontend/src/components/FilterOption.tsx
+++ b/frontend/src/components/FilterOption.tsx
@@ -18,6 +18,7 @@ function FilterOption({ label, options, selected, setSelected, parentRef, Custom
     const [isOpen, setIsOpen] = useState(false);
     const [maxHeight, setMaxHeight] = useState<string>('2500px'); 
     const dropdownRef = useRef<HTMLDivElement>(null);
+    const isActive = selected.length > 0 || showCustomFilterComponent;
 
     const toggleOption = (value: string) => {
         if (selected.includes(value)) {
@@ -56,8 +57,10 @@ function FilterOption({ label, options, selected, setSelected, parentRef, Custom
         <div ref={dropdownRef} className="ml-4 relative inline-block text-left">
             <button
                 onClick={() => setIsOpen(!isOpen)}
-                className={`py-1 px-2 rounded flex items-center gap-1 ${
+                className={`py-1 px-2 rounded flex items-center gap-1 border ${
                     isOpen ? 'bg-sky-950' : 'bg-sky-900'
+                } ${
+                    isActive ? 'border-cyan-400' : 'border-transparent'
                 } text-white hover:bg-sky-950`}
             >
                 {label}

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -2175,4 +2175,46 @@ describe('Vulnerability Table', () => {
             expect(contentDiv.getAttribute('style')).toContain('-webkit-box');
         });
     });
+
+     test('filter buttons have no active border by default', async () => {
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const sourceBtn = screen.getByRole('button', { name: /^source$/i });
+        const severityBtn = screen.getByRole('button', { name: /^severity$/i });
+        const statusBtn = screen.getByRole('button', { name: /^status$/i });
+
+        expect(sourceBtn).toHaveClass('border-transparent');
+        expect(sourceBtn).not.toHaveClass('border-cyan-400');
+        expect(severityBtn).toHaveClass('border-transparent');
+        expect(severityBtn).not.toHaveClass('border-cyan-400');
+        expect(statusBtn).toHaveClass('border-transparent');
+        expect(statusBtn).not.toHaveClass('border-cyan-400');
+    });
+
+    test('filter buttons show active border when a filter option is selected', async () => {
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const user = userEvent.setup();
+
+        // Source filter
+        const sourceBtn = screen.getByRole('button', { name: /^source$/i });
+        await user.click(sourceBtn);
+        await user.click(screen.getByRole('checkbox', { name: 'hardcoded' }));
+        expect(sourceBtn).toHaveClass('border-cyan-400');
+        expect(sourceBtn).not.toHaveClass('border-transparent');
+
+        // Severity filter
+        const severityBtn = screen.getByRole('button', { name: /^severity$/i });
+        await user.click(severityBtn);
+        await user.click(screen.getByRole('checkbox', { name: 'low' }));
+        expect(severityBtn).toHaveClass('border-cyan-400');
+        expect(severityBtn).not.toHaveClass('border-transparent');
+
+        // Status filter
+        const statusBtn = screen.getByRole('button', { name: /^status$/i });
+        await user.click(statusBtn);
+        await user.click(screen.getByRole('checkbox', { name: /exploitable/i }));
+        expect(statusBtn).toHaveClass('border-cyan-400');
+        expect(statusBtn).not.toHaveClass('border-transparent');
+    });
 });


### PR DESCRIPTION
### Changes proposed in this pull request:

Add border indication for active filters.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Before, it was unclear which filter was active without opening the filter list:
<img width="714" height="195" alt="image" src="https://github.com/user-attachments/assets/07f5d6c7-1994-44ce-91be-39d340f50ec7" />

<img width="714" height="195" alt="image" src="https://github.com/user-attachments/assets/ab029a7d-106f-4409-9238-282f4980def4" />

After, the border is highlighted when the filter is active:
<img width="714" height="195" alt="image" src="https://github.com/user-attachments/assets/8c0d64d7-287b-47f8-9744-8e0ef1f7997e" />

<img width="714" height="195" alt="image" src="https://github.com/user-attachments/assets/265590ea-8ec9-4fdb-92f4-e3c590041d63" />


### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [x] Added necessary reviewers


