### PR TITLE
Update assessment mechanism for variants

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -39,7 +39,8 @@ export default [
         { allowConstantExport: true },
       ],
       "no-undef": "off", // Disable no-undef for TypeScript files
-      "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true, "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }]
     },
   },
 ];

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import type { Assessment } from "../handlers/assessments";
+import type { Variant } from '../handlers/variant';
 import MessageBanner from './MessageBanner';
 
 type EditAssessmentData = {
@@ -9,6 +10,8 @@ type EditAssessmentData = {
     impact_statement?: string;
     status_notes?: string;
     workaround?: string;
+    variant_ids?: string[];
+    packages?: string[];
 }
 
 type Props = {
@@ -18,6 +21,10 @@ type Props = {
     clearFields?: boolean;
     onFieldsChange?: (hasChanges: boolean) => void;
     triggerBanner?: (message: string, type: "error" | "success") => void;
+    availableVariants?: Variant[];
+    defaultSelectedVariantIds?: string[];
+    availablePackages?: string[];
+    defaultSelectedPackages?: string[];
 }
 
 function EditAssessment({
@@ -26,13 +33,24 @@ function EditAssessment({
     onCancel,
     clearFields: shouldClearFields,
     onFieldsChange,
-    triggerBanner
+    triggerBanner,
+    availableVariants,
+    defaultSelectedVariantIds,
+    availablePackages,
+    defaultSelectedPackages
 }: Readonly<Props>) {
+    const isImpactStatus = assessment.status === 'not_affected' || assessment.status === 'false_positive';
     const [status, setStatus] = useState(assessment.status || "under_investigation");
     const [justification, setJustification] = useState(assessment.justification || "none");
-    const [statusNotes, setStatusNotes] = useState(assessment.status_notes || "");
+    // For non-impact statuses (fixed, affected, …) Yocto stores its notes in impact_statement.
+    // Pre-fill status_notes with that value so users see it in the right field.
+    const [statusNotes, setStatusNotes] = useState(
+        assessment.status_notes || (!isImpactStatus ? (assessment.impact_statement || "") : "")
+    );
     const [workaround, setWorkaround] = useState(assessment.workaround || "");
-    const [impact, setImpact] = useState(assessment.impact_statement || "");
+    const [impact, setImpact] = useState(isImpactStatus ? (assessment.impact_statement || "") : "");
+    const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>(defaultSelectedVariantIds ?? []);
+    const [selectedPackages, setSelectedPackages] = useState<string[]>(defaultSelectedPackages ?? []);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -49,15 +67,16 @@ function EditAssessment({
 
     // Check if fields have changes compared to original assessment
     useEffect(() => {
+        const initialStatusNotes = assessment.status_notes || (!isImpactStatus ? (assessment.impact_statement || "") : "");
         const hasChanges = (
             status !== assessment.status ||
             justification !== (assessment.justification || "none") ||
-            statusNotes !== (assessment.status_notes || "") ||
+            statusNotes !== initialStatusNotes ||
             workaround !== (assessment.workaround || "") ||
-            impact !== (assessment.impact_statement || "")
+            impact !== (isImpactStatus ? (assessment.impact_statement || "") : "")
         );
         onFieldsChange?.(hasChanges);
-    }, [status, justification, statusNotes, workaround, impact, onFieldsChange, assessment]);
+    }, [status, justification, statusNotes, workaround, impact, onFieldsChange, assessment, isImpactStatus]);
 
     function saveAssessment() {
         if (status == '' || justification == '')
@@ -71,6 +90,23 @@ function EditAssessment({
             return;
         }
 
+        if (availableVariants && availableVariants.length > 0 && selectedVariantIds.length === 0) {
+            if (triggerBanner) {
+                triggerBanner("You must select at least one variant", "error");
+            } else {
+                internalTriggerBanner("You must select at least one variant", "error");
+            }
+            return;
+        }
+        if (availablePackages && availablePackages.length > 0 && selectedPackages.length === 0) {
+            if (triggerBanner) {
+                triggerBanner("You must select at least one package", "error");
+            } else {
+                internalTriggerBanner("You must select at least one package", "error");
+            }
+            return;
+        }
+
         const includeJustificationAndImpact = status == "not_affected";
 
         onSaveAssessment({
@@ -79,17 +115,22 @@ function EditAssessment({
             justification: includeJustificationAndImpact ? justification : undefined,
             status_notes: statusNotes,
             workaround,
-            impact_statement: includeJustificationAndImpact ? impact : undefined
+            // For non-impact statuses the value was folded into status_notes; clear impact_statement.
+            impact_statement: includeJustificationAndImpact ? impact : "",
+            variant_ids: selectedVariantIds.length > 0 ? selectedVariantIds : undefined,
+            packages: selectedPackages.length > 0 ? selectedPackages : (availablePackages ?? [])
         });
     }
 
     const resetToOriginal = useCallback(() => {
         setStatus(assessment.status || "under_investigation");
         setJustification(assessment.justification || "none");
-        setStatusNotes(assessment.status_notes || "");
+        setStatusNotes(assessment.status_notes || (!isImpactStatus ? (assessment.impact_statement || "") : ""));
         setWorkaround(assessment.workaround || "");
-        setImpact(assessment.impact_statement || "");
-    }, [assessment]);
+        setImpact(isImpactStatus ? (assessment.impact_statement || "") : "");
+        setSelectedVariantIds(defaultSelectedVariantIds ?? []);
+        setSelectedPackages(defaultSelectedPackages ?? []);
+    }, [assessment, isImpactStatus, defaultSelectedVariantIds, defaultSelectedPackages]);
 
     useEffect(() => {
         if (shouldClearFields) {
@@ -143,16 +184,65 @@ function EditAssessment({
                 </>}
             </h3>
 
-            {(status == "not_affected" || status == "false_positive") && <>
-                    <textarea
+            {availableVariants && availableVariants.length > 0 && (
+                <div className="mt-2 mb-2 ml-1">
+                    <p className="text-sm font-medium text-gray-300 mb-1">Apply to variants:</p>
+                    <div className="flex flex-wrap gap-x-4 gap-y-1">
+                        {availableVariants.map(v => (
+                            <label key={v.id} className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
+                                <input
+                                    type="checkbox"
+                                    checked={selectedVariantIds.includes(v.id)}
+                                    onChange={(e) => {
+                                        if (e.target.checked) {
+                                            setSelectedVariantIds(prev => [...prev, v.id]);
+                                        } else {
+                                            setSelectedVariantIds(prev => prev.filter(id => id !== v.id));
+                                        }
+                                    }}
+                                    className="accent-blue-500"
+                                />
+                                <span className="text-gray-200">{v.name}</span>
+                            </label>
+                        ))}
+                    </div>
+                </div>
+            )}
+            {availablePackages && availablePackages.length > 1 && (
+                <div className="mt-2 mb-2 ml-1">
+                    <p className="text-sm font-medium text-gray-300 mb-1">Apply to packages:</p>
+                    <div className="flex flex-wrap gap-x-4 gap-y-1">
+                        {availablePackages.map(pkg => (
+                            <label key={pkg} className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
+                                <input
+                                    type="checkbox"
+                                    checked={selectedPackages.includes(pkg)}
+                                    onChange={(e) => {
+                                        if (e.target.checked) {
+                                            setSelectedPackages(prev => [...prev, pkg]);
+                                        } else {
+                                            setSelectedPackages(prev => prev.filter(p => p !== pkg));
+                                        }
+                                    }}
+                                    className="accent-blue-400"
+                                />
+                                <span className="font-mono text-gray-200">{pkg}</span>
+                            </label>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {(status === 'not_affected' || status === 'false_positive') && (
+                <><textarea
                         value={impact}
                         onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => setImpact(event.target.value)}
                         name="edit_assessment_impact"
                         className="bg-gray-700 text-white m-1 p-1 px-2 min-w-[50%] placeholder:text-slate-400 rounded resize-vertical whitespace-pre-wrap"
                         rows={3}
-                        placeholder="why this vulnerability is not exploitable ?"
-                    /><br/>
-            </>}
+                        placeholder="Why this vulnerability is not exploitable?"
+                    /><br/></>
+            )}
 
                 <textarea
                     value={statusNotes}

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import type { Vulnerability } from "../handlers/vulnerabilities";
 import StatusEditor from "./StatusEditor";
 import type { PostAssessment } from './StatusEditor';
@@ -6,6 +6,7 @@ import TimeEstimateEditor from "./TimeEstimateEditor";
 import type { PostTimeEstimate } from "./TimeEstimateEditor";
 import { asAssessment, Assessment } from "../handlers/assessments";
 import Iso8601Duration from '../handlers/iso8601duration';
+import Variants from '../handlers/variant';
 
 type Props = {
     vulnerabilities: Vulnerability[];
@@ -16,30 +17,71 @@ type Props = {
     triggerBanner: (message: string, type: 'error' | 'success') => void;
     hideBanner: () => void;
     variantId?: string;
+    /** Origin variant when compare mode is active */
+    baseVariantId?: string;
+    /** 'difference' or 'intersection' when compare mode is active */
+    compareOperation?: string;
 };
 
-function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssessment, patchVuln, triggerBanner, hideBanner, variantId} : Readonly<Props>) {
+function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssessment, patchVuln, triggerBanner, hideBanner, variantId, baseVariantId, compareOperation} : Readonly<Props>) {
 
     const [panelOpened, setPanelOpened] = useState<number>(0)
     const [isLoading, setIsLoading] = useState<boolean>(false)
+    const [affectedVariantNames, setAffectedVariantNames] = useState<string[]>([])
+    const [isAllVariantsMode, setIsAllVariantsMode] = useState<boolean>(false)
 
     if (selectedVulns.length == 0) {
         if (panelOpened) setPanelOpened(0)
         if (isLoading) setIsLoading(false)
     }
 
+    // Recompute affected variants whenever the status panel opens or the selection changes
+    useEffect(() => {
+        if (panelOpened !== 1 || selectedVulns.length === 0) {
+            setAffectedVariantNames([]);
+            setIsAllVariantsMode(false);
+            return;
+        }
+        let cancelled = false;
+        (async () => {
+            if (variantId) {
+                // Compare or single-variant context — resolve names
+                const allVariants = await Variants.listAll().catch(() => []);
+                const compareMatch = allVariants.find(v => v.id === variantId);
+                const names: string[] = compareMatch ? [compareMatch.name] : [variantId];
+                // Intersection mode: also include the base (origin) variant
+                if (compareOperation === 'intersection' && baseVariantId) {
+                    const baseMatch = allVariants.find(v => v.id === baseVariantId);
+                    const baseName = baseMatch ? baseMatch.name : baseVariantId;
+                    if (!names.includes(baseName)) names.push(baseName);
+                }
+                if (!cancelled) {
+                    setIsAllVariantsMode(false);
+                    setAffectedVariantNames(names);
+                }
+            } else {
+                // All-variants context — each CVE may have different variants, show generic message
+                if (!cancelled) {
+                    setIsAllVariantsMode(true);
+                    setAffectedVariantNames([]);
+                }
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [panelOpened, selectedVulns, variantId, baseVariantId, compareOperation]);
+
     // Get the status only if ALL selected vulnerabilities have the exact same status
     const uniformStatus = useMemo((): string | undefined => {
         if (selectedVulns.length === 0) return undefined;
-        
+
         const selectedVulnerabilities = vulnerabilities.filter(vuln => selectedVulns.includes(vuln.id));
         if (selectedVulnerabilities.length === 0) return undefined;
-        
+
         const firstStatus = selectedVulnerabilities[0].status;
         const allHaveSameStatus = selectedVulnerabilities.every(vuln => vuln.status === firstStatus);
-        
+
         // Debug logging
-        
+
         // Only return the status if ALL vulnerabilities have the same status
         return allHaveSameStatus ? firstStatus : undefined;
     }, [selectedVulns, vulnerabilities]);
@@ -58,15 +100,51 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
         const pkg_vulns = pkg_for_vulns();
         setIsLoading(true);
 
-        // Prepare batch request payload
-        const assessmentRequests = selectedVulns.map(vuln_id => ({
+        // Build (vuln_id, variant_id | undefined, packages[]) triples.
+        // - variantId set  → use that single variant for every vuln
+        // - variantId unset → fetch all variants per vuln and fan out
+        type Triple = { vuln_id: string; variant_id?: string; packages: string[] };
+        const triples: Triple[] = [];
+
+        if (variantId) {
+            // Compare or specific variant — one item per vuln for the compared variant
+            for (const vuln_id of selectedVulns) {
+                const pkgs = pkg_vulns[vuln_id] ?? [];
+                triples.push({ vuln_id, variant_id: variantId, packages: pkgs });
+            }
+            // Intersection mode: also create triples for the base (origin) variant
+            if (compareOperation === 'intersection' && baseVariantId) {
+                for (const vuln_id of selectedVulns) {
+                    const pkgs = pkg_vulns[vuln_id] ?? [];
+                    triples.push({ vuln_id, variant_id: baseVariantId, packages: pkgs });
+                }
+            }
+        } else {
+            // All-variants context — one item per (vuln, variant, pkg)
+            await Promise.all(selectedVulns.map(async (vuln_id) => {
+                const variants = await Variants.listByVuln(vuln_id).catch(() => []);
+                const pkgs = pkg_vulns[vuln_id] ?? [];
+                if (variants.length === 0) {
+                    // No variant data — create without variant_id
+                    triples.push({ vuln_id, packages: pkgs });
+                } else {
+                    for (const v of variants) {
+                        triples.push({ vuln_id, variant_id: v.id, packages: pkgs });
+                    }
+                }
+            }));
+        }
+
+        // Build batch request payload
+        const assessmentRequests = triples.map(({ vuln_id, variant_id, packages }) => ({
             vuln_id,
-            packages: pkg_vulns[vuln_id] ?? [],
+            packages,
             status: content.status,
             status_notes: content.status_notes,
             justification: content.justification,
             impact_statement: content.impact_statement,
-            workaround: content.workaround
+            workaround: content.workaround,
+            ...(variant_id ? { variant_id } : {})
         }));
 
         try {
@@ -80,14 +158,14 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
             });
 
             const data = await response.json().catch(() => ({}));
-            
+
             if (data?.status === 'success' && Array.isArray(data?.assessments)) {
                 // Process successful assessments
                 for (const assessmentData of data.assessments) {
                     const casted = asAssessment(assessmentData);
                     if (!Array.isArray(casted) && typeof casted === "object") {
                         appendAssessment(casted);
-                        
+
                         // Update the vulnerability
                         const vuln = vulnerabilities.find(v => v.id === casted.vuln_id);
                         if (vuln) {
@@ -102,7 +180,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                 const errorMsg = data.error_count ? ` (${data.error_count} failed)` : '';
                 triggerBanner(`Successfully added assessments to ${data.count} vulnerabilities${errorMsg}`, 'success');
             } else {
-                const errorMsg = data?.errors?.length 
+                const errorMsg = data?.errors?.length
                     ? `Errors: ${data.errors.map((e: {error?: string}) => e.error).join(', ')}`
                     : `HTTP ${response.status}`;
                 triggerBanner(`Failed to add assessments: ${errorMsg}`, 'error');
@@ -152,7 +230,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                             vuln.effort.likely = new Iso8601Duration(vulnData.effort.likely);
                         if (typeof vulnData?.effort?.pessimistic === "string")
                             vuln.effort.pessimistic = new Iso8601Duration(vulnData.effort.pessimistic);
-                        
+
                         patchVuln(vuln.id, vuln);
                     }
                 }
@@ -160,7 +238,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                 const errorMsg = data.error_count ? ` (${data.error_count} failed)` : '';
                 triggerBanner(`Successfully updated time estimates for ${data.count} vulnerabilities${errorMsg}`, 'success');
             } else {
-                const errorMsg = data?.errors?.length 
+                const errorMsg = data?.errors?.length
                     ? `Errors: ${data.errors.map((e: {error?: string}) => e.error).join(', ')}`
                     : `HTTP ${response.status}`;
                 triggerBanner(`Failed to save time estimates: ${errorMsg}`, 'error');
@@ -176,10 +254,13 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
     return (<>
         {selectedVulns.length >= 1 && <>
             {panelOpened > 0 && <div className="absolute top-0 left-0 right-0 bottom-0 z-30 bg-black/40"></div>}
-            
+
             {isLoading && (
-                <div className="absolute top-0 left-0 right-0 bottom-0 z-50 bg-black/50 flex items-center justify-center">
-                    <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-sky-500"></div>
+                <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
+                    <div className="flex flex-col items-center gap-3 text-white">
+                        <div className="w-10 h-10 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
+                        <span className="text-sm font-semibold">Editing multiple CVEs...</span>
+                    </div>
                 </div>
             )}
 
@@ -199,11 +280,33 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                 'absolute z-40 p-4 bg-slate-700 shadow-md shadow-slate-400/40 top-48 left-32 w-1/2',
                 panelOpened == 1 ? 'block' : 'hidden'
             ].join(' ')}>
-                <StatusEditor 
-                    onAddAssessment={(data) => addAssessment(data)} 
+                <StatusEditor
+                    onAddAssessment={(data) => addAssessment(data)}
                     progressBar={undefined}
                     defaultStatus={uniformStatus}
                 />
+                {(isAllVariantsMode || affectedVariantNames.length > 0) && (
+                    <div className="mt-3 pt-3 border-t border-slate-500">
+                        {isAllVariantsMode ? (
+                            <p className="text-sm font-medium text-gray-300">
+                                Will be applied to all possible variants on each CVE
+                            </p>
+                        ) : (
+                            <>
+                                <p className="text-sm font-medium text-gray-300 mb-1">
+                                    Will be applied to variant{affectedVariantNames.length > 1 ? 's' : ''}:
+                                </p>
+                                <div className="flex flex-wrap gap-1">
+                                    {affectedVariantNames.map(name => (
+                                        <span key={name} className="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                                            {name}
+                                        </span>
+                                    ))}
+                                </div>
+                            </>
+                        )}
+                    </div>
+                )}
             </div>
 
             <div className={[

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -21,15 +21,17 @@ type Props = {
     triggerBanner?: (message: string, type: "error" | "success") => void;
     defaultStatus?: string;
     variants?: Variant[];
+    availablePackages?: string[];
 }
 
-function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants}: Readonly<Props>) {
+function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants, availablePackages}: Readonly<Props>) {
     const [status, setStatus] = useState(defaultStatus);
     const [justification, setJustification] = useState("none");
     const [statusNotes, setStatusNotes] = useState("");
     const [workaround, setWorkaround] = useState("");
     const [impact, setImpact] = useState("");
     const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>([]);
+    const [selectedPackages, setSelectedPackages] = useState<string[]>(availablePackages ?? []);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -43,6 +45,11 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
     const closeBanner = () => {
         setBannerVisible(false);
     };
+
+    // Reset selected packages when the available list changes (e.g. navigating to a different vuln)
+    useEffect(() => {
+        setSelectedPackages(availablePackages ?? []);
+    }, [availablePackages]);
 
     // Update status when defaultStatus prop changes
     useEffect(() => {
@@ -80,13 +87,30 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             }
             return;
         }
+        if (variants && variants.length > 0 && selectedVariantIds.length === 0) {
+            if (triggerBanner) {
+                triggerBanner("You must select at least one variant", "error");
+            } else {
+                internalTriggerBanner("You must select at least one variant", "error");
+            }
+            return;
+        }
+        if (availablePackages && availablePackages.length > 0 && selectedPackages.length === 0) {
+            if (triggerBanner) {
+                triggerBanner("You must select at least one package", "error");
+            } else {
+                internalTriggerBanner("You must select at least one package", "error");
+            }
+            return;
+        }
         onAddAssessment({
             status,
             justification: status == "not_affected" ? justification : undefined,
             status_notes: statusNotes,
             workaround,
             impact_statement: (status == "not_affected" || status == "false_positive") ? impact : undefined,
-            variant_ids: selectedVariantIds.length > 0 ? selectedVariantIds : undefined
+            variant_ids: selectedVariantIds.length > 0 ? selectedVariantIds : undefined,
+            packages: selectedPackages.length > 0 ? selectedPackages : (availablePackages ?? [])
         });
     }
 
@@ -97,7 +121,8 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         setWorkaround("");
         setImpact("");
         setSelectedVariantIds([]);
-    }, [defaultStatus]);
+        setSelectedPackages(availablePackages ?? []);
+    }, [defaultStatus, availablePackages]);
 
     useEffect(() => {
         if (shouldClearFields) {
@@ -166,6 +191,30 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                                 className="accent-blue-500"
                             />
                             <span className="text-gray-200">{v.name}</span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+        )}
+        {availablePackages && availablePackages.length > 1 && (
+            <div className="mt-2 mb-2 ml-1">
+                <p className="text-sm font-medium text-gray-300 mb-1">Apply to packages:</p>
+                <div className="flex flex-wrap gap-x-4 gap-y-1">
+                    {availablePackages.map(pkg => (
+                        <label key={pkg} className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
+                            <input
+                                type="checkbox"
+                                checked={selectedPackages.includes(pkg)}
+                                onChange={(e) => {
+                                    if (e.target.checked) {
+                                        setSelectedPackages(prev => [...prev, pkg]);
+                                    } else {
+                                        setSelectedPackages(prev => prev.filter(p => p !== pkg));
+                                    }
+                                }}
+                                className="accent-blue-400"
+                            />
+                            <span className="font-mono text-gray-200">{pkg}</span>
                         </label>
                     ))}
                 </div>

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import MessageBanner from './MessageBanner';
+import type { Variant } from '../handlers/variant';
 
 type PostAssessment = {
     vuln_id?: string,
@@ -8,7 +9,8 @@ type PostAssessment = {
     justification?: string,
     impact_statement?: string,
     status_notes?: string,
-    workaround?: string
+    workaround?: string,
+    variant_ids?: string[]
 }
 
 type Props = {
@@ -18,14 +20,16 @@ type Props = {
     onFieldsChange?: (hasChanges: boolean) => void;
     triggerBanner?: (message: string, type: "error" | "success") => void;
     defaultStatus?: string;
+    variants?: Variant[];
 }
 
-function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation"}: Readonly<Props>) {
+function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants}: Readonly<Props>) {
     const [status, setStatus] = useState(defaultStatus);
     const [justification, setJustification] = useState("none");
     const [statusNotes, setStatusNotes] = useState("");
     const [workaround, setWorkaround] = useState("");
     const [impact, setImpact] = useState("");
+    const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>([]);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -81,7 +85,8 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             justification: status == "not_affected" ? justification : undefined,
             status_notes: statusNotes,
             workaround,
-            impact_statement: (status == "not_affected" || status == "false_positive") ? impact : undefined
+            impact_statement: (status == "not_affected" || status == "false_positive") ? impact : undefined,
+            variant_ids: selectedVariantIds.length > 0 ? selectedVariantIds : undefined
         });
     }
 
@@ -91,6 +96,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         setStatusNotes("");
         setWorkaround("");
         setImpact("");
+        setSelectedVariantIds([]);
     }, [defaultStatus]);
 
     useEffect(() => {
@@ -141,6 +147,30 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                 </select>
             </>}
         </h3>
+        {variants && variants.length > 0 && (
+            <div className="mt-2 mb-2 ml-1">
+                <p className="text-sm font-medium text-gray-300 mb-1">Apply to variants:</p>
+                <div className="flex flex-wrap gap-x-4 gap-y-1">
+                    {variants.map(v => (
+                        <label key={v.id} className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
+                            <input
+                                type="checkbox"
+                                checked={selectedVariantIds.includes(v.id)}
+                                onChange={(e) => {
+                                    if (e.target.checked) {
+                                        setSelectedVariantIds(prev => [...prev, v.id]);
+                                    } else {
+                                        setSelectedVariantIds(prev => prev.filter(id => id !== v.id));
+                                    }
+                                }}
+                                className="accent-blue-500"
+                            />
+                            <span className="text-gray-200">{v.name}</span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+        )}
         {(status == "not_affected" || status == "false_positive") && <>
             <textarea
                 value={impact}

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -56,11 +56,26 @@ const dt_options: Intl.DateTimeFormatOptions = {
     const [assessmentToDelete, setAssessmentToDelete] = useState<Assessment | null>(null);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [availableVariants, setAvailableVariants] = useState<Variant[]>([]);
+    const [allVulnAssessments, setAllVulnAssessments] = useState<Assessment[]>([]);
 
     // Fetch variants that have a finding for this specific vulnerability
     useEffect(() => {
         setAvailableVariants([]);
         Variants.listByVuln(vuln.id).then(setAvailableVariants).catch(() => {});
+    }, [vuln.id]);
+
+    // Fetch ALL assessments for this vuln (unfiltered) so variant tags are
+    // complete even when a variant filter is active in the explorer.
+    useEffect(() => {
+        setAllVulnAssessments([]);
+        fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/assessments`, { mode: 'cors' })
+            .then(r => r.json())
+            .then((data: any[]) => {
+                if (Array.isArray(data)) {
+                    setAllVulnAssessments(data.flatMap(asAssessment).filter((a): a is Assessment => !Array.isArray(a)));
+                }
+            })
+            .catch(() => {});
     }, [vuln.id]);
 
     const [hasTimeChanges, setHasTimeChanges] = useState(false);
@@ -761,11 +776,22 @@ const dt_options: Intl.DateTimeFormatOptions = {
                                                 ))}
                                             </div>
                                             {(() => {
-                                                const variantTags = [...new Set(
-                                                    group.assessments
-                                                        .map(a => a.variant_id)
-                                                        .filter((vid): vid is string => !!vid)
-                                                )].map(vid => availableVariants.find(v => v.id === vid)).filter(Boolean) as Variant[];
+                                                // Build the same content fingerprint used by groupAssessments,
+                                                // then find ALL matching records (across all variants) in the
+                                                // unfiltered allVulnAssessments so we can show every variant tag
+                                                // even when the explorer is filtered to a single variant.
+                                                const fp = `${firstAssess.simplified_status}|${firstAssess.justification || ''}|${firstAssess.impact_statement || ''}|${firstAssess.status_notes || ''}|${firstAssess.workaround || ''}`;
+                                                const allVariantIds = [...new Set(
+                                                    allVulnAssessments
+                                                        .filter(a => {
+                                                            const afp = `${a.simplified_status}|${a.justification || ''}|${a.impact_statement || ''}|${a.status_notes || ''}|${a.workaround || ''}`;
+                                                            return afp === fp && !!a.variant_id;
+                                                        })
+                                                        .map(a => a.variant_id as string)
+                                                )];
+                                                const variantTags = allVariantIds
+                                                    .map(vid => availableVariants.find(v => v.id === vid))
+                                                    .filter(Boolean) as Variant[];
                                                 return variantTags.length > 0 ? (
                                                     <div className="text-sm mb-2 flex flex-wrap gap-1">
                                                         {variantTags.map(v => (

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -17,6 +17,8 @@ import { faBox, faChevronLeft, faChevronRight, faPenToSquare, faTrash, faPlus, f
 import ConfirmationModal from "./ConfirmationModal";
 import EditAssessment from "./EditAssessment";
 import type { EditAssessmentData } from "./EditAssessment";
+import Variants from '../handlers/variant';
+import type { Variant } from '../handlers/variant';
 import { useState, useEffect, useRef, useCallback } from "react";
 
 type Props = {
@@ -53,6 +55,13 @@ const dt_options: Intl.DateTimeFormatOptions = {
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [assessmentToDelete, setAssessmentToDelete] = useState<Assessment | null>(null);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
+    const [availableVariants, setAvailableVariants] = useState<Variant[]>([]);
+
+    // Fetch variants that have a finding for this specific vulnerability
+    useEffect(() => {
+        setAvailableVariants([]);
+        Variants.listByVuln(vuln.id).then(setAvailableVariants).catch(() => {});
+    }, [vuln.id]);
 
     const [hasTimeChanges, setHasTimeChanges] = useState(false);
     const [hasAssessmentChanges, setHasAssessmentChanges] = useState(false);
@@ -355,47 +364,65 @@ const dt_options: Intl.DateTimeFormatOptions = {
     const defaultStatus = getDefaultStatus();
 
     const addAssessment = async (content: PostAssessment) => {
-        content.vuln_id = vuln.id
-        content.packages = vuln.packages
+        content.vuln_id = vuln.id;
+        content.packages = vuln.packages;
 
-        const response = await fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/assessments`, {
-            method: 'POST',
-            mode: 'cors',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(content)
-        })
-        const data = await response.json()
-        if (data?.status === 'success') {
-            const casted = asAssessment(data?.assessment);
-            if (!Array.isArray(casted) && typeof casted === "object") {
-                // Track this as a newly added assessment
-                setNewAssessmentIds(prev => new Set(prev).add(casted.id));
+        // Determine which variants to post to. If none selected, post once without a variant_id.
+        const variantIds: Array<string | undefined> =
+            content.variant_ids && content.variant_ids.length > 0
+                ? content.variant_ids
+                : [undefined];
 
-                // Remove the glow effect after animation completes
-                setTimeout(() => {
-                    setNewAssessmentIds(prev => {
-                        const newSet = new Set(prev);
-                        newSet.delete(casted.id);
-                        return newSet;
-                    });
-                }, 5500); // >2s that we used in css animation
+        const { variant_ids: _vids, ...baseContent } = content;
 
-                // Add the assessment immediately to the local vuln object for instant UI update
-                appendAssessment(casted);
-                vuln.assessments.push(casted);
-                vuln.status = casted.status;
-                vuln.simplified_status = casted.simplified_status;
+        let successCount = 0;
+        let lastCasted: Assessment | null = null;
 
-                // Also patch the vulnerability for real-time refresh in other views
-                patchVuln(vuln.id, vuln);
-                showMessage("Successfully added assessment.", "success");
-                setClearAssessmentFields(true);
-                setTimeout(() => setClearAssessmentFields(false), 100);
+        for (const vid of variantIds) {
+            const body = vid ? { ...baseContent, variant_id: vid } : baseContent;
+            const response = await fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/assessments`, {
+                method: 'POST',
+                mode: 'cors',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body)
+            });
+            const data = await response.json();
+            if (data?.status === 'success') {
+                const casted = asAssessment(data?.assessment);
+                if (!Array.isArray(casted) && typeof casted === 'object') {
+                    successCount++;
+                    lastCasted = casted;
+
+                    // Highlight the first result
+                    if (successCount === 1) {
+                        setNewAssessmentIds(prev => new Set(prev).add(casted.id));
+                        setTimeout(() => {
+                            setNewAssessmentIds(prev => {
+                                const newSet = new Set(prev);
+                                newSet.delete(casted.id);
+                                return newSet;
+                            });
+                        }, 5500);
+                    }
+
+                    appendAssessment(casted);
+                    vuln.assessments.push(casted);
+                    vuln.status = casted.status;
+                    vuln.simplified_status = casted.simplified_status;
+                }
+            } else {
+                showMessage(`Failed to add assessment: HTTP code ${Number(response?.status)} | ${escape(JSON.stringify(data))}`, 'error');
             }
-        } else {
-            showMessage(`Failed to add assessment: HTTP code ${Number(response?.status)} | ${escape(JSON.stringify(data))}`, "error");
+        }
+
+        if (lastCasted) {
+            patchVuln(vuln.id, vuln);
+            const msg = successCount > 1
+                ? `Successfully added assessment to ${successCount} variants.`
+                : 'Successfully added assessment.';
+            showMessage(msg, 'success');
+            setClearAssessmentFields(true);
+            setTimeout(() => setClearAssessmentFields(false), 100);
         }
     };
 
@@ -710,6 +737,7 @@ const dt_options: Intl.DateTimeFormatOptions = {
                                             onFieldsChange={setHasAssessmentChanges}
                                             triggerBanner={showMessage}
                                             defaultStatus={defaultStatus}
+                                            variants={availableVariants}
                                         />
                                     </li>
                                 )}
@@ -732,6 +760,22 @@ const dt_options: Intl.DateTimeFormatOptions = {
                                                     </span>
                                                 ))}
                                             </div>
+                                            {(() => {
+                                                const variantTags = [...new Set(
+                                                    group.assessments
+                                                        .map(a => a.variant_id)
+                                                        .filter((vid): vid is string => !!vid)
+                                                )].map(vid => availableVariants.find(v => v.id === vid)).filter(Boolean) as Variant[];
+                                                return variantTags.length > 0 ? (
+                                                    <div className="text-sm mb-2 flex flex-wrap gap-1">
+                                                        {variantTags.map(v => (
+                                                            <span key={v.id} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                                                                {v.name}
+                                                            </span>
+                                                        ))}
+                                                    </div>
+                                                ) : null;
+                                            })()}
                                             <div className="flex items-start justify-between">
                                                 <div className="flex-1">
                                                     <h3 className="text-lg font-semibold text-white mb-2 flex items-center">

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -42,6 +42,14 @@ const dt_options: Intl.DateTimeFormatOptions = {
     minute: 'numeric',
     timeZoneName: 'shortOffset'
 };
+
+type AssessmentGroup = {
+    key: string;
+    assessments: Assessment[];
+    timestamp: string;
+    packages: string[];
+};
+
   function VulnModal(props: Readonly<Props>) {
     const { vuln, isEditing: initialIsEditing, onClose, appendAssessment, appendCVSS, patchVuln, vulnerabilities, currentIndex, onNavigate, variantId } = props;
     const [isEditing, setIsEditing] = useState(initialIsEditing);
@@ -57,7 +65,8 @@ const dt_options: Intl.DateTimeFormatOptions = {
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [availableVariants, setAvailableVariants] = useState<Variant[]>([]);
     const [allVulnAssessments, setAllVulnAssessments] = useState<Assessment[]>([]);
-    const [isSubmittingAssessment, setIsSubmittingAssessment] = useState(false);
+    const [submittingMessage, setSubmittingMessage] = useState<string | null>(null);
+    const [editingGroup, setEditingGroup] = useState<AssessmentGroup | null>(null);
 
     // Fetch variants that have a finding for this specific vulnerability
     useEffect(() => {
@@ -178,12 +187,14 @@ const dt_options: Intl.DateTimeFormatOptions = {
         ? `Vulnerability ${currentIndex + 1} of ${vulnerabilities.length}`
         : null;
 
-    const handleEditAssessment = (assessmentId: string) => {
+    const handleEditAssessment = (assessmentId: string, group: AssessmentGroup) => {
         setEditingAssessmentId(assessmentId);
+        setEditingGroup(group);
     };
 
     const handleCancelEdit = () => {
         setEditingAssessmentId(null);
+        setEditingGroup(null);
     };
 
     const handleDeleteAssessment = (assessment: Assessment) => {
@@ -239,70 +250,158 @@ const dt_options: Intl.DateTimeFormatOptions = {
     };
 
     const saveEditedAssessment = async (data: EditAssessmentData) => {
-        try {
-            const response = await fetch(import.meta.env.VITE_API_URL + `/api/assessments/${encodeURIComponent(data.id)}`, {
-                method: 'PUT',
-                mode: 'cors',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({
-                    status: data.status,
-                    justification: data.justification,
-                    impact_statement: data.impact_statement,
-                    status_notes: data.status_notes,
-                    workaround: data.workaround
-                })
-            });
+        if (!editingGroup) return;
+        setSubmittingMessage('Editing assessment...');
 
-            if (response.ok) {
-                const responseData = await response.json();
-                if (responseData?.status === 'success' && responseData?.assessment) {
-                    // Find and update the assessment in vuln.assessments array
-                    const assessmentIndex = vuln.assessments.findIndex(
-                        assessment => assessment.id === data.id
-                    );
+        // Build target (package × variantId) combos from form selection
+        const targetVariantIds: Array<string | undefined> =
+            data.variant_ids && data.variant_ids.length > 0
+                ? data.variant_ids
+                : [undefined];
+        const targetPackages: string[] =
+            data.packages && data.packages.length > 0
+                ? data.packages
+                : editingGroup.packages;
 
-                    if (assessmentIndex !== -1) {
-                        // Update the assessment object with the response data
-                        let updatedAssessment = asAssessment(responseData.assessment);
-                        if (!Array.isArray(updatedAssessment) && typeof updatedAssessment === "object") {
-                            // Convert empty strings to undefined for non-relevant statuses
-                            const isRelevantStatus = updatedAssessment.status === "not_affected" || updatedAssessment.status === "false_positive";
-                            if (!isRelevantStatus) {
-                                updatedAssessment.justification = undefined;
-                                updatedAssessment.impact_statement = undefined;
-                            }
-
-                            // Replace the assessment in the array
-                            vuln.assessments[assessmentIndex] = updatedAssessment;
-
-                            // Update vulnerability status to match the edited assessment
-                            vuln.status = updatedAssessment.status;
-                            vuln.simplified_status = updatedAssessment.simplified_status;
-
-                            // Update the vuln object in the parent component
-                            patchVuln(vuln.id, vuln);
-
-                            showMessage("Assessment updated successfully!", "success");
-                        } else {
-                            showMessage("Error: Invalid assessment data received", "error");
-                        }
-                    } else {
-                        showMessage("Error: Assessment not found in local data", "error");
-                    }
-                } else {
-                    showMessage("Error: Invalid response from server", "error");
-                }
-            } else {
-                const errorData = await response.text();
-                showMessage(`Failed to update assessment: HTTP code ${response.status} | ${escape(errorData)}`, "error");
-            }
-        } catch (error) {
-            showMessage(`Failed to update assessment: ${escape(String(error))}`, "error");
+        // Index existing group assessments by (pkg, vid) key
+        const existingByKey = new Map<string, Assessment>();
+        for (const a of editingGroup.assessments) {
+            const pkg = a.packages[0] ?? '';
+            const vid = a.variant_id ?? '';
+            existingByKey.set(`${pkg}::${vid}`, a);
         }
 
+        // Build the desired target key set
+        const targetKeys = new Set<string>();
+        for (const pkg of targetPackages) {
+            for (const vid of targetVariantIds) {
+                targetKeys.add(`${pkg}::${vid ?? ''}`);
+            }
+        }
+
+        let anyError = false;
+
+        // Helper — normalise an Assessment from the API response
+        const normalise = (raw: unknown): Assessment | null => {
+            const a = asAssessment(raw);
+            if (Array.isArray(a) || typeof a !== 'object') return null;
+            const isRelevant = a.status === 'not_affected' || a.status === 'false_positive';
+            if (!isRelevant) {
+                a.justification = undefined;
+                a.impact_statement = undefined;
+            }
+            return a;
+        };
+
+        // 1. PUT-update persisting combos / DELETE removed combos
+        for (const [key, existing] of existingByKey) {
+            if (targetKeys.has(key)) {
+                try {
+                    const res = await fetch(import.meta.env.VITE_API_URL + `/api/assessments/${encodeURIComponent(existing.id)}`, {
+                        method: 'PUT', mode: 'cors',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            status: data.status,
+                            justification: data.justification,
+                            impact_statement: data.impact_statement,
+                            status_notes: data.status_notes,
+                            workaround: data.workaround
+                        })
+                    });
+                    if (res.ok) {
+                        const rd = await res.json();
+                        const updated = rd?.status === 'success' ? normalise(rd.assessment) : null;
+                        if (updated) {
+                            const idx = vuln.assessments.findIndex(a => a.id === existing.id);
+                            if (idx !== -1) vuln.assessments[idx] = updated;
+                            setAllVulnAssessments(prev => prev.map(a => a.id === updated.id ? updated : a));
+                        }
+                    } else {
+                        anyError = true;
+                        showMessage(`Failed to update assessment: HTTP ${res.status}`, 'error');
+                    }
+                } catch (e) {
+                    anyError = true;
+                    showMessage(`Failed to update assessment: ${escape(String(e))}`, 'error');
+                }
+            } else {
+                // Deselected — delete this record
+                try {
+                    const res = await fetch(import.meta.env.VITE_API_URL + `/api/assessments/${encodeURIComponent(existing.id)}`, {
+                        method: 'DELETE', mode: 'cors'
+                    });
+                    if (res.ok) {
+                        vuln.assessments = vuln.assessments.filter(a => a.id !== existing.id);
+                        setAllVulnAssessments(prev => prev.filter(a => a.id !== existing.id));
+                    } else {
+                        anyError = true;
+                        showMessage(`Failed to delete assessment: HTTP ${res.status}`, 'error');
+                    }
+                } catch (e) {
+                    anyError = true;
+                    showMessage(`Failed to delete assessment: ${escape(String(e))}`, 'error');
+                }
+            }
+        }
+
+        // 2. POST-create newly-added combos
+        for (const pkg of targetPackages) {
+            for (const vid of targetVariantIds) {
+                const key = `${pkg}::${vid ?? ''}`;
+                if (!existingByKey.has(key)) {
+                    try {
+                        const body: Record<string, unknown> = {
+                            vuln_id: vuln.id,
+                            packages: [pkg],
+                            status: data.status,
+                            justification: data.justification,
+                            impact_statement: data.impact_statement,
+                            status_notes: data.status_notes,
+                            workaround: data.workaround
+                        };
+                        if (vid) body.variant_id = vid;
+                        const res = await fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/assessments`, {
+                            method: 'POST', mode: 'cors',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(body)
+                        });
+                        const rd = await res.json();
+                        if (rd?.status === 'success') {
+                            const rawList: unknown[] = Array.isArray(rd.assessments) ? rd.assessments : (rd.assessment ? [rd.assessment] : []);
+                            for (const raw of rawList) {
+                                const casted = normalise(raw);
+                                if (casted) {
+                                    vuln.assessments.push(casted);
+                                    setAllVulnAssessments(prev => [...prev, casted]);
+                                }
+                            }
+                        } else {
+                            anyError = true;
+                            showMessage(`Failed to create assessment: HTTP ${res.status}`, 'error');
+                        }
+                    } catch (e) {
+                        anyError = true;
+                        showMessage(`Failed to create assessment: ${escape(String(e))}`, 'error');
+                    }
+                }
+            }
+        }
+
+        if (!anyError) {
+            const latest = vuln.assessments.slice().sort(
+                (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+            )[0];
+            if (latest) {
+                vuln.status = latest.status;
+                vuln.simplified_status = latest.simplified_status;
+            }
+            patchVuln(vuln.id, vuln);
+            showMessage('Assessment updated successfully!', 'success');
+        }
+
+        setSubmittingMessage(null);
         setEditingAssessmentId(null);
+        setEditingGroup(null);
     };
 
     // Handle keyboard navigation (ESC to close, arrow keys to navigate)
@@ -397,7 +496,7 @@ const dt_options: Intl.DateTimeFormatOptions = {
         let successCount = 0;
         let lastCasted: Assessment | null = null;
 
-        setIsSubmittingAssessment(true);
+        setSubmittingMessage('Adding assessment...');
         try {
         for (const vid of variantIds) {
             const body = vid ? { ...baseContent, variant_id: vid } : baseContent;
@@ -454,7 +553,7 @@ const dt_options: Intl.DateTimeFormatOptions = {
             setTimeout(() => setClearAssessmentFields(false), 100);
         }
         } finally {
-            setIsSubmittingAssessment(false);
+            setSubmittingMessage(null);
         }
     };
 
@@ -542,11 +641,11 @@ const dt_options: Intl.DateTimeFormatOptions = {
             tabIndex={-1}
             className="overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-full max-h-full bg-gray-900/90"
         >
-            {isSubmittingAssessment && (
+            {submittingMessage && (
                 <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
                     <div className="flex flex-col items-center gap-3 text-white">
                         <div className="w-10 h-10 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
-                        <span className="text-sm font-semibold">Adding assessment...</span>
+                        <span className="text-sm font-semibold">{submittingMessage}</span>
                     </div>
                 </div>
             )}
@@ -835,7 +934,7 @@ const dt_options: Intl.DateTimeFormatOptions = {
                                                         {isEditing && (
                                                             <div className="flex items-center ml-3 gap-2">
                                                                 <button
-                                                                    onClick={() => handleEditAssessment(firstAssess.id)}
+                                                                    onClick={() => handleEditAssessment(firstAssess.id, group)}
                                                                     className="text-blue-400 hover:text-blue-300 transition-colors"
                                                                     title="Edit assessment"
                                                                 >
@@ -868,6 +967,14 @@ const dt_options: Intl.DateTimeFormatOptions = {
                                                         onSaveAssessment={saveEditedAssessment}
                                                         onCancel={handleCancelEdit}
                                                         triggerBanner={showMessage}
+                                                        availableVariants={availableVariants}
+                                                        defaultSelectedVariantIds={[...new Set(
+                                                            group.assessments
+                                                                .map(a => a.variant_id)
+                                                                .filter((v): v is string => !!v)
+                                                        )]}
+                                                        availablePackages={vuln.packages}
+                                                        defaultSelectedPackages={group.packages}
                                                     />
                                                 </div>
                                             )}

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -310,11 +310,19 @@ type AssessmentGroup = {
                     });
                     if (res.ok) {
                         const rd = await res.json();
-                        const updated = rd?.status === 'success' ? normalise(rd.assessment) : null;
-                        if (updated) {
-                            const idx = vuln.assessments.findIndex(a => a.id === existing.id);
-                            if (idx !== -1) vuln.assessments[idx] = updated;
-                            setAllVulnAssessments(prev => prev.map(a => a.id === updated.id ? updated : a));
+                        if (rd?.status !== 'success') {
+                            anyError = true;
+                            showMessage('Error: invalid response from server', 'error');
+                        } else {
+                            const updated = normalise(rd.assessment);
+                            if (updated) {
+                                const idx = vuln.assessments.findIndex(a => a.id === existing.id);
+                                if (idx !== -1) vuln.assessments[idx] = updated;
+                                setAllVulnAssessments(prev => prev.map(a => a.id === updated.id ? updated : a));
+                            } else {
+                                anyError = true;
+                                showMessage('Error: invalid assessment data received', 'error');
+                            }
                         }
                     } else {
                         anyError = true;
@@ -491,7 +499,7 @@ type AssessmentGroup = {
                 ? content.variant_ids
                 : [undefined];
 
-        const { variant_ids: _vids, ...baseContent } = content;
+        const { variant_ids: _, ...baseContent } = content;
 
         let successCount = 0;
         let lastCasted: Assessment | null = null;

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -57,6 +57,7 @@ const dt_options: Intl.DateTimeFormatOptions = {
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [availableVariants, setAvailableVariants] = useState<Variant[]>([]);
     const [allVulnAssessments, setAllVulnAssessments] = useState<Assessment[]>([]);
+    const [isSubmittingAssessment, setIsSubmittingAssessment] = useState(false);
 
     // Fetch variants that have a finding for this specific vulnerability
     useEffect(() => {
@@ -380,7 +381,10 @@ const dt_options: Intl.DateTimeFormatOptions = {
 
     const addAssessment = async (content: PostAssessment) => {
         content.vuln_id = vuln.id;
-        content.packages = vuln.packages;
+        // packages come from StatusEditor selection; fall back to all vuln packages
+        if (!content.packages || content.packages.length === 0) {
+            content.packages = vuln.packages;
+        }
 
         // Determine which variants to post to. If none selected, post once without a variant_id.
         const variantIds: Array<string | undefined> =
@@ -393,6 +397,8 @@ const dt_options: Intl.DateTimeFormatOptions = {
         let successCount = 0;
         let lastCasted: Assessment | null = null;
 
+        setIsSubmittingAssessment(true);
+        try {
         for (const vid of variantIds) {
             const body = vid ? { ...baseContent, variant_id: vid } : baseContent;
             const response = await fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/assessments`, {
@@ -403,27 +409,35 @@ const dt_options: Intl.DateTimeFormatOptions = {
             });
             const data = await response.json();
             if (data?.status === 'success') {
-                const casted = asAssessment(data?.assessment);
-                if (!Array.isArray(casted) && typeof casted === 'object') {
-                    successCount++;
-                    lastCasted = casted;
+                // Backend returns an array (one record per package); support legacy single too
+                const rawList: unknown[] = Array.isArray(data?.assessments)
+                    ? data.assessments
+                    : (data?.assessment ? [data.assessment] : []);
+                for (const raw of rawList) {
+                    const casted = asAssessment(raw);
+                    if (!Array.isArray(casted) && typeof casted === 'object') {
+                        successCount++;
+                        lastCasted = casted;
 
-                    // Highlight the first result
-                    if (successCount === 1) {
-                        setNewAssessmentIds(prev => new Set(prev).add(casted.id));
-                        setTimeout(() => {
-                            setNewAssessmentIds(prev => {
-                                const newSet = new Set(prev);
-                                newSet.delete(casted.id);
-                                return newSet;
-                            });
-                        }, 5500);
+                        // Highlight the very first created assessment
+                        if (successCount === 1) {
+                            setNewAssessmentIds(prev => new Set(prev).add(casted.id));
+                            setTimeout(() => {
+                                setNewAssessmentIds(prev => {
+                                    const newSet = new Set(prev);
+                                    newSet.delete(casted.id);
+                                    return newSet;
+                                });
+                            }, 5500);
+                        }
+
+                        appendAssessment(casted);
+                        vuln.assessments.push(casted);
+                        // Keep allVulnAssessments in sync so variant tags appear immediately
+                        setAllVulnAssessments(prev => [...prev, casted]);
+                        vuln.status = casted.status;
+                        vuln.simplified_status = casted.simplified_status;
                     }
-
-                    appendAssessment(casted);
-                    vuln.assessments.push(casted);
-                    vuln.status = casted.status;
-                    vuln.simplified_status = casted.simplified_status;
                 }
             } else {
                 showMessage(`Failed to add assessment: HTTP code ${Number(response?.status)} | ${escape(JSON.stringify(data))}`, 'error');
@@ -438,6 +452,9 @@ const dt_options: Intl.DateTimeFormatOptions = {
             showMessage(msg, 'success');
             setClearAssessmentFields(true);
             setTimeout(() => setClearAssessmentFields(false), 100);
+        }
+        } finally {
+            setIsSubmittingAssessment(false);
         }
     };
 
@@ -525,6 +542,14 @@ const dt_options: Intl.DateTimeFormatOptions = {
             tabIndex={-1}
             className="overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-full max-h-full bg-gray-900/90"
         >
+            {isSubmittingAssessment && (
+                <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
+                    <div className="flex flex-col items-center gap-3 text-white">
+                        <div className="w-10 h-10 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
+                        <span className="text-sm font-semibold">Adding assessment...</span>
+                    </div>
+                </div>
+            )}
             <div className="relative p-16 h-full">
                 <div
                     ref={modalRef}
@@ -753,6 +778,7 @@ const dt_options: Intl.DateTimeFormatOptions = {
                                             triggerBanner={showMessage}
                                             defaultStatus={defaultStatus}
                                             variants={availableVariants}
+                                            availablePackages={vuln.packages}
                                         />
                                     </li>
                                 )}

--- a/frontend/src/handlers/assessments.ts
+++ b/frontend/src/handlers/assessments.ts
@@ -14,6 +14,7 @@ type Assessment = {
     id: string;
     vuln_id: string;
     packages: string[];
+    variant_id?: string;
     status: string;
     simplified_status: string;
     status_notes?: string;
@@ -43,6 +44,7 @@ const asAssessment = (data: any): Assessment | [] => {
         id: data.id,
         vuln_id: data.vuln_id,
         packages: asStringArray(data?.packages),
+        variant_id: undefined,
         status: data.status,
         simplified_status: `[invalid status] ${data.status}`,
         status_notes: undefined,
@@ -56,6 +58,7 @@ const asAssessment = (data: any): Assessment | [] => {
     };
     if (typeof STATUS_VEX_TO_GRAPH?.[data.status] === "string")
         item.simplified_status = STATUS_VEX_TO_GRAPH[data.status];
+    if (typeof data?.variant_id === "string") item.variant_id = data.variant_id;
     if (typeof data?.status_notes === "string") item.status_notes = data.status_notes;
     if (typeof data?.justification === "string") item.justification = data.justification;
     if (typeof data?.impact_statement === "string") item.impact_statement = data.impact_statement;
@@ -79,7 +82,7 @@ const removeDuplicateAssessments = (assessments: Assessment[]): Assessment[] => 
             assessment.workaround || ''
         ].join('|');
 
-        const duplicateKey = `${assessment.vuln_id}::${packagesKey}::${assessment.status}::${descriptionsKey}`;
+        const duplicateKey = `${assessment.vuln_id}::${packagesKey}::${assessment.status}::${descriptionsKey}::${assessment.variant_id ?? ''}`;
 
         if (!seen.has(duplicateKey)) {
             seen.add(duplicateKey);

--- a/frontend/src/handlers/variant.ts
+++ b/frontend/src/handlers/variant.ts
@@ -22,6 +22,38 @@ class Variants {
                 typeof v?.project_id === "string"
         ) as Variant[];
     }
+
+    static async listAll(): Promise<Variant[]> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/variants`,
+            { mode: "cors" }
+        );
+        if (!response.ok) return [];
+        const data = await response.json();
+        if (!Array.isArray(data)) return [];
+        return data.filter(
+            (v: any) =>
+                typeof v?.id === "string" &&
+                typeof v?.name === "string" &&
+                typeof v?.project_id === "string"
+        ) as Variant[];
+    }
+
+    static async listByVuln(vulnId: string): Promise<Variant[]> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vulnId)}/variants`,
+            { mode: "cors" }
+        );
+        if (!response.ok) return [];
+        const data = await response.json();
+        if (!Array.isArray(data)) return [];
+        return data.filter(
+            (v: any) =>
+                typeof v?.id === "string" &&
+                typeof v?.name === "string" &&
+                typeof v?.project_id === "string"
+        ) as Variant[];
+    }
 }
 
 export default Variants;

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -22,6 +22,7 @@ type Vulnerability = {
     found_by: string[];
     datasource: string;
     packages: string[];
+    variants: string[];
     urls: string[];
     published?: string;
     texts: {
@@ -94,6 +95,7 @@ const asVulnerability = (data: any): Vulnerability | [] => {
         found_by: asStringArray(data?.found_by),
         datasource: "unknown",
         packages: asStringArray(data?.packages),
+        variants: asStringArray(data?.variants),
         urls: asStringArray(data?.urls),
         texts: [],
         severity: {
@@ -264,14 +266,14 @@ class Vulnerabilities {
         } catch (e) {
             // Suppress expected invalid vector errors (e.g., from tests providing malformed CVSS strings)
             if (!(e instanceof Error && e.message === 'invalid vector')) {
-                 
+
                 console.error(e);
             }
             return null;
         }
     }
 
- 
+
 
 }
 

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -39,6 +39,8 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
     const [isLoadingData, setIsLoadingData] = useState<boolean>(true);
     const [defaultConfig, setDefaultConfig] = useState<AppConfig>({ project: null, variant: null });
     const [currentVariantId, setCurrentVariantId] = useState<string | undefined>(undefined);
+    const [currentBaseVariantId, setCurrentBaseVariantId] = useState<string | undefined>(undefined);
+    const [currentOperation, setCurrentOperation] = useState<string | undefined>(undefined);
 
     const triggerBanner = (message: string, type: 'error' | 'success') => {
         setBannerMessage(message);
@@ -71,7 +73,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         ])
         .then(([patchData, progress]) => {
             setNvdProgress(progress);
-            
+
             if (patchData.db_ready) {
                 setPatchDbReady(true);
                 loadPatchData(vulns_list);
@@ -124,6 +126,9 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
     const handleApply = useCallback((projectId: string, variantId: string, compareVariantId: string, operation: string) => {
         const effectiveVariantId = compareVariantId || variantId || undefined;
         setCurrentVariantId(effectiveVariantId);
+        // Track origin variant and operation separately for MultiEditBar intersection logic
+        setCurrentBaseVariantId(compareVariantId ? (variantId || undefined) : undefined);
+        setCurrentOperation(compareVariantId ? (operation || undefined) : undefined);
         loadData(
             variantId || undefined,
             variantId ? undefined : projectId || undefined,
@@ -250,6 +255,8 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     filterLabel={filterLabel}
                     filterValue={filterValue}
                     variantId={currentVariantId}
+                    baseVariantId={currentBaseVariantId}
+                    compareOperation={currentOperation}
                 />}
                 {tab == 'patch-finder' && <PatchFinder vulnerabilities={vulns} packages={pkgs} patchData={patchInfo} db_ready={patchDbReady} nvdProgress={nvdProgress} />}
                 {tab == 'exports' && <Exports />}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -26,6 +26,10 @@ type Props = {
     filterLabel?: "Source" | "Severity" | "Status" | "Package";
     filterValue?: string;
     variantId?: string;
+    /** Origin variant when compare mode is active */
+    baseVariantId?: string;
+    /** 'difference' or 'intersection' when compare mode is active */
+    compareOperation?: string;
 };
 
 const dt_options: Intl.DateTimeFormatOptions = {
@@ -69,7 +73,7 @@ const sortAttackVectorFn: SortingFn<Vulnerability> = (rowA, rowB) => {
 }
 
 const fuseKeys = [
-    'id', 
+    'id',
     'packages',
     'texts.content'
 ]
@@ -88,10 +92,10 @@ type PublishedDateFilterProps = {
     nvdProgress: NVDProgress | null;
 };
 
-function PublishedDateFilter({ 
+function PublishedDateFilter({
     filterType, dateValue, daysValue, dateFrom, dateTo,
-    setFilterType, setDateValue, setDaysValue, setDateFrom, setDateTo, 
-    nvdProgress 
+    setFilterType, setDateValue, setDaysValue, setDateFrom, setDateTo,
+    nvdProgress
 }: Readonly<PublishedDateFilterProps>) {
     const [isOpen, setIsOpen] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
@@ -263,7 +267,7 @@ function PublishedDateFilter({
 const SEVERITY_RANGE_MIN = 0;
 const SEVERITY_RANGE_MAX = 10;
 
-function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln, variantId }: Readonly<Props>) {
+function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln, variantId, baseVariantId, compareOperation }: Readonly<Props>) {
 
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);
     const [modalVulnIndex, setModalVulnIndex] = useState<number | undefined>(undefined);
@@ -694,12 +698,12 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             if (selectedStatuses.length && !selectedStatuses.includes(el.simplified_status)) return false;
             if (selectedSources.length && !selectedSources.some(src => el.found_by.includes(src))) return false;
             if (selectedPackages.length && !selectedPackages.some(pkg => el.packages.includes(pkg))) return false;
-            
+
             // Published date filter
             if (publishedDateFilterType && el.published) {
                 const publishedDate = new Date(el.published);
                 const today = new Date();
-                
+
                 switch (publishedDateFilterType) {
                     case 'is':
                         if (publishedDateValue) {
@@ -753,15 +757,15 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 // If filter is active but vulnerability has no published date, filter it out
                 return false;
             }
-            
+
             if(showCustomSeverityFilter){
                 // Use the max score as this is how the final severity level is determined
                 const maxScore = el.severity.max_score;
-            
+
                 if (maxScore === null) return false;
                 if (maxScore < severityRange.min || maxScore > severityRange.max) return false;
             }
-            
+
             return true;
         });
     }, [vulnerabilities, selectedSeverities, selectedStatuses, selectedSources, selectedPackages, publishedDateFilterType, publishedDateValue, publishedDaysValue, publishedDateFrom, publishedDateTo, showCustomSeverityFilter, severityRange]);
@@ -816,7 +820,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     useEffect(() => {
         const handleKeyPress = (event: KeyboardEvent) => {
             // Only trigger if not typing in an input/textarea
-            if (event.target instanceof HTMLInputElement || 
+            if (event.target instanceof HTMLInputElement ||
                 event.target instanceof HTMLTextAreaElement) {
                 return;
             }
@@ -1028,6 +1032,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             triggerBanner={triggerBanner}
             hideBanner={closeBanner}
             variantId={variantId}
+            baseVariantId={baseVariantId}
+            compareOperation={compareOperation}
         />
 
         <TableGeneric

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -429,6 +429,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         'severity.severity': 'Severity',
         'epss': 'EPSS Score',
         'packages': 'Packages Affected',
+        'variants': 'Variants',
         'severity': 'Attack Vector',
         'simplified_status': 'Status',
         'effort.likely': 'Estimated Effort',
@@ -631,6 +632,23 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 return dateA - dateB;
             },
             size: 90
+            }),
+            columnHelper.accessor('variants', {
+            id: 'variants',
+            header: () => <div className="flex items-center justify-center">Variants</div>,
+            cell: info => (
+                <div className="flex items-center justify-center h-full">
+                    <div className="flex flex-wrap gap-1 justify-center">
+                        {info.getValue().map((name: string) => (
+                            <span key={name} className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-900 text-green-300">
+                                {name}
+                            </span>
+                        ))}
+                    </div>
+                </div>
+            ),
+            enableSorting: false,
+            size: 120
             }),
             columnHelper.accessor('found_by', {
             id: 'found_by',
@@ -903,6 +921,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     'Severity',
                     'EPSS Score',
                     'Packages Affected',
+                    'Variants',
                     'Attack Vector',
                     'Status',
                     'Estimated Effort',

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -56,9 +56,9 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const cancelButton = screen.getByText('Cancel');
-        
+
         await user.click(cancelButton);
-        
+
         expect(mockOnCancel).toHaveBeenCalled();
     });
 
@@ -73,9 +73,9 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const saveButton = screen.getByText('Save Changes');
-        
+
         await user.click(saveButton);
-        
+
         expect(mockOnSave).toHaveBeenCalled();
     });
 
@@ -96,9 +96,9 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const saveButton = screen.getByText('Save Changes');
-        
+
         await user.click(saveButton);
-        
+
         // Internal banner should appear
         await waitFor(() => {
             expect(screen.getByText('You must provide a justification for this status')).toBeInTheDocument();
@@ -122,9 +122,9 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const saveButton = screen.getByText('Save Changes');
-        
+
         await user.click(saveButton);
-        
+
         // Internal banner should appear
         await waitFor(() => {
             expect(screen.getByText('You must provide a justification for this status')).toBeInTheDocument();
@@ -157,9 +157,9 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const saveButton = screen.getByText('Save Changes');
-        
+
         await user.click(saveButton);
-        
+
         expect(mockTriggerBanner).toHaveBeenCalledWith(
             'You must provide a justification for this status',
             'error'
@@ -245,14 +245,16 @@ describe('EditAssessment Component', () => {
         const user = userEvent.setup();
         const saveButton = screen.getByText('Save Changes');
         await user.click(saveButton);
-        
+
         expect(mockOnSave).toHaveBeenCalledWith({
             id: 'test-assessment-id',
             status: 'false_positive',
             justification: undefined,
             status_notes: 'test notes',
             workaround: 'test workaround',
-            impact_statement: undefined
+            impact_statement: '',
+            packages: [],
+            variant_ids: undefined
         });
     });
 
@@ -267,15 +269,15 @@ describe('EditAssessment Component', () => {
         );
 
         const user = userEvent.setup();
-        
+
         // Should initially have no changes
         expect(mockOnFieldsChange).toHaveBeenCalledWith(false);
-        
+
         // Modify a field
         const notesField = screen.getByPlaceholderText(/Free text notes/i);
         await user.clear(notesField);
         await user.type(notesField, 'new notes');
-        
+
         // Should detect changes
         expect(mockOnFieldsChange).toHaveBeenCalledWith(true);
     });
@@ -373,9 +375,9 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const statusSelect = screen.getByDisplayValue(/Affected \/ exploitable/i);
-        
+
         await user.selectOptions(statusSelect, 'not_affected');
-        
+
         // Justification dropdown should appear
         await waitFor(() => {
             expect(screen.getByDisplayValue(/No justification/i)).toBeInTheDocument();
@@ -393,9 +395,9 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const statusSelect = screen.getByDisplayValue(/Affected \/ exploitable/i);
-        
+
         await user.selectOptions(statusSelect, 'false_positive');
-        
+
         // Impact field should appear
         await waitFor(() => {
             expect(screen.getByPlaceholderText(/why this vulnerability is not exploitable/i)).toBeInTheDocument();
@@ -419,9 +421,9 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const justificationSelect = screen.getByDisplayValue(/Component not present/i);
-        
+
         await user.selectOptions(justificationSelect, 'code_not_reachable');
-        
+
         await waitFor(() => {
             expect(screen.getByDisplayValue(/The vulnerable code is not invoked at runtime/i)).toBeInTheDocument();
         });
@@ -444,16 +446,18 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const saveButton = screen.getByText('Save Changes');
-        
+
         await user.click(saveButton);
-        
+
         expect(mockOnSave).toHaveBeenCalledWith({
             id: 'test-assessment-id',
             status: 'not_affected',
             justification: 'component_not_present',
             status_notes: 'test notes',
             workaround: 'test workaround',
-            impact_statement: 'test impact'
+            impact_statement: 'test impact',
+            packages: [],
+            variant_ids: undefined
         });
     });
 
@@ -469,10 +473,10 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const notesField = screen.getByDisplayValue('test notes');
-        
+
         await user.clear(notesField);
         await user.type(notesField, 'updated notes');
-        
+
         expect(mockOnFieldsChange).toHaveBeenCalledWith(true);
     });
 
@@ -488,10 +492,10 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const workaroundField = screen.getByDisplayValue('test workaround');
-        
+
         await user.clear(workaroundField);
         await user.type(workaroundField, 'updated workaround');
-        
+
         expect(mockOnFieldsChange).toHaveBeenCalledWith(true);
     });
 
@@ -512,9 +516,9 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const saveButton = screen.getByText('Save Changes');
-        
+
         await user.click(saveButton);
-        
+
         expect(mockOnSave).not.toHaveBeenCalled();
     });
 
@@ -544,18 +548,18 @@ describe('EditAssessment Component', () => {
 
             const user = userEvent.setup();
             const justificationSelect = document.querySelector('select[name="edit_assessment_justification"]') as HTMLSelectElement;
-            
+
             await user.selectOptions(justificationSelect, justOption);
-            
+
             const saveButton = screen.getByText('Save Changes');
             await user.click(saveButton);
-            
+
             expect(mockOnSave).toHaveBeenCalledWith(
                 expect.objectContaining({
                     justification: justOption
                 })
             );
-            
+
             jest.clearAllMocks();
             unmount();
         }
@@ -580,10 +584,222 @@ describe('EditAssessment Component', () => {
 
         const user = userEvent.setup();
         const impactField = screen.getByDisplayValue('original impact');
-        
+
         await user.clear(impactField);
         await user.type(impactField, 'updated impact');
-        
+
         expect(mockOnFieldsChange).toHaveBeenCalledWith(true);
+    });
+
+    test('shows external triggerBanner when not_affected justification is none', async () => {
+        const notAffectedAssessment: Assessment = {
+            ...mockAssessment,
+            status: 'not_affected',
+            justification: 'none'
+        };
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={notAffectedAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                triggerBanner={mockTriggerBanner}
+            />
+        );
+
+        const saveButton = screen.getByText('Save Changes');
+        await user.click(saveButton);
+
+        expect(mockTriggerBanner).toHaveBeenCalledWith(
+            'You must provide a justification for this status',
+            'error'
+        );
+        expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    test('renders variant checkboxes when availableVariants is provided', () => {
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availableVariants={variants}
+            />
+        );
+
+        expect(screen.getByText('Apply to variants:')).toBeInTheDocument();
+        expect(screen.getByText('default')).toBeInTheDocument();
+        expect(screen.getByText('release')).toBeInTheDocument();
+    });
+
+    test('shows external error when no variant selected and variants are available', async () => {
+        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availableVariants={variants}
+                triggerBanner={mockTriggerBanner}
+            />
+        );
+
+        const saveButton = screen.getByText('Save Changes');
+        await user.click(saveButton);
+
+        expect(mockTriggerBanner).toHaveBeenCalledWith('You must select at least one variant', 'error');
+        expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    test('shows internal error when no variant selected', async () => {
+        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availableVariants={variants}
+            />
+        );
+
+        const saveButton = screen.getByText('Save Changes');
+        await user.click(saveButton);
+
+        expect(screen.getByText('You must select at least one variant')).toBeInTheDocument();
+        expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    test('includes selected variant_ids when variant checkbox is checked', async () => {
+        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availableVariants={variants}
+                defaultSelectedVariantIds={['v1']}
+            />
+        );
+
+        const saveButton = screen.getByText('Save Changes');
+        await user.click(saveButton);
+
+        expect(mockOnSave).toHaveBeenCalledWith(
+            expect.objectContaining({ variant_ids: ['v1'] })
+        );
+    });
+
+    test('toggles variant checkbox checked/unchecked', async () => {
+        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availableVariants={variants}
+                defaultSelectedVariantIds={['v1']}
+                triggerBanner={mockTriggerBanner}
+            />
+        );
+
+        const variantCheckbox = screen.getByRole('checkbox');
+        // Uncheck the variant
+        await user.click(variantCheckbox);
+
+        // Now save attempt should fail validation (no variant selected)
+        const saveButton = screen.getByText('Save Changes');
+        await user.click(saveButton);
+        expect(mockTriggerBanner).toHaveBeenCalledWith('You must select at least one variant', 'error');
+    });
+
+    test('renders package checkboxes when two or more packages available', () => {
+        const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availablePackages={packages}
+            />
+        );
+
+        expect(screen.getByText('Apply to packages:')).toBeInTheDocument();
+        expect(screen.getByText('pkg1@1.0.0')).toBeInTheDocument();
+        expect(screen.getByText('pkg2@2.0.0')).toBeInTheDocument();
+    });
+
+    test('shows external error when no package selected', async () => {
+        const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availablePackages={packages}
+                defaultSelectedPackages={[]}
+                triggerBanner={mockTriggerBanner}
+            />
+        );
+
+        const saveButton = screen.getByText('Save Changes');
+        await user.click(saveButton);
+
+        expect(mockTriggerBanner).toHaveBeenCalledWith('You must select at least one package', 'error');
+        expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    test('shows internal error when no package selected and no external triggerBanner', async () => {
+        const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availablePackages={packages}
+                defaultSelectedPackages={[]}
+            />
+        );
+
+        const saveButton = screen.getByText('Save Changes');
+        await user.click(saveButton);
+
+        expect(screen.getByText('You must select at least one package')).toBeInTheDocument();
+        expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    test('toggles package checkboxes and saves with selected packages', async () => {
+        const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availablePackages={packages}
+                defaultSelectedPackages={['pkg1@1.0.0', 'pkg2@2.0.0']}
+            />
+        );
+
+        // Uncheck pkg2 then re-check
+        const checkboxes = screen.getAllByRole('checkbox');
+        await user.click(checkboxes[1]); // uncheck pkg2
+        await user.click(checkboxes[1]); // re-check pkg2
+
+        const saveButton = screen.getByText('Save Changes');
+        await user.click(saveButton);
+
+        expect(mockOnSave).toHaveBeenCalledWith(
+            expect.objectContaining({ packages: expect.arrayContaining(['pkg1@1.0.0', 'pkg2@2.0.0']) })
+        );
     });
 });

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -35,6 +35,7 @@ describe('MultiEditBar', () => {
             },
             status: 'not_affected',
             simplified_status: 'not_affected',
+            variants: [],
             assessments: [],
             effort: {
                 optimistic: { formatAsIso8601: () => 'PT1H' } as any,
@@ -67,6 +68,7 @@ describe('MultiEditBar', () => {
             },
             status: 'affected',
             simplified_status: 'affected',
+            variants: [],
             assessments: [],
             effort: {
                 optimistic: { formatAsIso8601: () => 'PT1H' } as any,
@@ -191,6 +193,7 @@ describe('MultiEditBar', () => {
         const mockTriggerBanner = jest.fn();
         const mockAppendAssessment = jest.fn();
         const mockPatchVuln = jest.fn();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // Variants.listByVuln for vuln-1
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
             assessments: [{
@@ -447,5 +450,235 @@ describe('MultiEditBar', () => {
                 'error'
             );
         });
+    });
+
+    test('resolves and displays variant name when variantId prop is set and panel opens', async () => {
+        const mockTriggerBanner = jest.fn();
+        // Variants.listAll() call when panel opens
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'v-abc', name: 'machine-image', project_id: 'p1' }
+        ]));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            variantId: 'v-abc',
+            triggerBanner: mockTriggerBanner
+        };
+
+        const { getByText } = render(<MultiEditBar {...props} />);
+
+        await act(async () => { getByText('Change status').click(); });
+
+        await waitFor(() => {
+            expect(getByText('machine-image')).toBeInTheDocument();
+        });
+    });
+
+    test('uses variantId as name when listAll returns no match', async () => {
+        const mockTriggerBanner = jest.fn();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // no match for variantId
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            variantId: 'v-unknown',
+            triggerBanner: mockTriggerBanner
+        };
+
+        const { getByText } = render(<MultiEditBar {...props} />);
+
+        await act(async () => { getByText('Change status').click(); });
+
+        await waitFor(() => {
+            expect(getByText('v-unknown')).toBeInTheDocument();
+        });
+    });
+
+    test('intersection mode includes base variant name in panel', async () => {
+        const mockTriggerBanner = jest.fn();
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'v-cmp', name: 'compare-variant', project_id: 'p1' },
+            { id: 'v-base', name: 'base-variant', project_id: 'p1' },
+        ]));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            variantId: 'v-cmp',
+            baseVariantId: 'v-base',
+            compareOperation: 'intersection',
+            triggerBanner: mockTriggerBanner
+        };
+
+        const { getByText } = render(<MultiEditBar {...props} />);
+
+        await act(async () => { getByText('Change status').click(); });
+
+        await waitFor(() => {
+            expect(getByText('compare-variant')).toBeInTheDocument();
+            expect(getByText('base-variant')).toBeInTheDocument();
+        });
+    });
+
+    test('addAssessment with variantId sends correct batch without listByVuln call', async () => {
+        const mockTriggerBanner = jest.fn();
+        const mockAppendAssessment = jest.fn();
+        const mockPatchVuln = jest.fn();
+        // Only 1 fetch: the batch POST (no listByVuln)
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'v-abc', name: 'machine-image', project_id: 'p1' }
+        ])); // Variants.listAll for panel display
+        fetchMock.mockResponseOnce(JSON.stringify({
+            status: 'success',
+            assessments: [{
+                id: 'assess-2',
+                vuln_id: 'vuln-1',
+                packages: ['pkg1'],
+                status: 'affected',
+                simplified_status: 'affected',
+                timestamp: '2024-01-01T00:00:00Z',
+                responses: []
+            }],
+            count: 1
+        }));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            variantId: 'v-abc',
+            triggerBanner: mockTriggerBanner,
+            appendAssessment: mockAppendAssessment,
+            patchVuln: mockPatchVuln
+        };
+
+        const { getByText } = render(<MultiEditBar {...props} />);
+
+        await act(async () => { getByText('Change status').click(); });
+        await waitFor(() => expect(getByText('machine-image')).toBeInTheDocument());
+
+        const select = document.querySelector('[name="new_assessment_status"]') as HTMLSelectElement;
+        fireEvent.change(select, { target: { value: 'affected' } });
+
+        await act(async () => { getByText('Add assessment').click(); });
+
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith(
+                expect.stringContaining('Successfully added assessments'),
+                'success'
+            );
+        });
+    });
+
+    test('addAssessment fans out per variant when listByVuln returns results', async () => {
+        const mockTriggerBanner = jest.fn();
+        const mockAppendAssessment = jest.fn();
+        const mockPatchVuln = jest.fn();
+        // listByVuln returns one variant → should create 1 triple with variant_id
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'v1', name: 'default', project_id: 'p1' }
+        ])); // Variants.listByVuln for vuln-1
+        fetchMock.mockResponseOnce(JSON.stringify({
+            status: 'success',
+            assessments: [{
+                id: 'assess-3',
+                vuln_id: 'vuln-1',
+                packages: ['pkg1'],
+                status: 'affected',
+                simplified_status: 'affected',
+                timestamp: '2024-01-01T00:00:00Z',
+                responses: []
+            }],
+            count: 1
+        }));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            triggerBanner: mockTriggerBanner,
+            appendAssessment: mockAppendAssessment,
+            patchVuln: mockPatchVuln
+        };
+
+        const { getByText } = render(<MultiEditBar {...props} />);
+
+        await act(async () => { getByText('Change status').click(); });
+
+        const select = document.querySelector('[name="new_assessment_status"]') as HTMLSelectElement;
+        fireEvent.change(select, { target: { value: 'affected' } });
+
+        await act(async () => { getByText('Add assessment').click(); });
+
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith(
+                expect.stringContaining('Successfully added assessments'),
+                'success'
+            );
+        });
+        // The batch request body should include variant_id
+        const batchCall = fetchMock.mock.calls.find((c: any[]) =>
+            typeof c[0] === 'string' && c[0].includes('/api/assessments/batch')
+        ) as any[];
+        expect(batchCall).toBeDefined();
+        const body = JSON.parse(batchCall[1].body);
+        expect(body.assessments[0].variant_id).toBe('v1');
+    });
+
+    test('addAssessment intersection mode creates triples for both variants', async () => {
+        const mockTriggerBanner = jest.fn();
+        // Variants.listAll for panel + batch POST
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'v-cmp', name: 'compare', project_id: 'p1' },
+            { id: 'v-base', name: 'base', project_id: 'p1' },
+        ]));
+        fetchMock.mockResponseOnce(JSON.stringify({
+            status: 'success',
+            assessments: [{
+                id: 'assess-4',
+                vuln_id: 'vuln-1',
+                packages: ['pkg1'],
+                status: 'affected',
+                simplified_status: 'affected',
+                timestamp: '2024-01-01T00:00:00Z',
+                responses: []
+            }],
+            count: 2
+        }));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            variantId: 'v-cmp',
+            baseVariantId: 'v-base',
+            compareOperation: 'intersection',
+            triggerBanner: mockTriggerBanner
+        };
+
+        const { getByText } = render(<MultiEditBar {...props} />);
+
+        await act(async () => { getByText('Change status').click(); });
+        await waitFor(() => expect(getByText('compare')).toBeInTheDocument());
+
+        const select = document.querySelector('[name="new_assessment_status"]') as HTMLSelectElement;
+        fireEvent.change(select, { target: { value: 'affected' } });
+
+        await act(async () => { getByText('Add assessment').click(); });
+
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith(
+                expect.stringContaining('Successfully added assessments'),
+                'success'
+            );
+        });
+        // Should have created 2 triples (one per variant)
+        const batchCall = fetchMock.mock.calls.find((c: any[]) =>
+            typeof c[0] === 'string' && c[0].includes('/api/assessments/batch')
+        ) as any[];
+        expect(batchCall).toBeDefined();
+        const body = JSON.parse(batchCall[1].body);
+        expect(body.assessments).toHaveLength(2);
+        const variantIds = body.assessments.map((a: any) => a.variant_id);
+        expect(variantIds).toContain('v-cmp');
+        expect(variantIds).toContain('v-base');
     });
 });

--- a/frontend/tests/unit_tests/test_patch_finder.tsx
+++ b/frontend/tests/unit_tests/test_patch_finder.tsx
@@ -200,7 +200,7 @@ describe('compute_versions_and_patch', () => {
         });
         const current = { "test-pkg": "1.0.0" };
         const result = PatchFinderLogic.compute_versions_and_patch(data, current, [], '');
-        
+
         expect(result['test-pkg'].same_minor.solve).toBe(1); // 1.0.5 is same minor
         expect(result['test-pkg'].same_minor.version).toBe('1.0.5');
         expect(result['test-pkg'].same_major.solve).toBe(2); // 1.0.5 and 1.5.0 are same major
@@ -232,7 +232,7 @@ describe('compute_vulns_per_versions', () => {
         };
         const current = { "test-pkg": "1.0.0" };
         const result = PatchFinderLogic.compute_vulns_per_versions(data, current, ['nvd'], '');
-        
+
         expect(result['test-pkg']['1.2.3']).toHaveLength(1);
         expect(result['test-pkg']['1.2.3']).toContain('CVE-2021-1234');
         expect(result['test-pkg']['1.2.3']).not.toContain('CVE-2021-5678');
@@ -259,7 +259,7 @@ describe('compute_vulns_per_versions', () => {
         };
         const current = { "test-pkg": "1.0.0" };
         const result = PatchFinderLogic.compute_vulns_per_versions(data, current, [], '2.0.0');
-        
+
         expect(result['test-pkg']['2.0.0']).toBeDefined();
         expect(result['test-pkg']['1.2.3']).toBeUndefined();
     });
@@ -285,7 +285,7 @@ describe('compute_vulns_per_versions', () => {
         };
         const current = { "test-pkg": "1.0.0" };
         const result = PatchFinderLogic.compute_vulns_per_versions(data, current, [], 'CVE-2021-5678');
-        
+
         expect(result['test-pkg']['1.2.3']).toHaveLength(1);
         expect(result['test-pkg']['1.2.3']).toContain('CVE-2021-5678');
         expect(result['test-pkg']['1.2.3']).not.toContain('CVE-2021-1234');
@@ -325,6 +325,7 @@ describe('Render patch found', () => {
             },
             status: "",
             simplified_status: "",
+            variants: [],
             assessments: []
         }
     ];

--- a/frontend/tests/unit_tests/test_project_variant_handlers.ts
+++ b/frontend/tests/unit_tests/test_project_variant_handlers.ts
@@ -231,6 +231,93 @@ describe('Variants', () => {
         expect(variants).toHaveLength(1);
         expect(variants[0].id).toBe('v1');
     });
+
+    test('Variants.listAll returns all variants', async () => {
+        const mockData = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p2' },
+        ];
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve(mockData),
+            } as Response)
+        );
+
+        const variants = await Variants.listAll();
+
+        expect(variants).toHaveLength(2);
+        expect(variants[0]).toEqual({ id: 'v1', name: 'default', project_id: 'p1' });
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/variants'),
+            expect.objectContaining({ mode: 'cors' })
+        );
+    });
+
+    test('Variants.listAll returns empty array when response is not ok', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ ok: false, json: () => Promise.resolve([]) } as Response)
+        );
+        expect(await Variants.listAll()).toEqual([]);
+    });
+
+    test('Variants.listAll returns empty array when server returns non-array', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ ok: true, json: () => Promise.resolve({ error: 'not found' }) } as Response)
+        );
+        expect(await Variants.listAll()).toEqual([]);
+    });
+
+    test('Variants.listAll filters out items missing required fields', async () => {
+        const mockData = [
+            { id: 'v1', name: 'valid', project_id: 'p1' },
+            { name: 'no-id', project_id: 'p1' },
+        ];
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ ok: true, json: () => Promise.resolve(mockData) } as Response)
+        );
+        const result = await Variants.listAll();
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('v1');
+    });
+
+    test('Variants.listByVuln returns variants for a vulnerability', async () => {
+        const mockData = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ ok: true, json: () => Promise.resolve(mockData) } as Response)
+        );
+        const variants = await Variants.listByVuln('CVE-2023-1234');
+        expect(variants).toHaveLength(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/vulnerabilities/CVE-2023-1234/variants'),
+            expect.anything()
+        );
+    });
+
+    test('Variants.listByVuln returns empty array when response is not ok', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ ok: false, json: () => Promise.resolve([]) } as Response)
+        );
+        expect(await Variants.listByVuln('CVE-2023-1234')).toEqual([]);
+    });
+
+    test('Variants.listByVuln encodes vuln id in URL', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
+        );
+        await Variants.listByVuln('CVE 2023 1234');
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('CVE%202023%201234'),
+            expect.anything()
+        );
+    });
+
+    test('Variants.listByVuln returns empty array when server returns non-array', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ ok: true, json: () => Promise.resolve(null) } as Response)
+        );
+        expect(await Variants.listByVuln('CVE-2023-1234')).toEqual([]);
+    });
 });
 
 

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -38,7 +38,7 @@ describe('StatusEditor', () => {
 
     test('should render progress bar when progressBar prop is provided', () => {
         render(<StatusEditor {...defaultProps} progressBar={0.5} />);
-        
+
         const progressBar = screen.getByRole('progressbar');
         expect(progressBar).toBeInTheDocument();
         expect(progressBar).toHaveAttribute('value', '0.5');
@@ -47,7 +47,7 @@ describe('StatusEditor', () => {
     test('should show error when not_affected status has no justification and external triggerBanner is provided', async () => {
         const triggerBanner = jest.fn();
         const user = userEvent.setup();
-        
+
         render(<StatusEditor {...defaultProps} triggerBanner={triggerBanner} />);
 
         // Set status to not_affected with justification = none
@@ -66,7 +66,7 @@ describe('StatusEditor', () => {
 
     test('should show internal banner when not_affected status has no justification and no external triggerBanner', async () => {
         const user = userEvent.setup();
-        
+
         render(<StatusEditor {...defaultProps} />);
 
         // Set status to not_affected with justification = none
@@ -85,7 +85,7 @@ describe('StatusEditor', () => {
 
     test('should close internal banner when close button is clicked', async () => {
         const user = userEvent.setup();
-        
+
         render(<StatusEditor {...defaultProps} />);
 
         // Trigger error to show banner
@@ -127,7 +127,7 @@ describe('StatusEditor', () => {
         // Set status to not_affected first to show justification dropdown
         const statusSelect = screen.getByRole('combobox');
         await user.selectOptions(statusSelect, 'not_affected');
-        
+
         // Set justification to empty
         const justificationSelect = screen.getAllByRole('combobox')[1]; // Second combobox
         fireEvent.change(justificationSelect, { target: { value: '' } });
@@ -141,7 +141,7 @@ describe('StatusEditor', () => {
     test('should call onFieldsChange when fields change from defaults', async () => {
         const onFieldsChange = jest.fn();
         const user = userEvent.setup();
-        
+
         render(<StatusEditor {...defaultProps} onFieldsChange={onFieldsChange} />);
 
         // Initially should be called with false (no changes)
@@ -184,7 +184,7 @@ describe('StatusEditor', () => {
 
     test('should successfully add assessment with valid not_affected status and justification', async () => {
         const user = userEvent.setup();
-        
+
         render(<StatusEditor {...defaultProps} />);
 
         // Set status to not_affected with valid justification
@@ -212,13 +212,15 @@ describe('StatusEditor', () => {
             justification: 'component_not_present',
             status_notes: 'Reviewed and confirmed',
             workaround: 'No workaround needed',
-            impact_statement: 'Component not in use'
+            impact_statement: 'Component not in use',
+            packages: [],
+            variant_ids: undefined
         });
     });
 
     test('should add assessment for non-not_affected status without justification or impact', async () => {
         const user = userEvent.setup();
-        
+
         render(<StatusEditor {...defaultProps} />);
 
         // Set status to affected
@@ -236,7 +238,9 @@ describe('StatusEditor', () => {
             justification: undefined,
             status_notes: 'Confirmed vulnerability',
             workaround: '',
-            impact_statement: undefined
+            impact_statement: undefined,
+            packages: [],
+            variant_ids: undefined
         });
     });
 
@@ -245,9 +249,178 @@ describe('StatusEditor', () => {
         render(<StatusEditor {...defaultProps} />);
 
         const statusSelect = screen.getByRole('combobox');
-        
+
         // Test false_positive
         await user.selectOptions(statusSelect, 'false_positive');
         expect(screen.getByPlaceholderText('why this vulnerability is not exploitable ?')).toBeInTheDocument();
+    });
+
+    test('should show error when false_positive has no impact and external triggerBanner', async () => {
+        const triggerBanner = jest.fn();
+        const user = userEvent.setup();
+        render(<StatusEditor {...defaultProps} triggerBanner={triggerBanner} />);
+
+        const statusSelect = screen.getByRole('combobox');
+        await user.selectOptions(statusSelect, 'false_positive');
+
+        const addButton = screen.getByRole('button', { name: 'Add assessment' });
+        await user.click(addButton);
+
+        expect(triggerBanner).toHaveBeenCalledWith(
+            'You must provide an impact statement for false positive status',
+            'error'
+        );
+        expect(defaultProps.onAddAssessment).not.toHaveBeenCalled();
+    });
+
+    test('should show internal banner when false_positive has no impact', async () => {
+        const user = userEvent.setup();
+        render(<StatusEditor {...defaultProps} />);
+
+        const statusSelect = screen.getByRole('combobox');
+        await user.selectOptions(statusSelect, 'false_positive');
+
+        const addButton = screen.getByRole('button', { name: 'Add assessment' });
+        await user.click(addButton);
+
+        expect(screen.getByTestId('message-banner')).toBeInTheDocument();
+        expect(screen.getByText('You must provide an impact statement for false positive status')).toBeInTheDocument();
+        expect(defaultProps.onAddAssessment).not.toHaveBeenCalled();
+    });
+
+    test('should render variant checkboxes when variants prop is provided', () => {
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
+        render(<StatusEditor {...defaultProps} variants={variants} />);
+
+        expect(screen.getByText('Apply to variants:')).toBeInTheDocument();
+        expect(screen.getByText('default')).toBeInTheDocument();
+        expect(screen.getByText('release')).toBeInTheDocument();
+    });
+
+    test('should show external error when no variant selected and variants are available', async () => {
+        const triggerBanner = jest.fn();
+        const user = userEvent.setup();
+        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        render(<StatusEditor {...defaultProps} variants={variants} triggerBanner={triggerBanner} />);
+
+        const statusSelect = screen.getByRole('combobox');
+        await user.selectOptions(statusSelect, 'affected');
+        const addButton = screen.getByRole('button', { name: 'Add assessment' });
+        await user.click(addButton);
+
+        expect(triggerBanner).toHaveBeenCalledWith('You must select at least one variant', 'error');
+        expect(defaultProps.onAddAssessment).not.toHaveBeenCalled();
+    });
+
+    test('should show internal error when no variant selected and variants are available', async () => {
+        const user = userEvent.setup();
+        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        render(<StatusEditor {...defaultProps} variants={variants} />);
+
+        const statusSelect = screen.getByRole('combobox');
+        await user.selectOptions(statusSelect, 'affected');
+        const addButton = screen.getByRole('button', { name: 'Add assessment' });
+        await user.click(addButton);
+
+        expect(screen.getByTestId('message-banner')).toBeInTheDocument();
+        expect(screen.getByText('You must select at least one variant')).toBeInTheDocument();
+        expect(defaultProps.onAddAssessment).not.toHaveBeenCalled();
+    });
+
+    test('should submit with selected variant_ids when a variant is checked', async () => {
+        const user = userEvent.setup();
+        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        render(<StatusEditor {...defaultProps} variants={variants} />);
+
+        // Check the variant checkbox
+        const variantCheckbox = screen.getByRole('checkbox');
+        await user.click(variantCheckbox);
+
+        // Change status away from under_investigation (to pass validation)
+        const statusSelect = screen.getByRole('combobox');
+        await user.selectOptions(statusSelect, 'affected');
+
+        const addButton = screen.getByRole('button', { name: 'Add assessment' });
+        await user.click(addButton);
+
+        expect(defaultProps.onAddAssessment).toHaveBeenCalledWith(
+            expect.objectContaining({ variant_ids: ['v1'] })
+        );
+    });
+
+    test('should render package checkboxes when more than one package is available', () => {
+        const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
+        render(<StatusEditor {...defaultProps} availablePackages={packages} />);
+
+        expect(screen.getByText('Apply to packages:')).toBeInTheDocument();
+        expect(screen.getByText('pkg1@1.0.0')).toBeInTheDocument();
+        expect(screen.getByText('pkg2@2.0.0')).toBeInTheDocument();
+    });
+
+    test('should show external error when no package selected', async () => {
+        const triggerBanner = jest.fn();
+        const user = userEvent.setup();
+        const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
+        render(<StatusEditor {...defaultProps} availablePackages={packages} triggerBanner={triggerBanner} />);
+
+        // Uncheck all packages
+        const checkboxes = screen.getAllByRole('checkbox');
+        for (const cb of checkboxes) {
+            if ((cb as HTMLInputElement).checked) await user.click(cb);
+        }
+
+        const statusSelect = screen.getByRole('combobox');
+        await user.selectOptions(statusSelect, 'affected');
+        const addButton = screen.getByRole('button', { name: 'Add assessment' });
+        await user.click(addButton);
+
+        expect(triggerBanner).toHaveBeenCalledWith('You must select at least one package', 'error');
+        expect(defaultProps.onAddAssessment).not.toHaveBeenCalled();
+    });
+
+    test('should show internal error when no package selected', async () => {
+        const user = userEvent.setup();
+        const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
+        render(<StatusEditor {...defaultProps} availablePackages={packages} />);
+
+        // Uncheck all packages
+        const checkboxes = screen.getAllByRole('checkbox');
+        for (const cb of checkboxes) {
+            if ((cb as HTMLInputElement).checked) await user.click(cb);
+        }
+
+        const statusSelect = screen.getByRole('combobox');
+        await user.selectOptions(statusSelect, 'affected');
+        const addButton = screen.getByRole('button', { name: 'Add assessment' });
+        await user.click(addButton);
+
+        expect(screen.getByTestId('message-banner')).toBeInTheDocument();
+        expect(screen.getByText('You must select at least one package')).toBeInTheDocument();
+        expect(defaultProps.onAddAssessment).not.toHaveBeenCalled();
+    });
+
+    test('should toggle package checkboxes correctly', async () => {
+        const user = userEvent.setup();
+        const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
+        render(<StatusEditor {...defaultProps} availablePackages={packages} />);
+
+        const checkboxes = screen.getAllByRole('checkbox');
+        // Uncheck one package
+        await user.click(checkboxes[0]);
+        // Re-check it
+        await user.click(checkboxes[0]);
+
+        const statusSelect = screen.getByRole('combobox');
+        await user.selectOptions(statusSelect, 'affected');
+        const addButton = screen.getByRole('button', { name: 'Add assessment' });
+        await user.click(addButton);
+
+        // Both packages checked → should include both in the call
+        expect(defaultProps.onAddAssessment).toHaveBeenCalledWith(
+            expect.objectContaining({ packages: expect.arrayContaining(['pkg1@1.0.0', 'pkg2@2.0.0']) })
+        );
     });
 });

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -49,6 +49,7 @@ describe('Vulnerability Modal', () => {
         },
         status: 'affected',
         simplified_status: 'active',
+        variants: [],
         assessments: [{
             id: 'assessment-1',
             vuln_id: 'CVE-2010-1234',
@@ -167,6 +168,8 @@ describe('Vulnerability Modal', () => {
 
     test('adding assessment', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
         const thisFetch = fetchMock.mockImplementationOnce(() =>
             Promise.resolve({
@@ -207,7 +210,7 @@ describe('Vulnerability Modal', () => {
         await user.click(btn);
 
         // ASSERT
-        expect(thisFetch).toHaveBeenCalledTimes(1);
+        expect(thisFetch).toHaveBeenCalledTimes(3);
         expect(updateCb).toHaveBeenCalledTimes(1);
         alertSpy.mockRestore();
     })
@@ -234,23 +237,19 @@ describe('Vulnerability Modal', () => {
 
     test('edit effort estimations', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify({
+            id: vulnerability.id,
+            packages: vulnerability.packages,
+            effort: {
+                optimistic: 'PT5H',
+                likely: 'P2DT4H',
+                pessimistic: 'P2W3D'
+            },
+            responses: []
+        })); // estimation save response
         const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
-        const thisFetch = fetchMock.mockImplementationOnce(() =>
-            Promise.resolve({
-                json: () => Promise.resolve({
-                    id: vulnerability.id,
-                    packages: vulnerability.packages,
-                    effort: {
-                        optimistic: 'PT5H',
-                        likely: 'P2DT4H',
-                        pessimistic: 'P2W3D'
-                    },
-                    responses: []
-                }),
-                text: () => Promise.resolve('Text only usefull when error happens'),
-                status: 200
-            } as Response)
-        );
 
         // ARRANGE
         const updateCb = jest.fn();
@@ -270,12 +269,14 @@ describe('Vulnerability Modal', () => {
         await user.click(btn);
 
         // ASSERT
-        expect(thisFetch).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
         expect(updateCb).toHaveBeenCalledTimes(1);
         alertSpy.mockRestore();
     })
     test('invalid custom CVSS vector triggers alert and no network call', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         const closeCb = jest.fn();
         const patchVuln = jest.fn();
 
@@ -294,17 +295,19 @@ describe('Vulnerability Modal', () => {
         await user.click(addBtn);
 
         expect(appendCVSS).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledTimes(0);
-        
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
         // Check for error banner instead of alert
         const errorBanner = await screen.findByText(/the vector string is invalid/i);
         expect(errorBanner).toBeInTheDocument();
-        
+
         expect(closeCb).not.toHaveBeenCalled();
     });
 
     test('custom CVSS API error shows alert (error branch lines 80-93)', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         const closeCb = jest.fn();
         const patchVuln = jest.fn();
@@ -331,12 +334,12 @@ describe('Vulnerability Modal', () => {
         await user.click(await screen.getByRole('button', { name: /^add$/i }));
 
         expect(appendCVSS).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+
         // Check for error banner instead of alert
         const errorBanner = await screen.findByText(/failed to save cvss/i);
         expect(errorBanner).toBeInTheDocument();
-        
+
         expect(patchVuln).not.toHaveBeenCalled();
         expect(closeCb).not.toHaveBeenCalled();
         errorSpy.mockRestore();
@@ -344,6 +347,8 @@ describe('Vulnerability Modal', () => {
 
     test('custom CVSS success updates vulnerability and closes (lines 83-89)', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
 
         const closeCb = jest.fn();
         const patchVuln = jest.fn();
@@ -380,9 +385,9 @@ describe('Vulnerability Modal', () => {
         await user.type(vectorInput, 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
         await user.click(await screen.getByRole('button', { name: /^add$/i }));
 
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
         expect(patchVuln).toHaveBeenCalledTimes(1);
-        
+
         // Check for success banner instead of alert
         const successBanner = await screen.findByText(/successfully added custom cvss/i);
         expect(successBanner).toBeInTheDocument();
@@ -403,24 +408,24 @@ describe('Vulnerability Modal', () => {
         render(<VulnModal vuln={vulnerability} isEditing={true} onClose={closeCb} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         const user = userEvent.setup();
-        // Make some changes to trigger unsaved state in assessment editor
-        const selects = await screen.getAllByRole('combobox');
-        const selectSource = selects.find((el) => el.getAttribute('name')?.includes('new_assessment_status')) as HTMLElement;
-        if (selectSource) {
-            await user.selectOptions(selectSource, 'fixed');
-        }
-
+        // Type in time estimate field to trigger hasTimeChanges (avoids SELECT element intercepting Escape)
+        const optimistic = screen.getByPlaceholderText(/shortest estimate/i);
+        await user.type(optimistic, '5h');
         await user.keyboard('{Escape}');
 
-        // TODO: Fix unsaved changes detection - placeholder for coverage
-        // Should show confirmation modal instead of closing directly
-        // const confirmModalTitle = await screen.findByText('Unsaved Changes');
-        // expect(confirmModalTitle).toBeInTheDocument();
-        expect(closeCb).toHaveBeenCalledTimes(1); // Placeholder: currently closes directly
+        // Confirmation modal should appear for unsaved changes
+        const confirmModalTitle = await screen.findByText('Unsaved Changes');
+        expect(confirmModalTitle).toBeInTheDocument();
+        // Click "Yes, close" to actually close
+        const yesCloseBtn = screen.getByText(/yes, close/i);
+        await user.click(yesCloseBtn);
+        expect(closeCb).toHaveBeenCalledTimes(1);
     });
 
     test('addAssessment API failure shows error banner', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'error',
             message: 'Database connection failed'
@@ -429,7 +434,7 @@ describe('Vulnerability Modal', () => {
         const updateCb = jest.fn();
         const patchVuln = jest.fn();
         render(<VulnModal vuln={vulnerability} isEditing={true} onClose={() => {}} appendAssessment={updateCb} appendCVSS={() => null} patchVuln={patchVuln} />);
-        
+
         const user = userEvent.setup();
 
         const selects = await screen.getAllByRole('combobox');
@@ -441,10 +446,10 @@ describe('Vulnerability Modal', () => {
         await user.type(inputStatus, 'patched');
         await user.click(btn);
 
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
         expect(updateCb).not.toHaveBeenCalled();
         expect(patchVuln).not.toHaveBeenCalled();
-        
+
         const errorBanner = await screen.findByText(/failed to add assessment/i);
         expect(errorBanner).toBeInTheDocument();
     });
@@ -453,7 +458,7 @@ describe('Vulnerability Modal', () => {
         render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         const user = userEvent.setup();
-        
+
         // Find edit button
         const editBtn = screen.getByText(/edit$/i);
         expect(editBtn).toBeInTheDocument();
@@ -474,14 +479,14 @@ describe('Vulnerability Modal', () => {
         render(<VulnModal vuln={vulnerability} isEditing={true} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         const user = userEvent.setup();
-        
+
         // Find custom vector button
         const customBtn = screen.getByLabelText(/add custom cvss vector/i);
         expect(customBtn).toBeInTheDocument();
 
         // Click to show custom CVSS input
         await user.click(customBtn);
-        
+
         // CVSS input should be visible
         const cvssInput = await screen.findByPlaceholderText(/CVSS:3\.1/i);
         expect(cvssInput).toBeInTheDocument();
@@ -514,7 +519,7 @@ describe('Vulnerability Modal', () => {
         // Find edit and delete buttons for assessments
         const editBtn = screen.getByTitle(/edit assessment/i);
         const deleteBtn = screen.getByTitle(/delete assessment/i);
-        
+
         expect(editBtn).toBeInTheDocument();
         expect(deleteBtn).toBeInTheDocument();
     });
@@ -522,6 +527,8 @@ describe('Vulnerability Modal', () => {
     test('save estimation failure triggers alert (lines 121-122)', async () => {
         fetchMock.resetMocks();
 
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockImplementationOnce(() =>
             Promise.resolve({
                 status: 500,
@@ -548,12 +555,12 @@ describe('Vulnerability Modal', () => {
         const saveBtn = await screen.getByText(/save estimation/i);
         await user.click(saveBtn);
 
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+
         // Check for error banner instead of alert
         const errorBanner = await screen.findByText(/failed to save estimation/i);
         expect(errorBanner).toBeInTheDocument();
-        
+
         expect(patchVuln).not.toHaveBeenCalled();
         expect(closeCb).not.toHaveBeenCalled();
     });
@@ -594,6 +601,7 @@ describe('Vulnerability Modal', () => {
             },
             status: 'affected',
             simplified_status: 'active',
+            variants: [],
             assessments: []
         };
 
@@ -609,12 +617,12 @@ describe('Vulnerability Modal', () => {
         });
 
         test('should not render navigation buttons when currentIndex is not provided', () => {
-            render(<VulnModal 
-                vuln={vulnerability} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+            render(<VulnModal
+                vuln={vulnerability}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={vulnerabilities}
             />);
 
@@ -625,12 +633,12 @@ describe('Vulnerability Modal', () => {
         });
 
         test('should render navigation buttons when vulnerabilities and currentIndex are provided', () => {
-            render(<VulnModal 
-                vuln={vulnerability} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+            render(<VulnModal
+                vuln={vulnerability}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={vulnerabilities}
                 currentIndex={0}
                 onNavigate={() => {}}
@@ -639,18 +647,18 @@ describe('Vulnerability Modal', () => {
             // Navigation buttons should be present
             expect(screen.getByLabelText('Previous vulnerability')).toBeInTheDocument();
             expect(screen.getByLabelText('Next vulnerability')).toBeInTheDocument();
-            
+
             // Navigation info should be present
             expect(document.getElementById('navigation-info')).toHaveTextContent('Vulnerability 1 of 2');
         });
 
         test('should disable previous button on first vulnerability', () => {
-            render(<VulnModal 
-                vuln={vulnerability} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+            render(<VulnModal
+                vuln={vulnerability}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={vulnerabilities}
                 currentIndex={0}
                 onNavigate={() => {}}
@@ -664,12 +672,12 @@ describe('Vulnerability Modal', () => {
         });
 
         test('should disable next button on last vulnerability', () => {
-            render(<VulnModal 
-                vuln={vulnerability2} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+            render(<VulnModal
+                vuln={vulnerability2}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={vulnerabilities}
                 currentIndex={1}
                 onNavigate={() => {}}
@@ -684,13 +692,13 @@ describe('Vulnerability Modal', () => {
 
         test('should enable both buttons when in middle of vulnerabilities list', () => {
             const threeVulns = [vulnerability, vulnerability2, { ...vulnerability, id: 'CVE-2010-9999' }];
-            
-            render(<VulnModal 
-                vuln={vulnerability2} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+
+            render(<VulnModal
+                vuln={vulnerability2}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={threeVulns}
                 currentIndex={1}
                 onNavigate={() => {}}
@@ -701,20 +709,20 @@ describe('Vulnerability Modal', () => {
 
             expect(prevButton).toBeEnabled();
             expect(nextButton).toBeEnabled();
-            
+
             expect(document.getElementById('navigation-info')).toHaveTextContent('Vulnerability 2 of 3');
         });
 
         test('should call onNavigate with correct index when next button is clicked', async () => {
             const onNavigate = jest.fn();
             const user = userEvent.setup();
-            
-            render(<VulnModal 
-                vuln={vulnerability} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+
+            render(<VulnModal
+                vuln={vulnerability}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={vulnerabilities}
                 currentIndex={0}
                 onNavigate={onNavigate}
@@ -729,13 +737,13 @@ describe('Vulnerability Modal', () => {
         test('should call onNavigate with correct index when previous button is clicked', async () => {
             const onNavigate = jest.fn();
             const user = userEvent.setup();
-            
-            render(<VulnModal 
-                vuln={vulnerability2} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+
+            render(<VulnModal
+                vuln={vulnerability2}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={vulnerabilities}
                 currentIndex={1}
                 onNavigate={onNavigate}
@@ -750,13 +758,13 @@ describe('Vulnerability Modal', () => {
         test('should show confirmation modal when navigating with unsaved changes', async () => {
             const onNavigate = jest.fn();
             const user = userEvent.setup();
-            
-            render(<VulnModal 
-                vuln={vulnerability} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+
+            render(<VulnModal
+                vuln={vulnerability}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={vulnerabilities}
                 currentIndex={0}
                 onNavigate={onNavigate}
@@ -780,13 +788,13 @@ describe('Vulnerability Modal', () => {
         test('should navigate after confirming unsaved changes', async () => {
             const onNavigate = jest.fn();
             const user = userEvent.setup();
-            
-            render(<VulnModal 
-                vuln={vulnerability} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+
+            render(<VulnModal
+                vuln={vulnerability}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={vulnerabilities}
                 currentIndex={0}
                 onNavigate={onNavigate}
@@ -811,13 +819,13 @@ describe('Vulnerability Modal', () => {
         test('should cancel navigation when canceling confirmation modal', async () => {
             const onNavigate = jest.fn();
             const user = userEvent.setup();
-            
-            render(<VulnModal 
-                vuln={vulnerability} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+
+            render(<VulnModal
+                vuln={vulnerability}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={vulnerabilities}
                 currentIndex={0}
                 onNavigate={onNavigate}
@@ -843,13 +851,13 @@ describe('Vulnerability Modal', () => {
 
         test('should render navigation buttons but not navigate when onNavigate prop is not provided', async () => {
             const user = userEvent.setup();
-            
-            render(<VulnModal 
-                vuln={vulnerability} 
-                onClose={() => {}} 
-                appendAssessment={() => {}} 
-                appendCVSS={() => null} 
-                patchVuln={() => {}} 
+
+            render(<VulnModal
+                vuln={vulnerability}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
                 vulnerabilities={vulnerabilities}
                 currentIndex={0}
             />);
@@ -857,15 +865,60 @@ describe('Vulnerability Modal', () => {
             // Buttons should be present even without onNavigate
             const prevButton = screen.getByLabelText('Previous vulnerability');
             const nextButton = screen.getByLabelText('Next vulnerability');
-            
+
             expect(prevButton).toBeInTheDocument();
             expect(nextButton).toBeInTheDocument();
-            
+
             // Clicking buttons should not cause any errors (they should just do nothing)
             await user.click(nextButton);
             await user.click(prevButton);
-            
+
             // No error should occur - navigation just doesn't happen
+        });
+
+        test('ArrowRight key navigates to next vulnerability', async () => {
+            const onNavigate = jest.fn();
+            const user = userEvent.setup();
+
+            render(<VulnModal
+                vuln={vulnerability}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
+                vulnerabilities={vulnerabilities}
+                currentIndex={0}
+                onNavigate={onNavigate}
+            />);
+
+            // Focus the modal container (not a text field)
+            const modalTitle = screen.getByText('CVE-2010-1234');
+            modalTitle.focus();
+            await user.keyboard('{ArrowRight}');
+
+            expect(onNavigate).toHaveBeenCalledWith(1);
+        });
+
+        test('ArrowLeft key navigates to previous vulnerability', async () => {
+            const onNavigate = jest.fn();
+            const user = userEvent.setup();
+
+            render(<VulnModal
+                vuln={vulnerability2}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
+                vulnerabilities={vulnerabilities}
+                currentIndex={1}
+                onNavigate={onNavigate}
+            />);
+
+            const modalTitle = screen.getByText('CVE-2010-5678');
+            modalTitle.focus();
+            await user.keyboard('{ArrowLeft}');
+
+            expect(onNavigate).toHaveBeenCalledWith(0);
         });
     });
 
@@ -908,7 +961,7 @@ describe('Vulnerability Modal', () => {
         expect(screen.queryByRole('banner')).not.toBeInTheDocument();
 
         // Test with a vulnerability that would trigger banner in some scenario
-        // We can't directly test the banner without triggering the functions, 
+        // We can't directly test the banner without triggering the functions,
         // but we can test that the banner container is properly structured
         const modalBody = screen.getByText('CVE-2010-1234');
         expect(modalBody).toBeInTheDocument();
@@ -936,7 +989,7 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const editBtn = screen.getByTitle(/edit assessment/i);
-        
+
         await user.click(editBtn);
 
         // Should show EditAssessment component
@@ -965,7 +1018,7 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const deleteBtn = screen.getByTitle(/delete assessment/i);
-        
+
         await user.click(deleteBtn);
 
         // Should show delete confirmation modal
@@ -999,9 +1052,9 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const deleteBtn = screen.getByTitle(/delete assessment/i);
-        
+
         await user.click(deleteBtn);
-        
+
         const confirmBtn = screen.getByText(/yes, delete/i);
         await user.click(confirmBtn);
 
@@ -1014,6 +1067,8 @@ describe('Vulnerability Modal', () => {
 
     test('delete assessment API error', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockResponseOnce('Server error', { status: 500 });
 
         const vulnWithAssessment = {
@@ -1037,14 +1092,14 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const deleteBtn = screen.getByTitle(/delete assessment/i);
-        
+
         await user.click(deleteBtn);
-        
+
         const confirmBtn = screen.getByText(/yes, delete/i);
         await user.click(confirmBtn);
 
         expect(fetchMock).toHaveBeenCalled();
-        
+
         // Check for error banner
         const errorBanner = await screen.findByText(/failed to delete assessment/i);
         expect(errorBanner).toBeInTheDocument();
@@ -1052,6 +1107,8 @@ describe('Vulnerability Modal', () => {
 
     test('delete assessment network error', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockRejectOnce(new Error('Network error'));
 
         const vulnWithAssessment = {
@@ -1075,14 +1132,14 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const deleteBtn = screen.getByTitle(/delete assessment/i);
-        
+
         await user.click(deleteBtn);
-        
+
         const confirmBtn = screen.getByText(/yes, delete/i);
         await user.click(confirmBtn);
 
         expect(fetchMock).toHaveBeenCalled();
-        
+
         // Check for error banner
         const errorBanner = await screen.findByText(/failed to delete assessment.*network error/i);
         expect(errorBanner).toBeInTheDocument();
@@ -1110,9 +1167,9 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const deleteBtn = screen.getByTitle(/delete assessment/i);
-        
+
         await user.click(deleteBtn);
-        
+
         const cancelBtn = screen.getByText(/cancel/i);
         await user.click(cancelBtn);
 
@@ -1122,6 +1179,8 @@ describe('Vulnerability Modal', () => {
 
     test('edit assessment success', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
             assessment: {
@@ -1161,9 +1220,9 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const editBtn = screen.getByTitle(/edit assessment/i);
-        
+
         await user.click(editBtn);
-        
+
         // Should show EditAssessment component, simulate save
         const saveBtn = screen.getByText(/save changes/i);
         await user.click(saveBtn);
@@ -1173,7 +1232,7 @@ describe('Vulnerability Modal', () => {
             expect.objectContaining({ method: 'PUT' })
         );
         expect(patchVuln).toHaveBeenCalled();
-        
+
         // Check for success banner
         const successBanner = await screen.findByText(/assessment updated successfully/i);
         expect(successBanner).toBeInTheDocument();
@@ -1181,6 +1240,8 @@ describe('Vulnerability Modal', () => {
 
     test('edit assessment API error', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockResponseOnce('Server error', { status: 500 });
 
         const vulnWithAssessment = {
@@ -1204,14 +1265,14 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const editBtn = screen.getByTitle(/edit assessment/i);
-        
+
         await user.click(editBtn);
-        
+
         const saveBtn = screen.getByText(/save changes/i);
         await user.click(saveBtn);
 
         expect(fetchMock).toHaveBeenCalled();
-        
+
         // Check for error banner
         const errorBanner = await screen.findByText(/failed to update assessment/i);
         expect(errorBanner).toBeInTheDocument();
@@ -1219,6 +1280,8 @@ describe('Vulnerability Modal', () => {
 
     test('edit assessment invalid response', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'error',
             message: 'Invalid data'
@@ -1245,14 +1308,14 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const editBtn = screen.getByTitle(/edit assessment/i);
-        
+
         await user.click(editBtn);
-        
+
         const saveBtn = screen.getByText(/save changes/i);
         await user.click(saveBtn);
 
         expect(fetchMock).toHaveBeenCalled();
-        
+
         // Check for error banner
         const errorBanner = await screen.findByText(/error.*invalid response from server/i);
         expect(errorBanner).toBeInTheDocument();
@@ -1260,6 +1323,8 @@ describe('Vulnerability Modal', () => {
 
     test('edit assessment network error', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockRejectOnce(new Error('Network failure'));
 
         const vulnWithAssessment = {
@@ -1283,14 +1348,14 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const editBtn = screen.getByTitle(/edit assessment/i);
-        
+
         await user.click(editBtn);
-        
+
         const saveBtn = screen.getByText(/save changes/i);
         await user.click(saveBtn);
 
         expect(fetchMock).toHaveBeenCalled();
-        
+
         // Check for error banner
         const errorBanner = await screen.findByText(/failed to update assessment.*network failure/i);
         expect(errorBanner).toBeInTheDocument();
@@ -1318,9 +1383,9 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const editBtn = screen.getByTitle(/edit assessment/i);
-        
+
         await user.click(editBtn);
-        
+
         const cancelBtn = screen.getByText(/cancel/i);
         await user.click(cancelBtn);
 
@@ -1417,7 +1482,7 @@ describe('Vulnerability Modal', () => {
         // Should render CVSS section but no gauges
         const cvssHeading = screen.getByText(/^CVSS$/i);
         expect(cvssHeading).toBeInTheDocument();
-        
+
         // Should not have any CVSS gauges
         expect(screen.queryByText(/CVSS 3\./)).not.toBeInTheDocument();
     });
@@ -1489,30 +1554,29 @@ describe('Vulnerability Modal', () => {
         render(<VulnModal vuln={vulnerability} isEditing={true} onClose={closeCb} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         const user = userEvent.setup();
-        
-        // Make some changes to trigger unsaved state
-        const selects = await screen.getAllByRole('combobox');
-        const selectSource = selects.find((el: any) => el.getAttribute('name')?.includes('new_assessment_status')) as HTMLElement;
-        if (selectSource) {
-            await user.selectOptions(selectSource, 'fixed');
-        }
+
+        // Type in time estimate field to trigger hasTimeChanges (avoids SELECT element intercepting Escape)
+        const optimistic = screen.getByPlaceholderText(/shortest estimate/i);
+        await user.type(optimistic, '5h');
 
         // Try to close
         await user.keyboard('{Escape}');
 
-        // TODO: Fix unsaved changes detection - placeholder for coverage
-        // Should show confirmation modal
-        // expect(screen.getByText('Unsaved Changes')).toBeInTheDocument();
-        // Click cancel
-        // const cancelBtn = screen.getByText(/no, stay/i);
-        // await user.click(cancelBtn);
+        // Confirmation modal should appear
+        const unsavedTitle = await screen.findByText('Unsaved Changes');
+        expect(unsavedTitle).toBeInTheDocument();
+        // Click "No, stay" to cancel
+        const cancelBtn = screen.getByText(/no, stay/i);
+        await user.click(cancelBtn);
 
-        expect(closeCb).toHaveBeenCalledTimes(1); // Placeholder: currently closes directly
-        // expect(screen.queryByText('Unsaved Changes')).not.toBeInTheDocument();
+        expect(closeCb).not.toHaveBeenCalled();
+        expect(screen.queryByText('Unsaved Changes')).not.toBeInTheDocument();
     });
 
     test('edit assessment invalid assessment data', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
             assessment: ['invalid', 'array', 'instead', 'of', 'object']
@@ -1539,14 +1603,14 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const editBtn = screen.getByTitle(/edit assessment/i);
-        
+
         await user.click(editBtn);
-        
+
         const saveBtn = screen.getByText(/save changes/i);
         await user.click(saveBtn);
 
         expect(fetchMock).toHaveBeenCalled();
-        
+
         // Check for error banner about invalid assessment data
         const errorBanner = await screen.findByText(/error.*invalid assessment data received/i);
         expect(errorBanner).toBeInTheDocument();
@@ -1554,6 +1618,8 @@ describe('Vulnerability Modal', () => {
 
     test('edit assessment data mismatch', async () => {
         fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
             assessment: {
@@ -1592,21 +1658,21 @@ describe('Vulnerability Modal', () => {
 
         const user = userEvent.setup();
         const editBtn = screen.getByTitle(/edit assessment/i);
-        
+
         await user.click(editBtn);
-        
+
         const saveBtn = screen.getByText(/save changes/i);
         await user.click(saveBtn);
 
         expect(fetchMock).toHaveBeenCalled();
-        
+
         // Since the returned assessment ID doesn't match, it should show success anyway
         await screen.findByText('Assessment updated successfully!');
     });
 
     test('renders modal with view mode by default', () => {
         render(<VulnModal vuln={vulnerability} isEditing={false} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-        
+
         expect(screen.getByText('CVE-2010-1234')).toBeInTheDocument();
         expect(screen.queryByText('Edit Assessment')).not.toBeInTheDocument();
     });
@@ -1625,4 +1691,23 @@ describe('Vulnerability Modal', () => {
 
         expect(screen.getByText(/Fixed from version 1.2.3rc4/i)).toBeInTheDocument();
     })
+
+    test('shortcut helper button toggles the keyboard shortcuts dropdown', async () => {
+        const user = userEvent.setup();
+        render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        // Dropdown is initially hidden
+        expect(screen.queryByText('Keyboard Shortcuts')).not.toBeInTheDocument();
+
+        // Click the shortcut helper button
+        const helpBtn = screen.getByRole('button', { name: /shortcut helper/i });
+        await user.click(helpBtn);
+
+        // Dropdown should now be visible
+        expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
+
+        // Click again to hide
+        await user.click(helpBtn);
+        expect(screen.queryByText('Keyboard Shortcuts')).not.toBeInTheDocument();
+    });
 });

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -83,6 +83,7 @@ describe('Vulnerability Table', () => {
             status: 'affected',
             simplified_status: 'Exploitable',
             assessments: [],
+            variants: [],
             published: '2010-05-15T08:00:00Z'
         },
         {
@@ -142,7 +143,8 @@ describe('Vulnerability Table', () => {
             status: 'under_investigation',
             simplified_status: 'Pending Assessment',
             published: '2018-07-22T14:30:00Z',
-            assessments: []
+            assessments: [],
+            variants: []
         },
         {
             id: 'CVE-2024-56730',
@@ -206,7 +208,8 @@ describe('Vulnerability Table', () => {
                     last_update: '2026-02-06T17:43:14.254537+00:00',
                     responses: []
                 }
-            ]
+            ],
+            variants: []
         }
     ];
 
@@ -701,7 +704,8 @@ describe('Vulnerability Table', () => {
         await user.click(btn);
 
         // ASSERT
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        // 3 Variants.listByVuln calls (one per selected vulnerability) + 1 batch assessment API call
+        expect(fetchMock).toHaveBeenCalledTimes(4);
     })
 
     test('select and change time estimate', async () => {
@@ -819,7 +823,7 @@ describe('Vulnerability Table', () => {
         }, { timeout: 1000 });
 
         const vuln_abc = await screen.getByRole('cell', {name: /CVE-2010-1234/});
-        
+
         expect(vuln_abc).toBeInTheDocument();
     })
 
@@ -1687,6 +1691,7 @@ describe('Vulnerability Table', () => {
                 status: 'under_investigation',
                 simplified_status: 'Pending Assessment',
                 assessments: [],
+                variants: [],
                 // no 'published' field
             }
         ];
@@ -1896,6 +1901,7 @@ describe('Vulnerability Table', () => {
                 status: 'under_investigation',
                 simplified_status: 'Pending Assessment',
                 assessments: [],
+                variants: [],
                 // no 'published' field
             }
         ];

--- a/src/models/assessment.py
+++ b/src/models/assessment.py
@@ -352,6 +352,7 @@ class Assessment(Base):
             "source": self.source or "",
             "vuln_id": self.vuln_id,
             "packages": list(self.packages),
+            "variant_id": str(self.variant_id) if self.variant_id else None,
             "timestamp": ts,
             "last_update": ts or "",
             "status": self.status or "",

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -204,7 +204,21 @@ def init_app(app):
                 continue
 
             vuln_id = assessment.vuln_id
-            for pkg_string_id in (assessment.packages or []):
+            # Parse optional variant_id from the raw item
+            variant_id_raw = item.get('variant_id') or None
+            variant_id = None
+            if variant_id_raw:
+                try:
+                    import uuid as _uuid
+                    variant_id = _uuid.UUID(variant_id_raw)
+                except (ValueError, AttributeError):
+                    errors.append({"vuln_id": vuln_id, "error": "Invalid variant_id"})
+                    continue
+            pkg_list = assessment.packages or []
+            if not pkg_list:
+                errors.append({"vuln_id": vuln_id, "error": "No valid package found"})
+                continue
+            for pkg_string_id in pkg_list:
                 try:
                     # Resolve package from cache first, then DB
                     db_pkg = pkg_cache.get(pkg_string_id)
@@ -220,10 +234,20 @@ def init_app(app):
                     if finding is None:
                         finding = Finding.get_or_create(db_pkg.id, vuln_id)
                         finding_cache[f_key] = finding
-                    db_a = DBAssessment.from_vuln_assessment(assessment, finding_id=finding.id)
-                    db.session.commit()
+                    # Always create a new record — never overwrite an existing assessment
+                    db_a = DBAssessment.create(
+                        status=assessment.status,
+                        simplified_status=STATUS_TO_SIMPLIFIED.get(assessment.status, "Pending Assessment"),
+                        finding_id=finding.id,
+                        variant_id=variant_id,
+                        status_notes=assessment.status_notes,
+                        justification=assessment.justification,
+                        impact_statement=assessment.impact_statement,
+                        workaround=getattr(assessment, "workaround", None),
+                        responses=list(assessment.responses) if assessment.responses else [],
+                        commit=True,
+                    )
                     results.append(db_a.to_dict())
-                    break
                 except Exception as e:
                     errors.append({"vuln_id": vuln_id, "error": str(e)})
 
@@ -235,6 +259,8 @@ def init_app(app):
         if errors:
             response["errors"] = errors
             response["error_count"] = len(errors)
+        if results:
+            _save_openvex()
         return response, 200 if results else 400
 
     @app.route("/api/assessments/<assessment_id>", methods=["PUT", "PATCH"])

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -179,7 +179,8 @@ def init_app(app):
             return {"error": "No valid package found"}, 400
 
         _save_openvex()
-        return {"status": "success", "assessments": created}, 200
+        response_body = {"status": "success", "assessments": created, "assessment": created[0]}
+        return response_body, 200
 
     @app.route("/api/assessments/batch", methods=["POST"])
     def add_assessments_batch():

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -4,7 +4,7 @@
 
 from flask import request
 from datetime import datetime
-from ..models.assessment import Assessment as DBAssessment
+from ..models.assessment import Assessment as DBAssessment, STATUS_TO_SIMPLIFIED
 from ..models.package import Package
 from ..models.finding import Finding
 from ..views.openvex import OpenVex
@@ -153,8 +153,21 @@ def init_app(app):
                         variant_id = _uuid.UUID(variant_id_raw)
                     except (ValueError, AttributeError):
                         return {"error": "Invalid variant_id"}, 400
-                db_a = DBAssessment.from_vuln_assessment(assessment, finding_id=finding.id, variant_id=variant_id)
-                db.session.commit()
+                # Always create a new record — never merge with an existing one.
+                # from_vuln_assessment does a find-or-update which would overwrite
+                # previous user assessments on the same (finding, variant).
+                db_a = DBAssessment.create(
+                    status=assessment.status,
+                    simplified_status=STATUS_TO_SIMPLIFIED.get(assessment.status, "Pending Assessment"),
+                    finding_id=finding.id,
+                    variant_id=variant_id,
+                    status_notes=assessment.status_notes,
+                    justification=assessment.justification,
+                    impact_statement=assessment.impact_statement,
+                    workaround=getattr(assessment, "workaround", None),
+                    responses=list(assessment.responses) if assessment.responses else [],
+                    commit=True,
+                )
                 _save_openvex()
                 return {"status": "success", "assessment": db_a.to_dict()}, 200
             except Exception as e:

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -94,6 +94,33 @@ def init_app(app):
             return {a["id"]: a for a in assessments}
         return assessments, 200
 
+    @app.route('/api/vulnerabilities/<vuln_id>/variants', methods=['GET'])
+    def list_variants_by_vuln(vuln_id: str):
+        """Return all distinct variants that have a finding for this vulnerability
+        (via the Observation → Scan → Variant chain)."""
+        from ..models.observation import Observation
+        from ..models.scan import Scan
+        from ..models.variant import Variant as DBVariant
+        findings = Finding.get_by_vulnerability(vuln_id)
+        seen_variant_ids: set = set()
+        variants_out = []
+        for finding in findings:
+            for obs in Observation.get_by_finding(finding.id):
+                scan = db.session.get(Scan, obs.scan_id)
+                if scan is None:
+                    continue
+                if scan.variant_id in seen_variant_ids:
+                    continue
+                seen_variant_ids.add(scan.variant_id)
+                variant = db.session.get(DBVariant, scan.variant_id)
+                if variant:
+                    variants_out.append({
+                        "id": str(variant.id),
+                        "name": variant.name,
+                        "project_id": str(variant.project_id),
+                    })
+        return variants_out, 200
+
     @app.route("/api/vulnerabilities/<vuln_id>/assessments", methods=["POST"])
     def add_assessment(vuln_id: str):
         payload_data = request.get_json()
@@ -118,7 +145,8 @@ def init_app(app):
                 # Ensure vulnerability record exists before creating Finding (FK constraint)
                 DBVuln.get_or_create(vuln_id)
                 finding = Finding.get_or_create(db_pkg.id, vuln_id)
-                db_a = DBAssessment.from_vuln_assessment(assessment, finding_id=finding.id)
+                variant_id = payload_data.get('variant_id') or None
+                db_a = DBAssessment.from_vuln_assessment(assessment, finding_id=finding.id, variant_id=variant_id)
                 db.session.commit()
                 _save_openvex()
                 return {"status": "success", "assessment": db_a.to_dict()}, 200

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -145,7 +145,14 @@ def init_app(app):
                 # Ensure vulnerability record exists before creating Finding (FK constraint)
                 DBVuln.get_or_create(vuln_id)
                 finding = Finding.get_or_create(db_pkg.id, vuln_id)
-                variant_id = payload_data.get('variant_id') or None
+                variant_id_raw = payload_data.get('variant_id') or None
+                variant_id = None
+                if variant_id_raw:
+                    try:
+                        import uuid as _uuid
+                        variant_id = _uuid.UUID(variant_id_raw)
+                    except (ValueError, AttributeError):
+                        return {"error": "Invalid variant_id"}, 400
                 db_a = DBAssessment.from_vuln_assessment(assessment, finding_id=finding.id, variant_id=variant_id)
                 db.session.commit()
                 _save_openvex()

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -136,7 +136,18 @@ def init_app(app):
         if status != 200:
             return assessment, status
 
-        # Persist to DB
+        # Resolve variant_id once — same for all packages in this request
+        variant_id_raw = payload_data.get('variant_id') or None
+        variant_id = None
+        if variant_id_raw:
+            try:
+                import uuid as _uuid
+                variant_id = _uuid.UUID(variant_id_raw)
+            except (ValueError, AttributeError):
+                return {"error": "Invalid variant_id"}, 400
+
+        # Persist to DB — one Assessment record per package
+        created = []
         for pkg_string_id in (assessment.packages or []):
             try:
                 # find_or_create handles both lookup and creation in one query
@@ -145,14 +156,6 @@ def init_app(app):
                 # Ensure vulnerability record exists before creating Finding (FK constraint)
                 DBVuln.get_or_create(vuln_id)
                 finding = Finding.get_or_create(db_pkg.id, vuln_id)
-                variant_id_raw = payload_data.get('variant_id') or None
-                variant_id = None
-                if variant_id_raw:
-                    try:
-                        import uuid as _uuid
-                        variant_id = _uuid.UUID(variant_id_raw)
-                    except (ValueError, AttributeError):
-                        return {"error": "Invalid variant_id"}, 400
                 # Always create a new record — never merge with an existing one.
                 # from_vuln_assessment does a find-or-update which would overwrite
                 # previous user assessments on the same (finding, variant).
@@ -168,12 +171,15 @@ def init_app(app):
                     responses=list(assessment.responses) if assessment.responses else [],
                     commit=True,
                 )
-                _save_openvex()
-                return {"status": "success", "assessment": db_a.to_dict()}, 200
+                created.append(db_a.to_dict())
             except Exception as e:
                 return {"error": f"DB error: {e}"}, 500
 
-        return {"error": "No valid package found"}, 400
+        if not created:
+            return {"error": "No valid package found"}, 400
+
+        _save_openvex()
+        return {"status": "success", "assessments": created}, 200
 
     @app.route("/api/assessments/batch", methods=["POST"])
     def add_assessments_batch():

--- a/src/routes/variant.py
+++ b/src/routes/variant.py
@@ -10,6 +10,16 @@ from ..controllers.variants import VariantController
 
 def init_app(app):
 
+    @app.route('/api/variants')
+    def list_all_variants():
+        projects = ProjectController.get_all()
+        all_variants = []
+        for project in projects:
+            all_variants.extend(VariantController.serialize_list(
+                VariantController.get_by_project(project.id)
+            ))
+        return jsonify(all_variants)
+
     @app.route('/api/projects/<project_id>/variants')
     def list_variants_by_project(project_id):
         project = ProjectController.get(project_id)

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -136,6 +136,24 @@ def init_app(app):
         else:
             records = Vulnerability.get_all()
         vulns = [r.to_dict() for r in records]
+
+        # Enrich each vuln dict with sorted variant names in one batch query
+        vuln_ids = [v["id"] for v in vulns]
+        if vuln_ids:
+            rows = db.session.execute(
+                db.select(Finding.vulnerability_id, Variant.name)
+                .join(Observation, Finding.id == Observation.finding_id)
+                .join(Scan, Observation.scan_id == Scan.id)
+                .join(Variant, Scan.variant_id == Variant.id)
+                .where(Finding.vulnerability_id.in_(vuln_ids))
+                .distinct()
+            ).all()
+            variant_names_by_vuln: dict = {}
+            for vuln_id, variant_name in rows:
+                variant_names_by_vuln.setdefault(str(vuln_id), []).append(variant_name)
+            for v in vulns:
+                v["variants"] = sorted(variant_names_by_vuln.get(v["id"], []))
+
         if request.args.get('format', 'list') == "dict":
             return {v["id"]: v for v in vulns}
         return vulns

--- a/tests/webapp_tests/test_post_endpoints.py
+++ b/tests/webapp_tests/test_post_endpoints.py
@@ -66,7 +66,7 @@ def test_post_minimal_assessment(client):
     assert response.status_code == 200
     data = json.loads(response.data)
     data_str = response.get_data(as_text=True)
-    assert len(data) == 2
+    assert len(data) == 3
     assert "CVE-1999-12345" in data_str
     assert "Disable option X in configuration" in data_str
 
@@ -90,7 +90,7 @@ def test_post_detailled_assessment(client):
     assert response.status_code == 200
     data = json.loads(response.data)
     data_str = response.get_data(as_text=True)
-    assert len(data) == 2
+    assert len(data) == 3
     assert "CVE-1999-12345" in data_str
     assert "Demonstration assessment" in data_str
 

--- a/tests/webapp_tests/test_variant_features.py
+++ b/tests/webapp_tests/test_variant_features.py
@@ -1,0 +1,409 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Tests for variant-scoped assessment features introduced in commit b006e03:
+#   - GET /api/variants                           list all variants
+#   - GET /api/vulnerabilities/<vuln_id>/variants  variants linked to a CVE
+#   - POST assessment with variant_id             scope assessment to a variant
+#   - variant_id field in assessment serialisation
+
+import pytest
+import json
+import uuid
+from src.bin.webapp import create_app
+from . import write_demo_files, setup_demo_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def init_files(tmp_path):
+    files = {
+        "status": tmp_path / "status.txt",
+        "packages": tmp_path / "packages-merged.json",
+        "vulnerabilities": tmp_path / "vulnerabilities-merged.json",
+        "assessments": tmp_path / "assessments-merged.json",
+        "openvex": tmp_path / "openvex.json",
+        "time_estimates": tmp_path / "time_estimates.json",
+    }
+    write_demo_files(files)
+    return files
+
+
+@pytest.fixture()
+def app(init_files):
+    import os
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": init_files["status"],
+            "OPENVEX_FILE": init_files["openvex"],
+            "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
+        })
+        setup_demo_db(application)
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def app_with_variants(init_files):
+    """App fixture with a full Project → Variant → Scan → Observation chain."""
+    import os
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": init_files["status"],
+            "OPENVEX_FILE": init_files["openvex"],
+            "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
+        })
+        setup_demo_db(application)
+        _setup_variant_chain(application)
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+def _setup_variant_chain(app):
+    """Add Project → Variant → Scan → Observation so the vuln-variants endpoint works."""
+    from src.extensions import db
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.observation import Observation
+    from src.models.finding import Finding
+
+    with app.app_context():
+        project = Project.get_or_create("test-project")
+        variant_a = Variant.get_or_create("variant-a", project.id)
+        variant_b = Variant.get_or_create("variant-b", project.id)
+        db.session.commit()
+
+        scan_a = Scan(description="scan a", variant_id=variant_a.id)
+        scan_b = Scan(description="scan b", variant_id=variant_b.id)
+        db.session.add_all([scan_a, scan_b])
+        db.session.commit()
+
+        # The existing finding for CVE-2020-35492 / cairo was created by setup_demo_db
+        finding = db.session.execute(
+            db.select(Finding).where(Finding.vulnerability_id == "CVE-2020-35492")
+        ).scalar_one()
+
+        obs_a = Observation(finding_id=finding.id, scan_id=scan_a.id)
+        obs_b = Observation(finding_id=finding.id, scan_id=scan_b.id)
+        db.session.add_all([obs_a, obs_b])
+        db.session.commit()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def client_with_variants(app_with_variants):
+    return app_with_variants.test_client()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/variants
+# ---------------------------------------------------------------------------
+
+def test_list_all_variants_empty(client):
+    """When no projects/variants exist the endpoint returns an empty list."""
+    response = client.get("/api/variants")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert isinstance(data, list)
+
+
+def test_list_all_variants_returns_all(client_with_variants):
+    """GET /api/variants returns every variant across all projects."""
+    response = client_with_variants.get("/api/variants")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert isinstance(data, list)
+    names = [v["name"] for v in data]
+    assert "variant-a" in names
+    assert "variant-b" in names
+
+
+def test_list_all_variants_fields(client_with_variants):
+    """Each variant entry exposes id, name and project_id."""
+    response = client_with_variants.get("/api/variants")
+    data = json.loads(response.data)
+    for variant in data:
+        assert "id" in variant
+        assert "name" in variant
+        assert "project_id" in variant
+        # id and project_id must be valid UUIDs
+        uuid.UUID(variant["id"])
+        uuid.UUID(variant["project_id"])
+
+
+def test_list_all_variants_multiple_projects(app_with_variants, init_files):
+    """Variants from different projects all appear in the flat list."""
+    import os
+    from src.extensions import db
+    from src.models.project import Project
+    from src.models.variant import Variant
+
+    with app_with_variants.app_context():
+        other_project = Project.get_or_create("other-project")
+        Variant.get_or_create("other-variant", other_project.id)
+        db.session.commit()
+
+    client2 = app_with_variants.test_client()
+    response = client2.get("/api/variants")
+    data = json.loads(response.data)
+    names = [v["name"] for v in data]
+    assert "variant-a" in names
+    assert "other-variant" in names
+
+
+# ---------------------------------------------------------------------------
+# GET /api/vulnerabilities/<vuln_id>/variants
+# ---------------------------------------------------------------------------
+
+def test_variants_by_vuln_no_observations(client):
+    """CVE with a finding but no observations → no variants linked."""
+    response = client.get("/api/vulnerabilities/CVE-2020-35492/variants")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data == []
+
+
+def test_variants_by_vuln_returns_linked_variants(client_with_variants):
+    """Both variants observed for CVE-2020-35492 are returned."""
+    response = client_with_variants.get("/api/vulnerabilities/CVE-2020-35492/variants")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert isinstance(data, list)
+    assert len(data) == 2
+    names = {v["name"] for v in data}
+    assert names == {"variant-a", "variant-b"}
+
+
+def test_variants_by_vuln_fields(client_with_variants):
+    """Each variant entry has id, name and project_id."""
+    response = client_with_variants.get("/api/vulnerabilities/CVE-2020-35492/variants")
+    data = json.loads(response.data)
+    for v in data:
+        assert "id" in v
+        assert "name" in v
+        assert "project_id" in v
+        uuid.UUID(v["id"])
+        uuid.UUID(v["project_id"])
+
+
+def test_variants_by_vuln_deduplication(app_with_variants):
+    """Multiple scans on the same variant produce only one entry."""
+    from src.extensions import db
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.observation import Observation
+    from src.models.finding import Finding
+
+    with app_with_variants.app_context():
+        variant = db.session.execute(
+            db.select(Variant).where(Variant.name == "variant-a")
+        ).scalar_one()
+        finding = db.session.execute(
+            db.select(Finding).where(Finding.vulnerability_id == "CVE-2020-35492")
+        ).scalar_one()
+
+        # Add a second scan on variant-a with another observation
+        extra_scan = Scan(description="extra scan", variant_id=variant.id)
+        db.session.add(extra_scan)
+        db.session.commit()
+        db.session.add(Observation(finding_id=finding.id, scan_id=extra_scan.id))
+        db.session.commit()
+
+    client = app_with_variants.test_client()
+    response = client.get("/api/vulnerabilities/CVE-2020-35492/variants")
+    data = json.loads(response.data)
+    names = [v["name"] for v in data]
+    # variant-a must appear exactly once despite two observations
+    assert names.count("variant-a") == 1
+
+
+def test_variants_by_unknown_vuln(client):
+    """Unknown CVE returns an empty list (not a 404)."""
+    response = client.get("/api/vulnerabilities/CVE-9999-00000/variants")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data == []
+
+
+# ---------------------------------------------------------------------------
+# POST /api/vulnerabilities/<vuln_id>/assessments with variant_id
+# ---------------------------------------------------------------------------
+
+def test_post_assessment_with_variant_id(client_with_variants, app_with_variants):
+    """Assessment posted with a variant_id stores and returns that variant_id."""
+    with app_with_variants.app_context():
+        from src.models.variant import Variant
+        from src.extensions import db
+        variant = db.session.execute(
+            db.select(Variant).where(Variant.name == "variant-a")
+        ).scalar_one()
+        variant_id_str = str(variant.id)
+
+    response = client_with_variants.post(
+        "/api/vulnerabilities/CVE-2020-35492/assessments",
+        json={
+            "packages": ["cairo@1.16.0"],
+            "status": "affected",
+            "variant_id": variant_id_str,
+        },
+    )
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data["status"] == "success"
+    assert data["assessment"]["variant_id"] == variant_id_str
+
+
+def test_post_assessment_without_variant_id_has_null(client):
+    """When no variant_id is supplied the field is null in the response."""
+    response = client.post(
+        "/api/vulnerabilities/CVE-2020-35492/assessments",
+        json={"packages": ["cairo@1.16.0"], "status": "affected"},
+    )
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data["assessment"]["variant_id"] is None
+
+
+def test_post_assessment_invalid_variant_id(client):
+    """An unparseable variant_id is rejected with 400."""
+    response = client.post(
+        "/api/vulnerabilities/CVE-2020-35492/assessments",
+        json={
+            "packages": ["cairo@1.16.0"],
+            "status": "affected",
+            "variant_id": "not-a-uuid",
+        },
+    )
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert "variant_id" in data["error"]
+
+
+def test_post_assessment_variant_id_persisted(client_with_variants, app_with_variants):
+    """The variant_id is readable back via GET /api/assessments/<id>."""
+    with app_with_variants.app_context():
+        from src.models.variant import Variant
+        from src.extensions import db
+        variant = db.session.execute(
+            db.select(Variant).where(Variant.name == "variant-b")
+        ).scalar_one()
+        variant_id_str = str(variant.id)
+
+    post_resp = client_with_variants.post(
+        "/api/vulnerabilities/CVE-2020-35492/assessments",
+        json={
+            "packages": ["cairo@1.16.0"],
+            "status": "fixed",
+            "variant_id": variant_id_str,
+        },
+    )
+    assert post_resp.status_code == 200
+    assessment_id = json.loads(post_resp.data)["assessment"]["id"]
+
+    get_resp = client_with_variants.get(f"/api/assessments/{assessment_id}")
+    assert get_resp.status_code == 200
+    fetched = json.loads(get_resp.data)
+    assert fetched["variant_id"] == variant_id_str
+
+
+# ---------------------------------------------------------------------------
+# variant_id field in assessment serialisation (to_dict)
+# ---------------------------------------------------------------------------
+
+def test_assessment_to_dict_includes_variant_id_field(client):
+    """The variant_id key is always present in a serialised assessment."""
+    response = client.get("/api/assessments/da4d18f0-d89e-4d54-819d-86fc884cc737")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert "variant_id" in data
+    # Seed assessment has no variant → value should be None (or null)
+    assert data["variant_id"] is None
+
+
+def test_assessment_list_includes_variant_id_field(client):
+    """All entries returned by GET /api/assessments have a variant_id key."""
+    response = client.get("/api/assessments")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data) > 0
+    for entry in data:
+        assert "variant_id" in entry
+
+
+def test_assessment_variant_id_is_uuid_string_when_set(client_with_variants, app_with_variants):
+    """When a variant_id is stored it is serialised as a UUID string."""
+    with app_with_variants.app_context():
+        from src.models.variant import Variant
+        from src.extensions import db
+        variant = db.session.execute(
+            db.select(Variant).where(Variant.name == "variant-a")
+        ).scalar_one()
+        variant_id_str = str(variant.id)
+
+    post_resp = client_with_variants.post(
+        "/api/vulnerabilities/CVE-2020-35492/assessments",
+        json={
+            "packages": ["cairo@1.16.0"],
+            "status": "affected",
+            "variant_id": variant_id_str,
+        },
+    )
+    assert post_resp.status_code == 200
+    returned_id = json.loads(post_resp.data)["assessment"]["variant_id"]
+    # Must be a valid UUID string
+    uuid.UUID(returned_id)
+    assert returned_id == variant_id_str
+
+
+# ---------------------------------------------------------------------------
+# GET /api/assessments filtered by variant_id
+# ---------------------------------------------------------------------------
+
+def test_filter_assessments_by_variant_id(client_with_variants, app_with_variants):
+    """GET /api/assessments?variant_id=<id> returns only assessments for that variant."""
+    with app_with_variants.app_context():
+        from src.models.variant import Variant
+        from src.extensions import db
+        variant = db.session.execute(
+            db.select(Variant).where(Variant.name == "variant-a")
+        ).scalar_one()
+        variant_id_str = str(variant.id)
+
+    # Create one scoped and one unscoped assessment
+    client_with_variants.post(
+        "/api/vulnerabilities/CVE-2020-35492/assessments",
+        json={"packages": ["cairo@1.16.0"], "status": "affected", "variant_id": variant_id_str},
+    )
+    client_with_variants.post(
+        "/api/vulnerabilities/CVE-2020-35492/assessments",
+        json={"packages": ["cairo@1.16.0"], "status": "fixed"},
+    )
+
+    response = client_with_variants.get(f"/api/assessments?variant_id={variant_id_str}")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert all(a["variant_id"] == variant_id_str for a in data)
+
+
+def test_filter_assessments_by_invalid_variant_id(client):
+    """GET /api/assessments?variant_id=bad returns 400."""
+    response = client.get("/api/assessments?variant_id=not-a-uuid")
+    assert response.status_code == 400


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Possible to select variants/packages to new Assessments
* Possible to select variants/packages during Assessments Edit
* MultiEdit now select the correct variant depending of the context (variant comparaison, global project, variant selected...)
* Clean history assessment with tags for Variants
* Filter history if variant focused 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Setup: 

Build a new image `sfl:custom`:

```
docker build -t sfl:custom .
```

Set the Variable `VULNSCOUT_IMAGE` with the command: 

```
export VULNSCOUT_IMAGE="sfl:custom"
```

Clean the existing DB if any:

```
rm -rf .vulnscout/cache
```

Stop and remove the VulnScout container if any:

```
docker container stop vulnscout
docker container rm vulnscout
``` 

Then add two variants and start VulnScout web interface.

Try to: 

-Add an assessment
-Edit an assessment
-MultiEdit assessment
-Look at the history on CVEs with a selected variant. You should only see the assessment which concerned the variants. 