### PR TITLE
Various small improvements to VulnScout

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ This project contains default examples of VulnScout.
 To run VulnScout demo in interactive mode, you can simply run the command:
 [source,shell]
 ----
-./vulnscout serve --add-spdx $(pwd)/example/spdx3/core-image-minimal-qemux86-64.rootfs.spdx.json \
+./vulnscout --serve --add-spdx $(pwd)/example/spdx3/core-image-minimal-qemux86-64.rootfs.spdx.json \
 --add-cve-check $(pwd)/example/spdx3/core-image-minimal-qemux86-64.rootfs.json
 ----
 
@@ -67,7 +67,7 @@ If you don't need additional source files, VulnScout can be rerun directly witho
 
 [source,shell]
 ----
-./vulnscout serve
+./vulnscout --serve
 ----
 
 It is also possible to add sources files on a specific project and variant with the `--project` and `--variant` arguments:
@@ -157,7 +157,7 @@ If you want to use the non-interactive mode, without the web interface, you can 
 
 [source,shell]
 ----
-./vulnscout --project demo --match-condition "cvss >= 9.0 or (cvss >= 7.0 and epss >= 50%)"
+./vulnscout --project demo --match-condition "((cvss >= 9.0 or (cvss >= 7.0 and epss >= 30%)) and (pending == true or affected == true))"
 ----
 
 The command exits with code `2` if any vulnerability matches the condition, enabling use in CI pipelines.
@@ -171,7 +171,7 @@ You can combine inputs with a match condition in a single invocation:
 ./vulnscout --project demo \
   --add-spdx /path/to/sbom.spdx.json \
   --add-cve-check /path/to/cve-check.json \
-  --match-condition "cvss >= 9.0"
+  --match-condition "((cvss >= 9.0) and (pending == true or affected == true)) "
 ----
 
 ===  Performing a Grype Scan
@@ -197,7 +197,7 @@ Reports are generated from AsciiDoc templates. VulnScout ships with built-in tem
 [source,shell]
 ----
 # Generate a report from a built-in template
-./vulnscout --project demo report summary.adoc
+./vulnscout --project demo --report summary.adoc
 
 # Generate a match-condition report (lists vulnerabilities that triggered the condition)
 ./vulnscout --project demo --match-condition "cvss >= 9.0" --report match_condition.adoc
@@ -206,17 +206,17 @@ Reports are generated from AsciiDoc templates. VulnScout ships with built-in tem
 ./vulnscout --report /path/to/my-custom-report.adoc
 
 # Then generate a report from it by name
-./vulnscout --project demo report my-custom-report.adoc
+./vulnscout --project demo --report my-custom-report.adoc
 
 # Or pass the file path directly — registers and runs it in one step
-./vulnscout --project demo report /path/to/my-custom-report.adoc
+./vulnscout --project demo --report /path/to/my-custom-report.adoc
 ----
 
 Multiple reports can be generated in one command:
 
 [source,shell]
 ----
-./vulnscout --project demo report summary.adoc --report all_assessments.adoc
+./vulnscout --project demo --report summary.adoc --report all_assessments.adoc
 ----
 
 Reports are written to the outputs directory (default: `.vulnscout/outputs/`).
@@ -247,7 +247,7 @@ Export commands can be chained with inputs and reports in a single invocation:
   --add-spdx /path/to/sbom.spdx.json \
   --add-cve-check /path/to/cve-check.json \
   --export-spdx --export-cdx --export-openvex \
-  report summary.adoc
+  --report summary.adoc
 ----
 
 === Configuration
@@ -432,7 +432,7 @@ Or combined with a serve command:
 
 [source,shell]
 ----
-./vulnscout --dev serve
+./vulnscout --dev --serve
 ----
 
 The frontend dev server uses `VITE_API_URL` from the config to reach the backend (default: `http://localhost:7275`).

--- a/README_DEV.adoc
+++ b/README_DEV.adoc
@@ -60,7 +60,7 @@ Or start with inputs and the web UI in one step:
 
 [source,bash]
 ----
-./vulnscout --dev serve \
+./vulnscout --dev --serve \
   --add-spdx /path/to/sbom.spdx.json \
   --add-cve-check /path/to/cve-check.json
 ----
@@ -80,7 +80,7 @@ Or combined with a serve command that also loads input files:
 
 [source,bash]
 ----
-./vulnscout --dev serve \
+./vulnscout --dev --serve \
   --add-spdx /path/to/sbom.spdx.json \
   --add-cve-check /path/to/cve-check.json
 ----

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
   const [loading, setLoading] = useState(true);
   const [loadingText, setLoadingText] = useState({
     topline: 'Vulnerability analysis is running...',
-    details: 'Step 0 : starting script'
+    details: 'Starting...'
   });
   const [darkMode, setDarkMode] = useState(true);
   const [notification, setNotification] = useState<Notification | null>(null);
