### PR TITLE
Migration from YAML to database

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,10 +34,7 @@ VulnScout also provides a web interface for visualisation and a command line to 
 === Requirements & Installation
 
 VulnScout is designed to run locally in a Docker container.
-It will require having `docker-compose` or `docker compose` available on your host.
-
-If you need to install `docker compose`, look at:
-https://docs.docker.com/compose/install/[docker-compose]
+It only requires `docker` to be installed and running on your host.
 
 To install VulnScout, you only need to clone the repository:
 [source,bash]
@@ -295,13 +292,17 @@ The following environment variables can be set via `vulnscout config` or exporte
 |Docker image to use
 |`docker.io/sflinux/vulnscout:latest`
 
+|`VULNSCOUT_BUILD_DIR`
+|Root build directory on the host (parent of `cache/` and `outputs/`)
+|`./.vulnscout`
+
 |`VULNSCOUT_OUTPUTS_DIR`
 |Directory for output files on the host
-|`./.vulnscout/outputs`
+|`$VULNSCOUT_BUILD_DIR/outputs`
 
 |`VULNSCOUT_CACHE_DIR`
-|Cache base directory on the host
-|`./.vulnscout/cache`
+|Cache directory on the host (holds the SQLite database and config)
+|`$VULNSCOUT_BUILD_DIR/cache`
 
 |`FLASK_RUN_PORT`
 |Port the web UI listens on
@@ -384,6 +385,39 @@ If you want to run VulnScout with an HTTP proxy, set variables in the config:
 ----
 
 Or pass them directly as environment variables when calling `vulnscout`.
+
+=== Migrating from the Legacy docker-compose Workflow
+
+If you were previously running VulnScout with a `docker-compose.yml` file per variant,
+use `migration.sh` to import all your existing data into the new SQLite database.
+
+[source,shell]
+----
+# Migrate specifying the directory explicitly
+./migration.sh /path/to/.vulnscout --project myproject
+
+# Remove legacy YAML files and output dirs without prompting
+./migration.sh /path/to/.vulnscout --project myproject --remove-old
+
+# Keep legacy files (skip cleanup prompt)
+./migration.sh /path/to/.vulnscout --project myproject --keep-old
+----
+
+The script will:
+
+. Scan the build directory for sub-directories containing `docker-compose.yml` files.
+. Use each sub-directory name as the `--variant` for that import batch.
+. Extract host-side input paths from the compose volume mounts and import them.
+. Re-import legacy assessments from any `output/openvex.json` found alongside the compose file.
+. After all imports succeed, prompt whether to delete the old YAML files and output directories
+  (overridden by `--keep-old` / `--remove-old`).
+
+Once migration is complete, start VulnScout normally:
+
+[source,shell]
+----
+./vulnscout serve
+----
 
 === Developer Mode
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import Loading from "./pages/Loading";
 import Explorer from "./pages/Explorer";
