### PR TITLE
bugfix: resolve "Failed to load data"

### DIFF
--- a/frontend/src/handlers/assessments.ts
+++ b/frontend/src/handlers/assessments.ts
@@ -96,7 +96,7 @@ class Assessments {
      * @returns {Promise<Assessment[]>} A promise that resolves to a list of packages
      */
     static async list(variantId?: string, projectId?: string): Promise<Assessment[]> {
-        const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments");
+        const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments", window.location.href);
         url.searchParams.set('format', 'list');
         if (variantId) url.searchParams.set('variant_id', variantId);
         else if (projectId) url.searchParams.set('project_id', projectId);

--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -45,7 +45,7 @@ class Packages {
      * @returns {Promise<Package[]>} A promise that resolves to a list of packages
      */
     static async list(variantId?: string, projectId?: string): Promise<Package[]> {
-        const url = new URL(import.meta.env.VITE_API_URL + "/api/packages");
+        const url = new URL(import.meta.env.VITE_API_URL + "/api/packages", window.location.href);
         url.searchParams.set('format', 'list');
         if (variantId) url.searchParams.set('variant_id', variantId);
         else if (projectId) url.searchParams.set('project_id', projectId);

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -141,7 +141,7 @@ const asVulnerability = (data: any): Vulnerability | [] => {
 
 class Vulnerabilities {
     static async list(variantId?: string, projectId?: string, compareVariantId?: string, operation?: string): Promise<Vulnerability[]> {
-        const url = new URL(import.meta.env.VITE_API_URL + "/api/vulnerabilities");
+        const url = new URL(import.meta.env.VITE_API_URL + "/api/vulnerabilities", window.location.href);
         url.searchParams.set('format', 'list');
         if (variantId && compareVariantId) {
             url.searchParams.set('variant_id', variantId);
@@ -264,14 +264,14 @@ class Vulnerabilities {
         } catch (e) {
             // Suppress expected invalid vector errors (e.g., from tests providing malformed CVSS strings)
             if (!(e instanceof Error && e.message === 'invalid vector')) {
-                 
+
                 console.error(e);
             }
             return null;
         }
     }
 
- 
+
 
 }
 

--- a/vulnscout
+++ b/vulnscout
@@ -165,6 +165,7 @@ USER_UID=$(id -u)
 USER_GID=$(id -g)
 VULNSCOUT_VERSION=$VULNSCOUT_VERSION
 VULNSCOUT_CACHE_DIR=$VULNSCOUT_CACHE_DIR
+VITE_API_URL=http://localhost:7275
 EOF
         echo "Created default config at $VULNSCOUT_CONFIG_FILE"
     fi
@@ -215,7 +216,7 @@ start_frontend_dev() {
     fi
 
     if [ ! -f "$frontend_dir/.env" ]; then
-        echo 'VITE_API_URL="http://localhost:7275"' > "$frontend_dir/.env"
+        echo "VITE_API_URL=\"${VITE_API_URL:-http://localhost:7275}\"" > "$frontend_dir/.env"
     fi
 
     if [ ! -d "$frontend_dir/node_modules" ]; then


### PR DESCRIPTION
## Fixes # by Valentin

### Changes proposed in this pull request:

When VITE_API_URL is empty by passing window.location.href as base to new URL(). This update solve the issue and start the web interface correctly

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change


Setup: 

Build a new image `sfl:custom`:

```
docker build -t sfl:custom .
```

Set the Variable `VULNSCOUT_IMAGE` with the command: 

```
export VULNSCOUT_IMAGE="sfl:custom"
```

Clean the existing DB if any:

```
rm -rf .vulnscout/cache
```

Stop and remove the VulnScout container if any:

```
docker container stop vulnscout
docker container rm vulnscout
``` 

Test- Fill the database and start the Web UI: 

```
./vulnscout serve --add-spdx $(pwd)/.vulnscout/example/spdx3/core-image-minimal-qemux86-64.rootfs.spdx.json \
--add-cve-check $(pwd)/.vulnscout/example/spdx3/core-image-minimal-qemux86-64.rootfs.json
```