@@ -45,7 +45,7 @@ function App() {
         }
         setLoadingText({
           topline: 'Vulnerability analysis is running...',
-          details: `Step ${data?.step ?? '0'}/${data?.maxsteps ?? '?'} : ${data?.message}`
+          details: data?.message ?? 'Processing...'
         });
       })
       .catch(error => {

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -134,7 +134,7 @@ function EditAssessment({
         setImpact(isImpactStatus ? (assessment.impact_statement || "") : "");
         setSelectedVariantIds(defaultSelectedVariantIds ?? (availableVariants?.length === 1 ? [availableVariants[0].id] : []));
         setSelectedPackages(defaultSelectedPackages ?? (availablePackages?.length === 1 ? [availablePackages[0]] : []));
-    }, [assessment, isImpactStatus, defaultSelectedVariantIds, defaultSelectedPackages]);
+    }, [assessment, isImpactStatus, defaultSelectedVariantIds, defaultSelectedPackages, availableVariants, availablePackages]);
 
     useEffect(() => {
         if (shouldClearFields) {

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -49,8 +49,12 @@ function EditAssessment({
     );
     const [workaround, setWorkaround] = useState(assessment.workaround || "");
     const [impact, setImpact] = useState(isImpactStatus ? (assessment.impact_statement || "") : "");
-    const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>(defaultSelectedVariantIds ?? []);
-    const [selectedPackages, setSelectedPackages] = useState<string[]>(defaultSelectedPackages ?? []);
+    const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>(
+        defaultSelectedVariantIds ?? (availableVariants?.length === 1 ? [availableVariants[0].id] : [])
+    );
+    const [selectedPackages, setSelectedPackages] = useState<string[]>(
+        defaultSelectedPackages ?? (availablePackages?.length === 1 ? [availablePackages[0]] : [])
+    );
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -128,8 +132,8 @@ function EditAssessment({
         setStatusNotes(assessment.status_notes || (!isImpactStatus ? (assessment.impact_statement || "") : ""));
         setWorkaround(assessment.workaround || "");
         setImpact(isImpactStatus ? (assessment.impact_statement || "") : "");
-        setSelectedVariantIds(defaultSelectedVariantIds ?? []);
-        setSelectedPackages(defaultSelectedPackages ?? []);
+        setSelectedVariantIds(defaultSelectedVariantIds ?? (availableVariants?.length === 1 ? [availableVariants[0].id] : []));
+        setSelectedPackages(defaultSelectedPackages ?? (availablePackages?.length === 1 ? [availablePackages[0]] : []));
     }, [assessment, isImpactStatus, defaultSelectedVariantIds, defaultSelectedPackages]);
 
     useEffect(() => {

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -82,6 +82,11 @@ function EditAssessment({
         onFieldsChange?.(hasChanges);
     }, [status, justification, statusNotes, workaround, impact, onFieldsChange, assessment, isImpactStatus]);
 
+    // Auto-select single variant when availableVariants load asynchronously (e.g. Edit from Actions column)
+    useEffect(() => {
+        setSelectedVariantIds(defaultSelectedVariantIds ?? (availableVariants?.length === 1 ? [availableVariants[0].id] : []));
+    }, [availableVariants, defaultSelectedVariantIds]);
+
     function saveAssessment() {
         if (status == '' || justification == '')
             return;

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -36,14 +36,14 @@ function NavigationBar({ tab, changeTab, darkMode, setDarkMode, defaultProject, 
         </button>
       </li>
 
-      {/* === Packages === */}
+      {/* === SBOM === */}
       <li className={[bgHoverColor, tab == 'packages' && bgActiveColor].join(' ')}>
         <button
           onClick={() => changeTab('packages')}
           className="flex items-center h-full px-4 py-2"
         >
           <FontAwesomeIcon icon={faBox} className="mr-1" />
-          Packages
+          SBOM
         </button>
       </li>
 

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -53,6 +53,11 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         setSelectedPackages(availablePackages ?? []);
     }, [availablePackages]);
 
+    // Auto-select single variant when variants load asynchronously (e.g. Edit from Actions column)
+    useEffect(() => {
+        setSelectedVariantIds(variants?.length === 1 ? [variants[0].id] : []);
+    }, [variants]);
+
     // Update status when defaultStatus prop changes
     useEffect(() => {
         setStatus(defaultStatus);

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -30,7 +30,9 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
     const [statusNotes, setStatusNotes] = useState("");
     const [workaround, setWorkaround] = useState("");
     const [impact, setImpact] = useState("");
-    const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>([]);
+    const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>(
+        variants?.length === 1 ? [variants[0].id] : []
+    );
     const [selectedPackages, setSelectedPackages] = useState<string[]>(availablePackages ?? []);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
@@ -120,9 +122,9 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         setStatusNotes("");
         setWorkaround("");
         setImpact("");
-        setSelectedVariantIds([]);
+        setSelectedVariantIds(variants?.length === 1 ? [variants[0].id] : []);
         setSelectedPackages(availablePackages ?? []);
-    }, [defaultStatus, availablePackages]);
+    }, [defaultStatus, availablePackages, variants]);
 
     useEffect(() => {
         if (shouldClearFields) {

--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -9,6 +9,7 @@ type Package = {
     vulnerabilities: VulnCounts;
     maxSeverity: Severities;
     source: string[];
+    variants: string[];
 };
 
 export type { Package, VulnCounts, Severities };
@@ -28,6 +29,7 @@ const asPackage = (data: any): Package | [] => {
         vulnerabilities: {},
         maxSeverity: {},
         source: [],
+        variants: [],
     };
     if (typeof data?.id === "string" && data?.id != "") pkg.id = data.id;
     if (Array.isArray(data?.cpe)) {
@@ -96,6 +98,7 @@ class Packages {
                 vulnerabilities: counts,
                 maxSeverity: severities,
                 source: [...new Set(vulnerabilities.map((vuln) => vuln.found_by).flat())],
+                variants: [...new Set(vulnerabilities.flatMap((vuln) => vuln.variants || []))],
             };
         });
     }

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -11,8 +11,10 @@ type Scan = {
     is_first: boolean;
     findings_added: number | null;
     findings_removed: number | null;
+    findings_upgraded: number | null;
     packages_added: number | null;
     packages_removed: number | null;
+    packages_upgraded: number | null;
     vulns_added: number | null;
     vulns_removed: number | null;
 };
@@ -31,6 +33,21 @@ type PackageDiffEntry = {
     package_version: string;
 };
 
+type PackageUpgradeEntry = {
+    package_name: string;
+    old_version: string;
+    new_version: string;
+    old_package_id: string;
+    new_package_id: string;
+};
+
+type FindingUpgradeEntry = {
+    vulnerability_id: string;
+    package_name: string;
+    old_version: string;
+    new_version: string;
+};
+
 type ScanDiff = {
     scan_id: string;
     previous_scan_id: string | null;
@@ -40,13 +57,15 @@ type ScanDiff = {
     vuln_count: number;
     findings_added: FindingDiffEntry[];
     findings_removed: FindingDiffEntry[];
+    findings_upgraded: FindingUpgradeEntry[];
     packages_added: PackageDiffEntry[];
     packages_removed: PackageDiffEntry[];
+    packages_upgraded: PackageUpgradeEntry[];
     vulns_added: string[];
     vulns_removed: string[];
 };
 
-export type { Scan, FindingDiffEntry, PackageDiffEntry, ScanDiff };
+export type { Scan, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry, ScanDiff };
 
 class ScansHandler {
     static async list(variantId?: string, projectId?: string): Promise<Scan[]> {

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -26,6 +26,7 @@ type Vulnerability = {
     variants: string[];
     urls: string[];
     published?: string;
+    first_scan_date?: string;
     texts: {
         title: string;
         content: string;
@@ -140,6 +141,7 @@ const asVulnerability = (data: any): Vulnerability | [] => {
     if (typeof data?.effort?.pessimistic === "string") vuln.effort.pessimistic = new Iso8601Duration(data.effort.pessimistic)
     if (typeof data?.fix?.state === "string") vuln.fix.state = data.fix.state
     if (typeof data?.published === "string") vuln.published = data.published
+    if (typeof data?.first_scan_date === "string") vuln.first_scan_date = data.first_scan_date
     return vuln
 }
 

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -168,7 +168,7 @@ const vulnColumns = useMemo(
       header: () => <div className="flex items-center justify-center h-full">Severity</div>,
       cell: (info: any) => (
         <div className="flex items-center justify-center h-full text-center">
-          <SeverityTag severity={info.getValue()} />
+          <SeverityTag severity={info.getValue()} className="!py-0" />
         </div>
       ),
       size: 100,
@@ -182,7 +182,7 @@ const vulnColumns = useMemo(
         return (
           <div className="flex items-center justify-center h-full text-center">
             <button
-              className="bg-slate-800 hover:bg-slate-700 px-2 py-1 rounded-lg"
+              className="bg-slate-800 hover:bg-slate-700 px-2 rounded-lg"
               onClick={() => {
                 // Get the current TopVulns list and find the index
                 const currentTopVulns = [...vulnerabilities]
@@ -194,7 +194,7 @@ const vulnColumns = useMemo(
                       id: index + 1,
                       rank: 0,
                       cve: v.id,
-                      package: v.packages.join(", "),
+                      package: v.packages_current.join(", "),
                       severity: v.severity.severity,
                       maxCvss,
                       texts: v.texts,
@@ -410,7 +410,7 @@ const packageColumns = [
   const topVulnerablePackages = useMemo(() => {
     const counts: Record<string, { count: number; version?: string }> = {};
     vulnerabilities.forEach((vuln) => {
-      vuln.packages.forEach((pkg) => {
+      vuln.packages_current.forEach((pkg) => {
         const [pkgName, pkgVersion] = pkg.split("@");
         if (!counts[pkgName]) {
           counts[pkgName] = { count: 0, version: pkgVersion };
@@ -443,7 +443,7 @@ const packageColumns = [
           id: index + 1,
           rank: 0,
           cve: vuln.id,
-          package: vuln.packages.join(", "),
+          package: vuln.packages_current.join(", "),
           severity: vuln.severity.severity,
           maxCvss,
           texts: vuln.texts,
@@ -541,10 +541,10 @@ const packageColumns = [
             }
 
       return (
-        <div className="w-full">
+        <div className="w-full flex flex-col gap-4 pb-8">
 
           {/* === TOP CHART GRID === */}
-          <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
 
             {/* Vulnerabilities by Severity */}
             <div className="p-4">
@@ -627,7 +627,7 @@ const packageColumns = [
           </div>
 
         {/* === TABLES SECTION === */}
-        <div className="w-full grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="w-full grid grid-cols-1 lg:grid-cols-2">
 
           {/* Most Critical Unfixed Vulnerabilities */}
           <div className="p-4">
@@ -649,7 +649,6 @@ const packageColumns = [
               <TableGeneric
                 columns={vulnColumns}
                 data={TopVulns}
-                hoverField="texts"
                 hasPagination={false}
                 tableHeight="auto"
               />

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -596,7 +596,7 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
                 <DiffModal scanId={openDiffId} onClose={() => setOpenDiffId(null)} />
             )}
 
-            <div className="max-w-5xl mx-auto py-6">
+            <div className="max-w-7xl mx-auto py-6">
                 <h1 className="text-2xl font-bold mb-6 text-gray-800 dark:text-neutral-100">
                     Scan History
                 </h1>
@@ -626,26 +626,26 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
                                             /* First scan: total counts */
                                             <>
                                                 <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
-                                                    {(scan.package_count ?? 0).toLocaleString()} pkgs
+                                                    {(scan.package_count ?? 0).toLocaleString()} packages
                                                 </span>
                                                 <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
                                                     {(scan.finding_count ?? 0).toLocaleString()} findings
                                                 </span>
                                                 <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
-                                                    {(scan.vuln_count ?? 0).toLocaleString()} vulns
+                                                    {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities
                                                 </span>
                                             </>
                                         ) : (
                                             /* Subsequent scans: diff badges */
                                             <>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    +{(scan.packages_added ?? 0).toLocaleString()} pkgs
+                                                    +{(scan.packages_added ?? 0).toLocaleString()} packages
                                                 </span>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    −{(scan.packages_removed ?? 0).toLocaleString()} pkgs
+                                                    −{(scan.packages_removed ?? 0).toLocaleString()} packages
                                                 </span>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    ↑{(scan.packages_upgraded ?? 0).toLocaleString()} upgraded
+                                                    ↑{(scan.packages_upgraded ?? 0).toLocaleString()} packages upgraded
                                                 </span>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     +{(scan.findings_added ?? 0).toLocaleString()} findings
@@ -654,13 +654,13 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
                                                     −{(scan.findings_removed ?? 0).toLocaleString()} findings
                                                 </span>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    ↑{(scan.findings_upgraded ?? 0).toLocaleString()} upgraded
+                                                    ↑{(scan.findings_upgraded ?? 0).toLocaleString()} findings upgraded
                                                 </span>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    +{(scan.vulns_added ?? 0).toLocaleString()} vulns
+                                                    +{(scan.vulns_added ?? 0).toLocaleString()} vulnerabilities
                                                 </span>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    −{(scan.vulns_removed ?? 0).toLocaleString()} vulns
+                                                    −{(scan.vulns_removed ?? 0).toLocaleString()} vulnerabilities
                                                 </span>
                                             </>
                                         )}

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -11,12 +11,14 @@ type Props = {
 
 function formatDate(iso: string): string {
     const d = new Date(iso);
-    return d.toLocaleString(undefined, {
+    return d.toLocaleDateString(undefined, {
         year: 'numeric',
         month: 'short',
         day: '2-digit',
+    }) + ' ' + d.toLocaleTimeString(undefined, {
         hour: '2-digit',
         minute: '2-digit',
+        timeZoneName: 'short',
     });
 }
 

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import ScansHandler from "../handlers/scans";
-import type { Scan, ScanDiff, FindingDiffEntry, PackageDiffEntry } from "../handlers/scans";
+import type { Scan, ScanDiff, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry } from "../handlers/scans";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPencil, faCheck, faXmark } from "@fortawesome/free-solid-svg-icons";
 
@@ -44,15 +44,13 @@ function FindingDiffTable({ entries, label, colorClass }: {
                 <h3 className={["font-bold text-base", colorClass].join(' ')}>
                     {label} ({entries.length})
                 </h3>
-                {entries.length > 10 && (
-                    <input
-                        type="text"
-                        placeholder="Filter…"
-                        value={filter}
-                        onChange={e => setFilter(e.target.value)}
-                        className="text-xs px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 w-48"
-                    />
-                )}
+                <input
+                    type="text"
+                    placeholder="Filter\u2026"
+                    value={filter}
+                    onChange={e => setFilter(e.target.value)}
+                    className="text-xs px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 w-48"
+                />
             </div>
             {entries.length === 0 ? (
                 <p className="text-sm text-gray-400 italic">None</p>
@@ -71,6 +69,65 @@ function FindingDiffTable({ entries, label, colorClass }: {
                                 <tr key={e.finding_id} className="border-t border-gray-600 hover:bg-gray-600/40">
                                     <td className="px-3 py-1.5 font-mono">{e.package_name}</td>
                                     <td className="px-3 py-1.5 font-mono text-gray-400">{e.package_version}</td>
+                                    <td className="px-3 py-1.5 font-mono">{e.vulnerability_id}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function FindingUpgradeDiffTable({ entries, label, colorClass }: {
+    entries: FindingUpgradeEntry[];
+    label: string;
+    colorClass: string;
+}) {
+    const [filter, setFilter] = useState('');
+    const filtered = filter
+        ? entries.filter(e =>
+            e.package_name.toLowerCase().includes(filter.toLowerCase()) ||
+            e.vulnerability_id.toLowerCase().includes(filter.toLowerCase()) ||
+            e.old_version.toLowerCase().includes(filter.toLowerCase()) ||
+            e.new_version.toLowerCase().includes(filter.toLowerCase())
+        )
+        : entries;
+
+    return (
+        <div className="mb-6">
+            <div className="flex items-center justify-between mb-2 gap-3">
+                <h3 className={["font-bold text-base", colorClass].join(' ')}>
+                    {label} ({entries.length})
+                </h3>
+                <input
+                    type="text"
+                    placeholder="Filter&#x2026;"
+                    value={filter}
+                    onChange={e => setFilter(e.target.value)}
+                    className="text-xs px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 w-48"
+                />
+            </div>
+            {entries.length === 0 ? (
+                <p className="text-sm text-gray-400 italic">None</p>
+            ) : (
+                <div className="overflow-auto max-h-48 rounded border border-gray-600">
+                    <table className="w-full text-xs text-left">
+                        <thead className="sticky top-0 bg-gray-800 text-gray-300 uppercase">
+                            <tr>
+                                <th className="px-3 py-2">Package</th>
+                                <th className="px-3 py-2">Old Version</th>
+                                <th className="px-3 py-2">New Version</th>
+                                <th className="px-3 py-2">Vulnerability</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {filtered.map((e, i) => (
+                                <tr key={e.vulnerability_id + e.package_name + i} className="border-t border-gray-600 hover:bg-gray-600/40">
+                                    <td className="px-3 py-1.5 font-mono">{e.package_name}</td>
+                                    <td className="px-3 py-1.5 font-mono text-red-400">{e.old_version}</td>
+                                    <td className="px-3 py-1.5 font-mono text-green-400">{e.new_version}</td>
                                     <td className="px-3 py-1.5 font-mono">{e.vulnerability_id}</td>
                                 </tr>
                             ))}
@@ -127,6 +184,64 @@ function PackageDiffTable({ entries, label, colorClass }: {
                                 <tr key={e.package_id} className="border-t border-gray-600 hover:bg-gray-600/40">
                                     <td className="px-3 py-1.5 font-mono">{e.package_name}</td>
                                     <td className="px-3 py-1.5 font-mono text-gray-400">{e.package_version}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function PackageUpgradeDiffTable({ entries, label, colorClass }: {
+    entries: PackageUpgradeEntry[];
+    label: string;
+    colorClass: string;
+}) {
+    const [filter, setFilter] = useState('');
+    const filtered = filter
+        ? entries.filter(e =>
+            e.package_name.toLowerCase().includes(filter.toLowerCase()) ||
+            e.old_version.toLowerCase().includes(filter.toLowerCase()) ||
+            e.new_version.toLowerCase().includes(filter.toLowerCase())
+        )
+        : entries;
+
+    return (
+        <div className="mb-6">
+            <div className="flex items-center justify-between mb-2 gap-3">
+                <h3 className={["font-bold text-base", colorClass].join(' ')}>
+                    {label} ({entries.length})
+                </h3>
+                {entries.length > 10 && (
+                    <input
+                        type="text"
+                        placeholder="Filter…"
+                        value={filter}
+                        onChange={e => setFilter(e.target.value)}
+                        className="text-xs px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 w-48"
+                    />
+                )}
+            </div>
+            {entries.length === 0 ? (
+                <p className="text-sm text-gray-400 italic">None</p>
+            ) : (
+                <div className="overflow-auto max-h-48 rounded border border-gray-600">
+                    <table className="w-full text-xs text-left">
+                        <thead className="sticky top-0 bg-gray-800 text-gray-300 uppercase">
+                            <tr>
+                                <th className="px-3 py-2">Package</th>
+                                <th className="px-3 py-2">Old Version</th>
+                                <th className="px-3 py-2">New Version</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {filtered.map((e) => (
+                                <tr key={e.old_package_id + e.new_package_id} className="border-t border-gray-600 hover:bg-gray-600/40">
+                                    <td className="px-3 py-1.5 font-mono">{e.package_name}</td>
+                                    <td className="px-3 py-1.5 font-mono text-red-400">{e.old_version}</td>
+                                    <td className="px-3 py-1.5 font-mono text-green-400">{e.new_version}</td>
                                 </tr>
                             ))}
                         </tbody>
@@ -271,6 +386,9 @@ function DiffModal({ scanId, onClose }: { scanId: string; onClose: () => void })
                                         <span className={`ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold ${diff.packages_removed.length > 0 ? 'bg-red-900/40 text-red-300' : 'bg-gray-600 text-gray-400'}`}>
                                             −{diff.packages_removed.length.toLocaleString()}
                                         </span>
+                                        <span className={`ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold ${diff.packages_upgraded.length > 0 ? 'bg-yellow-900/40 text-yellow-300' : 'bg-gray-600 text-gray-400'}`}>
+                                            ↑{diff.packages_upgraded.length.toLocaleString()}
+                                        </span>
                                     </>
                                 )}
                             </button>
@@ -287,6 +405,9 @@ function DiffModal({ scanId, onClose }: { scanId: string; onClose: () => void })
                                         </span>
                                         <span className={`ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold ${diff.findings_removed.length > 0 ? 'bg-red-900/40 text-red-300' : 'bg-gray-600 text-gray-400'}`}>
                                             −{diff.findings_removed.length.toLocaleString()}
+                                        </span>
+                                        <span className={`ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold ${diff.findings_upgraded.length > 0 ? 'bg-yellow-900/40 text-yellow-300' : 'bg-gray-600 text-gray-400'}`}>
+                                            ↑{diff.findings_upgraded.length.toLocaleString()}
                                         </span>
                                     </>
                                 )}
@@ -334,6 +455,13 @@ function DiffModal({ scanId, onClose }: { scanId: string; onClose: () => void })
                                         colorClass="text-red-400"
                                     />
                                 )}
+                                {!diff.is_first && (
+                                    <PackageUpgradeDiffTable
+                                        entries={diff.packages_upgraded}
+                                        label="Upgraded packages"
+                                        colorClass="text-yellow-400"
+                                    />
+                                )}
                             </>
                         )}
                         {diff && section === 'findings' && (
@@ -353,6 +481,13 @@ function DiffModal({ scanId, onClose }: { scanId: string; onClose: () => void })
                                         entries={diff.findings_removed}
                                         label="Removed findings"
                                         colorClass="text-red-400"
+                                    />
+                                )}
+                                {!diff.is_first && diff.findings_upgraded.length > 0 && (
+                                    <FindingUpgradeDiffTable
+                                        entries={diff.findings_upgraded}
+                                        label="Findings on upgraded packages"
+                                        colorClass="text-yellow-400"
                                     />
                                 )}
                             </>
@@ -459,7 +594,7 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
                 <DiffModal scanId={openDiffId} onClose={() => setOpenDiffId(null)} />
             )}
 
-            <div className="max-w-3xl mx-auto py-6">
+            <div className="max-w-5xl mx-auto py-6">
                 <h1 className="text-2xl font-bold mb-6 text-gray-800 dark:text-neutral-100">
                     Scan History
                 </h1>
@@ -507,11 +642,17 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     −{(scan.packages_removed ?? 0).toLocaleString()} pkgs
                                                 </span>
+                                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                    ↑{(scan.packages_upgraded ?? 0).toLocaleString()} upgraded
+                                                </span>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     +{(scan.findings_added ?? 0).toLocaleString()} findings
                                                 </span>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     −{(scan.findings_removed ?? 0).toLocaleString()} findings
+                                                </span>
+                                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                    ↑{(scan.findings_upgraded ?? 0).toLocaleString()} upgraded
                                                 </span>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     +{(scan.vulns_added ?? 0).toLocaleString()} vulns

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -46,15 +46,15 @@ const fuseKeys = ['id', 'name', 'version', 'cpe', 'purl']
 function CpeCell({ version, cpe }: { version: string; cpe?: string[] }) {
     const [showCpeBox, setShowCpeBox] = useState(false);
     const buttonRef = useRef<HTMLSpanElement>(null);
-    
+
     return (
         <div className="flex items-center justify-center h-full text-center gap-1">
             <span>{version}</span>
             {cpe && cpe.length > 0 && (
                 <>
-                    <span 
+                    <span
                         ref={buttonRef}
-                        className="cursor-pointer text-blue-400 hover:text-blue-300 px-2 py-0.5 bg-blue-900/30 border border-blue-500/40 rounded text-xs font-semibold" 
+                        className="cursor-pointer text-blue-400 hover:text-blue-300 px-2 py-0.5 bg-blue-900/30 border border-blue-500/40 rounded text-xs font-semibold"
                         onClick={() => setShowCpeBox(!showCpeBox)}
                     >
                         CPE
@@ -114,7 +114,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
     useEffect(() => {
         const handleKeyPress = (event: KeyboardEvent) => {
             // Only trigger if not typing in an input/textarea
-            if (event.target instanceof HTMLInputElement || 
+            if (event.target instanceof HTMLInputElement ||
                 event.target instanceof HTMLTextAreaElement) {
                 return;
             }
@@ -197,6 +197,40 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                 },
                 sortingFn: (a, b) => sortVunerabilitiesFn(a, b, [])
             }
+            ),
+            columnHelper.accessor('variants', {
+                id: 'variants',
+                header: () => <div className="flex items-center justify-center">Variants</div>,
+                cell: info => (
+                    <div className="flex items-center justify-center h-full">
+                        <div className="flex flex-wrap gap-1 justify-center">
+                            {info.getValue().map((name: string) => (
+                                <span key={name} className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-900 text-green-300">
+                                    {name}
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+                ),
+                enableSorting: false,
+                size: 120
+            }),
+            columnHelper.accessor(
+                row => row.vulnerabilities['Pending Assessment'] ?? 0,
+                {
+                    id: 'remainingPendingVulns',
+                    header: () => <div className="flex items-center justify-center">Remaining Pending Vulns</div>,
+                    cell: info => (
+                        <div className="flex items-center justify-center h-full text-center">
+                            {info.getValue()}
+                        </div>
+                    ),
+                    sortingFn: (a, b) => {
+                        const countA = a.original.vulnerabilities['Pending Assessment'] ?? 0;
+                        const countB = b.original.vulnerabilities['Pending Assessment'] ?? 0;
+                        return countA - countB;
+                    }
+                }
             ),
             columnHelper.accessor('source', {
                 header: () => <div className="flex items-center justify-center">Sources</div>,

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -171,7 +171,8 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
             columnHelper.accessor('name', {
                 header: () => <div className="flex items-center justify-center">Name</div>,
                 cell: info => <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>,
-                footer: info => <div className="flex items-center justify-center h-full">{`Total: ${info.table.getRowCount()}`}</div>
+                footer: info => <div className="flex items-center justify-center h-full">{`Total: ${info.table.getRowCount()}`}</div>,
+                size: 300
             }),
             columnHelper.accessor('version', {
                 header: () => <div className="flex items-center justify-center">Version</div>,
@@ -195,7 +196,8 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                     </div>
                 );
                 },
-                sortingFn: (a, b) => sortVunerabilitiesFn(a, b, [])
+                sortingFn: (a, b) => sortVunerabilitiesFn(a, b, []),
+                size: 80
             }
             ),
             columnHelper.accessor('variants', {
@@ -219,7 +221,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                 row => row.vulnerabilities['Pending Assessment'] ?? 0,
                 {
                     id: 'remainingPendingVulns',
-                    header: () => <div className="flex items-center justify-center">Remaining Pending Vulns</div>,
+                    header: () => <div className="flex items-center justify-center">Remaining Pending Vulnerabilities</div>,
                     cell: info => (
                         <div className="flex items-center justify-center h-full text-center">
                             {info.getValue()}
@@ -229,7 +231,8 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                         const countA = a.original.vulnerabilities['Pending Assessment'] ?? 0;
                         const countB = b.original.vulnerabilities['Pending Assessment'] ?? 0;
                         return countA - countB;
-                    }
+                    },
+                    size: 80
                 }
             ),
             columnHelper.accessor('source', {

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -12,12 +12,12 @@ import VulnModal from "../components/VulnModal";
 import MultiEditBar from "../components/MultiEditBar";
 import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
-import ToggleSwitch from "../components/ToggleSwitch";
+
 import MessageBanner from "../components/MessageBanner";
 import NVDProgressHandler from "../handlers/nvd_progress";
 import EPSSProgressHandler from "../handlers/epss_progress";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes, faCaretDown, faCircleQuestion, faSync } from '@fortawesome/free-solid-svg-icons';
+import { faTimes, faFilter, faCaretDown, faCircleQuestion, faSync } from '@fortawesome/free-solid-svg-icons';
 import RangeSlider from "../components/RangeSlider";
 
 type Props = {
@@ -288,7 +288,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const [nvdProgress, setNvdProgress] = useState<NVDProgress | null>(null);
     const [epssProgress, setEpssProgress] = useState<EPSSProgress | null>(null);
     const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
-    const [hideFixed, setHideFixed] = useState<boolean>(false);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -300,11 +299,17 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
 
     const [showCustomSeverityFilter, setShowCustomSeverityFilter] = useState<boolean>(false);
     const [severityRange, setSeverityRange] = useState<{ min: number; max: number }>({ min: SEVERITY_RANGE_MIN, max: SEVERITY_RANGE_MAX });
+    const [showCustomEpssFilter, setShowCustomEpssFilter] = useState<boolean>(false);
+    const [epssRange, setEpssRange] = useState<{ min: number; max: number }>({ min: 0, max: 100 });
+    const [selectedAttackVectors, setSelectedAttackVectors] = useState<string[]>([]);
+    const [selectedFirstScanDates, setSelectedFirstScanDates] = useState<string[]>([]);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
+    const [showMoreFilters, setShowMoreFilters] = useState(false);
 
     const searchInputRef = useRef<HTMLInputElement>(null);
     const shortcutButtonRef = useRef<HTMLButtonElement>(null);
     const shortcutDropdownRef = useRef<HTMLDivElement>(null);
+    const moreFiltersRef = useRef<HTMLDivElement>(null);
 
     const keyboardShortcuts = [
         { key: '/', description: 'Focus search bar' },
@@ -377,6 +382,47 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const updateCustomSeverityFilter = debounce((value: { min: number; max: number }) => {
         setSeverityRange(value);
     }, 750, { maxWait: 5000 });
+
+    const updateCustomEpssFilter = debounce((value: { min: number; max: number }) => {
+        setEpssRange(value);
+    }, 750, { maxWait: 5000 });
+
+    const attack_vector_list = useMemo(() => {
+        const avSet = new Set<string>();
+        vulnerabilities.forEach(vuln => {
+            vuln.severity.cvss.forEach(cvss => {
+                if (cvss.attack_vector) avSet.add(cvss.attack_vector);
+            });
+        });
+        const order = ['NETWORK', 'ADJACENT', 'LOCAL', 'PHYSICAL'];
+        return Array.from(avSet).sort((a, b) => order.indexOf(a) - order.indexOf(b));
+    }, [vulnerabilities]);
+
+    // Build list of distinct first-scan timestamps, grouped by scan (same second = same scan)
+    const availableFirstScanDates = useMemo(() => {
+        const tsSet = new Set<number>();
+        vulnerabilities.forEach(vuln => {
+            if (vuln.first_scan_date) {
+                // Round to the nearest second to group identical scans
+                const ts = Math.round(new Date(vuln.first_scan_date).getTime() / 1000) * 1000;
+                tsSet.add(ts);
+            }
+        });
+        return Array.from(tsSet).sort((a, b) => a - b);
+    }, [vulnerabilities]);
+
+    const formatScanDate = useCallback((ts: number) => {
+        const d = new Date(ts);
+        return d.toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: '2-digit',
+        }) + ' ' + d.toLocaleTimeString(undefined, {
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZoneName: 'short',
+        });
+    }, []);
 
     const sources_list = useMemo(() => vulnerabilities.reduce((acc: string[], vuln) => {
         vuln.found_by.forEach(source => {
@@ -876,9 +922,30 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 if (maxScore < severityRange.min || maxScore > severityRange.max) return false;
             }
 
+            // EPSS range filter
+            if (showCustomEpssFilter) {
+                const epssScore = el.epss?.score;
+                if (epssScore === undefined || epssScore === null) return false;
+                const epssPct = epssScore * 100;
+                if (epssPct < epssRange.min || epssPct > epssRange.max) return false;
+            }
+
+            // Attack vector filter
+            if (selectedAttackVectors.length) {
+                const vulnAVs = new Set(el.severity.cvss.map(c => c.attack_vector).filter(Boolean));
+                if (!selectedAttackVectors.some(av => vulnAVs.has(av))) return false;
+            }
+
+            // First scan date filter (multi-select by scan timestamp)
+            if (selectedFirstScanDates.length > 0) {
+                if (!el.first_scan_date) return false;
+                const elTs = Math.round(new Date(el.first_scan_date).getTime() / 1000) * 1000;
+                if (!selectedFirstScanDates.includes(String(elTs))) return false;
+            }
+
             return true;
         });
-    }, [vulnerabilities, selectedSeverities, selectedStatuses, selectedSources, selectedPackages, publishedDateFilterType, publishedDateValue, publishedDaysValue, publishedDateFrom, publishedDateTo, showCustomSeverityFilter, severityRange]);
+    }, [vulnerabilities, selectedSeverities, selectedStatuses, selectedSources, selectedPackages, publishedDateFilterType, publishedDateValue, publishedDaysValue, publishedDateFrom, publishedDateTo, showCustomSeverityFilter, severityRange, showCustomEpssFilter, epssRange, selectedAttackVectors, selectedFirstScanDates]);
 
     const selectedVulns = useMemo(() => {
         return Object.entries(selectedRows).flatMap(([id, selected]) => selected ? [id] : [])
@@ -903,29 +970,14 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         setPublishedDateFrom('');
         setPublishedDateTo('');
         setSelectedRows({});
-        setHideFixed(false);
         setVisibleColumns(['ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Updated', 'Published Date']);
         setShowCustomSeverityFilter(false);
         setSeverityRange({ min: SEVERITY_RANGE_MIN, max: SEVERITY_RANGE_MAX });
+        setShowCustomEpssFilter(false);
+        setEpssRange({ min: 0, max: 100 });
+        setSelectedAttackVectors([]);
+        setSelectedFirstScanDates([]);
     }
-
-    const handleHideFixedToggle = (enabled: boolean) => {
-        setHideFixed(enabled);
-        if (enabled) {
-            const allStatuses = Array.from(new Set(vulnerabilities.map(v => v.simplified_status)));
-            const statusesExceptFixed = allStatuses.filter(status => status !== 'Fixed');
-            setSelectedStatuses(statusesExceptFixed);
-        } else {
-            setSelectedStatuses([]);
-        }
-    };
-
-    const handleStatusChange = (newStatuses: string[]) => {
-        setSelectedStatuses(newStatuses);
-        if (newStatuses.includes('Fixed') && hideFixed) {
-            setHideFixed(false);
-        }
-    };
 
     useEffect(() => {
         const handleKeyPress = (event: KeyboardEvent) => {
@@ -990,6 +1042,21 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         };
     }, [showShortcutHelper]);
 
+    // Close "More Filters" on click outside
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (moreFiltersRef.current && !moreFiltersRef.current.contains(event.target as Node)) {
+                setShowMoreFilters(false);
+            }
+        };
+        if (showMoreFilters) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [showMoreFilters]);
+
 
 
     return (<>
@@ -1002,7 +1069,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             />
         )}
 
-        <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2">
+        <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2 flex-wrap">
             <div>Search</div>
             <input ref={searchInputRef} onInput={updateSearch} type="search" className="py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[250px] grow max-w-[800px]" placeholder="Search by ID, packages, description, ..." />
 
@@ -1059,7 +1126,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 label="Status"
                 options={Array.from(new Set(vulnerabilities.map(v => v.simplified_status)))}
                 selected={selectedStatuses}
-                setSelected={handleStatusChange}
+                setSelected={setSelectedStatuses}
             />
 
             {/* Published Date Filter Dropdown */}
@@ -1077,6 +1144,119 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 nvdProgress={nvdProgress}
             />
 
+            {/* More Filters dropdown — EPSS Range, Attack Vector, First Scan Date */}
+            <div ref={moreFiltersRef} className="ml-1 relative inline-block text-left">
+                <button
+                    onClick={() => setShowMoreFilters(!showMoreFilters)}
+                    className={`py-1 px-2 rounded flex items-center gap-1 ${
+                        showMoreFilters ? 'bg-sky-950' : 'bg-sky-900 hover:bg-sky-950'
+                    } text-white`}
+                    title="More filters"
+                >
+                    <FontAwesomeIcon icon={faFilter} />
+                    More
+                    {(showCustomEpssFilter || selectedAttackVectors.length > 0 || selectedFirstScanDates.length > 0) && (
+                        <span className="ml-1 bg-sky-700 px-1 rounded text-xs">✓</span>
+                    )}
+                    <FontAwesomeIcon icon={faCaretDown} />
+                </button>
+
+                {showMoreFilters && (
+                    <div className="absolute mt-1 w-80 bg-sky-900 text-white border border-sky-800 rounded-md shadow-lg z-50 max-h-[70vh] overflow-y-auto">
+                        <div className="p-3 space-y-4">
+
+                            {/* EPSS Range Filter */}
+                            <div>
+                                <div className="flex items-center gap-2 mb-2">
+                                    <input
+                                        type="checkbox"
+                                        id="epss-range-filter"
+                                        checked={showCustomEpssFilter}
+                                        onChange={() => setShowCustomEpssFilter(!showCustomEpssFilter)}
+                                        className="form-checkbox text-sky-500 bg-sky-800 border-sky-600 focus:ring-0"
+                                    />
+                                    <label htmlFor="epss-range-filter" className="text-sm font-semibold">EPSS Range (%)</label>
+                                </div>
+                                {showCustomEpssFilter && (
+                                    <div className="ml-2">
+                                        <RangeSlider
+                                            min={0}
+                                            max={100}
+                                            initialMin={epssRange.min}
+                                            initialMax={epssRange.max}
+                                            step={0.5}
+                                            onChange={updateCustomEpssFilter}
+                                        />
+                                    </div>
+                                )}
+                            </div>
+
+                            <hr className="border-sky-700" />
+
+                            {/* Attack Vector Filter */}
+                            <div>
+                                <div className="text-sm font-semibold mb-2">Attack Vector</div>
+                                <div className="space-y-1 ml-2">
+                                    {attack_vector_list.map(av => (
+                                        <label key={av} className="flex items-center space-x-2">
+                                            <input
+                                                type="checkbox"
+                                                checked={selectedAttackVectors.includes(av)}
+                                                onChange={() => {
+                                                    if (selectedAttackVectors.includes(av)) {
+                                                        setSelectedAttackVectors(selectedAttackVectors.filter(v => v !== av));
+                                                    } else {
+                                                        setSelectedAttackVectors([...selectedAttackVectors, av]);
+                                                    }
+                                                }}
+                                                className="form-checkbox text-sky-500 bg-sky-800 border-sky-600 focus:ring-0"
+                                            />
+                                            <span>{av.charAt(0) + av.slice(1).toLowerCase()}</span>
+                                        </label>
+                                    ))}
+                                    {attack_vector_list.length === 0 && (
+                                        <span className="text-xs text-gray-400 italic">No attack vectors available</span>
+                                    )}
+                                </div>
+                            </div>
+
+                            <hr className="border-sky-700" />
+
+                            {/* First Scan Date Filter */}
+                            <div>
+                                <div className="text-sm font-semibold mb-2">First Scan Date</div>
+                                <div className="ml-2 space-y-1">
+                                    {availableFirstScanDates.length === 0 ? (
+                                        <span className="text-xs text-gray-400 italic">No scan dates available</span>
+                                    ) : (
+                                        availableFirstScanDates.map(ts => {
+                                            const key = String(ts);
+                                            return (
+                                                <label key={key} className="flex items-center space-x-2">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={selectedFirstScanDates.includes(key)}
+                                                        onChange={() => {
+                                                            if (selectedFirstScanDates.includes(key)) {
+                                                                setSelectedFirstScanDates(selectedFirstScanDates.filter(d => d !== key));
+                                                            } else {
+                                                                setSelectedFirstScanDates([...selectedFirstScanDates, key]);
+                                                            }
+                                                        }}
+                                                        className="form-checkbox text-sky-500 bg-sky-800 border-sky-600 focus:ring-0"
+                                                    />
+                                                    <span className="text-sm">{formatScanDate(ts)}</span>
+                                                </label>
+                                            );
+                                        })
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </div>
+
             {/* Package indicator (no dropdown, just display) */}
             {selectedPackages.length > 0 && (
                 <div className="flex items-center gap-1 bg-sky-900 px-2 py-1 rounded text-white border border-sky-700">
@@ -1091,12 +1271,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     </button>
                 </div>
             )}
-
-            <ToggleSwitch
-                enabled={hideFixed}
-                setEnabled={handleHideFixedToggle}
-                label="Hide Fixed"
-            />
 
             <div className="ml-auto flex items-center gap-2 relative">
                 <button

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -455,6 +455,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         'effort.likely': 'Estimated Effort',
         'assessments': 'Last Updated',
         'published': 'Published Date',
+        'first_scan_date': 'First Scan Date',
         'found_by': 'Sources',
         'actions': 'Actions'
     }), []);
@@ -691,6 +692,38 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 return dateA - dateB;
             },
             size: 90
+            }),
+            columnHelper.accessor('first_scan_date', {
+            id: 'first_scan_date',
+            header: () => <div className="flex items-center justify-center">First Scan Date</div>,
+            cell: info => {
+                const scanDate = info.getValue();
+                if (!scanDate) {
+                    return <div className="flex items-center justify-center h-full text-center text-gray-400">Unknown</div>;
+                }
+                const date = new Date(scanDate);
+                const formattedDate = date.toLocaleDateString(undefined, {
+                    year: 'numeric',
+                    month: 'short',
+                    day: '2-digit',
+                }) + ' ' + date.toLocaleTimeString(undefined, {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    timeZoneName: 'short',
+                });
+                return (
+                    <div className="flex items-center justify-center h-full text-center text-sm">
+                        {formattedDate}
+                    </div>
+                );
+            },
+            enableSorting: true,
+            sortingFn: (rowA, rowB) => {
+                const dateA = rowA.original.first_scan_date ? new Date(rowA.original.first_scan_date).getTime() : 0;
+                const dateB = rowB.original.first_scan_date ? new Date(rowB.original.first_scan_date).getTime() : 0;
+                return dateA - dateB;
+            },
+            size: 110
             }),
             columnHelper.accessor('variants', {
             id: 'variants',
@@ -986,6 +1019,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     'Estimated Effort',
                     'Last Updated',
                     'Published Date',
+                    'First Scan Date',
                     'Sources'
                 ]}
                 selected={visibleColumns}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -294,7 +294,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
     const [searchFilteredData, setSearchFilteredData] = useState<Vulnerability[]>([]);
     const [visibleColumns, setVisibleColumns] = useState<string[]>([
-        'ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Status', 'Last Updated', 'Published Date'
+        'ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Updated', 'Published Date'
     ]);
     const [focusedRowIndex, setFocusedRowIndex] = useState<number | null>(null);
 
@@ -871,7 +871,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         setPublishedDateTo('');
         setSelectedRows({});
         setHideFixed(false);
-        setVisibleColumns(['ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Status', 'Last Updated', 'Published Date']);
+        setVisibleColumns(['ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Updated', 'Published Date']);
         setShowCustomSeverityFilter(false);
         setSeverityRange({ min: SEVERITY_RANGE_MIN, max: SEVERITY_RANGE_MAX });
     }

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -637,7 +637,10 @@ describe('EditAssessment Component', () => {
     });
 
     test('shows external error when no variant selected and variants are available', async () => {
-        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
         const user = userEvent.setup();
         render(
             <EditAssessment
@@ -657,7 +660,10 @@ describe('EditAssessment Component', () => {
     });
 
     test('shows internal error when no variant selected', async () => {
-        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
         const user = userEvent.setup();
         render(
             <EditAssessment
@@ -697,7 +703,10 @@ describe('EditAssessment Component', () => {
     });
 
     test('toggles variant checkbox checked/unchecked', async () => {
-        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
         const user = userEvent.setup();
         render(
             <EditAssessment
@@ -705,19 +714,21 @@ describe('EditAssessment Component', () => {
                 onSaveAssessment={mockOnSave}
                 onCancel={mockOnCancel}
                 availableVariants={variants}
-                defaultSelectedVariantIds={['v1']}
+                defaultSelectedVariantIds={['v1', 'v2']}
                 triggerBanner={mockTriggerBanner}
             />
         );
 
-        const variantCheckbox = screen.getByRole('checkbox');
-        // Uncheck the variant
-        await user.click(variantCheckbox);
+        const variantCheckboxes = screen.getAllByRole('checkbox');
+        // Uncheck the first variant (v1)
+        await user.click(variantCheckboxes[0]);
 
-        // Now save attempt should fail validation (no variant selected)
+        // Save — should only have v2
         const saveButton = screen.getByText('Save Changes');
         await user.click(saveButton);
-        expect(mockTriggerBanner).toHaveBeenCalledWith('You must select at least one variant', 'error');
+        expect(mockOnSave).toHaveBeenCalledWith(
+            expect.objectContaining({ variant_ids: ['v2'] })
+        );
     });
 
     test('renders package checkboxes when two or more packages available', () => {

--- a/frontend/tests/unit_tests/test_export_docs.tsx
+++ b/frontend/tests/unit_tests/test_export_docs.tsx
@@ -51,6 +51,9 @@ describe('Exports Page', () => {
         // ASSERT - Component should still render without crashing
         const exportTitle = await screen.findByText(/export/i);
         expect(exportTitle).toBeInTheDocument();
+        await waitFor(() => {
+            expect(consoleSpy).toHaveBeenCalledWith('Error:', expect.any(Error));
+        });
         consoleSpy.mockRestore();
     })
 
@@ -240,5 +243,25 @@ describe('Exports Page', () => {
 
         const exportTitle = await screen.findByText(/export/i);
         expect(exportTitle).toBeInTheDocument();
+    })
+
+    test('clicking a file tag toggles its opened state', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: "report.adoc", category: ['built-in'], extension: "adoc" }
+        ]));
+
+        render(<Exports />);
+
+        const fileButton = await screen.findByText(/report\.adoc/i);
+        fireEvent.click(fileButton);
+
+        // Clicking the file tag should toggle the download options
+        await waitFor(() => {
+            expect(screen.getByText(/Download/i)).toBeInTheDocument();
+        });
+
+        // Clicking again should close it
+        fireEvent.click(fileButton);
     })
 });

--- a/frontend/tests/unit_tests/test_iso8601duration.ts
+++ b/frontend/tests/unit_tests/test_iso8601duration.ts
@@ -106,4 +106,37 @@ describe('Iso8601Duration', () => {
         const duration = new Iso8601Duration('1y 2m 3w 4d 5h 30m');
         expect(duration.formatAsIso8601()).toEqual('P1Y2M3W4DT5H30M');
     });
+
+    test('gitlab years standalone', () => {
+        const duration = new Iso8601Duration('2years');
+        expect(duration.total_seconds).toEqual(2 * 6912000);
+    });
+    test('gitlab months standalone (mo)', () => {
+        const duration = new Iso8601Duration('3months');
+        expect(duration.total_seconds).toEqual(3 * 576000);
+    });
+    test('gitlab weeks standalone', () => {
+        const duration = new Iso8601Duration('2weeks');
+        expect(duration.total_seconds).toEqual(2 * 144000);
+    });
+    test('gitlab hours standalone', () => {
+        const duration = new Iso8601Duration('4hours');
+        expect(duration.total_seconds).toEqual(4 * 3600);
+    });
+    test('gitlab minutes > 4 treated as minutes', () => {
+        const duration = new Iso8601Duration('30m');
+        expect(duration.total_seconds).toEqual(30 * 60);
+    });
+    test('gitlab minutes <= 4 treated as months', () => {
+        const duration = new Iso8601Duration('3m');
+        expect(duration.total_seconds).toEqual(3 * 576000);
+    });
+    test('formatHumanShort with individual units', () => {
+        expect(new Iso8601Duration('2y').formatHumanShort()).toEqual('2y');
+        expect(new Iso8601Duration('3mo').formatHumanShort()).toEqual('3mo');
+        expect(new Iso8601Duration('1w').formatHumanShort()).toEqual('1w');
+        expect(new Iso8601Duration('5d').formatHumanShort()).toEqual('5d');
+        expect(new Iso8601Duration('PT8H').formatHumanShort()).toEqual('8h');
+        expect(new Iso8601Duration('PT30M').formatHumanShort()).toEqual('30m');
+    });
 });

--- a/frontend/tests/unit_tests/test_patch_finder.tsx
+++ b/frontend/tests/unit_tests/test_patch_finder.tsx
@@ -340,6 +340,7 @@ describe('Render patch found', () => {
             vulnerabilities: {},
             maxSeverity: {},
             source: [],
+            variants: [],
         }
     ]
 

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -39,7 +39,8 @@ describe('Packages Table', () => {
                 "active": {label: 'low', index: 2},
                 "fixed": {label: 'medium', index: 3}
             },
-            source: ['hardcoded']
+            source: ['hardcoded'],
+            variants: []
         },
         {
             id: 'xxxyyyzzz@2.0.0',
@@ -49,7 +50,8 @@ describe('Packages Table', () => {
             purl: ['pkg:vendor/xxxyyyzzz@2.0.0'],
             vulnerabilities: {"active": 4},
             maxSeverity: {"active": {label: 'high', index: 4}},
-            source: ['cve-finder']
+            source: ['cve-finder'],
+            variants: []
         },
         {
             id: 'dddeeefff@1.5.0',
@@ -62,7 +64,8 @@ describe('Packages Table', () => {
                 "active": {label: 'medium', index: 3},
                 "fixed": {label: 'low', index: 2}
             },
-            source: ['cve-finder', 'hardcoded']
+            source: ['cve-finder', 'hardcoded'],
+            variants: []
         }
     ];
 
@@ -77,7 +80,7 @@ describe('Packages Table', () => {
         // ACT
         const name_header = await screen.getByRole('columnheader', {name: /name/i});
         const version_header = await screen.getByRole('columnheader', {name: /version/i});
-        const vuln_count_header = await screen.getByRole('columnheader', {name: /vulnerabilities/i});
+        const vuln_count_header = await screen.getByRole('columnheader', {name: /^Vulnerabilities$/i});
         const sources_header = await screen.getByRole('columnheader', {name: /sources/i});
 
         // ASSERT
@@ -169,7 +172,7 @@ describe('Packages Table', () => {
         render(<TablePackages packages={packages} />);
 
         const user = userEvent.setup();
-        const vuln_count_header = await screen.getByRole('columnheader', {name: /vulnerabilities/i});
+        const vuln_count_header = await screen.getByRole('columnheader', {name: /^Vulnerabilities$/i});
 
         await user.click(vuln_count_header); // numerical order -> reverse numerical order
         await waitFor(() => {
@@ -382,7 +385,8 @@ describe('Packages Table', () => {
                 purl: [],
                 vulnerabilities: {"active": 1},
                 maxSeverity: {"active": {label: 'low', index: 2}},
-                source: ['test']
+                source: ['test'],
+                variants: []
             }
         ];
 
@@ -407,7 +411,8 @@ describe('Packages Table', () => {
                 purl: [],
                 vulnerabilities: {"active": 1},
                 maxSeverity: {"active": {label: 'low', index: 2}},
-                source: ['test']
+                source: ['test'],
+                variants: []
             }
         ];
 
@@ -525,6 +530,96 @@ describe('Packages Table', () => {
         await user.keyboard('{Home}');
         await waitFor(() => {
             expect(document.activeElement).toBe(firstRow);
+        });
+    });
+
+    test('renders variant badges when packages have variants', async () => {
+        const packagesWithVariants: Package[] = [
+            {
+                id: 'pkg-var@1.0.0',
+                name: 'pkg-var',
+                version: '1.0.0',
+                cpe: [],
+                purl: [],
+                vulnerabilities: {"active": 1},
+                maxSeverity: {"active": {label: 'low', index: 2}},
+                source: ['test'],
+                variants: ['variant-A', 'variant-B']
+            }
+        ];
+
+        render(<TablePackages packages={packagesWithVariants} />);
+
+        expect(await screen.findByText('variant-A')).toBeTruthy();
+        expect(screen.getByText('variant-B')).toBeTruthy();
+    });
+
+    test('sorting by remaining pending vulnerabilities', async () => {
+        const packagesWithPending: Package[] = [
+            {
+                id: 'pkg-a@1.0.0',
+                name: 'pkg-a',
+                version: '1.0.0',
+                cpe: [],
+                purl: [],
+                vulnerabilities: {"Pending Assessment": 5, "active": 1},
+                maxSeverity: {"active": {label: 'low', index: 2}},
+                source: ['test'],
+                variants: []
+            },
+            {
+                id: 'pkg-b@1.0.0',
+                name: 'pkg-b',
+                version: '1.0.0',
+                cpe: [],
+                purl: [],
+                vulnerabilities: {"Pending Assessment": 1, "active": 2},
+                maxSeverity: {"active": {label: 'medium', index: 3}},
+                source: ['test'],
+                variants: []
+            }
+        ];
+
+        render(<TablePackages packages={packagesWithPending} />);
+
+        // Verify both pending values are rendered
+        const cells = screen.getAllByRole('cell');
+        const pendingValues = cells.filter(c => c.textContent === '5' || c.textContent === '1');
+        expect(pendingValues.length).toBeGreaterThanOrEqual(2);
+
+        const user = userEvent.setup();
+        const pendingHeader = await screen.getByRole('columnheader', {name: /remaining pending/i});
+
+        // Click to sort
+        await user.click(pendingHeader);
+
+        // Click again to sort in other direction
+        await user.click(pendingHeader);
+
+        // Verify sorting by checking the sort icon changed (sort was applied)
+        await waitFor(() => {
+            const html = document.body.innerHTML;
+            // Both names should still be present
+            expect(html).toContain('pkg-a');
+            expect(html).toContain('pkg-b');
+        });
+    });
+
+    test('CPE popup closes on Escape key', async () => {
+        render(<TablePackages packages={packages} />);
+
+        const user = userEvent.setup();
+
+        const cpeButtons = await screen.getAllByText('CPE');
+        await user.click(cpeButtons[0]);
+
+        const cpeId = await screen.getByText(/cpe:2.3:a:vendor:aaabbbccc:1.0.0/);
+        expect(cpeId).toBeTruthy();
+
+        await user.keyboard('{Escape}');
+
+        await waitFor(() => {
+            expect(screen.queryByText(/cpe:2.3:a:vendor:aaabbbccc:1.0.0/)).toBeNull();
         });
     });
 });

--- a/frontend/tests/unit_tests/test_popup_export_options.tsx
+++ b/frontend/tests/unit_tests/test_popup_export_options.tsx
@@ -109,4 +109,21 @@ describe('PopupExportOptions component', () => {
        expect(mockOnClose).toHaveBeenCalled();
    });
 
+   test('renders without onClose prop (uses default)', async () => {
+       render(<PopupExportOptions docName="report.txt" extension="adoc" />);
+       expect(screen.getByText(/Exporting/i)).toBeInTheDocument();
+       // Click close button to exercise the default no-op onClose
+       const closeBtn = screen.getByRole('button', { name: /close export options/i });
+       await userEvent.click(closeBtn);
+   });
+
+   test('changing export date updates generate link', async () => {
+       render(<PopupExportOptions docName="report.txt" extension="adoc" onClose={() => {}} />);
+       const exportDate = screen.getByLabelText(/export date/i) as HTMLInputElement;
+       fireEvent.change(exportDate, { target: { value: '2025-06-15' } });
+       expect(exportDate.value).toBe('2025-06-15');
+       const link = screen.getByRole('link', { name: /generate/i }) as HTMLAnchorElement;
+       expect(link.href).toContain('export_date=2025-06-15');
+   });
+
 });

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -303,7 +303,10 @@ describe('StatusEditor', () => {
     test('should show external error when no variant selected and variants are available', async () => {
         const triggerBanner = jest.fn();
         const user = userEvent.setup();
-        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
         render(<StatusEditor {...defaultProps} variants={variants} triggerBanner={triggerBanner} />);
 
         const statusSelect = screen.getByRole('combobox');
@@ -317,7 +320,10 @@ describe('StatusEditor', () => {
 
     test('should show internal error when no variant selected and variants are available', async () => {
         const user = userEvent.setup();
-        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
         render(<StatusEditor {...defaultProps} variants={variants} />);
 
         const statusSelect = screen.getByRole('combobox');
@@ -332,12 +338,15 @@ describe('StatusEditor', () => {
 
     test('should submit with selected variant_ids when a variant is checked', async () => {
         const user = userEvent.setup();
-        const variants = [{ id: 'v1', name: 'default', project_id: 'p1' }];
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
         render(<StatusEditor {...defaultProps} variants={variants} />);
 
-        // Check the variant checkbox
-        const variantCheckbox = screen.getByRole('checkbox');
-        await user.click(variantCheckbox);
+        // Check the first variant checkbox
+        const variantCheckboxes = screen.getAllByRole('checkbox');
+        await user.click(variantCheckboxes[0]);
 
         // Change status away from under_investigation (to pass validation)
         const statusSelect = screen.getByRole('combobox');
@@ -421,6 +430,31 @@ describe('StatusEditor', () => {
         // Both packages checked → should include both in the call
         expect(defaultProps.onAddAssessment).toHaveBeenCalledWith(
             expect.objectContaining({ packages: expect.arrayContaining(['pkg1@1.0.0', 'pkg2@2.0.0']) })
+        );
+    });
+
+    test('should uncheck a variant and submit with remaining variants', async () => {
+        const user = userEvent.setup();
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
+        render(<StatusEditor {...defaultProps} variants={variants} />);
+
+        const variantCheckboxes = screen.getAllByRole('checkbox');
+        // Check both variants
+        await user.click(variantCheckboxes[0]);
+        await user.click(variantCheckboxes[1]);
+        // Uncheck the first variant
+        await user.click(variantCheckboxes[0]);
+
+        const statusSelect = screen.getByRole('combobox');
+        await user.selectOptions(statusSelect, 'affected');
+        const addButton = screen.getByRole('button', { name: 'Add assessment' });
+        await user.click(addButton);
+
+        expect(defaultProps.onAddAssessment).toHaveBeenCalledWith(
+            expect.objectContaining({ variant_ids: ['v2'] })
         );
     });
 });

--- a/frontend/tests/unit_tests/test_table_generic.tsx
+++ b/frontend/tests/unit_tests/test_table_generic.tsx
@@ -124,7 +124,7 @@ describe('TableGeneric component (direct tests to raise coverage)', () => {
     await waitFor(() => {
       expect(screen.getByText(/551-600 \/ 600/)).toBeInTheDocument();
     });
-  });
+  }, 15000);
 
   test('changing items per page resets page index (lines 322-323)', async () => {
     render(

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -1732,4 +1732,201 @@ describe('Vulnerability Modal', () => {
         await user.click(helpBtn);
         expect(screen.queryByText('Keyboard Shortcuts')).not.toBeInTheDocument();
     });
+
+    test('delete assessment with remaining assessments updates status from most recent', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce('', { status: 200 }); // DELETE response
+
+        const patchVuln = jest.fn();
+        const vulnWithTwoAssessments = {
+            ...vulnerability,
+            assessments: [
+                {
+                    id: 'assessment-old',
+                    vuln_id: 'CVE-2010-1234',
+                    packages: ['aaabbbccc@1.0.0'],
+                    packages_current: [],
+                    status: 'fixed',
+                    simplified_status: 'Fixed',
+                    justification: 'old fix',
+                    impact_statement: '',
+                    status_notes: '',
+                    workaround: '',
+                    timestamp: '2020-06-01T00:00:00Z',
+                    responses: []
+                },
+                {
+                    id: 'assessment-new',
+                    vuln_id: 'CVE-2010-1234',
+                    packages: ['aaabbbccc@1.0.0'],
+                    packages_current: [],
+                    status: 'affected',
+                    simplified_status: 'Exploitable',
+                    justification: 'recent',
+                    impact_statement: 'bad',
+                    status_notes: 'still broken',
+                    workaround: 'none',
+                    timestamp: '2021-06-01T00:00:00Z',
+                    responses: []
+                }
+            ]
+        };
+
+        render(<VulnModal vuln={vulnWithTwoAssessments} isEditing={true} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={patchVuln} />);
+
+        const user = userEvent.setup();
+        // Find and click the delete button for the second (most recent) assessment
+        const deleteBtns = screen.getAllByTitle(/delete assessment/i);
+        await user.click(deleteBtns[deleteBtns.length - 1]);
+
+        const confirmBtn = screen.getByText(/yes, delete/i);
+        await user.click(confirmBtn);
+
+        await screen.findByText(/assessment deleted successfully/i);
+        // patchVuln should be called with updated status from remaining assessment
+        expect(patchVuln).toHaveBeenCalled();
+    });
+
+    test('adding assessment to multiple variants shows multi-variant success message', async () => {
+        fetchMock.resetMocks();
+        // Variants endpoint returns two variants
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'v1', name: 'Variant Alpha', project_id: 'proj1' },
+            { id: 'v2', name: 'Variant Beta', project_id: 'proj1' }
+        ]));
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        // Two POST responses for two variants
+        fetchMock.mockResponseOnce(JSON.stringify({
+            status: 'success',
+            assessment: {
+                id: 'new-assess-v1',
+                vuln_id: 'CVE-2010-1234',
+                packages: ['aaabbbccc@1.0.0'],
+                status: 'affected',
+                simplified_status: 'Exploitable',
+                justification: '',
+                impact_statement: '',
+                status_notes: 'multi test',
+                workaround: '',
+                timestamp: '2026-01-01T00:00:00Z',
+                responses: [],
+                variant_id: 'v1'
+            }
+        }));
+        fetchMock.mockResponseOnce(JSON.stringify({
+            status: 'success',
+            assessment: {
+                id: 'new-assess-v2',
+                vuln_id: 'CVE-2010-1234',
+                packages: ['aaabbbccc@1.0.0'],
+                status: 'affected',
+                simplified_status: 'Exploitable',
+                justification: '',
+                impact_statement: '',
+                status_notes: 'multi test',
+                workaround: '',
+                timestamp: '2026-01-01T00:00:00Z',
+                responses: [],
+                variant_id: 'v2'
+            }
+        }));
+
+        const appendCb = jest.fn();
+        const patchCb = jest.fn();
+        render(<VulnModal vuln={{...vulnerability, assessments: []}} isEditing={true} onClose={() => {}} appendAssessment={appendCb} appendCVSS={() => null} patchVuln={patchCb} />);
+        const user = userEvent.setup();
+
+        // Wait for variants to load, then select both
+        await screen.findByText('Variant Alpha');
+        const variantCheckboxes = screen.getAllByRole('checkbox');
+        // Select both variants
+        for (const cb of variantCheckboxes) {
+            const label = cb.closest('label');
+            if (label?.textContent?.includes('Variant Alpha') || label?.textContent?.includes('Variant Beta')) {
+                await user.click(cb);
+            }
+        }
+
+        const selectSource = screen.getAllByRole('combobox').find((el) => el.getAttribute('name')?.includes('new_assessment_status')) as HTMLElement;
+        await user.selectOptions(selectSource, 'affected');
+        const inputNotes = screen.getByPlaceholderText(/notes/i);
+        await user.type(inputNotes, 'multi test');
+        const btn = screen.getByText(/add assessment/i);
+        await user.click(btn);
+
+        // Should show multi-variant success message
+        const successMsg = await screen.findByText(/successfully added assessment to 2 variants/i);
+        expect(successMsg).toBeInTheDocument();
+        expect(appendCb).toHaveBeenCalledTimes(2);
+        expect(patchCb).toHaveBeenCalledTimes(1);
+    });
+
+    test('renders variant tags on assessments when variants are available', async () => {
+        fetchMock.resetMocks();
+        // Return variants for this vuln
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'var-1', name: 'Production', project_id: 'proj1' },
+            { id: 'var-2', name: 'Staging', project_id: 'proj1' }
+        ]));
+        // Return all assessments (unfiltered) including variant_id
+        fetchMock.mockResponseOnce(JSON.stringify([
+            {
+                id: 'assess-v1',
+                vuln_id: 'CVE-2010-1234',
+                packages: ['aaabbbccc@1.0.0'],
+                status: 'affected',
+                simplified_status: 'Exploitable',
+                justification: 'test',
+                impact_statement: '',
+                status_notes: '',
+                workaround: '',
+                timestamp: '2025-01-01T00:00:00Z',
+                responses: [],
+                variant_id: 'var-1'
+            },
+            {
+                id: 'assess-v2',
+                vuln_id: 'CVE-2010-1234',
+                packages: ['aaabbbccc@1.0.0'],
+                status: 'affected',
+                simplified_status: 'Exploitable',
+                justification: 'test',
+                impact_statement: '',
+                status_notes: '',
+                workaround: '',
+                timestamp: '2025-01-01T00:00:00Z',
+                responses: [],
+                variant_id: 'var-2'
+            }
+        ]));
+
+        const vulnWithVariantAssessments = {
+            ...vulnerability,
+            assessments: [
+                {
+                    id: 'assess-v1',
+                    vuln_id: 'CVE-2010-1234',
+                    packages: ['aaabbbccc@1.0.0'],
+                    packages_current: [],
+                    status: 'affected',
+                    simplified_status: 'Exploitable',
+                    justification: 'test',
+                    impact_statement: '',
+                    status_notes: '',
+                    workaround: '',
+                    timestamp: '2025-01-01T00:00:00Z',
+                    responses: [],
+                    variant_id: 'var-1'
+                }
+            ]
+        };
+
+        render(<VulnModal vuln={vulnWithVariantAssessments} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        // Wait for variant tags to render
+        await screen.findByText('Production');
+        expect(screen.getByText('Staging')).toBeInTheDocument();
+    });
 });

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -2,6 +2,8 @@
 import fetchMock from 'jest-fetch-mock';
 fetchMock.enableMocks();
 
+jest.setTimeout(15000);
+
 import { fireEvent, render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import "@testing-library/jest-dom";
@@ -16,7 +18,7 @@ import Iso8601Duration from '../../src/handlers/iso8601duration';
 jest.mock('../../src/handlers/nvd_progress', () => ({
     __esModule: true,
     default: {
-        getProgress: jest.fn().mockImplementation(() => new Promise(() => {})),
+        getProgress: jest.fn().mockResolvedValue(null),
         getProgressPercentage: jest.fn().mockReturnValue(0),
     },
 }));
@@ -25,7 +27,7 @@ jest.mock('../../src/handlers/nvd_progress', () => ({
 jest.mock('../../src/handlers/epss_progress', () => ({
     __esModule: true,
     default: {
-        getProgress: jest.fn().mockImplementation(() => new Promise(() => {})),
+        getProgress: jest.fn().mockResolvedValue(null),
         getProgressPercentage: jest.fn().mockReturnValue(0),
     },
 }));
@@ -555,12 +557,12 @@ describe('Vulnerability Table', () => {
         expect(sourceBtn).toBeInTheDocument();
         await user.click(sourceBtn);
 
-        const deletion = waitForElementToBeRemoved(() => screen.getByRole('cell', {name: /CVE-2010-1234/}), { timeout: 1000 });
-
         const srcCheckbox = await screen.getByRole('checkbox', { name: 'cve-finder' });
         await user.click(srcCheckbox);
 
-        await deletion;
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2010-1234/})).toBeNull();
+        }, { timeout: 5000 });
 
         const pkg_xyz = await screen.getByRole('cell', {name: /CVE-2018-5678/});
         expect(pkg_xyz).toBeInTheDocument();
@@ -577,7 +579,7 @@ describe('Vulnerability Table', () => {
 
         // Ensure the exploitable row exists before starting the removal watcher.
         const exploitableRow = await screen.findByRole('cell', {name: /CVE-2010-1234/});
-        const pending_deletion = waitForElementToBeRemoved(exploitableRow, { timeout: 1000 });
+        const pending_deletion = waitForElementToBeRemoved(exploitableRow, { timeout: 5000 });
 
         const pendingCheckbox = await screen.getByRole('checkbox', { name: /Pending Assessment/i });
         await user.click(pendingCheckbox);
@@ -599,7 +601,7 @@ describe('Vulnerability Table', () => {
 
         // Ensure the target row is present before starting removal watcher
         const communityRow = await screen.findByRole('cell', {name: /CVE-2018-5678/});
-        const pending_deletion = waitForElementToBeRemoved(communityRow, { timeout: 1000 });
+        const pending_deletion = waitForElementToBeRemoved(communityRow, { timeout: 5000 });
 
         // ACT
         const exploitableCheckbox = await screen.getByRole('checkbox', { name: /Exploitable/i });
@@ -794,12 +796,12 @@ describe('Vulnerability Table', () => {
         expect(severityBtn).toBeInTheDocument();
         await user.click(severityBtn);
 
-        const deletion = waitForElementToBeRemoved(() => screen.getByRole('cell', {name: /CVE-2018-5678/}), { timeout: 1000 });
-
         const lowCheckbox = await screen.getByRole('checkbox', { name: 'low' });
         await user.click(lowCheckbox);
 
-        await deletion;
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).toBeNull();
+        }, { timeout: 5000 });
 
         const vuln_abc = await screen.getByRole('cell', {name: /CVE-2010-1234/});
         expect(vuln_abc).toBeInTheDocument();
@@ -820,19 +822,21 @@ describe('Vulnerability Table', () => {
         expect(customCheckbox).toBeInTheDocument();
         await user.click(customCheckbox as HTMLElement);
 
-        const [minSlider, maxSlider] = await screen.findAllByRole('slider');
+        const sliders = await screen.findAllByRole('slider');
 
-        expect(minSlider).toBeInTheDocument();
-        expect(maxSlider).toBeInTheDocument();
+        expect(sliders).toHaveLength(2);
 
         // Vulneraibilities with the severity max score between 2 and 4 will remain.
-        fireEvent.change(minSlider, { target: { value: '2' } });
-        fireEvent.change(maxSlider, { target: { value: '4' } });
+        fireEvent.change(sliders[0], { target: { value: '2' } });
+
+        // Re-query sliders after state update to avoid stale references
+        const slidersAfter = screen.getAllByRole('slider');
+        fireEvent.change(slidersAfter[1], { target: { value: '4' } });
 
         await waitFor(() => {
             expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).toBeNull();
             expect(screen.queryByRole('cell', {name: /CVE-2024-56730/})).toBeNull();
-        }, { timeout: 1000 });
+        }, { timeout: 5000 });
 
         const vuln_abc = await screen.getByRole('cell', {name: /CVE-2010-1234/});
 
@@ -868,41 +872,6 @@ describe('Vulnerability Table', () => {
         await user.click(lowCheckbox);
         expect(lowCheckbox).toBeChecked();
         expect(customCheckbox).not.toBeChecked();
-    })
-
-    test('hide fixed toggle functionality', async () => {
-        const vulnWithFixed: Vulnerability[] = [
-            ...vulnerabilities,
-            {
-                ...vulnerabilities[0],
-                id: 'CVE-2020-9999',
-                simplified_status: 'Fixed'
-            }
-        ];
-
-        // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnWithFixed} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-
-        const user = userEvent.setup();
-        const hideFixedToggle = await screen.getByRole('button', { name: /Hide Fixed/i });
-        expect(hideFixedToggle).toBeInTheDocument();
-
-        // Ensure the fixed vulnerability is initially visible
-        const fixedVuln = await screen.getByRole('cell', {name: /CVE-2020-9999/});
-        expect(fixedVuln).toBeInTheDocument();
-
-        const deletion = waitForElementToBeRemoved(fixedVuln, { timeout: 1000 });
-
-        // ACT - Toggle hide fixed
-        await user.click(hideFixedToggle);
-
-        // ASSERT - Fixed vulnerability should be hidden
-        await deletion;
-        expect(screen.queryByRole('cell', {name: /CVE-2020-9999/})).not.toBeInTheDocument();
-
-        // Other vulnerabilities should still be visible
-        const otherVuln = await screen.getByRole('cell', {name: /CVE-2010-1234/});
-        expect(otherVuln).toBeInTheDocument();
     })
 
     test('reset filters button clears all filters', async () => {
@@ -983,47 +952,6 @@ describe('Vulnerability Table', () => {
         const vuln2 = await screen.getByRole('cell', {name: /CVE-2018-5678/});
         expect(vuln1).toBeInTheDocument();
         expect(vuln2).toBeInTheDocument();
-    })
-
-    test('hide fixed toggle interaction with status filter', async () => {
-        const vulnWithFixed: Vulnerability[] = [
-            ...vulnerabilities,
-            {
-                ...vulnerabilities[0],
-                id: 'CVE-2020-9999',
-                simplified_status: 'Fixed'
-            }
-        ];
-
-        // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnWithFixed} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-
-        const user = userEvent.setup();
-
-        // First enable hide fixed
-        const hideFixedToggle = await screen.getByRole('button', { name: /Hide Fixed/i });
-        await user.click(hideFixedToggle);
-
-        // Wait for fixed vulnerability to be hidden
-        await waitFor(() => {
-            expect(screen.queryByRole('cell', {name: /CVE-2020-9999/})).not.toBeInTheDocument();
-        });
-
-        // Now manually select 'fixed' in status filter
-        // Use getAllByRole to handle multiple buttons with 'status' in name, select the first (main button)
-        const statusButtons = await screen.getAllByRole('button', { name: /status/i });
-        await user.click(statusButtons[0]);
-        const fixedCheckbox = await screen.getByRole('checkbox', { name: 'Fixed' });
-        await user.click(fixedCheckbox);
-
-        // ASSERT - Hide fixed toggle should be disabled when fixed is manually selected
-        expect(hideFixedToggle).toHaveAttribute('aria-pressed', 'false');
-
-        // Fixed vulnerability should now be visible
-        await waitFor(() => {
-            const fixedVuln = screen.getByRole('cell', {name: /CVE-2020-9999/});
-            expect(fixedVuln).toBeInTheDocument();
-        });
     })
 
     test('search debounce functionality', async () => {
@@ -1300,61 +1228,6 @@ describe('Vulnerability Table', () => {
             const html = document.body.innerHTML;
             // CVE-2020-1111 should come first because last_update (March 25) is more recent than CVE-2020-2222's timestamp (March 20)
             expect(html.indexOf('CVE-2020-1111')).toBeLessThan(html.indexOf('CVE-2020-2222'));
-        });
-    })
-
-    test('handleHideFixedToggle filters out Fixed status when enabled', async () => {
-        const vulnsWithFixed: Vulnerability[] = [
-            {
-                ...vulnerabilities[0],
-                id: 'CVE-FIXED-001',
-                simplified_status: 'Fixed'
-            },
-            {
-                ...vulnerabilities[1],
-                id: 'CVE-ACTIVE-001',
-                simplified_status: 'Exploitable'
-            }
-        ];
-
-        render(<TableVulnerabilities vulnerabilities={vulnsWithFixed} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-
-        const user = userEvent.setup();
-
-        // Toggle "Hide Fixed"
-        const hideFixedToggle = await screen.getByRole('button', {name: /hide fixed/i});
-        await user.click(hideFixedToggle);
-
-        // Fixed vulnerability should not be visible
-        await waitFor(() => {
-            expect(screen.queryByText('CVE-FIXED-001')).not.toBeInTheDocument();
-            expect(screen.getByText('CVE-ACTIVE-001')).toBeInTheDocument();
-        });
-    })
-
-    test('handleHideFixedToggle can be toggled on and off', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-
-        const user = userEvent.setup();
-
-        // Enable "Hide Fixed"
-        const hideFixedToggle = await screen.getByRole('button', {name: /show hide fixed/i});
-        await user.click(hideFixedToggle);
-
-        // Toggle should change its aria-label
-        await waitFor(() => {
-            const toggleAfter = screen.getByRole('button', {name: /hide hide fixed/i});
-            expect(toggleAfter).toBeInTheDocument();
-        });
-
-        // Disable "Hide Fixed" by clicking again
-        const hideFixedToggle2 = await screen.getByRole('button', {name: /hide hide fixed/i});
-        await user.click(hideFixedToggle2);
-
-        // Toggle should revert
-        await waitFor(() => {
-            const toggleReverted = screen.getByRole('button', {name: /show hide fixed/i});
-            expect(toggleReverted).toBeInTheDocument();
         });
     })
 

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -1991,3 +1991,216 @@ describe('Vulnerability Table', () => {
         });
     });
 });
+
+describe('More Filters dropdown', () => {
+    const vulnerabilities: Vulnerability[] = [
+        {
+            id: 'CVE-2010-1234',
+            aliases: [],
+            related_vulnerabilities: [],
+            namespace: 'nvd:cve',
+            found_by: ['hardcoded'],
+            datasource: 'https://nvd.nist.gov/vuln/detail/CVE-2010-1234',
+            packages: ['pkg@1.0.0'],
+            packages_current: ['pkg@1.0.0'],
+            urls: [],
+            texts: [],
+            severity: {
+                severity: 'high',
+                min_score: 7,
+                max_score: 7,
+                cvss: [{
+                    author: 'test',
+                    severity: 'high',
+                    base_score: 7,
+                    vector_string: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N',
+                    version: '3.1',
+                    impact_score: 0,
+                    exploitability_score: 0,
+                    attack_vector: 'NETWORK'
+                }]
+            },
+            epss: { score: 0.5, percentile: 0.8 },
+            effort: {
+                optimistic: new Iso8601Duration(undefined),
+                likely: new Iso8601Duration(undefined),
+                pessimistic: new Iso8601Duration(undefined)
+            },
+            fix: { state: 'unknown' },
+            status: 'affected',
+            simplified_status: 'Exploitable',
+            assessments: [],
+            variants: [],
+            first_scan_date: '2025-01-15T10:00:00Z'
+        },
+        {
+            id: 'CVE-2020-5678',
+            aliases: [],
+            related_vulnerabilities: [],
+            namespace: 'nvd:cve',
+            found_by: ['scanner'],
+            datasource: 'https://nvd.nist.gov/vuln/detail/CVE-2020-5678',
+            packages: ['other@2.0.0'],
+            packages_current: ['other@2.0.0'],
+            urls: [],
+            texts: [],
+            severity: {
+                severity: 'low',
+                min_score: 2,
+                max_score: 2,
+                cvss: [{
+                    author: 'test',
+                    severity: 'low',
+                    base_score: 2,
+                    vector_string: 'CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L',
+                    version: '3.1',
+                    impact_score: 0,
+                    exploitability_score: 0,
+                    attack_vector: 'LOCAL'
+                }]
+            },
+            epss: { score: 0.01, percentile: 0.1 },
+            effort: {
+                optimistic: new Iso8601Duration(undefined),
+                likely: new Iso8601Duration(undefined),
+                pessimistic: new Iso8601Duration(undefined)
+            },
+            fix: { state: 'unknown' },
+            status: 'under_investigation',
+            simplified_status: 'Pending Assessment',
+            assessments: [],
+            variants: [],
+            first_scan_date: '2025-03-20T14:00:00Z'
+        }
+    ];
+
+    Element.prototype.getBoundingClientRect = jest.fn(function () {
+        return getDOMRect(500, 500);
+    });
+
+    beforeEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    test('opens More Filters dropdown and shows EPSS, Attack Vector, and First Scan Date sections', async () => {
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        // More Filters button should exist
+        const moreBtn = screen.getByText('More');
+        expect(moreBtn).toBeInTheDocument();
+
+        // Click to open
+        await user.click(moreBtn);
+
+        // EPSS Range section should appear
+        expect(screen.getByText('EPSS Range (%)')).toBeInTheDocument();
+
+        // Attack Vector section should appear
+        expect(screen.getByText('Attack Vector')).toBeInTheDocument();
+
+        // First Scan Date section should appear
+        expect(screen.getByText('First Scan Date')).toBeInTheDocument();
+    });
+
+    test('toggles Attack Vector checkbox filter', async () => {
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        // Open More Filters
+        await user.click(screen.getByText('More'));
+
+        // Find "Network" attack vector checkbox and click it
+        const networkLabel = screen.getByText('Network');
+        await user.click(networkLabel);
+
+        // Should show active filter indicator (checkmark)
+        expect(screen.getByText('✓')).toBeInTheDocument();
+    });
+
+    test('toggles First Scan Date checkbox filter', async () => {
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        // Open More Filters
+        await user.click(screen.getByText('More'));
+
+        // Find scan date checkboxes — there should be 2 dates from our test data
+        const checkboxes = screen.getAllByRole('checkbox');
+        // Find one that's in the First Scan Date section (look for scan date text)
+        const scanDateLabels = checkboxes.filter(cb => {
+            const parent = cb.closest('label');
+            return parent?.textContent?.match(/\d{4}/); // date contains a year
+        });
+        expect(scanDateLabels.length).toBeGreaterThanOrEqual(1);
+
+        // Click to select and then deselect
+        await user.click(scanDateLabels[0]);
+        expect(screen.getByText('✓')).toBeInTheDocument();
+        await user.click(scanDateLabels[0]);
+    });
+
+    test('enables EPSS range filter via checkbox', async () => {
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        // Open More Filters
+        await user.click(screen.getByText('More'));
+
+        // Find the EPSS Range checkbox
+        const epssCheckbox = screen.getByLabelText('EPSS Range (%)');
+        await user.click(epssCheckbox);
+
+        // Should show active filter indicator
+        expect(screen.getByText('✓')).toBeInTheDocument();
+    });
+
+    test('closes More Filters dropdown on outside click', async () => {
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        // Open More Filters
+        await user.click(screen.getByText('More'));
+        expect(screen.getByText('EPSS Range (%)')).toBeInTheDocument();
+
+        // Click outside the dropdown
+        await user.click(document.body);
+
+        // Dropdown content should be gone
+        await waitFor(() => {
+            expect(screen.queryByText('EPSS Range (%)')).not.toBeInTheDocument();
+        });
+    });
+
+    test('shows no scan dates message when none available', async () => {
+        const vulnsNoScanDate: Vulnerability[] = [{
+            ...vulnerabilities[0],
+            first_scan_date: undefined
+        }, {
+            ...vulnerabilities[1],
+            first_scan_date: undefined
+        }];
+
+        render(<TableVulnerabilities vulnerabilities={vulnsNoScanDate} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        await user.click(screen.getByText('More'));
+        expect(screen.getByText('No scan dates available')).toBeInTheDocument();
+    });
+
+    test('shows no attack vectors message when none available', async () => {
+        const vulnsNoCvss: Vulnerability[] = [{
+            ...vulnerabilities[0],
+            severity: { ...vulnerabilities[0].severity, cvss: [] }
+        }, {
+            ...vulnerabilities[1],
+            severity: { ...vulnerabilities[1].severity, cvss: [] }
+        }];
+
+        render(<TableVulnerabilities vulnerabilities={vulnsNoCvss} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        await user.click(screen.getByText('More'));
+        expect(screen.getByText('No attack vectors available')).toBeInTheDocument();
+    });
+});

--- a/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
+++ b/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
@@ -64,6 +64,26 @@ describe('Vulnerabilities parsing CVSS branches', () => {
     fetchMock.resetMocks();
   });
 
+  test('list with compareVariantId and operation sets compare query params', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([rawVuln()]));
+    const vulns = await Vulnerabilities.list('variant-1', undefined, 'variant-2', 'difference');
+    expect(vulns).toHaveLength(1);
+    const calledUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(calledUrl.searchParams.get('variant_id')).toBe('variant-1');
+    expect(calledUrl.searchParams.get('compare_variant_id')).toBe('variant-2');
+    expect(calledUrl.searchParams.get('operation')).toBe('difference');
+  });
+
+  test('list with compareVariantId but no operation omits operation param', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([rawVuln()]));
+    const vulns = await Vulnerabilities.list('variant-1', undefined, 'variant-2');
+    expect(vulns).toHaveLength(1);
+    const calledUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(calledUrl.searchParams.get('variant_id')).toBe('variant-1');
+    expect(calledUrl.searchParams.get('compare_variant_id')).toBe('variant-2');
+    expect(calledUrl.searchParams.has('operation')).toBe(false);
+  });
+
   test('filters invalid cvss entries and keeps valid ones with attack vector', async () => {
     const cvssArray = [
       { version: '3.1', base_score: 5.5, vector_string: 'CVSS:3.1/AV:N/BS:5.5' },
@@ -254,12 +274,12 @@ describe('append_assessment', () => {
     } as any;
 
     const result = Vulnerabilities.append_assessment(vulns, assessment);
-    
+
     const cve1 = result.find((v: any) => v.id === 'CVE-2021-1');
     expect(cve1?.status).toBe('investigating');
     expect(cve1?.simplified_status).toBe('open');
     expect(cve1?.assessments).toHaveLength(1);
-    
+
     const cve2 = result.find((v: any) => v.id === 'CVE-2021-2');
     expect(cve2?.status).toBe('unknown');
     expect(cve2?.assessments).toHaveLength(0);
@@ -295,7 +315,7 @@ describe('append_cvss', () => {
     };
 
     const result = Vulnerabilities.append_cvss(vulns, 'CVE-2021-1', cvss);
-    
+
     expect(result[0].severity.cvss).toHaveLength(1);
     expect(result[0].severity.cvss[0]).toEqual(cvss);
   });
@@ -340,7 +360,7 @@ describe('append_cvss', () => {
     };
 
     const result = Vulnerabilities.append_cvss(vulns, 'CVE-2021-1', cvss);
-    
+
     expect(result[0].severity.cvss).toHaveLength(1);
     expect(result[1].severity.cvss).toHaveLength(0);
   });
@@ -349,7 +369,7 @@ describe('append_cvss', () => {
 describe('calculate_cvss_from_vector error handling', () => {
   test('handles non-invalid vector errors by logging them', () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    
+
     // Mock the CVSS calculator to throw a different error
     const originalCvss3P1 = require('ae-cvss-calculator').Cvss3P1;
     require('ae-cvss-calculator').Cvss3P1 = jest.fn().mockImplementation(() => ({
@@ -359,10 +379,10 @@ describe('calculate_cvss_from_vector error handling', () => {
     }));
 
     const result = Vulnerabilities.calculate_cvss_from_vector('CVSS:3.1/AV:N/BS:5.5');
-    
+
     expect(result).toBeNull();
     expect(consoleErrorSpy).toHaveBeenCalled();
-    
+
     // Restore mocks
     require('ae-cvss-calculator').Cvss3P1 = originalCvss3P1;
     consoleErrorSpy.mockRestore();
@@ -370,13 +390,13 @@ describe('calculate_cvss_from_vector error handling', () => {
 
   test('suppresses expected invalid vector errors', () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    
+
     const result = Vulnerabilities.calculate_cvss_from_vector('INVALID_VECTOR');
-    
+
     expect(result).toBeNull();
     // Should NOT log the error since it's an expected 'invalid vector' error
     expect(consoleErrorSpy).not.toHaveBeenCalled();
-    
+
     consoleErrorSpy.mockRestore();
   });
 });

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -433,6 +433,54 @@ class VulnerabilitiesController:
             print(f"Error for {vuln_id}: {e}")
         return None
 
+    def fetch_published_dates(self):
+        """Fetch published dates for all vulnerabilities from local cache / GHSA API.
+
+        CVE-prefixed IDs are looked up from the local NVD SQLite cache (if
+        available).  GHSA-prefixed IDs are fetched from the GitHub Advisories
+        API via a thread pool.  All errors are silently caught so that a
+        single failure never aborts the whole run.
+        """
+        import sqlite3
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        nvd_db_path = os.path.join(
+            os.getenv("VULNSCOUT_CACHE_DIR", "/cache/vulnscout"), "nvd.db"
+        )
+
+        # CVE vulns: try local NVD SQLite cache
+        for vuln in self.vulnerabilities.values():
+            if vuln.id.startswith("CVE-"):
+                try:
+                    conn = sqlite3.connect(nvd_db_path)
+                    cursor = conn.execute(
+                        "SELECT published FROM cves WHERE id = ?", (vuln.id,)
+                    )
+                    row = cursor.fetchone()
+                    if row and row[0]:
+                        vuln.published = row[0]
+                    conn.close()
+                except Exception:
+                    pass
+
+        # GHSA vulns: fetch via GitHub Advisories API
+        ghsa_vulns = {vid: v for vid, v in self.vulnerabilities.items() if "GHSA" in vid}
+        if ghsa_vulns:
+            max_workers = min(10, len(ghsa_vulns))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                future_to_id = {
+                    executor.submit(self._fetch_ghsa_published, vid): vid
+                    for vid in ghsa_vulns
+                }
+                for future in as_completed(future_to_id, timeout=60):
+                    vid = future_to_id[future]
+                    try:
+                        published = future.result(timeout=15)
+                        if published:
+                            ghsa_vulns[vid].published = published
+                    except Exception:
+                        pass
+
     def fetch_nvd_data(self):
         """Fetch NVD data (published date, weaknesses, versions_data, patch_url) for all vulnerabilities.
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -484,6 +484,8 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h)
             show_help; exit 0 ;;
+        --version)
+            echo "${VULNSCOUT_VERSION:-unknown}"; exit 0 ;;
         --project)
             PROJECT_NAME="$2"; shift 2 ;;
         --variant)

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -272,8 +272,9 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             base["is_first"] = False
 
             upgraded_pairs = entry["upgraded_pairs"]
-            base["packages_added"] = entry.get("truly_added_p", len(entry["curr_p"] - packages_map.get(prev.id, set())))
-            base["packages_removed"] = entry.get("truly_removed_p", len(packages_map.get(prev.id, set()) - entry["curr_p"]))
+            prev_pkgs = packages_map.get(prev.id, set())
+            base["packages_added"] = entry.get("truly_added_p", len(entry["curr_p"] - prev_pkgs))
+            base["packages_removed"] = entry.get("truly_removed_p", len(prev_pkgs - entry["curr_p"]))
             base["packages_upgraded"] = len(upgraded_pairs)
 
             raw_added_f = curr_f - prev_f

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -95,6 +95,47 @@ def _pkg_to_dict(pkg: Package) -> dict:
     }
 
 
+def _classify_package_changes(added_pkg_ids: set, removed_pkg_ids: set, pkg_lookup: dict) -> tuple:
+    """Classify package changes into truly-added, truly-removed, and upgraded.
+
+    A package is "upgraded" when the same package name appears in both the
+    added and removed sets with different versions.
+
+    Returns (truly_added_ids, truly_removed_ids, upgraded_pairs) where
+    upgraded_pairs is a list of (old_pkg, new_pkg) Package dicts.
+    """
+    added_by_name: dict = {}
+    for pid in added_pkg_ids:
+        pkg = pkg_lookup.get(pid)
+        if pkg:
+            added_by_name.setdefault(pkg.name or "unknown", []).append(pkg)
+
+    removed_by_name: dict = {}
+    for pid in removed_pkg_ids:
+        pkg = pkg_lookup.get(pid)
+        if pkg:
+            removed_by_name.setdefault(pkg.name or "unknown", []).append(pkg)
+
+    upgraded_pairs = []
+    matched_added_ids: set = set()
+    matched_removed_ids: set = set()
+
+    for name in set(added_by_name) & set(removed_by_name):
+        new_pkgs = list(added_by_name[name])
+        old_pkgs = list(removed_by_name[name])
+        # Pair highest versions first so the closest predecessor matches
+        new_pkgs.sort(key=lambda p: p.version or "", reverse=True)
+        old_pkgs.sort(key=lambda p: p.version or "", reverse=True)
+        for i in range(min(len(new_pkgs), len(old_pkgs))):
+            upgraded_pairs.append((old_pkgs[i], new_pkgs[i]))
+            matched_added_ids.add(new_pkgs[i].id)
+            matched_removed_ids.add(old_pkgs[i].id)
+
+    truly_added_ids = added_pkg_ids - matched_added_ids
+    truly_removed_ids = removed_pkg_ids - matched_removed_ids
+    return truly_added_ids, truly_removed_ids, upgraded_pairs
+
+
 # ---------------------------------------------------------------------------
 # Helpers — variant / project names
 # ---------------------------------------------------------------------------
@@ -148,38 +189,120 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
     prev_map = _prev_scan_map(scans)
     variant_map = _variant_info(list({s.variant_id for s in scans}))
 
-    result = []
+    # First pass: compute package diffs and collect all finding IDs that need
+    # package-level info for upgrade classification.
+    scan_data = []
+    all_fids_needing_lookup: set = set()
+
     for scan in scans:
-        base = ScanController.serialize(scan)
-        variant_name, project_name = variant_map.get(scan.variant_id, (None, None))
-        base["variant_name"] = variant_name
-        base["project_name"] = project_name
         curr_f = findings_map.get(scan.id, set())
         curr_p = packages_map.get(scan.id, set())
         curr_v = vulns_map.get(scan.id, set())
         prev = prev_map.get(scan.id)
 
+        entry = {
+            "scan": scan,
+            "curr_f": curr_f, "curr_p": curr_p, "curr_v": curr_v,
+            "prev": prev,
+            "upgraded_pairs": [],
+            "raw_added_f": set(), "raw_removed_f": set(),
+        }
+
+        if prev is not None:
+            prev_p = packages_map.get(prev.id, set())
+            raw_added_p = curr_p - prev_p
+            raw_removed_p = prev_p - curr_p
+            if raw_added_p or raw_removed_p:
+                pkg_lk = _package_rows(raw_added_p | raw_removed_p)
+                truly_added, truly_removed, upgraded = _classify_package_changes(
+                    raw_added_p, raw_removed_p, pkg_lk
+                )
+                entry["truly_added_p"] = len(truly_added)
+                entry["truly_removed_p"] = len(truly_removed)
+                entry["upgraded_pairs"] = upgraded
+
+                if upgraded:
+                    prev_f = findings_map.get(prev.id, set())
+                    raw_added_f = curr_f - prev_f
+                    raw_removed_f = prev_f - curr_f
+                    entry["raw_added_f"] = raw_added_f
+                    entry["raw_removed_f"] = raw_removed_f
+                    all_fids_needing_lookup |= raw_added_f | raw_removed_f
+
+        scan_data.append(entry)
+
+    # Single batch query: finding_id -> (package_id, vulnerability_id)
+    fid_to_info: dict = {}
+    if all_fids_needing_lookup:
+        rows = db.session.execute(
+            db.select(Finding.id, Finding.package_id, Finding.vulnerability_id)
+            .where(Finding.id.in_(all_fids_needing_lookup))
+        ).all()
+        fid_to_info = {r[0]: (r[1], r[2]) for r in rows}
+
+    # Second pass: build result dicts
+    result = []
+    for entry in scan_data:
+        scan = entry["scan"]
+        base = ScanController.serialize(scan)
+        variant_name, project_name = variant_map.get(scan.variant_id, (None, None))
+        base["variant_name"] = variant_name
+        base["project_name"] = project_name
+        curr_f = entry["curr_f"]
+        curr_v = entry["curr_v"]
+        prev = entry["prev"]
+
         base["finding_count"] = len(curr_f)
-        base["package_count"] = len(curr_p)
+        base["package_count"] = len(entry["curr_p"])
         base["vuln_count"] = len(curr_v)
 
         if prev is None:
             base["is_first"] = True
             base["findings_added"] = None
             base["findings_removed"] = None
+            base["findings_upgraded"] = None
             base["packages_added"] = None
             base["packages_removed"] = None
+            base["packages_upgraded"] = None
             base["vulns_added"] = None
             base["vulns_removed"] = None
         else:
             prev_f = findings_map.get(prev.id, set())
-            prev_p = packages_map.get(prev.id, set())
             prev_v = vulns_map.get(prev.id, set())
             base["is_first"] = False
-            base["findings_added"] = len(curr_f - prev_f)
-            base["findings_removed"] = len(prev_f - curr_f)
-            base["packages_added"] = len(curr_p - prev_p)
-            base["packages_removed"] = len(prev_p - curr_p)
+
+            upgraded_pairs = entry["upgraded_pairs"]
+            base["packages_added"] = entry.get("truly_added_p", len(entry["curr_p"] - packages_map.get(prev.id, set())))
+            base["packages_removed"] = entry.get("truly_removed_p", len(packages_map.get(prev.id, set()) - entry["curr_p"]))
+            base["packages_upgraded"] = len(upgraded_pairs)
+
+            raw_added_f = curr_f - prev_f
+            raw_removed_f = prev_f - curr_f
+
+            if upgraded_pairs and entry["raw_added_f"]:
+                # Classify findings on upgraded packages
+                upgraded_old_ids = {str(old_pkg.id) for old_pkg, _ in upgraded_pairs}
+                upgraded_new_ids = {str(new_pkg.id) for _, new_pkg in upgraded_pairs}
+                # Vulns on removed side that belong to upgraded old packages
+                removed_vulns_on_upgraded = {
+                    fid_to_info[fid][1]
+                    for fid in raw_removed_f
+                    if fid in fid_to_info and str(fid_to_info[fid][0]) in upgraded_old_ids
+                }
+                upgraded_count = sum(
+                    1 for fid in raw_added_f
+                    if fid in fid_to_info
+                    and str(fid_to_info[fid][0]) in upgraded_new_ids
+                    and fid_to_info[fid][1] in removed_vulns_on_upgraded
+                )
+                base["findings_upgraded"] = upgraded_count
+                base["findings_added"] = len(raw_added_f) - upgraded_count
+                base["findings_removed"] = len(raw_removed_f) - upgraded_count
+            else:
+                base["findings_upgraded"] = 0
+                base["findings_added"] = len(raw_added_f)
+                base["findings_removed"] = len(raw_removed_f)
+
             base["vulns_added"] = len(curr_v - prev_v)
             base["vulns_removed"] = len(prev_v - curr_v)
 
@@ -214,6 +337,66 @@ def _obs_to_dict(obs: Observation) -> dict:
         "package_id": str(f.package_id),
         "vulnerability_id": f.vulnerability_id,
     }
+
+
+def _classify_finding_changes(findings_added, findings_removed, upgraded_pairs):
+    """Separate findings into truly-added, truly-removed, and upgraded.
+
+    A finding is "upgraded" when the same vulnerability_id appears in both
+    added and removed sets, and the package_id changed between an upgraded
+    package pair.
+
+    Args:
+        findings_added: list of obs dicts (from _obs_to_dict) that were added
+        findings_removed: list of obs dicts that were removed
+        upgraded_pairs: list of (old_pkg, new_pkg) Package objects
+
+    Returns (truly_added, truly_removed, upgraded_findings) where
+    upgraded_findings is a list of dicts with vuln_id, pkg_name, old_version, new_version.
+    """
+    # Build set of (old_pkg_id, new_pkg_id) from upgraded pairs
+    upgraded_pkg_map = {}  # old_pkg_id -> new_pkg Package
+    new_to_old_pkg = {}    # new_pkg_id -> old_pkg Package
+    for old_pkg, new_pkg in upgraded_pairs:
+        upgraded_pkg_map[str(old_pkg.id)] = new_pkg
+        new_to_old_pkg[str(new_pkg.id)] = old_pkg
+
+    # Index removed findings by (vuln_id, old_pkg_id) for matching
+    removed_by_key = {}
+    for f in findings_removed:
+        key = (f["vulnerability_id"], f["package_id"])
+        removed_by_key.setdefault(key, []).append(f)
+
+    upgraded_findings = []
+    matched_added_ids = set()
+    matched_removed_ids = set()
+
+    for f_added in findings_added:
+        pkg_id = f_added["package_id"]
+        vuln_id = f_added["vulnerability_id"]
+        if pkg_id not in new_to_old_pkg:
+            continue
+        old_pkg = new_to_old_pkg[pkg_id]
+        old_pkg_id_str = str(old_pkg.id)
+        key = (vuln_id, old_pkg_id_str)
+        candidates = removed_by_key.get(key, [])
+        for f_removed in candidates:
+            if f_removed["finding_id"] in matched_removed_ids:
+                continue
+            # Match found
+            upgraded_findings.append({
+                "vulnerability_id": vuln_id,
+                "package_name": f_added["package_name"],
+                "old_version": old_pkg.version or "",
+                "new_version": f_added["package_version"],
+            })
+            matched_added_ids.add(f_added["finding_id"])
+            matched_removed_ids.add(f_removed["finding_id"])
+            break
+
+    truly_added = [f for f in findings_added if f["finding_id"] not in matched_added_ids]
+    truly_removed = [f for f in findings_removed if f["finding_id"] not in matched_removed_ids]
+    return truly_added, truly_removed, upgraded_findings
 
 
 # ---------------------------------------------------------------------------
@@ -310,18 +493,42 @@ def init_app(app):
         curr_pkg_ids = pkg_sets.get(scan.id, set())
         prev_pkg_ids = pkg_sets.get(prev_scan_id, set()) if prev_scan_id else set()
 
-        added_pkg_ids = curr_pkg_ids - prev_pkg_ids
-        removed_pkg_ids = prev_pkg_ids - curr_pkg_ids
+        raw_added_pkg_ids = curr_pkg_ids - prev_pkg_ids
+        raw_removed_pkg_ids = prev_pkg_ids - curr_pkg_ids
 
-        all_relevant_pkg_ids = added_pkg_ids | removed_pkg_ids
+        all_relevant_pkg_ids = raw_added_pkg_ids | raw_removed_pkg_ids
         pkg_lookup = _package_rows(all_relevant_pkg_ids)
 
-        packages_added = [_pkg_to_dict(pkg_lookup[pid]) for pid in added_pkg_ids if pid in pkg_lookup]
-        packages_removed = [_pkg_to_dict(pkg_lookup[pid]) for pid in removed_pkg_ids if pid in pkg_lookup]
+        truly_added_ids, truly_removed_ids, upgraded_pairs = _classify_package_changes(
+            raw_added_pkg_ids, raw_removed_pkg_ids, pkg_lookup
+        )
+
+        packages_added = [_pkg_to_dict(pkg_lookup[pid]) for pid in truly_added_ids if pid in pkg_lookup]
+        packages_removed = [_pkg_to_dict(pkg_lookup[pid]) for pid in truly_removed_ids if pid in pkg_lookup]
+        packages_upgraded = [
+            {
+                "package_name": (old_pkg.name or "unknown"),
+                "old_version": (old_pkg.version or ""),
+                "new_version": (new_pkg.version or ""),
+                "old_package_id": str(old_pkg.id),
+                "new_package_id": str(new_pkg.id),
+            }
+            for old_pkg, new_pkg in upgraded_pairs
+        ]
+
+        # --- Classify findings on upgraded packages ---
+        if prev_scan_id is not None and upgraded_pairs:
+            findings_added, findings_removed, findings_upgraded = _classify_finding_changes(
+                findings_added, findings_removed, upgraded_pairs
+            )
+        else:
+            findings_upgraded = []
 
         # Sort for stable output
         packages_added.sort(key=lambda p: (p["package_name"], p["package_version"]))
         packages_removed.sort(key=lambda p: (p["package_name"], p["package_version"]))
+        packages_upgraded.sort(key=lambda p: (p["package_name"], p["old_version"]))
+        findings_upgraded.sort(key=lambda f: (f["package_name"], f["vulnerability_id"]))
 
         return jsonify({
             "scan_id": str(scan.id),
@@ -332,8 +539,10 @@ def init_app(app):
             "vuln_count": len(curr_vulns),
             "findings_added": findings_added,
             "findings_removed": findings_removed,
+            "findings_upgraded": findings_upgraded,
             "packages_added": packages_added,
             "packages_removed": packages_removed,
+            "packages_upgraded": packages_upgraded,
             "vulns_added": vulns_added,
             "vulns_removed": vulns_removed,
         })

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -398,6 +398,20 @@ def init_app(app):
             for v in vulns:
                 v["variants"] = sorted(variant_names_by_vuln.get(v["id"], []))
 
+            # Enrich with the date of the earliest scan where each vuln was first observed
+            first_scan_rows = db.session.execute(
+                db.select(Finding.vulnerability_id, func.min(Scan.timestamp))
+                .join(Observation, Finding.id == Observation.finding_id)
+                .join(Scan, Observation.scan_id == Scan.id)
+                .where(Finding.vulnerability_id.in_(vuln_ids))
+                .group_by(Finding.vulnerability_id)
+            ).all()
+            first_scan_by_vuln: dict = {}
+            for vuln_id, min_ts in first_scan_rows:
+                first_scan_by_vuln[str(vuln_id)] = min_ts.isoformat() if min_ts else None
+            for v in vulns:
+                v["first_scan_date"] = first_scan_by_vuln.get(v["id"])
+
         if request.args.get('format', 'list') == "dict":
             return {v["id"]: v for v in vulns}
         return vulns

--- a/tests/unit_tests/test_epss_db.py
+++ b/tests/unit_tests/test_epss_db.py
@@ -95,3 +95,125 @@ def test_epss_db_no_args():
     db = EPSS_DB()
     assert hasattr(db, "api_get_epss")
 
+
+# ---------------------------------------------------------------------------
+# api_get_epss — HTTPError paths (lines 52-55)
+# ---------------------------------------------------------------------------
+
+def test_api_get_epss_http_error_404(monkeypatch):
+    """HTTPError with code 404 should return None silently."""
+    import urllib.error
+
+    def raise_404(req, timeout=10):
+        raise urllib.error.HTTPError(
+            url="http://example.com", code=404, msg="Not Found",
+            hdrs=None, fp=None
+        )
+
+    monkeypatch.setattr("src.controllers.epss_db.urllib.request.urlopen", raise_404)
+    db = EPSS_DB()
+    result = db.api_get_epss("CVE-9999-0000")
+    assert result is None
+
+
+def test_api_get_epss_http_error_500(monkeypatch):
+    """HTTPError with non-404 code should return None and print."""
+    import urllib.error
+
+    def raise_500(req, timeout=10):
+        raise urllib.error.HTTPError(
+            url="http://example.com", code=500, msg="Server Error",
+            hdrs=None, fp=None
+        )
+
+    monkeypatch.setattr("src.controllers.epss_db.urllib.request.urlopen", raise_500)
+    db = EPSS_DB()
+    result = db.api_get_epss("CVE-2021-44228")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# api_get_epss_batch (lines 69-93)
+# ---------------------------------------------------------------------------
+
+def test_api_get_epss_batch_empty_list(monkeypatch):
+    """Batch with empty list returns empty dict without calling API."""
+    db = EPSS_DB()
+    result = db.api_get_epss_batch([])
+    assert result == {}
+
+
+def test_api_get_epss_batch_success(monkeypatch):
+    """Batch returns scores for all CVEs present in the API response."""
+    payload = {
+        "status": "OK",
+        "data": [
+            {"cve": "CVE-2021-44228", "epss": "0.97514", "percentile": "1.00000"},
+            {"cve": "CVE-2023-0001", "epss": "0.12345", "percentile": "0.56789"},
+        ]
+    }
+    monkeypatch.setattr(
+        "src.controllers.epss_db.urllib.request.urlopen",
+        lambda req, timeout=30: FakeResp(200, payload)
+    )
+    db = EPSS_DB()
+    result = db.api_get_epss_batch(["CVE-2021-44228", "CVE-2023-0001"])
+    assert len(result) == 2
+    assert abs(result["CVE-2021-44228"]["score"] - 0.97514) < 1e-5
+    assert abs(result["CVE-2023-0001"]["percentile"] - 0.56789) < 1e-5
+
+
+def test_api_get_epss_batch_non_200(monkeypatch):
+    """Batch with non-200 response returns empty dict."""
+    monkeypatch.setattr(
+        "src.controllers.epss_db.urllib.request.urlopen",
+        lambda req, timeout=30: FakeResp(500, {})
+    )
+    db = EPSS_DB()
+    result = db.api_get_epss_batch(["CVE-2021-44228"])
+    assert result == {}
+
+
+def test_api_get_epss_batch_http_error(monkeypatch):
+    """Batch with HTTPError returns empty dict."""
+    import urllib.error
+
+    def raise_err(req, timeout=30):
+        raise urllib.error.HTTPError(
+            url="http://example.com", code=503, msg="Unavailable",
+            hdrs=None, fp=None
+        )
+
+    monkeypatch.setattr("src.controllers.epss_db.urllib.request.urlopen", raise_err)
+    db = EPSS_DB()
+    result = db.api_get_epss_batch(["CVE-2021-44228"])
+    assert result == {}
+
+
+def test_api_get_epss_batch_network_error(monkeypatch):
+    """Batch with generic exception returns empty dict."""
+    def boom(req, timeout=30):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("src.controllers.epss_db.urllib.request.urlopen", boom)
+    db = EPSS_DB()
+    result = db.api_get_epss_batch(["CVE-2021-44228"])
+    assert result == {}
+
+
+def test_api_get_epss_batch_partial_data(monkeypatch):
+    """Batch returns only CVEs present in the response; missing ones are absent."""
+    payload = {
+        "status": "OK",
+        "data": [
+            {"cve": "CVE-2021-44228", "epss": "0.97514", "percentile": "1.00000"},
+        ]
+    }
+    monkeypatch.setattr(
+        "src.controllers.epss_db.urllib.request.urlopen",
+        lambda req, timeout=30: FakeResp(200, payload)
+    )
+    db = EPSS_DB()
+    result = db.api_get_epss_batch(["CVE-2021-44228", "CVE-9999-0000"])
+    assert "CVE-2021-44228" in result
+    assert "CVE-9999-0000" not in result

--- a/tests/unit_tests/test_proxy.py
+++ b/tests/unit_tests/test_proxy.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for src/helpers/proxy.py — covering proxy env var branches."""
+
+import urllib.request
+from unittest.mock import patch, MagicMock
+from src.helpers.proxy import install_proxy_opener
+
+
+def test_no_proxy_env_vars(monkeypatch):
+    """When no proxy env vars are set, install_opener is not called."""
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    with patch.object(urllib.request, "install_opener") as mock_install:
+        install_proxy_opener()
+        mock_install.assert_not_called()
+
+
+def test_http_proxy_set(monkeypatch):
+    """When HTTP_PROXY is set, a proxy opener is installed."""
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy:8080")
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    with patch.object(urllib.request, "install_opener") as mock_install:
+        install_proxy_opener()
+        mock_install.assert_called_once()
+
+
+def test_https_proxy_set(monkeypatch):
+    """When HTTPS_PROXY is set, a proxy opener is installed."""
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "https://proxy:8443")
+    monkeypatch.delenv("https_proxy", raising=False)
+    with patch.object(urllib.request, "install_opener") as mock_install:
+        install_proxy_opener()
+        mock_install.assert_called_once()
+
+
+def test_both_proxies_set(monkeypatch):
+    """When both HTTP and HTTPS proxy env vars are set, opener is installed."""
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy:8080")
+    monkeypatch.setenv("HTTPS_PROXY", "https://proxy:8443")
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    with patch.object(urllib.request, "install_opener") as mock_install:
+        install_proxy_opener()
+        mock_install.assert_called_once()
+
+
+def test_lowercase_proxy_vars(monkeypatch):
+    """Lowercase http_proxy / https_proxy env vars are also honoured."""
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.setenv("http_proxy", "http://proxy:8080")
+    monkeypatch.setenv("https_proxy", "https://proxy:8443")
+    with patch.object(urllib.request, "install_opener") as mock_install:
+        install_proxy_opener()
+        mock_install.assert_called_once()

--- a/tests/unit_tests/test_vulnerabilities_controller.py
+++ b/tests/unit_tests/test_vulnerabilities_controller.py
@@ -99,4 +99,156 @@ class TestVulnerabilitiesControllerIter:
         vuln_ids = [v.id for v in vuln_ctrl]
         assert db_vuln.id in vuln_ids
 
+# ---------------------------------------------------------------------------
+# fetch_published_dates — NVD SQLite error (lines 328-329)
+# ---------------------------------------------------------------------------
 
+class TestFetchPublishedDates:
+    def test_nvd_sqlite_error_is_silently_caught(self, app):
+        """A connection error to the NVD SQLite DB is caught, not raised (lines 328-329)."""
+        import sqlite3
+        from src.controllers.vulnerabilities import VulnerabilitiesController
+        from src.controllers.packages import PackagesController
+        from src.models.vulnerability import Vulnerability
+
+        vuln = Vulnerability("CVE-2025-NVD", [], "ds", "ns")
+        pkg_ctrl = PackagesController()
+        vuln_ctrl = VulnerabilitiesController(pkg_ctrl)
+        vuln_ctrl.vulnerabilities["CVE-2025-NVD"] = vuln
+
+        with patch("sqlite3.connect", side_effect=sqlite3.OperationalError("no such file")):
+            vuln_ctrl.fetch_published_dates()  # must not raise
+
+    # ---------------------------------------------------------------------------
+    # fetch_published_dates — GHSA thread-pool path (lines 346-359)
+    # ---------------------------------------------------------------------------
+
+    def test_ghsa_published_date_returned(self, app):
+        """GHSA vulns use the ThreadPoolExecutor path; a mocked date is applied (lines 346-347)."""
+        from src.controllers.vulnerabilities import VulnerabilitiesController
+        from src.controllers.packages import PackagesController
+        from src.models.vulnerability import Vulnerability
+
+        vuln = Vulnerability("GHSA-test-xxxx-0001", [], "ds", "ns")
+        pkg_ctrl = PackagesController()
+        vuln_ctrl = VulnerabilitiesController(pkg_ctrl)
+        vuln_ctrl.vulnerabilities["GHSA-test-xxxx-0001"] = vuln
+
+        with patch.object(
+            VulnerabilitiesController,
+            "_fetch_ghsa_published",
+            return_value="2024-06-01T00:00:00Z",
+        ):
+            vuln_ctrl.fetch_published_dates()
+
+        assert vuln.published == "2024-06-01T00:00:00Z"
+
+    def test_ghsa_future_exception_is_caught(self, app):
+        """An exception raised inside a GHSA future is caught, not re-raised (lines 357-359)."""
+        from src.controllers.vulnerabilities import VulnerabilitiesController
+        from src.controllers.packages import PackagesController
+        from src.models.vulnerability import Vulnerability
+
+        vuln = Vulnerability("GHSA-test-xxxx-0002", [], "ds", "ns")
+        pkg_ctrl = PackagesController()
+        vuln_ctrl = VulnerabilitiesController(pkg_ctrl)
+        vuln_ctrl.vulnerabilities["GHSA-test-xxxx-0002"] = vuln
+
+        with patch.object(
+            VulnerabilitiesController,
+            "_fetch_ghsa_published",
+            side_effect=RuntimeError("network error"),
+        ):
+            vuln_ctrl.fetch_published_dates()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# parse_refresh_delay (lines 47-58)
+# ---------------------------------------------------------------------------
+
+class TestParseRefreshDelay:
+    def test_none_returns_never(self):
+        from src.controllers.vulnerabilities import parse_refresh_delay
+        import datetime
+        result = parse_refresh_delay(None)
+        assert result == datetime.timedelta.max
+
+    def test_never_string(self):
+        from src.controllers.vulnerabilities import parse_refresh_delay
+        import datetime
+        assert parse_refresh_delay("never") == datetime.timedelta.max
+        assert parse_refresh_delay("  Never  ") == datetime.timedelta.max
+
+    def test_always_string(self):
+        from src.controllers.vulnerabilities import parse_refresh_delay
+        assert parse_refresh_delay("always") is None
+        assert parse_refresh_delay("  ALWAYS  ") is None
+
+    def test_hours(self):
+        from src.controllers.vulnerabilities import parse_refresh_delay
+        import datetime
+        result = parse_refresh_delay("48h")
+        assert result == datetime.timedelta(hours=48)
+
+    def test_days(self):
+        from src.controllers.vulnerabilities import parse_refresh_delay
+        import datetime
+        result = parse_refresh_delay("7d")
+        assert result == datetime.timedelta(days=7)
+
+    def test_weeks(self):
+        from src.controllers.vulnerabilities import parse_refresh_delay
+        import datetime
+        result = parse_refresh_delay("2w")
+        assert result == datetime.timedelta(weeks=2)
+
+    def test_minutes(self):
+        from src.controllers.vulnerabilities import parse_refresh_delay
+        import datetime
+        result = parse_refresh_delay("30m")
+        assert result == datetime.timedelta(minutes=30)
+
+    def test_invalid_raises(self):
+        from src.controllers.vulnerabilities import parse_refresh_delay
+        import pytest
+        with pytest.raises(ValueError):
+            parse_refresh_delay("bogus")
+
+    def test_invalid_numeric_raises(self):
+        from src.controllers.vulnerabilities import parse_refresh_delay
+        import pytest
+        with pytest.raises(ValueError):
+            parse_refresh_delay("abch")
+
+
+# ---------------------------------------------------------------------------
+# _should_refetch (lines 73, 78)
+# ---------------------------------------------------------------------------
+
+class TestShouldRefetch:
+    def test_always_returns_true(self):
+        from src.controllers.vulnerabilities import _should_refetch, _ALWAYS
+        import datetime
+        assert _should_refetch(datetime.datetime.utcnow(), _ALWAYS) is True
+
+    def test_fetched_at_none_returns_true(self):
+        from src.controllers.vulnerabilities import _should_refetch
+        import datetime
+        assert _should_refetch(None, datetime.timedelta(hours=1)) is True
+
+    def test_never_with_existing_returns_false(self):
+        from src.controllers.vulnerabilities import _should_refetch, _NEVER
+        import datetime
+        assert _should_refetch(datetime.datetime.utcnow(), _NEVER) is False
+
+    def test_data_older_than_delay(self):
+        from src.controllers.vulnerabilities import _should_refetch
+        import datetime
+        old = datetime.datetime.utcnow() - datetime.timedelta(hours=50)
+        assert _should_refetch(old, datetime.timedelta(hours=48)) is True
+
+    def test_data_newer_than_delay(self):
+        from src.controllers.vulnerabilities import _should_refetch
+        import datetime
+        recent = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+        assert _should_refetch(recent, datetime.timedelta(hours=48)) is False

--- a/tests/webapp_tests/test_epss_progress.py
+++ b/tests/webapp_tests/test_epss_progress.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for src/routes/epss_progress.py — covering the GET endpoint."""
+
+import pytest
+import os
+from src.bin.webapp import create_app
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        with application.app_context():
+            from src.extensions import db as _db
+            _db.create_all()
+            yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_get_epss_progress(client):
+    """GET /api/epss/progress returns progress dict with expected keys."""
+    resp = client.get("/api/epss/progress")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "in_progress" in data
+    assert "phase" in data
+    assert "current" in data
+    assert "total" in data
+    assert "message" in data

--- a/tests/webapp_tests/test_notifications.py
+++ b/tests/webapp_tests/test_notifications.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for src/routes/notifications.py — covering all branches."""
+
+import pytest
+import json
+import os
+from src.bin.webapp import create_app
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        with application.app_context():
+            from src.extensions import db as _db
+            _db.create_all()
+            yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+class TestNotificationsRoute:
+    def test_no_file_returns_empty_list(self, client, monkeypatch):
+        """When the notification file does not exist, return []."""
+        monkeypatch.setattr("src.routes.notifications.NOTIFICATION_FILE", "/nonexistent.json")
+        resp = client.get("/api/notifications")
+        assert resp.status_code == 200
+        assert resp.get_json() == []
+
+    def test_file_with_list(self, client, tmp_path, monkeypatch):
+        """When the file contains a JSON list, return it as-is."""
+        notif_file = tmp_path / "notif.json"
+        notif_file.write_text(json.dumps([{"level": "warning", "title": "test"}]))
+        monkeypatch.setattr("src.routes.notifications.NOTIFICATION_FILE", str(notif_file))
+        resp = client.get("/api/notifications")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["level"] == "warning"
+
+    def test_file_with_dict_normalised_to_list(self, client, tmp_path, monkeypatch):
+        """When the file contains a single dict, wrap it in a list."""
+        notif_file = tmp_path / "notif.json"
+        notif_file.write_text(json.dumps({"level": "info", "title": "single"}))
+        monkeypatch.setattr("src.routes.notifications.NOTIFICATION_FILE", str(notif_file))
+        resp = client.get("/api/notifications")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["title"] == "single"
+
+    def test_invalid_json_returns_empty_list(self, client, tmp_path, monkeypatch):
+        """When the file contains invalid JSON, return []."""
+        notif_file = tmp_path / "notif.json"
+        notif_file.write_text("not valid json{{{")
+        monkeypatch.setattr("src.routes.notifications.NOTIFICATION_FILE", str(notif_file))
+        resp = client.get("/api/notifications")
+        assert resp.status_code == 200
+        assert resp.get_json() == []

--- a/vulnscout
+++ b/vulnscout
@@ -40,6 +40,8 @@ Container lifecycle:
   start                           Start VulnScout container (auto-started by other commands)
   stop                            Stop and remove VulnScout container
   restart                         Restart VulnScout container
+  --update                        Pull latest image and restart if a new version is available
+  --version                       Show current version
   --dev                           Dev mode: mount local src/ into container and start frontend npm dev server
 
 Note: The container runs as a daemon. All commands auto-start it if needed and
@@ -335,6 +337,24 @@ parse_and_run() {
                 config_clear "$2"; shift 2 ;;
             help|--help|-h)
                 show_help; shift ;;
+            version|--version)
+                echo "VulnScout $VULNSCOUT_VERSION"
+                shift ;;
+            update)
+                echo "Pulling latest image..."
+                docker pull "$DOCKER_IMAGE"
+                NEW_VERSION="$(docker inspect "$DOCKER_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.version"}}' 2>/dev/null || echo unknown)"
+                if [ "$VULNSCOUT_VERSION" != "$NEW_VERSION" ]; then
+                    echo "Updating: $VULNSCOUT_VERSION -> $NEW_VERSION"
+                    config_set VULNSCOUT_VERSION "$NEW_VERSION"
+                    if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+                        echo "Restarting container with new version..."
+                        do_start
+                    fi
+                else
+                    echo "Already up to date ($VULNSCOUT_VERSION)."
+                fi
+                shift ;;
             *)
                 echo "Unknown command: $1"
                 echo "Run 'vulnscout help' for usage."

--- a/vulnscout
+++ b/vulnscout
@@ -55,9 +55,9 @@ Input commands (can be chained, triggers scan automatically):
 
 Scan & output commands:
   --match-condition <expr>        Run vulnerability scan
-  serve                           Run scan then start web UI (port 7275)
-  report <template>               Generate a report from a template
-  report <path>                   Stage a local report template file and generate a report from it
+  --serve                         Run scan then start web UI (port 7275)
+  --report <template>             Generate a report from a template
+  --report <path>                 Stage a local report template file and generate a report from it
   --export-spdx                   Export project as SPDX 3.0 SBOM
   --export-cdx                    Export project as CycloneDX 1.6 SBOM
   --export-openvex                Export project as OpenVEX document
@@ -77,9 +77,8 @@ Environment variables:
 Examples:
   vulnscout --project test --variant x86 --add-cve-check ./cve.json --add-spdx ./sbom.json
   vulnscout --project test --match-condition "cvss >= 9.0"
-  vulnscout serve --project test
-  vulnscout serve
-  vulnscout report summary.adoc
+  vulnscout --serve
+  vulnscout --report summary.adoc
   vulnscout config NVD_API_KEY abc123
 
 Exit codes:

--- a/vulnscout
+++ b/vulnscout
@@ -37,10 +37,13 @@ VulnScout - Vulnerability Scanner
 Usage: vulnscout [--project <name>] [--variant <name>] <command> [options]
 
 Container lifecycle:
-  start                           Start VulnScout container
+  start                           Start VulnScout container (auto-started by other commands)
   stop                            Stop and remove VulnScout container
   restart                         Restart VulnScout container
   --dev                           Dev mode: mount local src/ into container and start frontend npm dev server
+
+Note: The container runs as a daemon. All commands auto-start it if needed and
+leave it running afterward (including --serve). Use 'stop' to remove it.
 
 Global flags:
   --project <name>                Set project name (default: 'default')
@@ -342,22 +345,14 @@ parse_and_run() {
     # Auto-trigger scan if inputs were staged: one entrypoint call handles move + scan
     local _exit=0
     if [ "$SERVE_REQUESTED" = true ]; then
-        if [ ${#PENDING_ARGS[@]} -gt 0 ]; then
-            # Files already staged — keep container alive, just free port 7275
-            ensure_running
-            docker exec "$CONTAINER_NAME" pkill -f 'flask.*run' 2>/dev/null || true
-            sleep 1
-        else
-            # No staged files: full restart to ensure clean state
-            docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
-            do_start
-        fi
+        ensure_running
+        # Kill any previous Flask process to free port 7275
+        docker exec "$CONTAINER_NAME" pkill -f 'flask.*run' 2>/dev/null || true
+        sleep 1
         if [ "$DEV_MODE" = true ]; then
             start_frontend_dev
         fi
-        trap "echo; echo 'Stopping container...'; docker rm -f '$CONTAINER_NAME' 2>/dev/null || true" SIGINT SIGTERM EXIT
         exec_container --project "$PROJECT" --variant "$VARIANT" ${PENDING_ARGS[@]+"${PENDING_ARGS[@]}"} --serve || _exit=$?
-        trap - SIGINT SIGTERM EXIT
     elif [ ${#PENDING_ARGS[@]} -gt 0 ]; then
         local -a scan_args=()
         [ -n "$MATCH_CONDITION" ] && scan_args+=(--match-condition "$MATCH_CONDITION")


### PR DESCRIPTION
## Fixes # by Valentin

### Changes proposed in this pull request:

* Package tab: Add two new columns 'Variants' and 'Remaining Pending Vulnerabilities'. Also, renamed the tab as 'SBOM' as requested by users. 
* Vulnerabilities: Show the 'Variants' column by default. Add a new hidden 'First Scan Date' in the 'Column' filter. Add new filters (EPSS, First Scan date, attack vector)
* Assessments: Check a variant/package by default on the checkbox list if this is the only one
* Loading screen: Removed (1/8) step, which doesn't make sense anymore
* Scan: Added 'Upgrade' feature. Add timezone in the date
* README.md: Fix the "--" for consistency and updated the examples to be realistic
* Metrics: Fix frontend issues with empty white space & the two arrays had a different raw size which was wrong
* vulnscout: Removed the trap for "--serve" command. For consistency the container is running in a daemon and should always be up
* add "vulnscout --version" command 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Mostly UI fixes easy to test