+import NotificationModal, { type Notification } from "./components/NotificationModal";
 
 
 /**
@@ -15,6 +16,19 @@ function App() {
     details: 'Step 0 : starting script'
   });
   const [darkMode, setDarkMode] = useState(true);
+  const [notification, setNotification] = useState<Notification | null>(null);
+
+  // Fetch any system notification once on mount
+  useEffect(() => {
+    fetch(import.meta.env.VITE_API_URL + "/api/notifications", { mode: 'cors' })
+      .then(res => res.json())
+      .then((data: Notification[]) => {
+        if (Array.isArray(data) && data.length > 0) {
+          setNotification(data[0]);
+        }
+      })
+      .catch(() => { /* non-critical, ignore */ });
+  }, []);
 
   useEffect(() => {
     if (!loading) return;
@@ -49,6 +63,11 @@ function App() {
 
   return (
     <div className={darkMode ? "dark" : "light"}>
+      {notification && (
+        <NotificationModal
+          notification={notification}
+        />
+      )}
       {
         loading ? (
           <Loading

--- a/frontend/src/components/NotificationModal.tsx
+++ b/frontend/src/components/NotificationModal.tsx
@@ -1,0 +1,50 @@
+import { createPortal } from 'react-dom';
+
+type Notification = {
+    level: 'warning' | 'error' | 'info';
+    title: string;
+    message: string;
+    action?: string;
+};
+
+type Props = {
+    notification: Notification;
+};
+
+const LEVEL_STYLES: Record<string, string> = {
+    warning: 'border-yellow-500 bg-yellow-900/30',
+    error:   'border-red-500 bg-red-900/30',
+    info:    'border-blue-500 bg-blue-900/30',
+};
+
+const LEVEL_ICON: Record<string, string> = {
+    warning: '⚠️',
+    error:   '🚫',
+    info:    'ℹ️',
+};
+
+function NotificationModal({ notification }: Readonly<Props>) {
+    const borderStyle = LEVEL_STYLES[notification.level] ?? LEVEL_STYLES.info;
+    const icon = LEVEL_ICON[notification.level] ?? LEVEL_ICON.info;
+
+    return createPortal(
+        <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60">
+            <div className={`w-full max-w-lg rounded-lg border-2 p-6 shadow-2xl text-white ${borderStyle}`}>
+                <div className="flex items-start gap-3 mb-4">
+                    <span className="text-2xl">{icon}</span>
+                    <h2 className="text-lg font-semibold leading-tight">{notification.title}</h2>
+                </div>
+                <p className="text-sm text-gray-200 mb-3">{notification.message}</p>
+                {notification.action && (
+                    <p className="text-sm font-mono bg-black/40 rounded p-2 text-yellow-200">
+                        {notification.action}
+                    </p>
+                )}
+            </div>
+        </div>,
+        document.body
+    );
+}
+
+export default NotificationModal;
+export type { Notification };

--- a/frontend/src/components/NotificationModal.tsx
+++ b/frontend/src/components/NotificationModal.tsx
@@ -1,4 +1,6 @@
 import { createPortal } from 'react-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTriangleExclamation, faBan, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 
 type Notification = {
     level: 'warning' | 'error' | 'info';
@@ -11,32 +13,39 @@ type Props = {
     notification: Notification;
 };
 
-const LEVEL_STYLES: Record<string, string> = {
-    warning: 'border-yellow-500 bg-yellow-900/30',
-    error:   'border-red-500 bg-red-900/30',
-    info:    'border-blue-500 bg-blue-900/30',
+const LEVEL_ACCENT: Record<string, { border: string; label: string; icon: string; iconColor: string }> = {
+    warning: { border: 'border-yellow-500', label: 'text-yellow-400', icon: 'warning', iconColor: 'text-yellow-400' },
+    error:   { border: 'border-red-500',    label: 'text-red-400',    icon: 'error',   iconColor: 'text-red-400'    },
+    info:    { border: 'border-cyan-500',   label: 'text-cyan-300',   icon: 'info',    iconColor: 'text-cyan-300'   },
 };
 
-const LEVEL_ICON: Record<string, string> = {
-    warning: '⚠️',
-    error:   '🚫',
-    info:    'ℹ️',
+const LEVEL_FA_ICON = {
+    warning: faTriangleExclamation,
+    error:   faBan,
+    info:    faCircleInfo,
 };
 
 function NotificationModal({ notification }: Readonly<Props>) {
-    const borderStyle = LEVEL_STYLES[notification.level] ?? LEVEL_STYLES.info;
-    const icon = LEVEL_ICON[notification.level] ?? LEVEL_ICON.info;
+    const accent = LEVEL_ACCENT[notification.level] ?? LEVEL_ACCENT.info;
+    const faIcon = LEVEL_FA_ICON[notification.level] ?? LEVEL_FA_ICON.info;
 
     return createPortal(
-        <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60">
-            <div className={`w-full max-w-lg rounded-lg border-2 p-6 shadow-2xl text-white ${borderStyle}`}>
+        <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60 backdrop-blur-sm">
+            <div className={`w-full max-w-lg rounded-lg border ${accent.border} bg-cyan-900 text-neutral-50 shadow-xl p-6`}>
+
+                <p className={`text-xs font-semibold uppercase tracking-wide mb-3 ${accent.label}`}>
+                    {notification.level}
+                </p>
+
                 <div className="flex items-start gap-3 mb-4">
-                    <span className="text-2xl">{icon}</span>
-                    <h2 className="text-lg font-semibold leading-tight">{notification.title}</h2>
+                    <FontAwesomeIcon icon={faIcon} className={`mt-0.5 text-xl shrink-0 ${accent.iconColor}`} />
+                    <h2 className="text-base font-semibold leading-snug">{notification.title}</h2>
                 </div>
-                <p className="text-sm text-gray-200 mb-3">{notification.message}</p>
+
+                <p className="text-sm text-cyan-100 mb-3 leading-relaxed">{notification.message}</p>
+
                 {notification.action && (
-                    <p className="text-sm font-mono bg-black/40 rounded p-2 text-yellow-200">
+                    <p className="text-xs font-mono bg-black/40 border border-cyan-700 rounded px-3 py-2 text-cyan-200 break-all">
                         {notification.action}
                     </p>
                 )}

--- a/migration.sh
+++ b/migration.sh
@@ -139,6 +139,17 @@ for v in raw_vols:
         parsed.append((parts[0] if len(parts) > 0 else "",
                         parts[1] if len(parts) > 1 else ""))
 
+import os
+compose_dir = os.path.dirname(os.path.abspath(compose_file))
+
+def resolve(path):
+    """Resolve path relative to the compose file's directory."""
+    if not path:
+        return path
+    if not os.path.isabs(path):
+        return os.path.normpath(os.path.join(compose_dir, path))
+    return path
+
 # Container-path prefix → vulnscout flag
 TYPE_MAP = {
     "/scan/inputs/spdx/":            "--add-spdx",
@@ -151,6 +162,7 @@ inputs = []   # list of [flag, host_path]
 output_dir = ""
 
 for host, container in parsed:
+    host = resolve(host)
     if container.rstrip("/") == "/scan/outputs":
         output_dir = host
         continue
@@ -173,15 +185,22 @@ if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
     docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 fi
 
+# Point the vulnscout wrapper's cache and outputs at the target directory so
+# the DB and config land there rather than next to the vulnscout script itself.
+export VULNSCOUT_CACHE_DIR="$VULNSCOUT_DIR/cache"
+export VULNSCOUT_OUTPUTS_DIR="$VULNSCOUT_DIR/outputs"
+
 # ---------------------------------------------------------------------------
 # Main loop — walk sub-directories of <vulnscout_dir>
 # ---------------------------------------------------------------------------
 found_any=false
+found_yaml=false
 
 while IFS= read -r -d '' yaml_file; do
     subdir="$(dirname "$yaml_file")"
     variant="$(basename "$subdir")"
 
+    found_yaml=true
     echo "──────────────────────────────────────────────"
     echo "Variant : $variant"
     echo "YAML    : $yaml_file"
@@ -281,8 +300,14 @@ done < <(find "$VULNSCOUT_DIR" -maxdepth 2 \
 
 echo "──────────────────────────────────────────────"
 
-if [[ "$found_any" == "false" ]]; then
+if [[ "$found_yaml" == "false" ]]; then
     echo "No docker-compose YAML files found under $VULNSCOUT_DIR"
+    exit 1
+fi
+
+if [[ "$found_any" == "false" ]]; then
+    echo "Warning: YAML files were found but all variants were skipped (no SBOM/CVE input files)."
+    echo "Check that the input paths in the compose files are accessible."
     exit 1
 fi
 

--- a/migration.sh
+++ b/migration.sh
@@ -18,9 +18,11 @@
 #   4. If the sub-directory contains an output/openvex.json (old assessments),
 #      adds it as --add-openvex so existing statuses are preserved.
 #   5. Calls './vulnscout' with the discovered flags to populate the DB.
+#   6. Once all imports succeed, asks whether to delete the old YAML files and
+#      output directories (can be skipped with --keep-old or --remove-old).
 #
 # Usage:
-#   ./migration.sh <vulnscout_dir> [--project <name>] [--dry-run]
+#   ./migration.sh <vulnscout_dir> [--project <name>] [--dry-run] [--keep-old|--remove-old]
 #
 # Arguments:
 #   <vulnscout_dir>   Path to the .vulnscout directory (contains sub-dirs with
@@ -30,6 +32,8 @@
 #   --project <name>  Project name passed to vulnscout for all imports.
 #                     Defaults to the basename of <vulnscout_dir>'s parent.
 #   --dry-run         Print the vulnscout commands without executing them.
+#   --keep-old        Keep old YAML files and output directories after migration.
+#   --remove-old      Remove old YAML files and output directories without prompting.
 #   -h, --help        Show this help.
 
 set -euo pipefail
@@ -40,14 +44,17 @@ VULNSCOUT="$SCRIPT_DIR/vulnscout"
 VULNSCOUT_DIR=""
 PROJECT=""
 DRY_RUN=false
+CLEAN_OLD=""   # empty = ask interactively; "yes" = remove; "no" = keep
 
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --project)  PROJECT="$2"; shift 2 ;;
-        --dry-run)  DRY_RUN=true; shift ;;
+        --project)    PROJECT="$2"; shift 2 ;;
+        --dry-run)    DRY_RUN=true; shift ;;
+        --keep-old)   CLEAN_OLD="no"; shift ;;
+        --remove-old) CLEAN_OLD="yes"; shift ;;
         -h|--help)
             sed -n '/^# Usage:/,/^[^#]/{ /^[^#]/d; s/^# \?//; p }' "$0"
             exit 0 ;;
@@ -63,9 +70,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$VULNSCOUT_DIR" ]]; then
-    echo "Error: <vulnscout_dir> is required."
-    echo "Usage: $0 <vulnscout_dir> [--project <name>] [--dry-run]"
-    exit 1
+    sed -n '/^# Usage:/,/^[^#]/{ /^[^#]/d; s/^# \?//; p }' "$0"
+    exit 0
 fi
 
 if [[ ! -d "$VULNSCOUT_DIR" ]]; then
@@ -195,6 +201,9 @@ export VULNSCOUT_OUTPUTS_DIR="$VULNSCOUT_DIR/outputs"
 # ---------------------------------------------------------------------------
 found_any=false
 found_yaml=false
+cleanup_yaml_files=()
+cleanup_dirs=()
+cleanup_subdirs=()
 
 while IFS= read -r -d '' yaml_file; do
     subdir="$(dirname "$yaml_file")"
@@ -270,25 +279,15 @@ PYEOF
         "$VULNSCOUT" "${vulnscout_args[@]}"
         echo "  ✓ Import complete."
 
-        # Clean up: remove the YAML file and the output directory now that
-        # all data has been merged into the database.
-        echo "  Removing $yaml_file"
-        rm -f "$yaml_file"
-        # Remove the compose-declared output dir if present
+        # Collect files/dirs to clean up after all imports
+        cleanup_yaml_files+=("$yaml_file")
         if [[ -n "$output_dir" && -d "$output_dir" ]]; then
-            echo "  Removing output dir $output_dir"
-            rm -rf "$output_dir"
+            cleanup_dirs+=("$output_dir")
         fi
-        # Also remove a sibling output/ directory if it exists
         if [[ -d "$subdir/output" ]]; then
-            echo "  Removing output dir $subdir/output"
-            rm -rf "$subdir/output"
+            cleanup_dirs+=("$subdir/output")
         fi
-        # Remove the sub-directory if it is now empty
-        if [[ -d "$subdir" ]] && [[ -z "$(find "$subdir" -mindepth 1 -print -quit)" ]]; then
-            echo "  Removing empty dir $subdir"
-            rmdir "$subdir"
-        fi
+        cleanup_subdirs+=("$subdir")
     fi
 
     found_any=true
@@ -313,5 +312,43 @@ fi
 
 if [[ "$DRY_RUN" == "false" ]]; then
     echo ""
-    echo "Migration complete. Run './vulnscout serve' to browse the imported data."
+    echo "Migration complete. Run 'export VULNSCOUT_BUILD_DIR=\"$VULNSCOUT_DIR\" && ./vulnscout serve' to browse the imported data."
+
+    # -----------------------------------------------------------------------
+    # Cleanup prompt
+    # -----------------------------------------------------------------------
+    if [[ ${#cleanup_yaml_files[@]} -gt 0 || ${#cleanup_dirs[@]} -gt 0 ]]; then
+        if [[ -z "$CLEAN_OLD" ]]; then
+            echo ""
+            echo "The following legacy files/directories are no longer needed:"
+            for f in "${cleanup_yaml_files[@]}"; do echo "  $f"; done
+            for d in "${cleanup_dirs[@]}";      do echo "  $d/"; done
+            read -r -p "Delete them now? [y/N] " _answer
+            case "$_answer" in
+                [Yy]*) CLEAN_OLD="yes" ;;
+                *)     CLEAN_OLD="no"  ;;
+            esac
+        fi
+
+        if [[ "$CLEAN_OLD" == "yes" ]]; then
+            echo "Cleaning up legacy artefacts..."
+            for f in "${cleanup_yaml_files[@]}"; do
+                echo "  Removing $f"
+                rm -f "$f"
+            done
+            for d in "${cleanup_dirs[@]}"; do
+                echo "  Removing $d"
+                rm -rf "$d"
+            done
+            # Remove sub-directories that are now empty
+            for subdir in "${cleanup_subdirs[@]}"; do
+                if [[ -d "$subdir" ]] && [[ -z "$(find "$subdir" -mindepth 1 -print -quit)" ]]; then
+                    echo "  Removing empty dir $subdir"
+                    rmdir "$subdir"
+                fi
+            done
+        else
+            echo "Legacy files kept."
+        fi
+    fi
 fi

--- a/migration.sh
+++ b/migration.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# migration.sh — Migrate from the legacy docker-compose workflow to the new
+# vulnscout entrypoint + SQLite database workflow.
+#
+# The old workflow stored input files as docker-compose volume mounts and
+# exports (openvex.json, sbom.spdx.json, …) in an output directory.
+# The new workflow uses the 'vulnscout' wrapper and a SQLite database.
+#
+# This script:
+#   1. Scans <vulnscout_dir> for sub-directories that contain YAML files.
+#   2. Each sub-directory name becomes the --variant for that import batch.
+#   3. Parses every YAML file to extract host-side input file paths from the
+#      container volume mounts under /scan/inputs/*.
+#   4. If the sub-directory contains an output/openvex.json (old assessments),
+#      adds it as --add-openvex so existing statuses are preserved.
+#   5. Calls './vulnscout' with the discovered flags to populate the DB.
+#
+# Usage:
+#   ./migration.sh <vulnscout_dir> [--project <name>] [--dry-run]
+#
+# Arguments:
+#   <vulnscout_dir>   Path to the .vulnscout directory (contains sub-dirs with
+#                     docker-compose YAML files).  Required.
+#
+# Options:
+#   --project <name>  Project name passed to vulnscout for all imports.
+#                     Defaults to the basename of <vulnscout_dir>'s parent.
+#   --dry-run         Print the vulnscout commands without executing them.
+#   -h, --help        Show this help.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+VULNSCOUT="$SCRIPT_DIR/vulnscout"
+
+VULNSCOUT_DIR=""
+PROJECT=""
+DRY_RUN=false
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --project)  PROJECT="$2"; shift 2 ;;
+        --dry-run)  DRY_RUN=true; shift ;;
+        -h|--help)
+            sed -n '/^# Usage:/,/^[^#]/{ /^[^#]/d; s/^# \?//; p }' "$0"
+            exit 0 ;;
+        -*)
+            echo "Unknown option: $1  (run with --help for usage)"; exit 1 ;;
+        *)
+            if [[ -z "$VULNSCOUT_DIR" ]]; then
+                VULNSCOUT_DIR="$1"; shift
+            else
+                echo "Unexpected argument: $1"; exit 1
+            fi ;;
+    esac
+done
+
+if [[ -z "$VULNSCOUT_DIR" ]]; then
+    echo "Error: <vulnscout_dir> is required."
+    echo "Usage: $0 <vulnscout_dir> [--project <name>] [--dry-run]"
+    exit 1
+fi
+
+if [[ ! -d "$VULNSCOUT_DIR" ]]; then
+    echo "Error: directory not found: $VULNSCOUT_DIR"
+    exit 1
+fi
+
+VULNSCOUT_DIR="$(readlink -f "$VULNSCOUT_DIR")"
+
+# Default project name = parent directory basename
+if [[ -z "$PROJECT" ]]; then
+    PROJECT="$(basename "$(dirname "$VULNSCOUT_DIR")")"
+fi
+
+if [[ ! -x "$VULNSCOUT" ]]; then
+    echo "Error: vulnscout wrapper not found or not executable: $VULNSCOUT"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Inline Python: parse a single YAML compose file and return JSON with volumes
+# and the detected output directory
+# ---------------------------------------------------------------------------
+parse_compose_yaml() {
+    python3 - "$1" <<'PYEOF'
+import sys, json
+
+compose_file = sys.argv[1]
+
+def parse_volumes_naive(path):
+    """Fallback line-by-line parser when PyYAML is not available."""
+    volumes = []
+    environment = {}
+    in_volumes = in_env = False
+    with open(path) as fh:
+        for line in fh:
+            s = line.strip()
+            if s.startswith("volumes:"):
+                in_volumes, in_env = True, False; continue
+            if s.startswith("environment:"):
+                in_env, in_volumes = True, False; continue
+            if s.startswith("- ") and in_volumes:
+                volumes.append(s[2:].strip().strip("'\""))
+            elif s.startswith("- ") and in_env:
+                item = s[2:].strip().strip("'\"")
+                if "=" in item:
+                    k, v = item.split("=", 1); environment[k] = v
+            elif s and not s.startswith("#") and not s.startswith("- "):
+                in_volumes = in_env = False
+    return volumes, environment
+
+try:
+    import yaml
+    with open(compose_file) as fh:
+        data = yaml.safe_load(fh)
+    svc = next(iter(data.get("services", {}).values()))
+    raw_vols = svc.get("volumes", [])
+    env = svc.get("environment", {})
+    if isinstance(env, list):
+        env = dict(item.split("=", 1) for item in env if "=" in item)
+except ImportError:
+    raw_vols, env = parse_volumes_naive(compose_file)
+
+# Normalise volume entries to (host, container) pairs
+parsed = []
+for v in raw_vols:
+    if isinstance(v, dict):
+        parsed.append((v.get("source", ""), v.get("target", "")))
+    else:
+        parts = str(v).split(":")
+        parsed.append((parts[0] if len(parts) > 0 else "",
+                        parts[1] if len(parts) > 1 else ""))
+
+# Container-path prefix → vulnscout flag
+TYPE_MAP = {
+    "/scan/inputs/spdx/":            "--add-spdx",
+    "/scan/inputs/cdx/":             "--add-cdx",
+    "/scan/inputs/openvex/":         "--add-openvex",
+    "/scan/inputs/yocto_cve_check/": "--add-cve-check",
+}
+
+inputs = []   # list of [flag, host_path]
+output_dir = ""
+
+for host, container in parsed:
+    if container.rstrip("/") == "/scan/outputs":
+        output_dir = host
+        continue
+    for prefix, flag in TYPE_MAP.items():
+        if container.startswith(prefix):
+            inputs.append([flag, host])
+            break
+
+print(json.dumps({"inputs": inputs, "output_dir": output_dir}))
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Ensure a clean container state before starting (stale overlay mounts can
+# cause "not a directory" errors when the container is reused across sessions)
+# ---------------------------------------------------------------------------
+CONTAINER_NAME="${VULNSCOUT_CONTAINER:-vulnscout}"
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "Removing existing container '$CONTAINER_NAME' for a clean start..."
+    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+fi
+
+# ---------------------------------------------------------------------------
+# Main loop — walk sub-directories of <vulnscout_dir>
+# ---------------------------------------------------------------------------
+found_any=false
+
+while IFS= read -r -d '' yaml_file; do
+    subdir="$(dirname "$yaml_file")"
+    variant="$(basename "$subdir")"
+
+    echo "──────────────────────────────────────────────"
+    echo "Variant : $variant"
+    echo "YAML    : $yaml_file"
+
+    # Parse the compose file
+    parsed=$(parse_compose_yaml "$yaml_file")
+
+    mapfile -t input_pairs < <(python3 - "$parsed" <<'PYEOF'
+import sys, json
+data = json.loads(sys.argv[1])
+for flag, path in data["inputs"]:
+    print(flag + "||" + path)
+PYEOF
+)
+    output_dir=$(python3 - "$parsed" <<'PYEOF'
+import sys, json
+data = json.loads(sys.argv[1])
+print(data.get("output_dir", ""))
+PYEOF
+)
+
+    # Build vulnscout argument list
+    vulnscout_args=(--project "$PROJECT" --variant "$variant")
+    sbom_input_count=0   # count of real SBOM/CVE inputs (not just openvex/assessments)
+
+    for pair in "${input_pairs[@]:-}"; do
+        [[ -z "$pair" ]] && continue
+        flag="${pair%%||*}"
+        path="${pair##*||}"
+        if [[ ! -f "$path" ]] && [[ ! -d "$path" ]]; then
+            echo "  Warning: path not found, skipping: $path"
+            continue
+        fi
+        echo "  $flag $path"
+        vulnscout_args+=("$flag" "$path")
+        # openvex-only imports are not useful without SBOM data
+        [[ "$flag" != "--add-openvex" ]] && sbom_input_count=$(( sbom_input_count + 1 ))
+    done
+
+    # Re-import old assessments from openvex.json.
+    # Primary source: the /scan/outputs mount declared in the compose file.
+    # Fallback: a sibling output/ directory next to the compose file (the
+    # natural layout when each variant has its own output folder).
+    openvex_src=""
+    if [[ -n "$output_dir" && -f "$output_dir/openvex.json" ]]; then
+        openvex_src="$output_dir/openvex.json"
+    elif [[ -f "$subdir/output/openvex.json" ]]; then
+        openvex_src="$subdir/output/openvex.json"
+    fi
+
+    if [[ -n "$openvex_src" ]]; then
+        echo "  --add-openvex $openvex_src  (legacy assessments)"
+        vulnscout_args+=(--add-openvex "$openvex_src")
+    fi
+
+    if [[ $sbom_input_count -eq 0 ]]; then
+        echo "  (no SBOM/CVE input files found — skipping variant '$variant')"
+        continue
+    fi
+
+    echo ""
+    echo "  Command: $VULNSCOUT ${vulnscout_args[*]}"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "  (dry-run — skipping)"
+    else
+        "$VULNSCOUT" "${vulnscout_args[@]}"
+        echo "  ✓ Import complete."
+
+        # Clean up: remove the YAML file and the output directory now that
+        # all data has been merged into the database.
+        echo "  Removing $yaml_file"
+        rm -f "$yaml_file"
+        # Remove the compose-declared output dir if present
+        if [[ -n "$output_dir" && -d "$output_dir" ]]; then
+            echo "  Removing output dir $output_dir"
+            rm -rf "$output_dir"
+        fi
+        # Also remove a sibling output/ directory if it exists
+        if [[ -d "$subdir/output" ]]; then
+            echo "  Removing output dir $subdir/output"
+            rm -rf "$subdir/output"
+        fi
+        # Remove the sub-directory if it is now empty
+        if [[ -d "$subdir" ]] && [[ -z "$(find "$subdir" -mindepth 1 -print -quit)" ]]; then
+            echo "  Removing empty dir $subdir"
+            rmdir "$subdir"
+        fi
+    fi
+
+    found_any=true
+
+done < <(find "$VULNSCOUT_DIR" -maxdepth 2 \
+    \( -name "docker-*.yml" -o -name "docker-*.yaml" \
+       -o -name "compose*.yml" -o -name "compose*.yaml" \) \
+    -print0 | sort -z)
+
+echo "──────────────────────────────────────────────"
+
+if [[ "$found_any" == "false" ]]; then
+    echo "No docker-compose YAML files found under $VULNSCOUT_DIR"
+    exit 1
+fi
+
+if [[ "$DRY_RUN" == "false" ]]; then
+    echo ""
+    echo "Migration complete. Run './vulnscout serve' to browse the imported data."
+fi

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -375,10 +375,27 @@ SCAN_REQUIRED=false
 # ---------------------------------------------------------------------------
 # Legacy setup detection: if an openvex.json output exists but no database,
 # this container is being started with the old docker-compose workflow.
+# LEGACY_SETUP_DETECTED may also be injected by the host-side 'vulnscout'
+# wrapper when it finds legacy artefacts outside the /scan/outputs mount.
 # ---------------------------------------------------------------------------
+# Pre-scan args so INTERACTIVE_MODE is correct before the legacy check,
+# even when this script is called with --serve via 'docker exec'.
+for _prearg in "$@"; do
+    [[ "$_prearg" == "--serve" ]] && INTERACTIVE_MODE="true"
+done
+unset _prearg
+
+# Only run legacy detection when we are in (or about to enter) interactive/serve
+# mode. When the new 'vulnscout' wrapper starts the container with the 'daemon'
+# command, skip this block entirely — it will be re-evaluated correctly once
+# 'exec_container --serve' is called and INTERACTIVE_MODE becomes true.
+_run_legacy_check=false
+[[ "${INTERACTIVE_MODE:-false}" == "true" ]] && _run_legacy_check=true
+
 _LEGACY_OPENVEX="${OUTPUTS_DIR:-/scan/outputs}/openvex.json"
 _DB_FILE="/cache/vulnscout/vulnscout.db"
-if [[ -f "$_LEGACY_OPENVEX" ]] && [[ ! -f "$_DB_FILE" ]]; then
+if [[ "$_run_legacy_check" == "true" ]] && \
+   ( [[ "${LEGACY_SETUP_DETECTED:-false}" == "true" ]] || ( [[ -f "$_LEGACY_OPENVEX" ]] && [[ ! -f "$_DB_FILE" ]] ) ); then
     if [[ "${INTERACTIVE_MODE:-false}" == "true" ]]; then
         # Write a notification that the web UI will display as a popup
         mkdir -p /scan
@@ -387,7 +404,7 @@ if [[ -f "$_LEGACY_OPENVEX" ]] && [[ ! -f "$_DB_FILE" ]]; then
   "level": "warning",
   "title": "Legacy setup detected — migration required",
   "message": "This container was started using the old docker-compose workflow. Your data (inputs + assessments) has not been imported into the new database yet.",
-  "action": "Run migration.sh scriptavailable on https://github.com/savoirfairelinux/vulnscout to import your data in the new vulnscout.db. After migration, use the 'vulnscout' wrapper instead of docker-compose to start the container with the new workflow."
+  "action": "Run migration.sh script (available on https://github.com/savoirfairelinux/vulnscout) to import your data in the new vulnscout.db. After migration, use the 'vulnscout' wrapper instead of docker-compose to start the container with the new workflow."
 }
 EOF
         echo "WARNING: Legacy setup detected. A notification has been queued for the web UI."
@@ -405,7 +422,7 @@ EOF
         exit 2
     fi
 fi
-unset _LEGACY_OPENVEX _DB_FILE
+unset _LEGACY_OPENVEX _DB_FILE _run_legacy_check
 
 if [[ $# -eq 0 ]]; then
     cmd_daemon

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -372,6 +372,41 @@ REPORT_TEMPLATES=()
 EXPORT_FORMATS=()
 SCAN_REQUIRED=false
 
+# ---------------------------------------------------------------------------
+# Legacy setup detection: if an openvex.json output exists but no database,
+# this container is being started with the old docker-compose workflow.
+# ---------------------------------------------------------------------------
+_LEGACY_OPENVEX="${OUTPUTS_DIR:-/scan/outputs}/openvex.json"
+_DB_FILE="/cache/vulnscout/vulnscout.db"
+if [[ -f "$_LEGACY_OPENVEX" ]] && [[ ! -f "$_DB_FILE" ]]; then
+    if [[ "${INTERACTIVE_MODE:-false}" == "true" ]]; then
+        # Write a notification that the web UI will display as a popup
+        mkdir -p /scan
+        cat > /scan/legacy_notification.json <<EOF
+{
+  "level": "warning",
+  "title": "Legacy setup detected — migration required",
+  "message": "This container was started using the old docker-compose workflow. Your data (inputs + assessments) has not been imported into the new database yet.",
+  "action": "Run migration.sh scriptavailable on https://github.com/savoirfairelinux/vulnscout to import your data in the new vulnscout.db. After migration, use the 'vulnscout' wrapper instead of docker-compose to start the container with the new workflow."
+}
+EOF
+        echo "WARNING: Legacy setup detected. A notification has been queued for the web UI."
+        # Write a completed status so the scan middleware doesn't block all routes
+        echo "2 <!-- __END_OF_SCAN_SCRIPT__ -->" > "$BASE_DIR/status.txt"
+        cd "$BASE_DIR"
+        flask --app src.bin.webapp db upgrade
+        flask --app src.bin.webapp run
+        exit $?
+    else
+        echo "ERROR: Legacy docker-compose setup detected." >&2
+        echo "This container was started using the old docker-compose workflow. Your data (inputs + assessments) has not been imported into the new database yet." >&2
+        echo "       Run migration.sh to import your data into the new database format," >&2
+        echo "       Run migration.sh scriptavailable on https://github.com/savoirfairelinux/vulnscout to import your data in the new vulnscout.db. After migration, use the 'vulnscout' wrapper instead of docker-compose to start the container with the new workflow." >&2
+        exit 2
+    fi
+fi
+unset _LEGACY_OPENVEX _DB_FILE
+
 if [[ $# -eq 0 ]]; then
     cmd_daemon
     exit 0

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -13,6 +13,7 @@ from .project import init_app as init_project_app
 from .variant import init_app as init_variant_app
 from .scans import init_app as init_scans_app
 from .config import init_app as init_config_app
+from .notifications import init_app as init_notifications_app
 from .frontpage import init_app as init_front_app
 
 
@@ -28,6 +29,7 @@ def init_app(app):
     init_variant_app(app)
     init_scans_app(app)
     init_config_app(app)
+    init_notifications_app(app)
     # keep front endpoint at the end
     init_front_app(app)
     return app

--- a/src/routes/notifications.py
+++ b/src/routes/notifications.py
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import json
+import os
+from flask import jsonify
+
+NOTIFICATION_FILE = "/scan/legacy_notification.json"
+
+
+def init_app(app):
+
+    @app.route('/api/notifications')
+    def get_notifications():
+        """Return any pending system notification (e.g. legacy-setup warning).
+
+        Returns an empty list when no notification is pending, or a list with
+        one notification object::
+
+            [{"level": "warning", "title": "...", "message": "...", "action": "..."}]
+        """
+        if not os.path.isfile(NOTIFICATION_FILE):
+            return jsonify([])
+        try:
+            with open(NOTIFICATION_FILE) as fh:
+                data = json.load(fh)
+            # Normalise: always return a list
+            if isinstance(data, dict):
+                data = [data]
+            return jsonify(data)
+        except (OSError, json.JSONDecodeError):
+            return jsonify([])

--- a/vulnscout
+++ b/vulnscout
@@ -173,10 +173,11 @@ do_start() {
     local uid gid
     uid="$(id -u)"; gid="$(id -g)"
     docker run --rm \
+        --entrypoint sh \
         -v "$VULNSCOUT_CACHE_DIR:/mnt/cache" \
         -v "$VULNSCOUT_OUTPUTS_DIR:/mnt/outputs" \
         "$DOCKER_IMAGE" \
-        sh -c "rm -rf /mnt/cache/config.env; chown -R ${uid}:${gid} /mnt/cache /mnt/outputs" \
+        -c "rm -rf /mnt/cache/config.env; chown -R ${uid}:${gid} /mnt/cache /mnt/outputs" \
         2>/dev/null || true
     if [ ! -f "$VULNSCOUT_CONFIG_FILE" ]; then
         cat > "$VULNSCOUT_CONFIG_FILE" <<EOF

--- a/vulnscout
+++ b/vulnscout
@@ -151,6 +151,19 @@ config_clear() {
     echo "Config cleared: $key"
 }
 
+_detect_legacy() {
+    # If the new DB already exists, no migration needed.
+    [[ -f "$VULNSCOUT_CACHE_DIR/vulnscout.db" ]] && return
+    # Walk sibling dirs of the cache dir for legacy docker-compose/output artefacts.
+    local parent
+    parent="$(dirname "$VULNSCOUT_CACHE_DIR")"
+    if find "$parent" -maxdepth 4 \( -name 'openvex.json' -o -name 'docker-*.yml' \) 2>/dev/null | grep -q .; then
+        LEGACY_SETUP_DETECTED=true
+    fi
+}
+
+LEGACY_SETUP_DETECTED=false
+
 do_start() {
     docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
     mkdir -p "$VULNSCOUT_CACHE_DIR" "$VULNSCOUT_OUTPUTS_DIR" "$(dirname "$VULNSCOUT_CONFIG_FILE")"
@@ -180,11 +193,13 @@ EOF
         echo "Created default config at $VULNSCOUT_CONFIG_FILE"
     fi
     local -a env_args=()
+    _detect_legacy
     while IFS='=' read -r key value; do
         [ -z "$key" ] && continue
         [ "${key#\#}" = "$key" ] || continue
         env_args+=(-e "${key}=${value}")
     done < "$VULNSCOUT_CONFIG_FILE"
+    [[ "$LEGACY_SETUP_DETECTED" == true ]] && env_args+=(-e LEGACY_SETUP_DETECTED=true)
     local -a vol_args=(
         -v "$VULNSCOUT_CACHE_DIR":/cache/vulnscout
         -v "$VULNSCOUT_OUTPUTS_DIR":/scan/outputs

--- a/vulnscout
+++ b/vulnscout
@@ -3,16 +3,19 @@ set -euo pipefail
 
 CONTAINER_NAME="${VULNSCOUT_CONTAINER:-vulnscout}"
 DOCKER_IMAGE="${VULNSCOUT_IMAGE:-docker.io/sflinux/vulnscout:latest}"
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")" 
-VULNSCOUT_CACHE_DIR="${VULNSCOUT_CACHE_DIR:-$SCRIPT_DIR/.vulnscout/cache}"
-VULNSCOUT_OUTPUTS_DIR="${VULNSCOUT_OUTPUTS_DIR:-$SCRIPT_DIR/.vulnscout/outputs}"
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+VULNSCOUT_BUILD_DIR="${VULNSCOUT_BUILD_DIR:-$SCRIPT_DIR/.vulnscout}"
+VULNSCOUT_CACHE_DIR="${VULNSCOUT_CACHE_DIR:-$VULNSCOUT_BUILD_DIR/cache}"
+VULNSCOUT_OUTPUTS_DIR="${VULNSCOUT_OUTPUTS_DIR:-$VULNSCOUT_BUILD_DIR/outputs}"
 VULNSCOUT_CONFIG_FILE="${VULNSCOUT_CACHE_DIR}/config.env"
 
-# Source config early so stored values (e.g. VULNSCOUT_CACHE_DIR) take effect
+# Source config early so stored values (e.g. VULNSCOUT_BUILD_DIR) take effect
 if [ -f "$VULNSCOUT_CONFIG_FILE" ]; then
     # shellcheck source=/dev/null
     . "$VULNSCOUT_CONFIG_FILE"
 fi
+# Re-derive VULNSCOUT_CONFIG_FILE in case VULNSCOUT_CACHE_DIR was updated by config
+VULNSCOUT_CONFIG_FILE="${VULNSCOUT_CACHE_DIR}/config.env"
 
 VULNSCOUT_VERSION="$(docker inspect "$DOCKER_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.version"}}' 2>/dev/null || echo unknown)"
 VARIANT="default"
@@ -67,8 +70,9 @@ Configuration:
 Environment variables:
   VULNSCOUT_CONTAINER   Container name (default: vulnscout)
   VULNSCOUT_IMAGE       Docker image (default: docker.io/sflinux/vulnscout:latest)
-  VULNSCOUT_OUTPUTS_DIR Output directory (default: ./.vulnscout/outputs)
-  VULNSCOUT_CACHE_DIR        Cache base dir (default: ./.vulnscout/cache)
+  VULNSCOUT_BUILD_DIR   Build base dir (default: ./.vulnscout)
+  VULNSCOUT_CACHE_DIR   Cache dir (default: VULNSCOUT_BUILD_DIR/cache)
+  VULNSCOUT_OUTPUTS_DIR Output directory (default: VULNSCOUT_BUILD_DIR/outputs)
 
 Examples:
   vulnscout --project test --variant x86 --add-cve-check ./cve.json --add-spdx ./sbom.json
@@ -154,10 +158,10 @@ config_clear() {
 _detect_legacy() {
     # If the new DB already exists, no migration needed.
     [[ -f "$VULNSCOUT_CACHE_DIR/vulnscout.db" ]] && return
-    # Walk sibling dirs of the cache dir for legacy docker-compose/output artefacts.
-    local parent
-    parent="$(dirname "$VULNSCOUT_CACHE_DIR")"
-    if find "$parent" -maxdepth 4 \( -name 'openvex.json' -o -name 'docker-*.yml' \) 2>/dev/null | grep -q .; then
+    # Walk inside the build dir for legacy docker-compose/output artefacts.
+    # Legacy project dirs (e.g. oip-image-*/docker-compose.yml) sit directly
+    # alongside the cache/ and outputs/ subdirs, so maxdepth 2 reaches them.
+    if find "$VULNSCOUT_BUILD_DIR" -maxdepth 2 \( -name 'openvex.json' -o -name 'docker-*.yml' \) 2>/dev/null | grep -q .; then
         LEGACY_SETUP_DETECTED=true
     fi
 }
@@ -189,7 +193,7 @@ USER_UID=$(id -u)
 USER_GID=$(id -g)
 VULNSCOUT_VERSION=$VULNSCOUT_VERSION
 VITE_API_URL=http://localhost:7275
-REFRESH_REMOTE_DELAY=48h
+REFRESH_REMOTE_DELAY=2w
 EOF
         echo "Created default config at $VULNSCOUT_CONFIG_FILE"
     fi


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Provide a script to generate a cache with `vulnscout.db` based on the old YAML files. 
* Provide a web interface/container warning if a new container is started with the old openvex without the new database

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change
Setup: 

Build a new image `sfl:custom`:

```
docker build -t sfl:custom .
```

Set the Variable `VULNSCOUT_IMAGE` with the command: 

```
export VULNSCOUT_IMAGE="sfl:custom"
```

Clean the existing DB if any:

```
rm -rf .vulnscout/cache
```

Stop and remove the VulnScout container if any:

```
docker container stop vulnscout
docker container rm vulnscout
``` 

Test 1-: Get an old .vulnscout project with the YAML structure (c.f procedure available on `staging`)

Test 2-: Replace the container image to `image: sfl:custom` in the YAML file

Test 3-a: Start the container and see the warning on the web ui:

E.g.:
```
docker compose -f .vulnscout/demo/docker-demo.yml up
``` 

Test 3-b: Start the container and see the warning on the web ui with new `vulnscout` script:

```
./vulnscout --serve
``` 

Test 4-: migrate to a dabatase

```
./migration.sh .vulnscout --project test
```

