### PR TITLE
fix: match assessments ignoring version

### DIFF
--- a/src/controllers/assessments.py
+++ b/src/controllers/assessments.py
@@ -51,7 +51,11 @@ class AssessmentsController:
         """Return a list of assessments by vulnerability id (str) and package id (str)."""
         vuln_str = vuln_id if isinstance(vuln_id, str) else vuln_id.id
         pkg_str = pkg_id if isinstance(pkg_id, str) else pkg_id.id
-        return [a for a in self.assessments.values() if a.vuln_id == vuln_str and pkg_str in a.packages]
+        pkg_name = pkg_str.split("@")[0]
+        return [
+            a for a in self.assessments.values()
+            if a.vuln_id == vuln_str and any(p.split("@")[0] == pkg_name for p in a.packages)
+        ]
 
     def add(self, assessment: VulnAssessment):
         """Add an assessment to the list, merging it with an existing one if present."""


### PR DESCRIPTION
## Fixes # by Valentin

Based on: https://github.com/savoirfairelinux/vulnscout/issues/237

### Changes proposed in this pull request:

gets_by_vuln_pkg was comparing full package IDs (name@version), so a version bump would prevent existing assessments from being reused, causing duplicate entries in the output openvex.json.

Now only the name part (before '@') is compared, so assessments are correctly carried over when a package upgrades to a new version.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Create a file `test.json`:


```
{
  "version": "1",
  "package": [
    {
      "name": "linux-yocto",
      "layer": "meta",
      "version": "6.12.38+git",
      "products": [
        {
          "product": "linux_kernel",
          "cvesInRecord": "Yes"
        },
        {
          "product": "linux",
          "cvesInRecord": "No"
        }
      ],
      "issue": [
            {
            "id": "CVE-2019-14899",
            "status": "Unpatched",
            "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-14899",
            "summary": "A vulnerability was discovered in Linux, FreeBSD, OpenBSD, MacOS, iOS, and Android that allows a malicious access point, or an adjacent user, to determine if a connected user is using a VPN, make positive inferences about the websites they are visiting, and determine the correct sequence and acknowledgement numbers in use, allowing the bad actor to inject data into the TCP stream. This provides everything that is needed for an attacker to hijack active connections inside the VPN tunnel.",
            "scorev2": "4.9",
            "scorev3": "7.4",
            "scorev4": "0.0",
            "modified": "2024-11-21T04:27:38.590",
            "vector": "ADJACENT_NETWORK",
            "vectorString": "AV:A/AC:M/Au:S/C:P/I:P/A:P",
            "detail": "version-in-range"
            }
        ]
    }]
}
```

Create a `test2.json` with a different kernel version:

```
{
  "version": "1",
  "package": [
    {
      "name": "linux-yocto",
      "layer": "meta",
      "version": "6.12.48+git",
      "products": [
        {
          "product": "linux_kernel",
          "cvesInRecord": "Yes"
        },
        {
          "product": "linux",
          "cvesInRecord": "No"
        }
      ],
      "issue": [
            {
            "id": "CVE-2019-14899",
            "status": "Unpatched",
            "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-14899",
            "summary": "A vulnerability was discovered in Linux, FreeBSD, OpenBSD, MacOS, iOS, and Android that allows a malicious access point, or an adjacent user, to determine if a connected user is using a VPN, make positive inferences about the websites they are visiting, and determine the correct sequence and acknowledgement numbers in use, allowing the bad actor to inject data into the TCP stream. This provides everything that is needed for an attacker to hijack active connections inside the VPN tunnel.",
            "scorev2": "4.9",
            "scorev3": "7.4",
            "scorev4": "0.0",
            "modified": "2025-12-24T04:27:38.590",
            "vector": "ADJACENT_NETWORK",
            "vectorString": "AV:A/AC:M/Au:S/C:P/I:P/A:P",
            "detail": "version-in-range"
            }
        ]
    }]
}
```

Start both an observe a single assessment in `openvex.json`. 

Starting commands: 

```
./vulnscout.sh --name variant_demo --cve-check test.json  --dev --skip-grype-scan

./vulnscout.sh --name variant_demo --cve-check test2.json  --dev --skip-grype-scan
```
