### PR TITLE
Compact data handling in API endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,13 +52,15 @@ RUN curl -sSfL "https://github.com/CycloneDX/cyclonedx-cli/releases/download/$CY
 ARG GRYPE_VERSION=v0.97.2
 RUN curl -sSfL "https://raw.githubusercontent.com/anchore/grype/$GRYPE_VERSION/install.sh" | sh -s -- -b /usr/local/bin
 
-# ARG PYSPY_VERSION=0.4.1
-# RUN curl -sSfL \
-#     "https://github.com/benfred/py-spy/releases/download/v${PYSPY_VERSION}/py_spy-${PYSPY_VERSION}-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl" \
-#     -o /tmp/py_spy.whl \
-#     && unzip -j /tmp/py_spy.whl "py_spy-${PYSPY_VERSION}.data/scripts/py-spy" -d /usr/local/bin/ \
-#     && chmod +x /usr/local/bin/py-spy \
-#     && rm /tmp/py_spy.whl
+# Install py-spy (sampling profiler) for the --pyspy benchmarking subcommand.
+# Uses the manylinux wheel; gcompat (installed above) provides the glibc ABI on Alpine/musl.
+ARG PYSPY_VERSION=0.4.1
+RUN curl -sSfL \
+    "https://github.com/benfred/py-spy/releases/download/v${PYSPY_VERSION}/py_spy-${PYSPY_VERSION}-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl" \
+    -o /tmp/py_spy.whl \
+    && unzip -j /tmp/py_spy.whl "py_spy-${PYSPY_VERSION}.data/scripts/py-spy" -d /usr/local/bin/ \
+    && chmod +x /usr/local/bin/py-spy \
+    && rm /tmp/py_spy.whl
 
 # Install dependencies for python backend
 COPY requirements/base.txt ./

--- a/example/yocto_cve_check/cve-check-duplicate-versions.json
+++ b/example/yocto_cve_check/cve-check-duplicate-versions.json
@@ -1,0 +1,279 @@
+{
+    "version": "1",
+    "package": [
+        {
+            "name": "openssl",
+            "layer": "meta",
+            "version": "3.1.4",
+            "products": [
+                {
+                    "product": "openssl",
+                    "cvesInRecord": "Yes"
+                }
+            ],
+            "issue": [
+                {
+                    "id": "CVE-2024-0727",
+                    "summary": "Issue summary field not supported for PKCS12 files can cause a denial of service when parsing PKCS12 certificates.",
+                    "scorev2": "0.0",
+                    "scorev3": "5.5",
+                    "vector": "LOCAL",
+                    "status": "Patched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-0727"
+                },
+                {
+                    "id": "CVE-2023-5678",
+                    "summary": "Generating excessively long X9.42 DH keys or checking excessively long X9.42 DH keys or parameters may be very slow.",
+                    "scorev2": "0.0",
+                    "scorev3": "5.3",
+                    "vector": "NETWORK",
+                    "status": "Patched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-5678"
+                }
+            ]
+        },
+        {
+            "name": "openssl",
+            "layer": "meta-networking",
+            "version": "1.1.1w",
+            "products": [
+                {
+                    "product": "openssl",
+                    "cvesInRecord": "Yes"
+                }
+            ],
+            "issue": [
+                {
+                    "id": "CVE-2023-5678",
+                    "summary": "Generating excessively long X9.42 DH keys or checking excessively long X9.42 DH keys or parameters may be very slow.",
+                    "scorev2": "0.0",
+                    "scorev3": "5.3",
+                    "vector": "NETWORK",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-5678"
+                },
+                {
+                    "id": "CVE-2023-3446",
+                    "summary": "Checking excessively long DH keys or parameters may be very slow due to a bug in the DH_check() function.",
+                    "scorev2": "0.0",
+                    "scorev3": "5.3",
+                    "vector": "NETWORK",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-3446"
+                },
+                {
+                    "id": "CVE-2023-0286",
+                    "summary": "There is a type confusion vulnerability relating to X.400 address processing inside an X.509 GeneralName which may allow an attacker to read memory contents or cause a denial of service.",
+                    "scorev2": "0.0",
+                    "scorev3": "7.4",
+                    "vector": "NETWORK",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-0286"
+                }
+            ]
+        },
+        {
+            "name": "curl",
+            "layer": "meta",
+            "version": "8.5.0",
+            "products": [
+                {
+                    "product": "curl",
+                    "cvesInRecord": "Yes"
+                }
+            ],
+            "issue": [
+                {
+                    "id": "CVE-2024-2398",
+                    "summary": "When an application tells libcurl it wants to allow HTTP/2 server push, and the amount of received headers for the push surpasses the maximum allowed limit, libcurl aborts the server push causing a memory leak.",
+                    "scorev2": "0.0",
+                    "scorev3": "7.5",
+                    "vector": "NETWORK",
+                    "status": "Patched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-2398"
+                }
+            ]
+        },
+        {
+            "name": "curl",
+            "layer": "meta-oe",
+            "version": "7.88.1",
+            "products": [
+                {
+                    "product": "curl",
+                    "cvesInRecord": "Yes"
+                }
+            ],
+            "issue": [
+                {
+                    "id": "CVE-2024-2398",
+                    "summary": "When an application tells libcurl it wants to allow HTTP/2 server push, and the amount of received headers for the push surpasses the maximum allowed limit, libcurl aborts the server push causing a memory leak.",
+                    "scorev2": "0.0",
+                    "scorev3": "7.5",
+                    "vector": "NETWORK",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-2398"
+                },
+                {
+                    "id": "CVE-2023-38545",
+                    "summary": "This flaw makes curl overflow a heap based buffer in the SOCKS5 proxy handshake. The root cause is that the hostname is too long for the target buffer.",
+                    "scorev2": "0.0",
+                    "scorev3": "9.8",
+                    "vector": "NETWORK",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-38545"
+                },
+                {
+                    "id": "CVE-2023-27534",
+                    "summary": "A path traversal vulnerability exists in curl before 8.0.0 for SFTP that could be exploited using both the tilde and dot path components.",
+                    "scorev2": "0.0",
+                    "scorev3": "8.8",
+                    "vector": "NETWORK",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-27534"
+                }
+            ]
+        },
+        {
+            "name": "busybox",
+            "layer": "meta",
+            "version": "1.36.1",
+            "products": [
+                {
+                    "product": "busybox",
+                    "cvesInRecord": "Yes"
+                }
+            ],
+            "issue": [
+                {
+                    "id": "CVE-2023-42366",
+                    "summary": "A heap-buffer-overflow was discovered in BusyBox v.1.36.1 in the next_token function at awk.c.",
+                    "scorev2": "0.0",
+                    "scorev3": "5.5",
+                    "vector": "LOCAL",
+                    "status": "Ignored",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-42366"
+                }
+            ]
+        },
+        {
+            "name": "zlib",
+            "layer": "meta",
+            "version": "1.3.1",
+            "products": [
+                {
+                    "product": "zlib",
+                    "cvesInRecord": "Yes"
+                }
+            ],
+            "issue": [
+                {
+                    "id": "CVE-2023-45853",
+                    "summary": "MiniZip in zlib through 1.3 has an integer overflow and resultant heap-based buffer overflow in zipOpenNewFileInZip4_64 via a long filename, comment, or extra field.",
+                    "scorev2": "0.0",
+                    "scorev3": "9.8",
+                    "vector": "NETWORK",
+                    "status": "Patched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-45853"
+                }
+            ]
+        },
+        {
+            "name": "zlib",
+            "layer": "meta-oe",
+            "version": "1.2.13",
+            "products": [
+                {
+                    "product": "zlib",
+                    "cvesInRecord": "Yes"
+                }
+            ],
+            "issue": [
+                {
+                    "id": "CVE-2023-45853",
+                    "summary": "MiniZip in zlib through 1.3 has an integer overflow and resultant heap-based buffer overflow in zipOpenNewFileInZip4_64 via a long filename, comment, or extra field.",
+                    "scorev2": "0.0",
+                    "scorev3": "9.8",
+                    "vector": "NETWORK",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-45853"
+                }
+            ]
+        },
+        {
+            "name": "libxml2",
+            "layer": "meta",
+            "version": "2.12.4",
+            "products": [
+                {
+                    "product": "libxml2",
+                    "cvesInRecord": "Yes"
+                }
+            ],
+            "issue": [
+                {
+                    "id": "CVE-2024-25062",
+                    "summary": "An issue was discovered in libxml2 before 2.12.5. xmlValidatePopElement in valid.c has a use-after-free when a valid DTD is used.",
+                    "scorev2": "0.0",
+                    "scorev3": "7.5",
+                    "vector": "NETWORK",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-25062"
+                }
+            ]
+        },
+        {
+            "name": "glibc",
+            "layer": "meta",
+            "version": "2.39",
+            "products": [
+                {
+                    "product": "glibc",
+                    "cvesInRecord": "Yes"
+                }
+            ],
+            "issue": [
+                {
+                    "id": "CVE-2024-2961",
+                    "summary": "The iconv() function in the GNU C Library versions 2.39 and older may overflow the output buffer passed to it by up to 4 bytes during ISO-2022-CN-EXT character set conversion.",
+                    "scorev2": "0.0",
+                    "scorev3": "8.8",
+                    "vector": "NETWORK",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-2961"
+                }
+            ]
+        },
+        {
+            "name": "glibc",
+            "layer": "meta-virtualization",
+            "version": "2.37",
+            "products": [
+                {
+                    "product": "glibc",
+                    "cvesInRecord": "Yes"
+                }
+            ],
+            "issue": [
+                {
+                    "id": "CVE-2024-2961",
+                    "summary": "The iconv() function in the GNU C Library versions 2.39 and older may overflow the output buffer passed to it by up to 4 bytes during ISO-2022-CN-EXT character set conversion.",
+                    "scorev2": "0.0",
+                    "scorev3": "8.8",
+                    "vector": "NETWORK",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-2961"
+                },
+                {
+                    "id": "CVE-2023-6246",
+                    "summary": "A heap-based buffer overflow was found in the __vsyslog_internal function of the glibc library. This function is called by the syslog and vsyslog functions.",
+                    "scorev2": "0.0",
+                    "scorev3": "7.8",
+                    "vector": "LOCAL",
+                    "status": "Unpatched",
+                    "link": "https://nvd.nist.gov/vuln/detail/CVE-2023-6246"
+                }
+            ]
+        }
+    ]
+}

--- a/frontend/src/components/TableGeneric.tsx
+++ b/frontend/src/components/TableGeneric.tsx
@@ -7,6 +7,14 @@ import { useMemo, useRef, useState, useEffect, useCallback } from "react";
 import Fuse from 'fuse.js';
 
 /* tslint:disable:no-explicit-any */
+type ServerPagination = {
+    page: number;       // 0-indexed
+    pageSize: number;
+    total: number;
+    onPageChange: (page: number) => void;
+    onPageSizeChange: (size: number) => void;
+};
+
 type Props<DataType> = {
 
     columns: any[];
@@ -22,6 +30,8 @@ type Props<DataType> = {
     hasPagination?: boolean;
     onFilteredDataChange?: (filteredData: DataType[]) => void;
     onFocusedRowChange?: (rowIndex: number | null) => void;
+    serverPagination?: ServerPagination;
+    onSortingChange?: (sorting: SortingState) => void;
 };
 /* tslint:enable:no-explicit-any */
 
@@ -38,8 +48,11 @@ function TableGeneric<DataType> ({
     updateSelected = () => {},
     hasPagination = true,
     onFilteredDataChange,
-    onFocusedRowChange
+    onFocusedRowChange,
+    serverPagination,
+    onSortingChange,
 }: Readonly<Props<DataType>>) {
+    const isServerMode = !!serverPagination;
     const [pageIndex, setPageIndex] = useState(0)
     const [itemsPerPage, setItemsPerPage] = useState(50)
     const [sorting, setSorting] = useState<SortingState>([])
@@ -60,6 +73,7 @@ function TableGeneric<DataType> ({
     }, [fuseKeys, data]);
 
     const filteredData = useMemo(() => {
+        if (isServerMode) return data;
         if (search && search.length > 2) {
             const buildFuseQuery = (raw: string) => {
                 // FuseJS search query example: https://www.fusejs.io/api/query.html#use-with-extended-searching
@@ -109,6 +123,7 @@ function TableGeneric<DataType> ({
     }, [filteredData, onFilteredDataChange]);
 
     const sortedData = useMemo(() => {
+        if (isServerMode) return filteredData;
         if (sorting.length === 0) return filteredData;
         const sorted = [...filteredData];
         const { id, desc } = sorting[0];
@@ -138,12 +153,25 @@ function TableGeneric<DataType> ({
     }, [filteredData, sorting, columns]);
 
     const paginatedData = useMemo(() => {
+        if (isServerMode) return sortedData;
         const start = pageIndex * itemsPerPage
         return sortedData.slice(start, start + itemsPerPage)
-    }, [sortedData, pageIndex, itemsPerPage])
+    }, [isServerMode, sortedData, pageIndex, itemsPerPage])
+
+    // Notify parent when sorting changes in server mode
+    useEffect(() => {
+        if (isServerMode && onSortingChange) {
+            onSortingChange(sorting);
+        }
+    }, [sorting, isServerMode, onSortingChange]);
+
+    const effectivePageIndex = isServerMode ? serverPagination!.page : pageIndex;
+    const effectiveItemsPerPage = isServerMode ? serverPagination!.pageSize : itemsPerPage;
+    const effectiveTotal = isServerMode ? serverPagination!.total : filteredData.length;
+    const pageCount = Math.ceil(effectiveTotal / effectiveItemsPerPage);
 
     const paginationSizes = useMemo(() => {
-        const total = filteredData.length;
+        const total = effectiveTotal;
 
         const roundToNearest100 = (n: number) => Math.round(n / 100) * 100;
 
@@ -158,9 +186,7 @@ function TableGeneric<DataType> ({
             .sort((a, b) => a - b);
 
         return uniqueSorted;
-    }, [filteredData.length]);
-
-    const pageCount = Math.ceil(filteredData.length / itemsPerPage)
+    }, [effectiveTotal]);
 
     const table = useReactTable({
         columns,
@@ -471,21 +497,26 @@ function TableGeneric<DataType> ({
             <div className="rounded-b-md flex justify-between items-center py-4 px-4 text-white bg-slate-800 border-t border-slate-600 text-sm">
             <div className="flex items-center gap-2">
                 <span>
-                {pageIndex * itemsPerPage + 1}-
-                {Math.min((pageIndex + 1) * itemsPerPage, filteredData.length)} / {filteredData.length}
+                {effectivePageIndex * effectiveItemsPerPage + 1}-
+                {Math.min((effectivePageIndex + 1) * effectiveItemsPerPage, effectiveTotal)} / {effectiveTotal}
                 </span>
                 <span>- Results per page:</span>
                 <select
-                value={itemsPerPage}
+                value={effectiveItemsPerPage}
                 onChange={(e) => {
-                    setPageIndex(0)
-                    setItemsPerPage(Number(e.target.value))
+                    const newSize = Number(e.target.value);
+                    if (isServerMode) {
+                        serverPagination!.onPageSizeChange(newSize);
+                    } else {
+                        setPageIndex(0);
+                        setItemsPerPage(newSize);
+                    }
                 }}
                 className="bg-slate-700 text-white border border-slate-500 rounded px-2 py-1"
                 >
                 {paginationSizes.map(size => (
                     <option key={size} value={size}>
-                    {size === filteredData.length ? `${size} (All)` : size}
+                    {size === effectiveTotal ? `${size} (All)` : size}
                     </option>
                 ))}
                 </select>
@@ -494,19 +525,19 @@ function TableGeneric<DataType> ({
             <div className="flex flex-wrap justify-end items-center gap-2">
                 <button
                 className="px-2 py-1 bg-slate-600 rounded disabled:opacity-50"
-                disabled={pageIndex === 0}
-                onClick={() => setPageIndex(0)}
+                disabled={effectivePageIndex === 0}
+                onClick={() => isServerMode ? serverPagination!.onPageChange(0) : setPageIndex(0)}
                 >
                 First
                 </button>
                 <button
                 className="px-2 py-1 bg-slate-600 rounded disabled:opacity-50"
-                disabled={pageIndex === 0}
-                onClick={() => setPageIndex(prev => Math.max(prev - 1, 0))}
+                disabled={effectivePageIndex === 0}
+                onClick={() => isServerMode ? serverPagination!.onPageChange(Math.max(effectivePageIndex - 1, 0)) : setPageIndex(prev => Math.max(prev - 1, 0))}
                 >
                 Previous
                 </button>
-                {getPageNumbers(pageIndex, pageCount).map((p, i) =>
+                {getPageNumbers(effectivePageIndex, pageCount).map((p, i) =>
                 typeof p === 'string' ? (
                     <span key={i} className="px-2">...</span>
                 ) : (
@@ -514,9 +545,9 @@ function TableGeneric<DataType> ({
                     key={i}
                     className={[
                         'px-2 py-1 rounded',
-                        p === pageIndex ? 'bg-blue-600' : 'bg-slate-600'
+                        p === effectivePageIndex ? 'bg-blue-600' : 'bg-slate-600'
                     ].join(' ')}
-                    onClick={() => setPageIndex(p)}
+                    onClick={() => isServerMode ? serverPagination!.onPageChange(p) : setPageIndex(p)}
                     >
                     {p + 1}
                     </button>
@@ -524,15 +555,15 @@ function TableGeneric<DataType> ({
                 )}
                 <button
                 className="px-2 py-1 bg-slate-600 rounded disabled:opacity-50"
-                disabled={pageIndex + 1 >= pageCount}
-                onClick={() => setPageIndex(prev => prev + 1)}
+                disabled={effectivePageIndex + 1 >= pageCount}
+                onClick={() => isServerMode ? serverPagination!.onPageChange(effectivePageIndex + 1) : setPageIndex(prev => prev + 1)}
                 >
                 Next
                 </button>
                 <button
                 className="px-2 py-1 bg-slate-600 rounded disabled:opacity-50"
-                disabled={pageIndex + 1 >= pageCount}
-                onClick={() => setPageIndex(pageCount - 1)}
+                disabled={effectivePageIndex + 1 >= pageCount}
+                onClick={() => isServerMode ? serverPagination!.onPageChange(pageCount - 1) : setPageIndex(pageCount - 1)}
                 >
                 Last
                 </button>

--- a/frontend/src/handlers/metrics.ts
+++ b/frontend/src/handlers/metrics.ts
@@ -1,0 +1,230 @@
+import { asStringArray } from "./assessments";
+import type { Assessment } from "./assessments";
+import type { Vulnerability, CVSS } from "./vulnerabilities";
+
+const STATUS_VEX_TO_GRAPH: Record<string, string> = {
+    under_investigation: "Pending Assessment",
+    in_triage: "Pending Assessment",
+    false_positive: "Not affected",
+    not_affected: "Not affected",
+    exploitable: "Exploitable",
+    affected: "Exploitable",
+    resolved: "Fixed",
+    fixed: "Fixed",
+    resolved_with_pedigree: "Fixed",
+};
+
+// ---------------------------------------------------------------------------
+// Types for /api/metrics response
+// ---------------------------------------------------------------------------
+
+type MetricsEvolution = {
+    labels: string[];
+    data: number[];
+};
+
+type MetricsSource = {
+    labels: string[];
+    data: number[];
+};
+
+type TopPackageEntry = {
+    id: number;
+    name: string;
+    version: string;
+    count: number;
+};
+
+type TopVulnEntry = {
+    rank: number;
+    cve: string;
+    package: string;
+    severity: string;
+    max_cvss: number;
+    texts: Record<string, string>;
+    original: Vulnerability;
+};
+
+export type MetricsData = {
+    vuln_by_severity: number[];   // [Unknown, Low, Medium, High, Critical]
+    vuln_by_status: number[];     // [Not affected, Fixed, Pending Assessment, Exploitable]
+    vuln_evolution: MetricsEvolution;
+    vuln_by_source: MetricsSource;
+    top_packages: TopPackageEntry[];
+    top_vulns: TopVulnEntry[];
+};
+
+export type { TopPackageEntry, TopVulnEntry };
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+function _asAssessmentFromVuln(data: any): Assessment {
+    const sstat = data?.simplified_status
+        || (STATUS_VEX_TO_GRAPH[data?.status ?? ''] ?? `[invalid] ${data?.status ?? ''}`);
+    return {
+        id: data?.id ?? "",
+        vuln_id: data?.vuln_id ?? "",
+        packages: asStringArray(data?.packages),
+        variant_id: data?.variant_id ?? undefined,
+        status: data?.status ?? "",
+        simplified_status: sstat,
+        status_notes: data?.status_notes ?? undefined,
+        justification: data?.justification ?? undefined,
+        impact_statement: data?.impact_statement ?? undefined,
+        workaround: data?.workaround ?? undefined,
+        timestamp: data?.timestamp ?? "",
+        last_update: data?.last_update ?? undefined,
+        responses: asStringArray(data?.responses),
+    };
+}
+
+function _asVulnerabilityFromMetrics(data: any): Vulnerability | null {
+    if (typeof data !== "object" || typeof data?.id !== "string") return null;
+    const cvss: CVSS[] = Array.isArray(data?.severity?.cvss)
+        ? data.severity.cvss.flatMap((c: any) => {
+            if (typeof c?.base_score !== "number") return [];
+            return [{
+                author: c.author ?? "unknown",
+                severity: c.severity ?? "unknown",
+                version: c.version ?? "",
+                vector_string: c.vector_string ?? "",
+                base_score: Number(c.base_score),
+                exploitability_score: Number(c.exploitability_score ?? 0),
+                impact_score: Number(c.impact_score ?? 0),
+            } satisfies CVSS];
+          })
+        : [];
+
+    const assessments: Assessment[] = Array.isArray(data?.assessments)
+        ? data.assessments.map(_asAssessmentFromVuln)
+        : [];
+
+    // Derive status/simplified_status from assessment list
+    const sorted = [...assessments].sort(
+        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+    const latest = sorted.at(-1);
+
+    return {
+        id: data.id,
+        aliases: asStringArray(data?.aliases),
+        related_vulnerabilities: asStringArray(data?.related_vulnerabilities),
+        namespace: data?.namespace ?? "unknown",
+        found_by: asStringArray(data?.found_by),
+        datasource: data?.datasource ?? "unknown",
+        packages: asStringArray(data?.packages),
+        packages_current: asStringArray(data?.packages_current),
+        variants: asStringArray(data?.variants),
+        urls: asStringArray(data?.urls),
+        published: typeof data?.published === "string" ? data.published : undefined,
+        first_scan_date: typeof data?.first_scan_date === "string" ? data.first_scan_date : undefined,
+        texts: typeof data?.texts === "object"
+            ? Object.entries(data.texts).flatMap(([key, value]) =>
+                typeof value === "string" ? [{ title: key, content: value }] : []
+              )
+            : [],
+        severity: {
+            severity: data?.severity?.severity ?? "unknown",
+            min_score: Number(data?.severity?.min_score ?? 0),
+            max_score: Number(data?.severity?.max_score ?? 0),
+            cvss,
+        },
+        epss: {
+            score: isNaN(Number(data?.epss?.score)) ? undefined : Number(data?.epss?.score),
+            percentile: isNaN(Number(data?.epss?.percentile)) ? undefined : Number(data?.epss?.percentile),
+        },
+        effort: {
+            optimistic: data?.effort?.optimistic as any,
+            likely: data?.effort?.likely as any,
+            pessimistic: data?.effort?.pessimistic as any,
+        },
+        fix: { state: data?.fix?.state ?? "unknown" },
+        status: latest?.status ?? "unknown",
+        simplified_status: latest?.simplified_status ?? data?.simplified_status ?? "unknown",
+        assessments,
+    };
+}
+
+function _asTopVuln(data: any): TopVulnEntry | null {
+    if (typeof data !== "object") return null;
+    const original = _asVulnerabilityFromMetrics(data?.vuln);
+    if (!original) return null;
+    return {
+        rank: Number(data.rank ?? 0),
+        cve: String(data.cve ?? ""),
+        package: String(data.package ?? ""),
+        severity: String(data.severity ?? "unknown"),
+        max_cvss: Number(data.max_cvss ?? 0),
+        texts: typeof data.texts === "object" ? data.texts : {},
+        original,
+    };
+}
+
+function _parseMetrics(data: any): MetricsData {
+    const safeInts = (arr: any, len: number): number[] => {
+        if (!Array.isArray(arr) || arr.length !== len) return new Array(len).fill(0);
+        return arr.map(Number);
+    };
+
+    return {
+        vuln_by_severity: safeInts(data?.vuln_by_severity, 5),
+        vuln_by_status: safeInts(data?.vuln_by_status, 4),
+        vuln_evolution: {
+            labels: asStringArray(data?.vuln_evolution?.labels),
+            data: Array.isArray(data?.vuln_evolution?.data)
+                ? data.vuln_evolution.data.map(Number)
+                : [],
+        },
+        vuln_by_source: {
+            labels: asStringArray(data?.vuln_by_source?.labels),
+            data: Array.isArray(data?.vuln_by_source?.data)
+                ? data.vuln_by_source.data.map(Number)
+                : [],
+        },
+        top_packages: Array.isArray(data?.top_packages)
+            ? data.top_packages.map((p: any) => ({
+                id: Number(p.id ?? 0),
+                name: String(p.name ?? ""),
+                version: String(p.version ?? "-"),
+                count: Number(p.count ?? 0),
+              }))
+            : [],
+        top_vulns: Array.isArray(data?.top_vulns)
+            ? data.top_vulns.flatMap((v: any) => {
+                const entry = _asTopVuln(v);
+                return entry ? [entry] : [];
+              })
+            : [],
+    };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP client
+// ---------------------------------------------------------------------------
+
+class MetricsHandler {
+    static async fetch(
+        variantId?: string,
+        projectId?: string,
+        timeScale?: string,
+    ): Promise<MetricsData> {
+        const url = new URL(
+            import.meta.env.VITE_API_URL + "/api/metrics",
+            window.location.href,
+        );
+        if (variantId) url.searchParams.set("variant_id", variantId);
+        else if (projectId) url.searchParams.set("project_id", projectId);
+        if (timeScale) url.searchParams.set("time_scale", timeScale);
+
+        const response = await fetch(url.toString(), { mode: "cors" });
+        if (!response.ok) {
+            throw new Error(`/api/metrics returned ${response.status}`);
+        }
+        const data = await response.json();
+        return _parseMetrics(data);
+    }
+}
+
+export default MetricsHandler;

--- a/frontend/src/handlers/metrics.ts
+++ b/frontend/src/handlers/metrics.ts
@@ -76,6 +76,7 @@ function _asAssessmentFromVuln(data: any): Assessment {
         workaround: data?.workaround ?? undefined,
         timestamp: data?.timestamp ?? "",
         last_update: data?.last_update ?? undefined,
+        origin: data?.origin ?? "",
         responses: asStringArray(data?.responses),
     };
 }

--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -16,6 +16,8 @@ export type { Package, VulnCounts, Severities };
 import type { Vulnerability } from "./vulnerabilities";
 import { SEVERITY_ORDER } from "./vulnerabilities";
 
+const _SEVERITY_INDEX: {[key: string]: number} = {NONE: 0, UNKNOWN: 1, LOW: 2, MEDIUM: 3, HIGH: 4, CRITICAL: 5};
+
 const asPackage = (data: any): Package | [] => {
     if (typeof data !== "object") return [];
     if (typeof data?.name !== "string") return [];
@@ -43,6 +45,22 @@ const asPackage = (data: any): Package | [] => {
     }
     if (Array.isArray(data?.sources)) {
         for (const s of data.sources) if (typeof s === "string") pkg.source.push(s);
+    }
+    if (typeof data?.vulnerabilities === "object" && !Array.isArray(data.vulnerabilities)) {
+        for (const [status, count] of Object.entries(data.vulnerabilities)) {
+            if (typeof count === "number") pkg.vulnerabilities[status] = count;
+        }
+    }
+    if (typeof data?.maxSeverity === "object" && !Array.isArray(data.maxSeverity)) {
+        for (const [status, sev] of Object.entries(data.maxSeverity)) {
+            const s = sev as any;
+            if (typeof s?.label === "string") {
+                pkg.maxSeverity[status] = {
+                    label: s.label,
+                    index: _SEVERITY_INDEX[s.label?.toUpperCase()] ?? 0,
+                };
+            }
+        }
     }
     return pkg
 };

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -56,6 +56,24 @@ type Vulnerability = {
 
 export type { Vulnerability, CVSS };
 
+type Facets = {
+    severities: string[];
+    statuses: string[];
+    sources: string[];
+    attack_vectors: string[];
+    first_scan_dates: number[];
+};
+
+type PaginatedResponse = {
+    items: Vulnerability[];
+    total: number;
+    page: number;
+    page_size: number;
+    facets: Facets;
+};
+
+export type { Facets, PaginatedResponse };
+
 const SEVERITY_ORDER = ['NONE', 'UNKNOWN', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
 
 const asCVSS = (data: any): CVSS | [] => {
@@ -166,6 +184,76 @@ class Vulnerabilities {
         });
         const data = await response.json();
         return data.flatMap(asVulnerability);
+    }
+
+    static async listPaginated(params: {
+        variantId?: string;
+        projectId?: string;
+        compareVariantId?: string;
+        operation?: string;
+        page: number;
+        pageSize: number;
+        sortBy?: string;
+        sortDir?: string;
+        search?: string;
+        severity?: string[];
+        simplifiedStatus?: string[];
+        foundBy?: string[];
+        packages?: string[];
+        epssMin?: number;
+        epssMax?: number;
+        severityMin?: number;
+        severityMax?: number;
+        attackVector?: string[];
+        publishedDateFilter?: string;
+        publishedDateValue?: string;
+        publishedDateFrom?: string;
+        publishedDateTo?: string;
+        publishedDaysValue?: string;
+        firstScanDate?: string[];
+        signal?: AbortSignal;
+    }): Promise<PaginatedResponse> {
+        const url = new URL(import.meta.env.VITE_API_URL + "/api/vulnerabilities", window.location.href);
+        url.searchParams.set('page', String(params.page));
+        url.searchParams.set('page_size', String(params.pageSize));
+        if (params.variantId && params.compareVariantId) {
+            url.searchParams.set('variant_id', params.variantId);
+            url.searchParams.set('compare_variant_id', params.compareVariantId);
+            if (params.operation) url.searchParams.set('operation', params.operation);
+        } else if (params.variantId) {
+            url.searchParams.set('variant_id', params.variantId);
+        } else if (params.projectId) {
+            url.searchParams.set('project_id', params.projectId);
+        }
+        if (params.sortBy) url.searchParams.set('sort_by', params.sortBy);
+        if (params.sortDir) url.searchParams.set('sort_dir', params.sortDir);
+        if (params.search) url.searchParams.set('search', params.search);
+        if (params.severity?.length) url.searchParams.set('severity', params.severity.join(','));
+        if (params.simplifiedStatus?.length) url.searchParams.set('simplified_status', params.simplifiedStatus.join(','));
+        if (params.foundBy?.length) url.searchParams.set('found_by', params.foundBy.join(','));
+        if (params.packages?.length) url.searchParams.set('package', params.packages.join(','));
+        if (params.epssMin !== undefined) url.searchParams.set('epss_min', String(params.epssMin));
+        if (params.epssMax !== undefined) url.searchParams.set('epss_max', String(params.epssMax));
+        if (params.severityMin !== undefined) url.searchParams.set('severity_min', String(params.severityMin));
+        if (params.severityMax !== undefined) url.searchParams.set('severity_max', String(params.severityMax));
+        if (params.attackVector?.length) url.searchParams.set('attack_vector', params.attackVector.join(','));
+        if (params.publishedDateFilter) {
+            url.searchParams.set('published_date_filter', params.publishedDateFilter);
+            if (params.publishedDateValue) url.searchParams.set('published_date_value', params.publishedDateValue);
+            if (params.publishedDateFrom) url.searchParams.set('published_date_from', params.publishedDateFrom);
+            if (params.publishedDateTo) url.searchParams.set('published_date_to', params.publishedDateTo);
+            if (params.publishedDaysValue) url.searchParams.set('published_days_value', params.publishedDaysValue);
+        }
+        if (params.firstScanDate?.length) url.searchParams.set('first_scan_date', params.firstScanDate.join(','));
+        const response = await fetch(url.toString(), { mode: "cors", signal: params.signal });
+        const data = await response.json();
+        return {
+            items: (data.items || []).flatMap(asVulnerability),
+            total: data.total ?? 0,
+            page: data.page ?? 1,
+            page_size: data.page_size ?? params.pageSize,
+            facets: data.facets ?? { severities: [], statuses: [], sources: [], attack_vectors: [], first_scan_dates: [] },
+        };
     }
 
     static enrich_with_assessments(vulns: Vulnerability[], assessments: Assessment[]): Vulnerability[] {

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -1,5 +1,5 @@
 import type { Assessment } from "./assessments";
-import { asStringArray } from "./assessments";
+import { asStringArray, asAssessment } from "./assessments";
 import Iso8601Duration from "./iso8601duration";
 import { Cvss2, Cvss3P0, Cvss3P1, Cvss4P0 } from 'ae-cvss-calculator';
 
@@ -142,6 +142,9 @@ const asVulnerability = (data: any): Vulnerability | [] => {
     if (typeof data?.fix?.state === "string") vuln.fix.state = data.fix.state
     if (typeof data?.published === "string") vuln.published = data.published
     if (typeof data?.first_scan_date === "string") vuln.first_scan_date = data.first_scan_date
+    if (typeof data?.status === "string") vuln.status = data.status
+    if (typeof data?.simplified_status === "string") vuln.simplified_status = data.simplified_status
+    if (Array.isArray(data?.assessments)) vuln.assessments = data.assessments.flatMap(asAssessment)
     return vuln
 }
 

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -124,7 +124,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         });
     }, [checkPatchReady]);
 
-    // On mount: fetch default project/variant from config, then load data
+    // On mount: fetch default project/variant from config
     useEffect(() => {
         Config.get()
             .then(config => {
@@ -133,10 +133,9 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                 const projectId = variantId ? undefined : (config.project?.id || undefined);
                 setCurrentVariantId(variantId);
                 setCurrentProjectId(projectId);
-                loadData(variantId, projectId);
             })
-            .catch(() => loadData(undefined));
-    }, [loadData]);
+            .catch(() => {});
+    }, []);
 
     const handleApply = useCallback((projectId: string, variantId: string, compareVariantId: string, operation: string) => {
         const effectiveVariantId = compareVariantId || variantId || undefined;

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -132,7 +132,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                 const variantId = config.variant?.id || undefined;
                 const projectId = variantId ? undefined : (config.project?.id || undefined);
                 setCurrentVariantId(variantId);
-                setCurrentProjectId(config.project?.id || undefined);
+                setCurrentProjectId(projectId);
                 loadData(variantId, projectId);
             })
             .catch(() => loadData(undefined));
@@ -140,8 +140,9 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
 
     const handleApply = useCallback((projectId: string, variantId: string, compareVariantId: string, operation: string) => {
         const effectiveVariantId = compareVariantId || variantId || undefined;
+        const effectiveProjectId = effectiveVariantId ? undefined : (projectId || undefined);
         setCurrentVariantId(effectiveVariantId);
-        setCurrentProjectId(projectId || undefined);
+        setCurrentProjectId(effectiveProjectId);
         // Track origin variant and operation separately for MultiEditBar intersection logic
         setCurrentBaseVariantId(compareVariantId ? (variantId || undefined) : undefined);
         setCurrentOperation(compareVariantId ? (operation || undefined) : undefined);
@@ -254,8 +255,8 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
             <div className="p-5 flex-1 overflow-auto">
                 {tab === 'metrics' &&
                 <Metrics
-                    packages={pkgs}
-                    vulnerabilities={vulns}
+                    variantId={currentVariantId}
+                    projectId={currentProjectId}
                     goToVulnsTabWithFilter={goToVulnsTabWithFilter}
                     appendAssessment={appendAssessment}
                     patchVuln={patchVuln}

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import NavigationBar from "../components/NavigationBar";
 import MessageBanner from "../components/MessageBanner";
 import VersionDisplay from "../components/VersionDisplay";
 import type { Package } from "../handlers/packages";
-import type { CVSS, Vulnerability } from "../handlers/vulnerabilities";
+import type { Vulnerability } from "../handlers/vulnerabilities";
 import type { Assessment } from "../handlers/assessments";
 import type { PackageVulnerabilities } from "../handlers/patch_finder";
 import type { NVDProgress } from "../handlers/nvd_progress";
@@ -35,18 +35,22 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
     const [patchInfo, setPatchInfo] = useState<PackageVulnerabilities>({});
     const [patchDbReady, setPatchDbReady] = useState<boolean>(false);
     const [nvdProgress, setNvdProgress] = useState<NVDProgress | null>(null);
+    const [isLoadingPatchData, setIsLoadingPatchData] = useState<boolean>(false);
+    // Stored apply params for lazy PatchFinder loading
+    const lastApplyParamsRef = useRef<{variantId?: string, projectId?: string, compareVariantId?: string, operation?: string} | null>(null);
+
     const [filterLabel, setFilterLabel] = useState<"Source" | "Severity" | "Status" | "Package" | undefined>(undefined);
     const [filterValue, setFilterValue] = useState<string | undefined>(undefined);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
-    const [isLoadingData, setIsLoadingData] = useState<boolean>(true);
     const [loadingMessage, setLoadingMessage] = useState<string>("Loading data...");
     const [defaultConfig, setDefaultConfig] = useState<AppConfig>({ project: null, variant: null });
     const [currentVariantId, setCurrentVariantId] = useState<string | undefined>(undefined);
     const [currentProjectId, setCurrentProjectId] = useState<string | undefined>(undefined);
     const [currentBaseVariantId, setCurrentBaseVariantId] = useState<string | undefined>(undefined);
     const [currentOperation, setCurrentOperation] = useState<string | undefined>(undefined);
+    const [tab, setTab] = useState("metrics");
 
     const triggerBanner = (message: string, type: 'error' | 'success') => {
         setBannerMessage(message);
@@ -72,14 +76,12 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
     }, []);
 
     const checkPatchReady = useCallback((vulns_list: Vulnerability[]) => {
-        // Check both patch status and NVD progress
         Promise.all([
             PatchFinderLogic.status(),
             NVDProgressHandler.getProgress()
         ])
         .then(([patchData, progress]) => {
             setNvdProgress(progress);
-
             if (patchData.db_ready) {
                 setPatchDbReady(true);
                 loadPatchData(vulns_list);
@@ -91,11 +93,12 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         .catch((err) => {
             console.error(err);
             triggerBanner("Failed to load patch data", "error");
-        })
+        });
     }, [loadPatchData]);
 
-    const loadData = useCallback((variantId?: string, projectId?: string, compareVariantId?: string, operation?: string) => {
-        setIsLoadingData(true);
+    // Load packages + vulns + assessments for PatchFinder only
+    const loadDataForPatchFinder = useCallback((variantId?: string, projectId?: string, compareVariantId?: string, operation?: string) => {
+        setIsLoadingPatchData(true);
 
         const assessPromise: Promise<Assessment[]> = (compareVariantId && variantId)
             ? Promise.all([
@@ -109,17 +112,14 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
             Vulnerabilities.list(variantId, projectId, compareVariantId, operation),
             assessPromise,
         ]).then(([pkgsResult, vulnsResult, assessResult]) => {
-            setIsLoadingData(false);
-            setLoadingMessage("Loading data...");
+            setIsLoadingPatchData(false);
             if (pkgsResult.status === 'rejected' || vulnsResult.status === 'rejected' || assessResult.status === 'rejected') {
-                console.error(pkgsResult, vulnsResult);
-                triggerBanner("Failed to load data", "error");
+                triggerBanner("Failed to load patch data", "error");
                 return;
             }
             const enriched_vulns = Vulnerabilities.enrich_with_assessments(vulnsResult.value, assessResult.value);
             setVulns(enriched_vulns);
-            const enrichedPkgs = Packages.enrich_with_vulns(pkgsResult.value, enriched_vulns);
-            setPkgs(enrichedPkgs);
+            setPkgs(Packages.enrich_with_vulns(pkgsResult.value, enriched_vulns));
             setTimeout(() => checkPatchReady(enriched_vulns), 100);
         });
     }, [checkPatchReady]);
@@ -133,6 +133,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                 const projectId = variantId ? undefined : (config.project?.id || undefined);
                 setCurrentVariantId(variantId);
                 setCurrentProjectId(projectId);
+                lastApplyParamsRef.current = { variantId, projectId };
             })
             .catch(() => {});
     }, []);
@@ -142,62 +143,25 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         const effectiveProjectId = effectiveVariantId ? undefined : (projectId || undefined);
         setCurrentVariantId(effectiveVariantId);
         setCurrentProjectId(effectiveProjectId);
-        // Track origin variant and operation separately for MultiEditBar intersection logic
         setCurrentBaseVariantId(compareVariantId ? (variantId || undefined) : undefined);
         setCurrentOperation(compareVariantId ? (operation || undefined) : undefined);
-        loadData(
-            variantId || undefined,
-            variantId ? undefined : projectId || undefined,
-            compareVariantId || undefined,
-            operation || undefined,
-        );
-    }, [loadData]);
-
-
-
-    function appendAssessment(added: Assessment) {
-        const updatedVulns = Vulnerabilities.append_assessment(vulns, added);
-        setVulns(updatedVulns);
-
-        // Update packages with the new vulnerability data
-        setPkgs(Packages.enrich_with_vulns(pkgs, updatedVulns));
-
-        // Update patch data if db is ready (status changes might affect patch relevance)
-        if (patchDbReady) {
-            loadPatchData(updatedVulns);
+        // Store params so PatchFinder can lazily load them
+        lastApplyParamsRef.current = {
+            variantId: variantId || undefined,
+            projectId: variantId ? undefined : projectId || undefined,
+            compareVariantId: compareVariantId || undefined,
+            operation: operation || undefined,
+        };
+        // New: if already on patch-finder tab, load immediately
+        if (tab === 'patch-finder') {
+            loadDataForPatchFinder(
+                variantId || undefined,
+                variantId ? undefined : projectId || undefined,
+                compareVariantId || undefined,
+                operation || undefined,
+            );
         }
-    }
-
-    function appendCVSS(vulnId: string, vector: string) {
-        const cvss: CVSS | null = Vulnerabilities.calculate_cvss_from_vector(vector) ?? null;
-        if (cvss !== null) {
-            const updatedVulns = Vulnerabilities.append_cvss(vulns, vulnId, cvss);
-            setVulns(updatedVulns);
-
-            // Update packages with the new vulnerability data
-            setPkgs(Packages.enrich_with_vulns(pkgs, updatedVulns));
-            return cvss;
-        }
-        return null;
-    }
-
-    function patchVuln(vulnId: string, replace_vuln: Vulnerability) {
-        const updatedVulns = vulns.map(vuln => {
-            if (vuln.id === vulnId) {
-                return replace_vuln;
-            }
-            return vuln;
-        });
-        setVulns(updatedVulns);
-
-        // Update packages with the new vulnerability data
-        setPkgs(Packages.enrich_with_vulns(pkgs, updatedVulns));
-
-        // Update patch data if db is ready (status changes might affect patch relevance)
-        if (patchDbReady) {
-            loadPatchData(updatedVulns);
-        }
-    }
+    }, [loadDataForPatchFinder, tab]);
 
     function goToVulnsTabWithFilter(filterType: "Source" | "Severity" | "Status" | "Package", value: string) {
         setFilterLabel(filterType);
@@ -209,13 +173,15 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         goToVulnsTabWithFilter("Package", packageId);
     }
 
-    const [tab, setTab] = useState("metrics");
-
-    // This function ensures vulns get reset when switching outside filtering context
     function handleTabChange(newTab: string) {
         if (newTab === 'vulnerabilities' && tab !== 'vulnerabilities') {
             setFilterLabel(undefined);
             setFilterValue(undefined);
+        }
+        // Lazy-load PatchFinder data on first navigation to that tab
+        if (newTab === 'patch-finder' && tab !== 'patch-finder') {
+            const params = lastApplyParamsRef.current;
+            loadDataForPatchFinder(params?.variantId, params?.projectId, params?.compareVariantId, params?.operation);
         }
         setTab(newTab);
     }
@@ -242,7 +208,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                 />
             </div>
 
-            {isLoadingData && (
+            {isLoadingPatchData && (
                 <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
                     <div className="flex flex-col items-center gap-3 text-white">
                         <div className="w-10 h-10 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
@@ -257,22 +223,26 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     variantId={currentVariantId}
                     projectId={currentProjectId}
                     goToVulnsTabWithFilter={goToVulnsTabWithFilter}
-                    appendAssessment={appendAssessment}
-                    patchVuln={patchVuln}
+                    appendAssessment={() => {}}
+                    patchVuln={() => {}}
                     setTab={setTab}
-                    appendCVSS={appendCVSS}
+                    appendCVSS={() => null}
                 />}
-                {tab === 'packages' && <TablePackages packages={pkgs} onShowVulns={showVulnsForPackage} />}
+                {tab === 'packages' &&
+                <TablePackages
+                    variantId={currentVariantId}
+                    projectId={currentProjectId}
+                    compareVariantId={currentBaseVariantId ? currentVariantId : undefined}
+                    compareOperation={currentOperation}
+                    onShowVulns={showVulnsForPackage}
+                />}
                 {tab === 'vulnerabilities' &&
                 <TableVulnerabilities
-                    appendAssessment={appendAssessment}
-                    appendCVSS={appendCVSS}
-                    patchVuln={patchVuln}
-                    vulnerabilities={vulns}
+                    variantId={currentBaseVariantId ? currentBaseVariantId : currentVariantId}
+                    projectId={currentProjectId}
                     filterLabel={filterLabel}
                     filterValue={filterValue}
-                    variantId={currentVariantId}
-                    baseVariantId={currentBaseVariantId}
+                    baseVariantId={currentBaseVariantId ? currentVariantId : undefined}
                     compareOperation={currentOperation}
                 />}
                 {tab === 'patch-finder' && <PatchFinder vulnerabilities={vulns} packages={pkgs} patchData={patchInfo} db_ready={patchDbReady} nvdProgress={nvdProgress} />}
@@ -283,13 +253,12 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     if (message) setLoadingMessage(message);
                     Config.get().then(config => setDefaultConfig(config)).catch(() => {});
                     setSelectorKey(k => k + 1);
-                    loadData(currentVariantId, currentVariantId ? undefined : currentProjectId);
                 }} onLoadingMessage={(msg) => {
                     if (msg) {
                         setLoadingMessage(msg);
-                        setIsLoadingData(true);
+                        setIsLoadingPatchData(true);
                     } else {
-                        setIsLoadingData(false);
+                        setIsLoadingPatchData(false);
                         setLoadingMessage("Loading data...");
                     }
                 }} />}

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { CVSS } from "../handlers/vulnerabilities";
-import { SEVERITY_ORDER } from "../handlers/vulnerabilities";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement, BarElement, LogarithmicScale, ChartEvent, LegendItem, LegendElement } from 'chart.js';
 import { Pie, Line, Bar } from 'react-chartjs-2';
 import TableGeneric from "../components/TableGeneric";
@@ -328,5 +327,4 @@ function Metrics({ variantId, projectId, goToVulnsTabWithFilter, appendAssessmen
     );
 }
 
-export { SEVERITY_ORDER };
 export default Metrics;

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -1,711 +1,332 @@
-import { useMemo, useState } from "react";
-        import type { Package } from "../handlers/packages";
-        import type { CVSS } from "../handlers/vulnerabilities";
-        import type { Vulnerability } from "../handlers/vulnerabilities";
-        import { SEVERITY_ORDER } from "../handlers/vulnerabilities";
-        import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement, BarElement, LogarithmicScale, ChartEvent, LegendItem, LegendElement } from 'chart.js';
-        import { Pie, Line, Bar } from 'react-chartjs-2';
-        import TableGeneric from "../components/TableGeneric";
-        import SeverityTag from "../components/SeverityTag";
-        import VulnModal from "../components/VulnModal";
-        import type { Assessment } from "../handlers/assessments";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { CVSS } from "../handlers/vulnerabilities";
+import { SEVERITY_ORDER } from "../handlers/vulnerabilities";
+import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement, BarElement, LogarithmicScale, ChartEvent, LegendItem, LegendElement } from 'chart.js';
+import { Pie, Line, Bar } from 'react-chartjs-2';
+import TableGeneric from "../components/TableGeneric";
+import SeverityTag from "../components/SeverityTag";
+import VulnModal from "../components/VulnModal";
+import type { Assessment } from "../handlers/assessments";
+import MetricsHandler from "../handlers/metrics";
+import type { MetricsData } from "../handlers/metrics";
 
-        ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement, BarElement, LogarithmicScale);
+ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement, BarElement, LogarithmicScale);
 
-        type Props = {
-            packages: Package[];
-            vulnerabilities: Vulnerability[];
-            goToVulnsTabWithFilter: (filterType: "Source" | "Severity" | "Status", value: string) => void;
-            appendAssessment: (added: Assessment) => void;
-            patchVuln: (vulnId: string, data: any) => void;
-            setTab: (tab: string) => void;
-            appendCVSS: (vulnId: string, vector: string) => CVSS | null;
-        };
+type Props = {
+    variantId?: string;
+    projectId?: string;
+    goToVulnsTabWithFilter: (filterType: "Source" | "Severity" | "Status", value: string) => void;
+    appendAssessment: (added: Assessment) => void;
+    patchVuln: (vulnId: string, data: any) => void;
+    setTab: (tab: string) => void;
+    appendCVSS: (vulnId: string, vector: string) => CVSS | null;
+};
 
-        const pieOptions = {
-            maintainAspectRatio: true,
-            plugins: {
-                legend: {
-                    position: 'bottom' as const,
-                    labels: {
-                        color: '#ccc'
-                    }
-                }
-            }
+const pieOptions = {
+    maintainAspectRatio: true,
+    plugins: {
+        legend: {
+            position: 'bottom' as const,
+            labels: { color: '#ccc' }
         }
+    }
+};
 
-        const LineOptions = {
-            maintainAspectRatio: false,
-            plugins: {
-                legend: {
-                    display: false
-                }
-            },
-            elements: {
-                point: {
-                    radius: 6
-                },
-                line: {
-                    borderWidth: 3,
-                    borderColor: '#aaa'
-                }
-            },
-            scales: {
-              x: {
-                ticks: {
-                  color: 'white'
-                }
-              },
-              y: {
-                beginAtZero: true,
-                ticks: {
-                  color: 'white'
-                }
-              }
-            }
-        }
-
-        const BarOptions = {
-                    maintainAspectRatio: false,
-                    plugins: {
-                        legend: {
-                            display: false
-                        }
-                    },
-                    scales: {
-                      x: {
-                        ticks: {
-                          color: 'white'
-                        }
-                      },
-                      y: {
-                        ticks: {
-                          color: 'white'
-                        }
-                      }
-                    }
-                };
-
-
-        function zeroise_date (date: Date, unit: string) {
-            if (unit.startsWith('month')) date.setDate(1);
-
-            if (unit.startsWith('hour')) {
-                date.setMinutes(0, 0, 0);
-            } else {
-                date.setHours(0, 0, 0, 0);
-            }
-        }
-
-
-        function previous_date (date: Date, unit: string): Date {
-            if (unit.startsWith('week')) {
-                date = new Date(date.getTime() - (7 * 86400000));
-            } else if (unit.startsWith('hour')) {
-                date = new Date(date.getTime() - 3600000);
-            } else {
-                date = new Date(date.getTime() - 86400000);
-            }
-            return date;
-        }
-
-        function formatSourceName(source: string): string {
-            const map: Record<string, string> = {
-                openvex: 'OpenVex',
-                local_user_data: 'Local User Data',
-                yocto: 'Yocto',
-                spdx3: 'SPDX3',
-                grype: 'Grype',
-                cyclonedx: 'CycloneDx'
-            };
-
-            return map[source] || source;
-        }
-
-
-
-function Metrics({ vulnerabilities, goToVulnsTabWithFilter, appendAssessment, appendCVSS, patchVuln, setTab }: Readonly<Props>) {
-            const defaultPieHandler = ChartJS.overrides.pie.plugins.legend.onClick
-
-            const [timeScale, setTimeScale] = useState<string>("6_months")
-            const [modalVuln, setModalVuln] = useState<Vulnerability | undefined>(undefined);
-            const [modalVulnIndex, setModalVulnIndex] = useState<number | undefined>(undefined);
-            const [isEditing, setIsEditing] = useState<boolean>(false);
-
-const vulnColumns = useMemo(
-  () => [
-    {
-      accessorKey: "rank",
-      header: () => <div className="flex items-center justify-center h-full">#</div>,
-      cell: (info: any) => <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>,
-      size: 30,
-      enableSorting: false,
+const LineOptions = {
+    maintainAspectRatio: false,
+    plugins: { legend: { display: false } },
+    elements: {
+        point: { radius: 6 },
+        line: { borderWidth: 3, borderColor: '#aaa' }
     },
-    {
-      accessorKey: "cve",
-      header: () => (
-        <div className="flex items-center justify-center h-full">CVE</div>
-      ),
-      cell: (info: any) => (
-        <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>
-      ),
-      size: 200,
-      enableSorting: false,
-    },
-    {
-      accessorKey: "package",
-      header: () => (
-        <div className="flex items-center justify-center h-full">Package</div>
-      ),
-      cell: (info: any) => (
-        <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>
-      ),
-      size: 200,
-      enableSorting: false,
-    },
-    {
-      accessorKey: "severity",
-      header: () => <div className="flex items-center justify-center h-full">Severity</div>,
-      cell: (info: any) => (
-        <div className="flex items-center justify-center h-full text-center">
-          <SeverityTag severity={info.getValue()} className="!py-0" />
-        </div>
-      ),
-      size: 100,
-      enableSorting: false,
-    },
-    {
-      accessorKey: "edit",
-      header: () => <div className="flex items-center justify-center h-full">Actions</div>,
-      cell: (info: any) => {
-        const vuln = info.row.original.original;
-        return (
-          <div className="flex items-center justify-center h-full text-center">
-            <button
-              className="bg-slate-800 hover:bg-slate-700 px-2 rounded-lg"
-              onClick={() => {
-                // Get the current TopVulns list and find the index
-                const currentTopVulns = [...vulnerabilities]
-                  .map((v, index) => {
-                    const maxCvss = v.severity.cvss?.length
-                      ? Math.max(...v.severity.cvss.map((cvss) => cvss.base_score || 0))
-                      : 0;
-                    return {
-                      id: index + 1,
-                      rank: 0,
-                      cve: v.id,
-                      package: v.packages_current.join(", "),
-                      severity: v.severity.severity,
-                      maxCvss,
-                      texts: v.texts,
-                      original: v,
-                    };
-                  })
-                  .sort((a, b) => b.maxCvss - a.maxCvss)
-                  .slice(0, 5)
-                  .map((v, idx) => ({
-                    ...v,
-                    rank: idx + 1,
-                  }));
+    scales: {
+        x: { ticks: { color: 'white' } },
+        y: { beginAtZero: true, ticks: { color: 'white' } }
+    }
+};
 
-                const index = currentTopVulns.findIndex(item => item.original.id === vuln.id);
-                setModalVuln(vuln);
-                setModalVulnIndex(index >= 0 ? index : undefined);
-                setIsEditing(true);
-              }}
-            >
-              Edit
-            </button>
-          </div>
-        );
-      },
-      size: 50,
-      enableSorting: false,
-    },
-  ],
-  [vulnerabilities]
-);
+const BarOptions = {
+    maintainAspectRatio: false,
+    plugins: { legend: { display: false } },
+    scales: {
+        x: { ticks: { color: 'white' } },
+        y: { ticks: { color: 'white' } }
+    }
+};
 
-const packageColumns = [
-  {
-    accessorKey: "id",
-    header: () => (
-      <div className="flex items-center justify-center h-full">
-        #
-      </div>
-    ),
-    cell: (info: any) => (
-      <div className="flex items-center justify-center py-1 h-full text-center">
-        {info.getValue()}
-      </div>
-    ),
-    size: 30,
-    enableSorting: false,
-  },
-  {
-    accessorKey: "name",
-    size: 350,
-    header: () => (
-      <div className="flex items-center justify-center h-full">
-        Name
-      </div>
-    ),
-    cell: (info: any) => (
-      <div className="flex items-center justify-center h-full text-center">
-        {info.getValue()}
-      </div>
-    ),
-    enableSorting: false,
-  },
-  {
-    accessorKey: "version",
-    size: 100,
-    header: () => (
-      <div className="flex items-center justify-center h-full">
-        Version
-      </div>
-    ),
-    cell: (info: any) => (
-      <div className="flex items-center justify-center h-full text-center">
-        <span className="truncate max-w-full block" title={info.getValue()}>
-          {info.getValue()}
-        </span>
-      </div>
-    ),
-    enableSorting: false,
-  },
-  {
-    accessorKey: "count",
-    size: 100,
-    header: () => (
-      <div className="flex items-center justify-center h-full">
-        Vulnerabilities
-      </div>
-    ),
-    cell: (info: any) => (
-      <div className="flex items-center justify-center h-full text-center">
-        {info.getValue()}
-      </div>
-    ),
-    enableSorting: false,
-  },
-];
+function Metrics({ variantId, projectId, goToVulnsTabWithFilter, appendAssessment, appendCVSS, patchVuln, setTab }: Readonly<Props>) {
+    const defaultPieHandler = ChartJS.overrides.pie.plugins.legend.onClick;
 
-            const time_scales = useMemo(() => {
-                const scale = Number(timeScale.split('_')[0]);
-                const unit = timeScale.split('_')[1];
-                if (isNaN(scale) || scale < 2 || !unit || unit == ''){
-                    console.error("Invalid time scale, must be <number>_<unit>. eg: 6_months")
-                    return [];
-                }
-                let refs: Date[] = [];
-                let date = new Date();
-                do {
-                    // clean date and insert it
-                    zeroise_date(date, unit)
-                    refs.splice(0, 0, date);
+    const [timeScale, setTimeScale] = useState<string>("6_months");
+    const [metricsData, setMetricsData] = useState<MetricsData | null>(null);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [modalVulnIndex, setModalVulnIndex] = useState<number | undefined>(undefined);
+    const [isEditing, setIsEditing] = useState<boolean>(false);
 
-                    // generate previous date for use in next iteration
-                    date = previous_date(date, unit)
-                } while (refs.length < scale);
+    const fetchMetrics = useCallback(() => {
+        MetricsHandler.fetch(variantId, projectId, timeScale)
+            .then(data => { setMetricsData(data); setLoadError(null); })
+            .catch(err => { console.error("Failed to load metrics:", err); setLoadError("Failed to load metrics data."); });
+    }, [variantId, projectId, timeScale]);
 
-                return refs;
-            }, [timeScale]);
+    useEffect(() => { fetchMetrics(); }, [fetchMetrics]);
 
-            const dataSetVulnBySeverity = useMemo(() => {
-                return {
-                    labels: ['Unknown', 'Low', 'Medium', 'High', 'Critical'],
-                    datasets: [{
-                        label: '# of Vulnerabilities',
-                        data: vulnerabilities.reduce((acc, vuln) => {
-                            const severity = vuln.severity.severity.toUpperCase();
-                            const index = Math.max(SEVERITY_ORDER.indexOf(severity) - 1, 0)
-                            acc[index]++;
-                            return acc;
-                        }, [0, 0, 0, 0, 0]),
-                        backgroundColor: [
-                            'rgba(180, 180, 180)',
-                            'rgba(0, 150, 150)',
-                            '#F8DE22',
-                            '#F94C10',
-                            '#FC2947',
-                        ],
-                        hoverOffset: 4
-                    }]
-                }
-            }, [vulnerabilities]);
+    const modalVuln = metricsData && modalVulnIndex !== undefined
+        ? metricsData.top_vulns[modalVulnIndex]?.original
+        : undefined;
 
-            const dataSetVulnByStatus = useMemo(() => {
-                return {
-                    labels: ['Not affected', 'Fixed', 'Pending Assessment', 'Exploitable'],
-                    datasets: [{
-                        label: '# of Vulnerabilities',
-                        data: vulnerabilities.reduce((acc, vuln) => {
-                            const status = vuln.simplified_status;
-                            const index = status == 'Not affected' ? 0 : status == 'Fixed' ? 1 : status == 'Pending Assessment' ? 2 : 3;
-                            acc[index]++;
-                            return acc;
-                        }, [0, 0, 0, 0]),
-                        backgroundColor: [
-                            'rgba(0, 150, 150)',
-                            '#009900',
-                            'rgba(255, 128, 0)',
-                            '#F94C10',
-                        ],
-                        hoverOffset: 4
-                    }]
-                }
-            }, [vulnerabilities]);
+    const handleAppendAssessment = useCallback((added: Assessment) => {
+        appendAssessment(added);
+        fetchMetrics();
+    }, [appendAssessment, fetchMetrics]);
 
-            const nb_points = Number(timeScale.split('_')[0])
-            const vulnEvolutionTime = {
-                labels: time_scales.map(date => date.toLocaleString(undefined, {
-                    day: timeScale.includes('_month') ? undefined : 'numeric',
-                    month: 'short',
-                    year: timeScale.includes('_hour') ? undefined : '2-digit',
-                    hour: timeScale.includes('_hour') ? 'numeric' : undefined,
-                    minute: undefined,
-                    second: undefined,
-                    timeZone: undefined,
-                    hour12: false
-                })),
-                datasets: [{
-                    label: '# of Vulnerabilities',
-                    data: vulnerabilities.reduce((acc, vuln) => {
-                        let is_active = false
-                        let date_index = 0
-                        let was_active = new Array(nb_points).fill(false)
-
-                        vuln.assessments.forEach(assess => {
-                            const dt = new Date(assess.timestamp);
-
-                            // forward time index if needed
-                            while (dt.getTime() > time_scales[date_index+1]?.getTime() && date_index < (nb_points - 1)) {
-                                if (is_active) was_active[date_index] = true;
-                                date_index++;
-                            }
-
-                            const should_be_active = (assess.simplified_status != 'Not affected' && assess.simplified_status != 'Fixed');
-                            if (is_active != should_be_active) {
-                                if (should_be_active && dt.getTime() >= time_scales[date_index]?.getTime()) {
-                                    // if vulnerability was active at least one time in the month, then classify as active for while month
-                                    was_active[date_index] = true
-                                }
-                                is_active = should_be_active;
-                            }
-                        })
-
-                        while (date_index < nb_points) {
-                            if (is_active) was_active[date_index] = true;
-                            date_index++;
-                        }
-                        was_active.forEach((v, i) => acc[i] += v ? 1 : 0);
-                        return acc;
-                    }, new Array(nb_points).fill(0)),
-                    backgroundColor: 'rgba(0, 150, 150, 0.7)',
-                    hoverOffset: 4
-                }]
-            }
-
-  const topVulnerablePackages = useMemo(() => {
-    const counts: Record<string, { count: number; version?: string }> = {};
-    vulnerabilities.forEach((vuln) => {
-      vuln.packages_current.forEach((pkg) => {
-        const [pkgName, pkgVersion] = pkg.split("@");
-        if (!counts[pkgName]) {
-          counts[pkgName] = { count: 0, version: pkgVersion };
-        }
-        counts[pkgName].count += 1;
-      });
-    });
-    return Object.entries(counts)
-      .sort(([, a], [, b]) => b.count - a.count)
-      .slice(0, 5)
-      .map(([name, { count, version }], index) => ({
-        id: index + 1,
-        name,
-        version: version ?? "-",
-        count,
-        vulnerabilities: { exploitable: count },
-        maxSeverity: { label: "UNKNOWN", index: 0 },
-        source: [],
-      }));
-  }, [vulnerabilities]);
-
-  const TopVulns = useMemo(() => {
-    return [...vulnerabilities]
-      .filter((vuln) => vuln.simplified_status !== 'Fixed' && vuln.simplified_status !== 'Not affected')
-      .map((vuln, index) => {
-        const maxCvss = vuln.severity.cvss?.length
-          ? Math.max(...vuln.severity.cvss.map((cvss) => cvss.base_score || 0))
-          : 0;
-        return {
-          id: index + 1,
-          rank: 0,
-          cve: vuln.id,
-          package: vuln.packages_current.join(", "),
-          severity: vuln.severity.severity,
-          maxCvss,
-          texts: vuln.texts,
-          original: vuln,
-        };
-      })
-      .sort((a, b) => b.maxCvss - a.maxCvss)
-      .slice(0, 5)
-      .map((vuln, idx) => ({
-        ...vuln,
-        rank: idx + 1,
-        }));
-    }, [vulnerabilities]);
+    const handlePatchVuln = useCallback((vulnId: string, data: any) => {
+        patchVuln(vulnId, data);
+        fetchMetrics();
+    }, [patchVuln, fetchMetrics]);
 
     const handleModalNavigation = (newIndex: number) => {
-        if (newIndex >= 0 && newIndex < TopVulns.length) {
-            setModalVuln(TopVulns[newIndex].original);
+        if (metricsData && newIndex >= 0 && newIndex < metricsData.top_vulns.length) {
             setModalVulnIndex(newIndex);
         }
     };
 
-              const dataSetVulnBySource = useMemo(() => {
-                const uniqueSources = Array.from(
-                    new Set(vulnerabilities.flatMap(vuln => vuln.found_by))
-                ).sort((a, b) =>
-                    vulnerabilities.filter(vuln => vuln.found_by.includes(b)).length -
-                    vulnerabilities.filter(vuln => vuln.found_by.includes(a)).length
-                );
-                return {
-                    labels: uniqueSources.map(formatSourceName),
-                    datasets: [{
-                        label: '# of Vulnerabilities',
-                        data: uniqueSources.map(source =>
-                            vulnerabilities.filter(vuln => vuln.found_by.includes(source)).length
-                        ),
-                        backgroundColor: 'rgba(0, 150, 150, 0.7)',
-                        hoverOffset: 4
-                    }]
-                }
-            }, [vulnerabilities]);
+    // Chart datasets
 
+    const dataSetVulnBySeverity = useMemo(() => ({
+        labels: ['Unknown', 'Low', 'Medium', 'High', 'Critical'],
+        datasets: [{
+            label: '# of Vulnerabilities',
+            data: metricsData?.vuln_by_severity ?? [0, 0, 0, 0, 0],
+            backgroundColor: ['rgba(180, 180, 180)', 'rgba(0, 150, 150)', '#F8DE22', '#F94C10', '#FC2947'],
+            hoverOffset: 4
+        }]
+    }), [metricsData]);
 
-            const vulnBySeverityOptions = {
-                ...pieOptions,
-                plugins: {
-                    ...pieOptions.plugins,
-                    legend: {
-                        ...pieOptions.plugins.legend,
-                        onClick: function (this: LegendElement<"pie">, e: ChartEvent, legendItem: LegendItem, legend: LegendElement<"pie">) {
-                            defaultPieHandler.call(this, e, legendItem, legend);
-                        }
-                    }
-                },
-                onClick: (_e: ChartEvent, elements: any[]) => {
-                    if (!elements.length) return;
-                    const index = elements[0].index;
-                    const severityOrder = ['UNKNOWN', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
-                    const targetSeverity = severityOrder[index];
+    const dataSetVulnByStatus = useMemo(() => ({
+        labels: ['Not affected', 'Fixed', 'Pending Assessment', 'Exploitable'],
+        datasets: [{
+            label: '# of Vulnerabilities',
+            data: metricsData?.vuln_by_status ?? [0, 0, 0, 0],
+            backgroundColor: ['rgba(0, 150, 150)', '#009900', 'rgba(255, 128, 0)', '#F94C10'],
+            hoverOffset: 4
+        }]
+    }), [metricsData]);
 
-                    const matchingSeverity = vulnerabilities.find(v =>
-                        v.severity.severity.toUpperCase() === targetSeverity
-                    )?.severity.severity;
+    const vulnEvolutionTime = useMemo(() => ({
+        labels: metricsData?.vuln_evolution.labels ?? [],
+        datasets: [{
+            label: '# of Vulnerabilities',
+            data: metricsData?.vuln_evolution.data ?? [],
+            backgroundColor: 'rgba(0, 150, 150, 0.7)',
+            hoverOffset: 4
+        }]
+    }), [metricsData]);
 
-                    if (matchingSeverity) {
-                        goToVulnsTabWithFilter("Severity", matchingSeverity);
-                    }
+    const dataSetVulnBySource = useMemo(() => ({
+        labels: metricsData?.vuln_by_source.labels ?? [],
+        datasets: [{
+            label: '# of Vulnerabilities',
+            data: metricsData?.vuln_by_source.data ?? [],
+            backgroundColor: 'rgba(0, 150, 150, 0.7)',
+            hoverOffset: 4
+        }]
+    }), [metricsData]);
+
+    // Column definitions
+
+    const vulnColumns = useMemo(() => [
+        {
+            accessorKey: "rank",
+            header: () => <div className="flex items-center justify-center h-full">#</div>,
+            cell: (info: any) => <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>,
+            size: 30, enableSorting: false,
+        },
+        {
+            accessorKey: "cve",
+            header: () => <div className="flex items-center justify-center h-full">CVE</div>,
+            cell: (info: any) => <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>,
+            size: 200, enableSorting: false,
+        },
+        {
+            accessorKey: "package",
+            header: () => <div className="flex items-center justify-center h-full">Package</div>,
+            cell: (info: any) => <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>,
+            size: 200, enableSorting: false,
+        },
+        {
+            accessorKey: "severity",
+            header: () => <div className="flex items-center justify-center h-full">Severity</div>,
+            cell: (info: any) => (
+                <div className="flex items-center justify-center h-full text-center">
+                    <SeverityTag severity={info.getValue()} className="!py-0" />
+                </div>
+            ),
+            size: 100, enableSorting: false,
+        },
+        {
+            accessorKey: "edit",
+            header: () => <div className="flex items-center justify-center h-full">Actions</div>,
+            cell: (info: any) => (
+                <div className="flex items-center justify-center h-full text-center">
+                    <button
+                        className="bg-slate-800 hover:bg-slate-700 px-2 rounded-lg"
+                        onClick={() => { setModalVulnIndex(info.row.index); setIsEditing(true); }}
+                    >
+                        Edit
+                    </button>
+                </div>
+            ),
+            size: 50, enableSorting: false,
+        },
+    ], []);
+
+    const packageColumns = [
+        { accessorKey: "id", header: () => <div className="flex items-center justify-center h-full">#</div>, cell: (info: any) => <div className="flex items-center justify-center py-1 h-full text-center">{info.getValue()}</div>, size: 30, enableSorting: false },
+        { accessorKey: "name", size: 350, header: () => <div className="flex items-center justify-center h-full">Name</div>, cell: (info: any) => <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>, enableSorting: false },
+        { accessorKey: "version", size: 100, header: () => <div className="flex items-center justify-center h-full">Version</div>, cell: (info: any) => <div className="flex items-center justify-center h-full text-center"><span className="truncate max-w-full block" title={info.getValue()}>{info.getValue()}</span></div>, enableSorting: false },
+        { accessorKey: "count", size: 100, header: () => <div className="flex items-center justify-center h-full">Vulnerabilities</div>, cell: (info: any) => <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>, enableSorting: false },
+    ];
+
+    // Pie click options
+
+    const vulnBySeverityOptions = {
+        ...pieOptions,
+        plugins: {
+            ...pieOptions.plugins,
+            legend: {
+                ...pieOptions.plugins.legend,
+                onClick: function (this: LegendElement<"pie">, e: ChartEvent, legendItem: LegendItem, legend: LegendElement<"pie">) {
+                    defaultPieHandler.call(this, e, legendItem, legend);
                 }
             }
+        },
+        onClick: (_e: ChartEvent, elements: any[]) => {
+            if (!elements.length) return;
+            const severityOrder = ['UNKNOWN', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
+            const targetSeverity = severityOrder[elements[0].index];
+            if (targetSeverity) {
+                goToVulnsTabWithFilter("Severity", targetSeverity.charAt(0) + targetSeverity.slice(1).toLowerCase());
+            }
+        }
+    };
 
-            const vulnByStatusOptions = {
-                ...pieOptions,
-                plugins: {
-                    ...pieOptions.plugins,
-                    legend: {
-                        ...pieOptions.plugins.legend,
-                        onClick: function (this: LegendElement<"pie">, e: ChartEvent, legendItem: LegendItem, legend: LegendElement<"pie">) {
-                            defaultPieHandler.call(this, e, legendItem, legend);
-                        }
-                    }
-                },
-                onClick: (_e: ChartEvent, elements: any[]) => {
-                    if (!elements.length) return;
-                    const index = elements[0].index;
-                    const statusOrder = ['Not affected', 'Fixed', 'Pending Assessment', 'Exploitable'];
-                    const targetStatus = statusOrder[index];
-
-                    const matchingStatus = vulnerabilities.find(v =>
-                        v.simplified_status === targetStatus
-                    )?.simplified_status;
-
-                    if (matchingStatus) {
-                        goToVulnsTabWithFilter("Status", matchingStatus);
-                    }
+    const vulnByStatusOptions = {
+        ...pieOptions,
+        plugins: {
+            ...pieOptions.plugins,
+            legend: {
+                ...pieOptions.plugins.legend,
+                onClick: function (this: LegendElement<"pie">, e: ChartEvent, legendItem: LegendItem, legend: LegendElement<"pie">) {
+                    defaultPieHandler.call(this, e, legendItem, legend);
                 }
             }
+        },
+        onClick: (_e: ChartEvent, elements: any[]) => {
+            if (!elements.length) return;
+            const statusOrder = ['Not affected', 'Fixed', 'Pending Assessment', 'Exploitable'];
+            const targetStatus = statusOrder[elements[0].index];
+            if (targetStatus) goToVulnsTabWithFilter("Status", targetStatus);
+        }
+    };
 
-      return (
+    if (loadError) {
+        return <div className="w-full flex flex-col items-center justify-center py-16 text-red-400"><p>{loadError}</p></div>;
+    }
+
+    return (
         <div className="w-full flex flex-col gap-4 pb-8">
 
-          {/* === TOP CHART GRID === */}
-          <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+            {/* TOP CHART GRID */}
+            <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
 
-            {/* Vulnerabilities by Severity */}
-            <div className="p-4">
-              <div className="bg-zinc-700 p-2 text-center text-xl text-white whitespace-nowrap rounded-t-md">
-                Vulnerabilities by Severity
-              </div>
-              <div className="bg-zinc-700 p-4 w-full aspect-square rounded-b-md">
-                <div className="h-full">
-                  <Pie
-                    data={dataSetVulnBySeverity}
-                    options={{ ...vulnBySeverityOptions, maintainAspectRatio: false }}
-                  />
+                <div className="p-4">
+                    <div className="bg-zinc-700 p-2 text-center text-xl text-white whitespace-nowrap rounded-t-md">Vulnerabilities by Severity</div>
+                    <div className="bg-zinc-700 p-4 w-full aspect-square rounded-b-md">
+                        <div className="h-full"><Pie data={dataSetVulnBySeverity} options={{ ...vulnBySeverityOptions, maintainAspectRatio: false }} /></div>
+                    </div>
                 </div>
-              </div>
-            </div>
 
-            {/* Vulnerabilities by Status */}
-            <div className="p-4">
-              <div className="bg-zinc-700 p-2 text-center text-xl text-white whitespace-nowrap rounded-t-md">
-                Vulnerabilities by Status
-              </div>
-              <div className="bg-zinc-700 p-4 w-full aspect-square rounded-b-md">
-                <div className="h-full">
-                  <Pie
-                    data={dataSetVulnByStatus}
-                    options={{ ...vulnByStatusOptions, maintainAspectRatio: false }}
-                  />
+                <div className="p-4">
+                    <div className="bg-zinc-700 p-2 text-center text-xl text-white whitespace-nowrap rounded-t-md">Vulnerabilities by Status</div>
+                    <div className="bg-zinc-700 p-4 w-full aspect-square rounded-b-md">
+                        <div className="h-full"><Pie data={dataSetVulnByStatus} options={{ ...vulnByStatusOptions, maintainAspectRatio: false }} /></div>
+                    </div>
                 </div>
-              </div>
-            </div>
 
-            {/* Exploitable Vulnerabilities */}
-            <div className="p-4">
-              <div className="bg-zinc-700 p-2 flex items-center justify-center gap-2 rounded-t-md">
-                <div
-                  className="text-xl text-white whitespace-nowrap"
-                  title="Active vulnerabilities is the sum of exploitable and Pending Assessment vulnerabilities."
-                >
-                  Active vulnerabilities
+                <div className="p-4">
+                    <div className="bg-zinc-700 p-2 flex items-center justify-center gap-2 rounded-t-md">
+                        <div className="text-xl text-white whitespace-nowrap" title="Active vulnerabilities is the sum of exploitable and Pending Assessment vulnerabilities.">
+                            Active vulnerabilities
+                        </div>
+                        <select className="bg-zinc-800 p-1 text-white rounded w-36" value={timeScale} onChange={(event) => setTimeScale(event.target.value)}>
+                            <option value="12_months">1 year</option>
+                            <option value="6_months">6 months</option>
+                            <option value="12_weeks">12 weeks</option>
+                            <option value="6_weeks">6 weeks</option>
+                            <option value="31_days">1 month</option>
+                            <option value="7_days">1 week</option>
+                            <option value="24_hours">24 hours</option>
+                        </select>
+                    </div>
+                    <div className="bg-zinc-700 p-4 w-full aspect-square rounded-b-md">
+                        <div className="h-full"><Line data={vulnEvolutionTime} options={{ ...LineOptions, maintainAspectRatio: false }} /></div>
+                    </div>
                 </div>
-                <select
-                  className="bg-zinc-800 p-1 text-white rounded w-36"
-                  value={timeScale}
-                  onChange={(event) => setTimeScale(event.target.value)}
-                >
-                  <option value="12_months">1 year</option>
-                  <option value="6_months">6 months</option>
-                  <option value="12_weeks">12 weeks</option>
-                  <option value="6_weeks">6 weeks</option>
-                  <option value="31_days">1 month</option>
-                  <option value="7_days">1 week</option>
-                  <option value="24_hours">24 hours</option>
-                </select>
-              </div>
-              <div className="bg-zinc-700 p-4 w-full aspect-square rounded-b-md">
-                <div className="h-full">
-                  <Line
-                    data={vulnEvolutionTime}
-                    options={{ ...LineOptions, maintainAspectRatio: false }}
-                  />
+
+                <div className="p-4">
+                    <div className="bg-zinc-700 p-2 text-center text-xl text-white whitespace-nowrap rounded-t-md">Vulnerabilities by Database</div>
+                    <div className="bg-zinc-700 p-4 w-full aspect-square rounded-b-md">
+                        <div className="h-full"><Bar data={dataSetVulnBySource} options={{ ...BarOptions, maintainAspectRatio: false }} /></div>
+                    </div>
                 </div>
-              </div>
+
             </div>
 
-            {/* Vulnerabilities by Database */}
-            <div className="p-4">
-              <div className="bg-zinc-700 p-2 text-center text-xl text-white whitespace-nowrap rounded-t-md">
-                Vulnerabilities by Database
-              </div>
-              <div className="bg-zinc-700 p-4 w-full aspect-square rounded-b-md">
-                <div className="h-full">
-                  <Bar
-                    data={dataSetVulnBySource}
-                    options={{ ...BarOptions, maintainAspectRatio: false }}
-                  />
+            {/* TABLES SECTION */}
+            <div className="w-full grid grid-cols-1 lg:grid-cols-2">
+
+                <div className="p-4">
+                    <div className="bg-zinc-700 px-4 py-2 flex items-center justify-between rounded-t-md">
+                        <h3 className="text-2xl font-bold text-white whitespace-nowrap">Most critical unfixed vulnerabilities</h3>
+                        <button className="bg-cyan-800 hover:bg-cyan-700 focus:ring-4 focus:outline-none focus:ring-blue-800 font-medium rounded-lg px-4 py-2 text-center text-white" onClick={() => setTab('vulnerabilities')}>See all</button>
+                    </div>
+                    <div className="bg-zinc-700 p-4 rounded-b-md">
+                        <TableGeneric columns={vulnColumns} data={metricsData?.top_vulns ?? []} hasPagination={false} tableHeight="auto" />
+                    </div>
                 </div>
-              </div>
+
+                <div className="p-4">
+                    <div className="bg-zinc-700 px-4 py-2 flex items-center justify-between rounded-t-md">
+                        <h3 className="text-2xl font-bold text-white whitespace-nowrap">Most vulnerable packages</h3>
+                        <button className="bg-cyan-800 hover:bg-cyan-700 focus:ring-4 focus:outline-none focus:ring-blue-800 font-medium rounded-lg px-4 py-2 text-center text-white" onClick={() => setTab('packages')}>See all</button>
+                    </div>
+                    <div className="bg-zinc-700 p-4 rounded-b-md">
+                        <div className="w-full h-full overflow-y-auto">
+                            <TableGeneric columns={packageColumns} data={metricsData?.top_packages ?? []} hasPagination={false} tableHeight="auto" />
+                        </div>
+                    </div>
+                </div>
+
             </div>
 
-          </div>
-
-        {/* === TABLES SECTION === */}
-        <div className="w-full grid grid-cols-1 lg:grid-cols-2">
-
-          {/* Most Critical Unfixed Vulnerabilities */}
-          <div className="p-4">
-            {/* Table Header */}
-            <div className="bg-zinc-700 px-4 py-2 flex items-center justify-between rounded-t-md">
-              <h3 className="text-2xl font-bold text-white whitespace-nowrap">
-                Most critical unfixed vulnerabilities
-              </h3>
-              <button
-                className="bg-cyan-800 hover:bg-cyan-700 focus:ring-4 focus:outline-none focus:ring-blue-800 font-medium rounded-lg px-4 py-2 text-center text-white"
-                onClick={() => setTab('vulnerabilities')}
-              >
-                See all
-              </button>
-            </div>
-
-            {/* Table Body */}
-            <div className="bg-zinc-700 p-4 rounded-b-md">
-              <TableGeneric
-                columns={vulnColumns}
-                data={TopVulns}
-                hasPagination={false}
-                tableHeight="auto"
-              />
-            </div>
-          </div>
-
-          {/* Most Vulnerable Packages */}
-          <div className="p-4">
-            {/* Table Header */}
-            <div className="bg-zinc-700 px-4 py-2 flex items-center justify-between rounded-t-md">
-              <h3 className="text-2xl font-bold text-white whitespace-nowrap">
-                Most vulnerable packages
-              </h3>
-              <button
-                className="bg-cyan-800 hover:bg-cyan-700 focus:ring-4 focus:outline-none focus:ring-blue-800 font-medium rounded-lg px-4 py-2 text-center text-white"
-                onClick={() => setTab('packages')}
-              >
-                See all
-              </button>
-            </div>
-
-            {/* Table Body */}
-            <div className="bg-zinc-700 p-4 rounded-b-md">
-              <div className="w-full h-full overflow-y-auto">
-                <TableGeneric
-                  columns={packageColumns}
-                  data={topVulnerablePackages}
-                  hasPagination={false}
-                  tableHeight="auto"
+            {/* MODAL */}
+            {modalVuln && metricsData && (
+                <VulnModal
+                    vuln={modalVuln}
+                    isEditing={isEditing}
+                    onClose={() => { setModalVulnIndex(undefined); setIsEditing(false); }}
+                    appendAssessment={handleAppendAssessment}
+                    appendCVSS={appendCVSS}
+                    patchVuln={handlePatchVuln}
+                    vulnerabilities={metricsData.top_vulns.map(item => item.original)}
+                    currentIndex={modalVulnIndex}
+                    onNavigate={handleModalNavigation}
                 />
-              </div>
-            </div>
-          </div>
-
+            )}
         </div>
+    );
+}
 
-        {/* === MODAL === */}
-        {modalVuln && (
-          <VulnModal
-            vuln={modalVuln}
-            isEditing={isEditing}
-            onClose={() => {
-              setModalVuln(undefined);
-              setModalVulnIndex(undefined);
-              setIsEditing(false);
-            }}
-            appendAssessment={appendAssessment}
-            appendCVSS={appendCVSS}
-            patchVuln={patchVuln}
-            vulnerabilities={TopVulns.map(item => item.original)}
-            currentIndex={modalVulnIndex}
-            onNavigate={handleModalNavigation}
-          />
-        )}
-        </div>
-      );
-
-        }
-
-        export default Metrics;
+export { SEVERITY_ORDER };
+export default Metrics;

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -1,6 +1,7 @@
 import type { Package, VulnCounts, Severities } from "../handlers/packages";
+import Packages from "../handlers/packages";
 import { createColumnHelper, Row } from '@tanstack/react-table'
-import { useMemo, useState, useRef, useEffect } from "react";
+import { useMemo, useState, useRef, useEffect, useCallback } from "react";
 import SeverityTag from "../components/SeverityTag";
 import TableGeneric from "../components/TableGeneric";
 import debounce from 'lodash-es/debounce';
@@ -11,7 +12,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleQuestion, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 
 type Props = {
-    packages: Package[];
+    variantId?: string;
+    projectId?: string;
+    compareVariantId?: string;
+    compareOperation?: string;
     onShowVulns?: (packageId: string) => void;
 };
 
@@ -88,7 +92,9 @@ function CpeCell({ version, cpe }: { version: string; cpe?: string[] }) {
     );
 }
 
-function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
+function TablePackages({ variantId, projectId, compareVariantId, compareOperation, onShowVulns }: Readonly<Props>) {
+    const [packages, setPackages] = useState<Package[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
     const [showSeverity, setShowSeverity] = useState(false);
     const [search, setSearch] = useState<string>('');
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
@@ -113,6 +119,18 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         { syntax: 'term1 | term2', description: 'OR: either term matches' },
         { syntax: '-term', description: 'NOT: exclude rows with term' },
     ];
+
+    const fetchPackages = useCallback(() => {
+        setIsLoading(true);
+        Packages.list(variantId, projectId, compareVariantId, compareOperation)
+            .then(pkgs => setPackages(pkgs))
+            .catch(err => console.error('Failed to load packages', err))
+            .finally(() => setIsLoading(false));
+    }, [variantId, projectId, compareVariantId, compareOperation]);
+
+    useEffect(() => {
+        fetchPackages();
+    }, [fetchPackages]);
 
     const updateSearch = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
         if (event.target.value.length < 2) {
@@ -374,7 +392,10 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         </div>
 
         <div ref={tableRef}>
-            <TableGeneric fuseKeys={fuseKeys} search={search} columns={columns} data={filteredPackages} estimateRowHeight={57} />
+            {isLoading
+                ? <div className="flex items-center justify-center h-32 text-white text-sm">Loading packages…</div>
+                : <TableGeneric fuseKeys={fuseKeys} search={search} columns={columns} data={filteredPackages} estimateRowHeight={57} />
+            }
         </div>
     </>);
 }

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -3,6 +3,7 @@ import type { CVSS } from "../handlers/vulnerabilities";
 import type { Assessment } from "../handlers/assessments";
 import type { NVDProgress } from "../handlers/nvd_progress";
 import type { EPSSProgress } from "../handlers/epss_progress";
+import Vulnerabilities from "../handlers/vulnerabilities";
 import { createColumnHelper, SortingFn, RowSelectionState, Row, Table } from '@tanstack/react-table'
 import { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import SeverityTag from "../components/SeverityTag";
@@ -21,17 +22,14 @@ import { faTimes, faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo 
 import RangeSlider from "../components/RangeSlider";
 
 type Props = {
-    vulnerabilities: Vulnerability[];
-    appendAssessment: (added: Assessment) => void;
-    appendCVSS: (vulnId: string, vector: string) => CVSS | null;
-    patchVuln: (vulnId: string, replace_vuln: Vulnerability) => void;
-    filterLabel?: "Source" | "Severity" | "Status" | "Package";
-    filterValue?: string;
     variantId?: string;
+    projectId?: string;
     /** Origin variant when compare mode is active */
     baseVariantId?: string;
     /** 'difference' or 'intersection' when compare mode is active */
     compareOperation?: string;
+    filterLabel?: "Source" | "Severity" | "Status" | "Package";
+    filterValue?: string;
 };
 
 const dt_options: Intl.DateTimeFormatOptions = {
@@ -269,8 +267,10 @@ function PublishedDateFilter({
 const SEVERITY_RANGE_MIN = 0;
 const SEVERITY_RANGE_MAX = 10;
 
-function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln, variantId, baseVariantId, compareOperation }: Readonly<Props>) {
+function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue, baseVariantId, compareOperation }: Readonly<Props>) {
 
+    const [vulnerabilities, setVulnerabilities] = useState<Vulnerability[]>([]);
+    const [isLoadingVulns, setIsLoadingVulns] = useState(false);
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);
     const [modalVulnIndex, setModalVulnIndex] = useState<number | undefined>(undefined);
     const [modalVulnSnapshot, setModalVulnSnapshot] = useState<Vulnerability[]>([]);
@@ -337,6 +337,38 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         if (filterLabel === "Status") setSelectedStatuses([filterValue]);
         if (filterLabel === "Package") setSelectedPackages([filterValue]);
     }, [filterLabel, filterValue]);
+
+    // Fetch vulnerabilities (including inline assessments) when scope changes
+    const fetchVulns = useCallback(() => {
+        setIsLoadingVulns(true);
+        // Compare mode: baseVariantId is the "from" variant, variantId is the "to" variant
+        const compareVariantId = baseVariantId ? variantId : undefined;
+        const effectiveVariantId = baseVariantId || variantId;
+        Vulnerabilities.list(effectiveVariantId, projectId, compareVariantId, compareOperation)
+            .then(data => setVulnerabilities(data))
+            .catch(err => console.error('Failed to load vulnerabilities', err))
+            .finally(() => setIsLoadingVulns(false));
+    }, [variantId, projectId, baseVariantId, compareOperation]);
+
+    useEffect(() => {
+        fetchVulns();
+    }, [fetchVulns]);
+
+    const appendAssessment = useCallback((added: Assessment) => {
+        setVulnerabilities(prev => Vulnerabilities.append_assessment(prev, added));
+    }, []);
+
+    const appendCVSS = useCallback((vulnId: string, vector: string): CVSS | null => {
+        const cvss = Vulnerabilities.calculate_cvss_from_vector(vector) ?? null;
+        if (cvss !== null) {
+            setVulnerabilities(prev => Vulnerabilities.append_cvss(prev, vulnId, cvss));
+        }
+        return cvss;
+    }, []);
+
+    const patchVuln = useCallback((vulnId: string, replace_vuln: Vulnerability) => {
+        setVulnerabilities(prev => prev.map(v => v.id === vulnId ? replace_vuln : v));
+    }, []);
 
     // Fetch NVD progress on mount and periodically
     useEffect(() => {
@@ -1078,7 +1110,10 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
 
 
     return (<>
-        {bannerVisible && (
+        {isLoadingVulns && (
+            <div className="flex items-center justify-center h-32 text-white text-sm">Loading vulnerabilities…</div>
+        )}
+        {!isLoadingVulns && bannerVisible && (
             <MessageBanner
                 type={bannerType}
                 message={bannerMessage}
@@ -1087,6 +1122,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             />
         )}
 
+        <div className={isLoadingVulns ? 'hidden' : undefined}>
         <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2 flex-wrap">
             <div>Search</div>
             <input ref={searchInputRef} onInput={updateSearch} type="search" className="py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[250px] grow max-w-[800px]" placeholder="Search by ID, packages, description, ..." />
@@ -1408,6 +1444,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             onNavigate={handleModalNavigation}
             variantId={variantId}
         ></VulnModal>}
+        </div>
     </>)
 }
 

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -1,10 +1,11 @@
 import type { Vulnerability } from "../handlers/vulnerabilities";
 import type { CVSS } from "../handlers/vulnerabilities";
+import type { Facets } from "../handlers/vulnerabilities";
 import type { Assessment } from "../handlers/assessments";
 import type { NVDProgress } from "../handlers/nvd_progress";
 import type { EPSSProgress } from "../handlers/epss_progress";
 import Vulnerabilities from "../handlers/vulnerabilities";
-import { createColumnHelper, SortingFn, RowSelectionState, Row, Table } from '@tanstack/react-table'
+import { createColumnHelper, SortingFn, RowSelectionState, Row, Table, SortingState } from '@tanstack/react-table'
 import { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import SeverityTag from "../components/SeverityTag";
 import { SEVERITY_ORDER } from "../handlers/vulnerabilities";
@@ -269,7 +270,12 @@ const SEVERITY_RANGE_MAX = 10;
 
 function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue, baseVariantId, compareOperation }: Readonly<Props>) {
 
-    const [vulnerabilities, setVulnerabilities] = useState<Vulnerability[]>([]);
+    const [pageItems, setPageItems] = useState<Vulnerability[]>([]);
+    const [serverTotal, setServerTotal] = useState(0);
+    const [facets, setFacets] = useState<Facets>({ severities: [], statuses: [], sources: [], attack_vectors: [], first_scan_dates: [] });
+    const [page, setPage] = useState(0); // 0-indexed
+    const [pageSize, setPageSize] = useState(50);
+    const [serverSorting, setServerSorting] = useState<SortingState>([]);
     const [isLoadingVulns, setIsLoadingVulns] = useState(false);
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);
     const [modalVulnIndex, setModalVulnIndex] = useState<number | undefined>(undefined);
@@ -338,36 +344,97 @@ function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue,
         if (filterLabel === "Package") setSelectedPackages([filterValue]);
     }, [filterLabel, filterValue]);
 
-    // Fetch vulnerabilities (including inline assessments) when scope changes
-    const fetchVulns = useCallback(() => {
+    // Fetch a page of vulnerabilities with server-side filtering/sorting
+    const abortRef = useRef<AbortController | null>(null);
+
+    const fetchPage = useCallback((requestedPage?: number) => {
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+
         setIsLoadingVulns(true);
-        // Compare mode: baseVariantId is the "from" variant, variantId is the "to" variant
         const compareVariantId = baseVariantId ? variantId : undefined;
         const effectiveVariantId = baseVariantId || variantId;
-        Vulnerabilities.list(effectiveVariantId, projectId, compareVariantId, compareOperation)
-            .then(data => setVulnerabilities(data))
-            .catch(err => console.error('Failed to load vulnerabilities', err))
-            .finally(() => setIsLoadingVulns(false));
-    }, [variantId, projectId, baseVariantId, compareOperation]);
 
+        const sortCol = serverSorting[0];
+        Vulnerabilities.listPaginated({
+            variantId: effectiveVariantId,
+            projectId,
+            compareVariantId,
+            operation: compareOperation,
+            page: (requestedPage ?? page) + 1, // API is 1-indexed
+            pageSize,
+            sortBy: sortCol?.id,
+            sortDir: sortCol ? (sortCol.desc ? 'desc' : 'asc') : undefined,
+            search: search || undefined,
+            severity: selectedSeverities.length ? selectedSeverities : undefined,
+            simplifiedStatus: selectedStatuses.length ? selectedStatuses : undefined,
+            foundBy: selectedSources.length ? selectedSources : undefined,
+            packages: selectedPackages.length ? selectedPackages : undefined,
+            epssMin: showCustomEpssFilter ? epssRange.min : undefined,
+            epssMax: showCustomEpssFilter ? epssRange.max : undefined,
+            severityMin: showCustomSeverityFilter ? severityRange.min : undefined,
+            severityMax: showCustomSeverityFilter ? severityRange.max : undefined,
+            attackVector: selectedAttackVectors.length ? selectedAttackVectors : undefined,
+            publishedDateFilter: publishedDateFilterType || undefined,
+            publishedDateValue: publishedDateValue || undefined,
+            publishedDateFrom: publishedDateFrom || undefined,
+            publishedDateTo: publishedDateTo || undefined,
+            publishedDaysValue: publishedDaysValue || undefined,
+            firstScanDate: selectedFirstScanDates.length ? selectedFirstScanDates : undefined,
+            signal: controller.signal,
+        })
+            .then(res => {
+                setPageItems(res.items);
+                setServerTotal(res.total);
+                setFacets(res.facets);
+            })
+            .catch(err => { if (err.name !== 'AbortError') console.error('Failed to load vulnerabilities', err); })
+            .finally(() => setIsLoadingVulns(false));
+    }, [variantId, projectId, baseVariantId, compareOperation, page, pageSize,
+        serverSorting, search, selectedSeverities, selectedStatuses, selectedSources,
+        selectedPackages, showCustomEpssFilter, epssRange, showCustomSeverityFilter,
+        severityRange, selectedAttackVectors, publishedDateFilterType,
+        publishedDateValue, publishedDateFrom, publishedDateTo, publishedDaysValue,
+        selectedFirstScanDates]);
+
+    // Re-fetch when any dependency changes
+    useEffect(() => { fetchPage(); }, [fetchPage]);
+
+    // Reset to page 0 when filters change (but not when page itself changes)
+    const filterDepsRef = useRef<string>('');
     useEffect(() => {
-        fetchVulns();
-    }, [fetchVulns]);
+        const key = JSON.stringify([
+            search, selectedSeverities, selectedStatuses, selectedSources,
+            selectedPackages, showCustomEpssFilter, epssRange,
+            showCustomSeverityFilter, severityRange, selectedAttackVectors,
+            publishedDateFilterType, publishedDateValue, publishedDateFrom,
+            publishedDateTo, publishedDaysValue, selectedFirstScanDates,
+        ]);
+        if (filterDepsRef.current && filterDepsRef.current !== key) {
+            setPage(0);
+        }
+        filterDepsRef.current = key;
+    }, [search, selectedSeverities, selectedStatuses, selectedSources,
+        selectedPackages, showCustomEpssFilter, epssRange,
+        showCustomSeverityFilter, severityRange, selectedAttackVectors,
+        publishedDateFilterType, publishedDateValue, publishedDateFrom,
+        publishedDateTo, publishedDaysValue, selectedFirstScanDates]);
 
     const appendAssessment = useCallback((added: Assessment) => {
-        setVulnerabilities(prev => Vulnerabilities.append_assessment(prev, added));
+        setPageItems(prev => Vulnerabilities.append_assessment(prev, added));
     }, []);
 
     const appendCVSS = useCallback((vulnId: string, vector: string): CVSS | null => {
         const cvss = Vulnerabilities.calculate_cvss_from_vector(vector) ?? null;
         if (cvss !== null) {
-            setVulnerabilities(prev => Vulnerabilities.append_cvss(prev, vulnId, cvss));
+            setPageItems(prev => Vulnerabilities.append_cvss(prev, vulnId, cvss));
         }
         return cvss;
     }, []);
 
     const patchVuln = useCallback((vulnId: string, replace_vuln: Vulnerability) => {
-        setVulnerabilities(prev => prev.map(v => v.id === vulnId ? replace_vuln : v));
+        setPageItems(prev => prev.map(v => v.id === vulnId ? replace_vuln : v));
     }, []);
 
     // Fetch NVD progress on mount and periodically
@@ -430,28 +497,14 @@ function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue,
     }, 750, { maxWait: 5000 });
 
     const attack_vector_list = useMemo(() => {
-        const avSet = new Set<string>();
-        vulnerabilities.forEach(vuln => {
-            vuln.severity.cvss.forEach(cvss => {
-                if (cvss.attack_vector) avSet.add(cvss.attack_vector);
-            });
-        });
         const order = ['NETWORK', 'ADJACENT', 'LOCAL', 'PHYSICAL'];
-        return Array.from(avSet).sort((a, b) => order.indexOf(a) - order.indexOf(b));
-    }, [vulnerabilities]);
+        return [...facets.attack_vectors].sort((a, b) => order.indexOf(a) - order.indexOf(b));
+    }, [facets.attack_vectors]);
 
-    // Build list of distinct first-scan timestamps, grouped by scan (same second = same scan)
+    // Build list of distinct first-scan timestamps from facets
     const availableFirstScanDates = useMemo(() => {
-        const tsSet = new Set<number>();
-        vulnerabilities.forEach(vuln => {
-            if (vuln.first_scan_date) {
-                // Round to the nearest second to group identical scans
-                const ts = Math.round(new Date(vuln.first_scan_date).getTime() / 1000) * 1000;
-                tsSet.add(ts);
-            }
-        });
-        return Array.from(tsSet).sort((a, b) => a - b);
-    }, [vulnerabilities]);
+        return facets.first_scan_dates;
+    }, [facets.first_scan_dates]);
 
     const formatScanDate = useCallback((ts: number) => {
         const d = new Date(ts);
@@ -466,13 +519,7 @@ function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue,
         });
     }, []);
 
-    const sources_list = useMemo(() => vulnerabilities.reduce((acc: string[], vuln) => {
-        vuln.found_by.forEach(source => {
-            if (!acc.includes(source) && source != '')
-                acc.push(source)
-        });
-        return acc;
-    }, []), [vulnerabilities])
+    const sources_list = useMemo(() => facets.sources, [facets.sources])
 
     const sources_display_list = useMemo(
         () =>
@@ -890,105 +937,6 @@ function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue,
         });
     }, [allColumns, visibleColumns, columnDisplayNames]);
 
-    const dataToDisplay = useMemo(() => {
-        return vulnerabilities.filter((el) => {
-            if (selectedSeverities.length && !selectedSeverities.includes(el.severity.severity)) return false;
-            if (selectedStatuses.length && !selectedStatuses.includes(el.simplified_status)) return false;
-            if (selectedSources.length && !selectedSources.some(src => el.found_by.includes(src))) return false;
-            if (selectedPackages.length && !selectedPackages.some(pkg => el.packages_current.includes(pkg))) return false;
-
-            // Published date filter
-            if (publishedDateFilterType && el.published) {
-                const publishedDate = new Date(el.published);
-                const today = new Date();
-
-                switch (publishedDateFilterType) {
-                    case 'is':
-                        if (publishedDateValue) {
-                            const targetDate = new Date(publishedDateValue);
-                            // Compare dates in UTC to avoid timezone issues
-                            const publishedUTC = Date.UTC(publishedDate.getUTCFullYear(), publishedDate.getUTCMonth(), publishedDate.getUTCDate());
-                            const targetUTC = Date.UTC(targetDate.getUTCFullYear(), targetDate.getUTCMonth(), targetDate.getUTCDate());
-                            if (publishedUTC !== targetUTC) return false;
-                        }
-                        break;
-                    case '>=':
-                        if (publishedDateValue) {
-                            const targetDate = new Date(publishedDateValue);
-                            const publishedUTC = Date.UTC(publishedDate.getUTCFullYear(), publishedDate.getUTCMonth(), publishedDate.getUTCDate());
-                            const targetUTC = Date.UTC(targetDate.getUTCFullYear(), targetDate.getUTCMonth(), targetDate.getUTCDate());
-                            if (publishedUTC < targetUTC) return false;
-                        }
-                        break;
-                    case '<=':
-                        if (publishedDateValue) {
-                            const targetDate = new Date(publishedDateValue);
-                            const publishedUTC = Date.UTC(publishedDate.getUTCFullYear(), publishedDate.getUTCMonth(), publishedDate.getUTCDate());
-                            const targetUTC = Date.UTC(targetDate.getUTCFullYear(), targetDate.getUTCMonth(), targetDate.getUTCDate());
-                            if (publishedUTC > targetUTC) return false;
-                        }
-                        break;
-                    case 'between':
-                        if (publishedDateFrom && publishedDateTo) {
-                            const fromDate = new Date(publishedDateFrom);
-                            const toDate = new Date(publishedDateTo);
-                            const publishedUTC = Date.UTC(publishedDate.getUTCFullYear(), publishedDate.getUTCMonth(), publishedDate.getUTCDate());
-                            const fromUTC = Date.UTC(fromDate.getUTCFullYear(), fromDate.getUTCMonth(), fromDate.getUTCDate());
-                            const toUTC = Date.UTC(toDate.getUTCFullYear(), toDate.getUTCMonth(), toDate.getUTCDate());
-                            if (publishedUTC < fromUTC || publishedUTC > toUTC) return false;
-                        }
-                        break;
-                    case 'days_ago':
-                        if (publishedDaysValue) {
-                            const daysAgo = parseInt(publishedDaysValue);
-                            if (!isNaN(daysAgo)) {
-                                const cutoffDate = new Date(today);
-                                cutoffDate.setDate(cutoffDate.getDate() - daysAgo);
-                                const publishedUTC = Date.UTC(publishedDate.getUTCFullYear(), publishedDate.getUTCMonth(), publishedDate.getUTCDate());
-                                const cutoffUTC = Date.UTC(cutoffDate.getUTCFullYear(), cutoffDate.getUTCMonth(), cutoffDate.getUTCDate());
-                                if (publishedUTC < cutoffUTC) return false;
-                            }
-                        }
-                        break;
-                }
-            } else if (publishedDateFilterType && !el.published) {
-                // If filter is active but vulnerability has no published date, filter it out
-                return false;
-            }
-
-            if(showCustomSeverityFilter){
-                // Use the max score as this is how the final severity level is determined
-                const maxScore = el.severity.max_score;
-
-                if (maxScore === null) return false;
-                if (maxScore < severityRange.min || maxScore > severityRange.max) return false;
-            }
-
-            // EPSS range filter
-            if (showCustomEpssFilter) {
-                const epssScore = el.epss?.score;
-                if (epssScore === undefined || epssScore === null) return false;
-                const epssPct = epssScore * 100;
-                if (epssPct < epssRange.min || epssPct > epssRange.max) return false;
-            }
-
-            // Attack vector filter
-            if (selectedAttackVectors.length) {
-                const vulnAVs = new Set(el.severity.cvss.map(c => c.attack_vector).filter(Boolean));
-                if (!selectedAttackVectors.some(av => vulnAVs.has(av))) return false;
-            }
-
-            // First scan date filter (multi-select by scan timestamp)
-            if (selectedFirstScanDates.length > 0) {
-                if (!el.first_scan_date) return false;
-                const elTs = Math.round(new Date(el.first_scan_date).getTime() / 1000) * 1000;
-                if (!selectedFirstScanDates.includes(String(elTs))) return false;
-            }
-
-            return true;
-        });
-    }, [vulnerabilities, selectedSeverities, selectedStatuses, selectedSources, selectedPackages, publishedDateFilterType, publishedDateValue, publishedDaysValue, publishedDateFrom, publishedDateTo, showCustomSeverityFilter, severityRange, showCustomEpssFilter, epssRange, selectedAttackVectors, selectedFirstScanDates]);
-
     const selectedVulns = useMemo(() => {
         return Object.entries(selectedRows).flatMap(([id, selected]) => selected ? [id] : [])
     }, [selectedRows])
@@ -1185,7 +1133,7 @@ function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue,
 
             <FilterOption
                 label="Severity"
-                options={Array.from(new Set(vulnerabilities.map(v => v.severity.severity))).sort((a, b) =>
+                options={[...facets.severities].sort((a, b) =>
                     SEVERITY_ORDER.map(s => s.toLowerCase()).indexOf(b.toLowerCase()) - SEVERITY_ORDER.map(s => s.toLowerCase()).indexOf(a.toLowerCase())
                 )}
                 selected={selectedSeverities}
@@ -1207,7 +1155,7 @@ function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue,
 
             <FilterOption
                 label="Status"
-                options={Array.from(new Set(vulnerabilities.map(v => v.simplified_status)))}
+                options={facets.statuses}
                 selected={selectedStatuses}
                 setSelected={setSelectedStatuses}
             />
@@ -1393,7 +1341,7 @@ function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue,
         </div>
 
         <MultiEditBar
-            vulnerabilities={vulnerabilities}
+            vulnerabilities={pageItems}
             selectedVulns={selectedVulns}
             resetVulns={() => setSelectedRows({})}
             appendAssessment={appendAssessment}
@@ -1408,7 +1356,6 @@ function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue,
         <TableGeneric
             fuseKeys={fuseKeys}
             hoverField="texts"
-            search={search}
             columns={columns}
             tableHeight={
                 selectedVulns.length >= 1 ?
@@ -1419,12 +1366,20 @@ function TableVulnerabilities ({ variantId, projectId, filterLabel, filterValue,
                     'calc(100vh - 44px - 64px - 48px - 16px - 8px - 64px)' :
                     'calc(100vh - 44px - 64px - 48px - 16px - 8px)')
             }
-            data={dataToDisplay}
+            data={pageItems}
             estimateRowHeight={66}
             selected={selectedRows}
             updateSelected={setSelectedRows}
             onFilteredDataChange={setSearchFilteredData}
             onFocusedRowChange={setFocusedRowIndex}
+            serverPagination={{
+                page,
+                pageSize,
+                total: serverTotal,
+                onPageChange: setPage,
+                onPageSizeChange: (size: number) => { setPageSize(size); setPage(0); },
+            }}
+            onSortingChange={setServerSorting}
         />
 
         {modalVuln != undefined && <VulnModal

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -8,6 +8,14 @@ expect.extend(matchers);
 import type { Package } from "../../src/handlers/packages";
 import TablePackages from '../../src/pages/TablePackages';
 
+// Mock Packages handler so the component doesn't make real fetch calls
+jest.mock('../../src/handlers/packages', () => ({
+    __esModule: true,
+    default: {
+        list: jest.fn(),
+    },
+}));
+
 
 const getDOMRect = (width: number, height: number) => ({
     width,
@@ -73,12 +81,19 @@ describe('Packages Table', () => {
         return getDOMRect(500, 500)
     }
 
+    const Packages = require('../../src/handlers/packages').default;
+
+    beforeEach(() => {
+        Packages.list.mockResolvedValue(packages);
+    });
+
     test('render headers with empty array', async () => {
         // ARRANGE
-        render(<TablePackages packages={[]} />);
+        Packages.list.mockResolvedValueOnce([]);
+        render(<TablePackages />);
 
         // ACT
-        const name_header = await screen.getByRole('columnheader', {name: /name/i});
+        const name_header = await screen.findByRole('columnheader', {name: /name/i});
         const version_header = await screen.getByRole('columnheader', {name: /version/i});
         const vuln_count_header = await screen.getByRole('columnheader', {name: /^Vulnerabilities$/i});
         const sources_header = await screen.getByRole('columnheader', {name: /sources/i});
@@ -92,10 +107,10 @@ describe('Packages Table', () => {
 
     test('render with packages', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         // ACT
-        const name_col = await screen.getByRole('cell', {name: /aaabbbccc/});
+        const name_col = await screen.findByRole('cell', {name: /aaabbbccc/});
         const version_col = await screen.getByRole('cell', {name: /1.0.0/});
         const vuln_count_col = await screen.getByRole('cell', {name: /^8$/});
         const source_col = await screen.getByRole('cell', {name: /^hardcoded$/});
@@ -109,7 +124,7 @@ describe('Packages Table', () => {
 
     test('render severity when toggle activated', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         // ACT
         const user = userEvent.setup();
@@ -117,7 +132,7 @@ describe('Packages Table', () => {
 
         await user.click(severity_toggle); // switch to enabled mode
 
-        const btn_enabled = await screen.getByRole('button', {name: /hide severity/i});
+        const btn_enabled = await screen.findByRole('button', {name: /hide severity/i});
         const severity_high = await screen.getByText('high');
         const severity_mediums = await screen.getAllByText('medium');
 
@@ -129,10 +144,10 @@ describe('Packages Table', () => {
 
     test('sorting by name', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
-        const name_header = await screen.getByRole('columnheader', {name: /name/i});
+        const name_header = await screen.findByRole('columnheader', {name: /name/i});
 
         await user.click(name_header); // un-ordoned -> alphabetical order
         await waitFor(() => {
@@ -149,10 +164,10 @@ describe('Packages Table', () => {
 
     test('sorting by version', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
-        const version_header = await screen.getByRole('columnheader', {name: /version/i});
+        const version_header = await screen.findByRole('columnheader', {name: /version/i});
 
         await user.click(version_header); // un-ordoned -> alphabetical order
         await waitFor(() => {
@@ -169,10 +184,10 @@ describe('Packages Table', () => {
 
     test('sorting by vulnerabilities count', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
-        const vuln_count_header = await screen.getByRole('columnheader', {name: /^Vulnerabilities$/i});
+        const vuln_count_header = await screen.findByRole('columnheader', {name: /^Vulnerabilities$/i});
 
         await user.click(vuln_count_header); // numerical order -> reverse numerical order
         await waitFor(() => {
@@ -189,10 +204,13 @@ describe('Packages Table', () => {
 
     test('searching for package name', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
+
+        // Wait for data to load before typing
+        await screen.findByRole('cell', {name: /aaabbbccc/});
 
         await user.type(search_bar, 'yyy');
 
@@ -204,7 +222,7 @@ describe('Packages Table', () => {
 
     test('searching with negation text', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
@@ -224,10 +242,13 @@ describe('Packages Table', () => {
 
     test('searching with a combination of queries', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
+
+        // Wait for data to load before typing
+        await screen.findByRole('cell', {name: /aaabbbccc/});
 
         await user.type(search_bar, '-aaabbbccc xxxyyyzzz');
 
@@ -243,9 +264,12 @@ describe('Packages Table', () => {
 
     test('filter by source', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
+
+        // Wait for data to load
+        await screen.findByRole('cell', {name: /aaabbbccc/});
 
         // Open the "Source" filter dropdown
         const source_btn = await screen.getByRole('button', { name: /source/i });
@@ -272,7 +296,7 @@ describe('Packages Table', () => {
 
     test('reset filters button clears all filters', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
 
@@ -301,12 +325,12 @@ describe('Packages Table', () => {
 
     test('CPE button shows popup with CPE IDs', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
 
         // ACT: Click CPE button
-        const cpeButtons = await screen.getAllByText('CPE');
+        const cpeButtons = await screen.findAllByText('CPE');
         await user.click(cpeButtons[0]);
 
         // ASSERT: CPE ID should be visible in popup
@@ -316,12 +340,12 @@ describe('Packages Table', () => {
 
     test('CPE popup close button works', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
 
         // Open CPE popup
-        const cpeButtons = await screen.getAllByText('CPE');
+        const cpeButtons = await screen.findAllByText('CPE');
         await user.click(cpeButtons[0]);
 
         // ACT: Click close button in popup
@@ -337,12 +361,12 @@ describe('Packages Table', () => {
 
     test('CPE popup closes when clicking CPE button again', async () => {
         // ARRANGE
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
 
         // Open CPE popup
-        const cpeButtons = await screen.getAllByText('CPE');
+        const cpeButtons = await screen.findAllByText('CPE');
         await user.click(cpeButtons[0]);
 
         // Verify popup is open
@@ -362,12 +386,12 @@ describe('Packages Table', () => {
     test('show vulnerabilities button calls onShowVulns', async () => {
         // ARRANGE
         const mockOnShowVulns = jest.fn();
-        render(<TablePackages packages={packages} onShowVulns={mockOnShowVulns} />);
+        render(<TablePackages onShowVulns={mockOnShowVulns} />);
 
         const user = userEvent.setup();
 
         // ACT: Click show vulnerabilities button
-        const showVulnsButtons = await screen.getAllByRole('button', { name: /show vulnerabilities/i });
+        const showVulnsButtons = await screen.findAllByRole('button', { name: /show vulnerabilities/i });
         await user.click(showVulnsButtons[0]);
 
         // ASSERT
@@ -390,7 +414,11 @@ describe('Packages Table', () => {
             }
         ];
 
-        render(<TablePackages packages={packagesNoCpe} />);
+        Packages.list.mockResolvedValueOnce(packagesNoCpe);
+        render(<TablePackages />);
+
+        // Wait for loading to complete
+        await waitFor(() => expect(screen.queryByText(/loading packages/i)).toBeNull());
 
         // ACT & ASSERT
         const cpeButtons = screen.queryAllByText('CPE');
@@ -416,12 +444,13 @@ describe('Packages Table', () => {
             }
         ];
 
-        render(<TablePackages packages={packagesMultiCpe} />);
+        Packages.list.mockResolvedValueOnce(packagesMultiCpe);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
 
         // ACT: Click CPE button
-        const cpeButton = await screen.getByText('CPE');
+        const cpeButton = await screen.findByText('CPE');
         await user.click(cpeButton);
 
         // ASSERT: Both CPE IDs should be visible
@@ -432,14 +461,14 @@ describe('Packages Table', () => {
     });
 
     test('shortcut helper icon is visible', async () => {
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const helperBtn = await screen.getByRole('button', { name: /shortcut helper/i });
         expect(helperBtn).toBeTruthy();
     });
 
     test('shortcut helper shows keyboard shortcuts content', async () => {
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
         const helperBtn = await screen.getByRole('button', { name: /shortcut helper/i });
@@ -455,7 +484,7 @@ describe('Packages Table', () => {
     });
 
     test('search syntax helper is visible and shows syntax content when clicked', async () => {
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
         const helperBtn = screen.getByRole('button', { name: /search syntax helper/i });
@@ -471,7 +500,7 @@ describe('Packages Table', () => {
     });
 
     test('pressing / focuses search bar', async () => {
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
         const searchBar = await screen.getByRole('searchbox') as HTMLInputElement;
@@ -484,7 +513,7 @@ describe('Packages Table', () => {
     });
 
     test('pressing / while search bar is focused types slash in search', async () => {
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
         const searchBar = await screen.getByRole('searchbox') as HTMLInputElement;
@@ -499,9 +528,11 @@ describe('Packages Table', () => {
     });
 
     test('ArrowDown and ArrowUp navigate focused table row', async () => {
-        const { container } = render(<TablePackages packages={packages} />);
+        const { container } = render(<TablePackages />);
 
         const user = userEvent.setup();
+        // Wait for table rows to be rendered
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThanOrEqual(3));
         const rows = container.querySelectorAll('tr.row-with-hover-effect');
 
         expect(rows.length).toBeGreaterThanOrEqual(3);
@@ -524,9 +555,11 @@ describe('Packages Table', () => {
     });
 
     test('Home and End navigate to first and last focused table row', async () => {
-        const { container } = render(<TablePackages packages={packages} />);
+        const { container } = render(<TablePackages />);
 
         const user = userEvent.setup();
+        // Wait for table rows to be rendered
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThanOrEqual(3));
         const rows = container.querySelectorAll('tr.row-with-hover-effect');
 
         expect(rows.length).toBeGreaterThanOrEqual(3);
@@ -564,7 +597,8 @@ describe('Packages Table', () => {
             }
         ];
 
-        render(<TablePackages packages={packagesWithVariants} />);
+        Packages.list.mockResolvedValueOnce(packagesWithVariants);
+        render(<TablePackages />);
 
         expect(await screen.findByText('variant-A')).toBeTruthy();
         expect(screen.getByText('variant-B')).toBeTruthy();
@@ -596,15 +630,16 @@ describe('Packages Table', () => {
             }
         ];
 
-        render(<TablePackages packages={packagesWithPending} />);
+        Packages.list.mockResolvedValueOnce(packagesWithPending);
+        render(<TablePackages />);
 
         // Verify both pending values are rendered
-        const cells = screen.getAllByRole('cell');
+        const cells = await screen.findAllByRole('cell');
         const pendingValues = cells.filter(c => c.textContent === '5' || c.textContent === '1');
         expect(pendingValues.length).toBeGreaterThanOrEqual(2);
 
         const user = userEvent.setup();
-        const pendingHeader = await screen.getByRole('columnheader', {name: /remaining pending/i});
+        const pendingHeader = await screen.findByRole('columnheader', {name: /remaining pending/i});
 
         // Click to sort
         await user.click(pendingHeader);
@@ -622,11 +657,11 @@ describe('Packages Table', () => {
     });
 
     test('CPE popup closes on Escape key', async () => {
-        render(<TablePackages packages={packages} />);
+        render(<TablePackages />);
 
         const user = userEvent.setup();
 
-        const cpeButtons = await screen.getAllByText('CPE');
+        const cpeButtons = await screen.findAllByText('CPE');
         await user.click(cpeButtons[0]);
 
         const cpeId = await screen.getByText(/cpe:2.3:a:vendor:aaabbbccc:1.0.0/);

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -32,6 +32,20 @@ jest.mock('../../src/handlers/epss_progress', () => ({
     },
 }));
 
+// Mock Vulnerabilities handler so the component doesn't make real fetch calls
+jest.mock('../../src/handlers/vulnerabilities', () => ({
+    __esModule: true,
+    default: {
+        list: jest.fn(),
+        enrich_with_assessments: jest.requireActual('../../src/handlers/vulnerabilities').default.enrich_with_assessments,
+        append_assessment: jest.requireActual('../../src/handlers/vulnerabilities').default.append_assessment,
+        append_cvss: jest.requireActual('../../src/handlers/vulnerabilities').default.append_cvss,
+        calculate_cvss_from_vector: jest.requireActual('../../src/handlers/vulnerabilities').default.calculate_cvss_from_vector,
+    },
+    asVulnerability: jest.requireActual('../../src/handlers/vulnerabilities').asVulnerability,
+    SEVERITY_ORDER: jest.requireActual('../../src/handlers/vulnerabilities').SEVERITY_ORDER,
+}));
+
 
 const getDOMRect = (width: number, height: number) => ({
     width,
@@ -261,13 +275,17 @@ describe('Vulnerability Table', () => {
         return getDOMRect(500, 500)
     })
 
+    const Vulnerabilities = require('../../src/handlers/vulnerabilities').default;
+
     beforeEach(() => {
         fetchMock.resetMocks();
+        Vulnerabilities.list.mockResolvedValue(vulnerabilities);
     });
 
     test('render headers with empty array', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        Vulnerabilities.list.mockResolvedValueOnce([]);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
 
@@ -309,12 +327,12 @@ describe('Vulnerability Table', () => {
 
     test('render with vulnerabilities', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
 
         // ACT - Check default visible columns
-        const id_col = await screen.getByRole('cell', {name: /CVE-2010-1234/});
+        const id_col = await screen.findByRole('cell', {name: /CVE-2010-1234/});
         const severity_col = await screen.getByRole('cell', {name: /low/});
         const epss_col = await screen.getByRole('cell', {name: /35\.68%/});
         const packages_col = await screen.getByRole('cell', {name: /aaabbbccc@1\.0\.0/i});
@@ -353,7 +371,7 @@ describe('Vulnerability Table', () => {
 
     test('sorting by name', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const id_header = await screen.getByRole('columnheader', {name: /id/i});
@@ -373,7 +391,7 @@ describe('Vulnerability Table', () => {
 
     test('sorting by severity', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const severity_header = await screen.getByRole('columnheader', {name: /severity/i});
@@ -393,7 +411,7 @@ describe('Vulnerability Table', () => {
 
     test('sorting by attack vector', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
 
@@ -422,7 +440,7 @@ describe('Vulnerability Table', () => {
 
     test('sorting by exploitability score', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const exploit_header = await screen.getByRole('columnheader', {name: /EPSS score/i});
@@ -442,7 +460,7 @@ describe('Vulnerability Table', () => {
 
     test('sorting by efforts needed', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
 
@@ -471,7 +489,7 @@ describe('Vulnerability Table', () => {
 
     test('sorting by status', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const status_header = await screen.getByRole('columnheader', {name: /status/i});
@@ -491,7 +509,7 @@ describe('Vulnerability Table', () => {
 
     test('searching for vulnerability ID', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
@@ -510,7 +528,7 @@ describe('Vulnerability Table', () => {
 
     test('searching for package name', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
@@ -527,7 +545,7 @@ describe('Vulnerability Table', () => {
 
     test('searching with negation text', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
@@ -544,7 +562,7 @@ describe('Vulnerability Table', () => {
 
     test('searching with a combination of queries', async () => {
         // ARRANGE
-         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+         render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
@@ -563,7 +581,7 @@ describe('Vulnerability Table', () => {
 
     test('searching for description', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
@@ -580,7 +598,7 @@ describe('Vulnerability Table', () => {
 
     test('filter by source', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const sourceBtn = await screen.getByRole('button', { name: /source/i });
@@ -600,7 +618,7 @@ describe('Vulnerability Table', () => {
 
     test('filter out Exploitable', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const statusBtn = await screen.getByRole('button', { name: /status/i });
@@ -622,7 +640,7 @@ describe('Vulnerability Table', () => {
 
     test('filter out Pending Assessment', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const statusBtn = await screen.getByRole('button', { name: /status/i });
@@ -645,16 +663,18 @@ describe('Vulnerability Table', () => {
 
     test('select all in table and unselecting', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
+        // Wait for data to load before selecting all
+        await screen.findByRole('cell', {name: /CVE-2010-1234/});
         const select_all = await screen.getByTitle(/select all/i);
         expect(select_all).toBeInTheDocument();
 
         await user.click(select_all)
         expect(select_all).toBeChecked();
 
-        const uniques_selections = await screen.getAllByTitle(/unselect/i);
+        const uniques_selections = await screen.findAllByTitle(/unselect/i);
         expect(uniques_selections.length).toBeGreaterThanOrEqual(1);
         uniques_selections.forEach((el) => expect(el).toBeChecked());
 
@@ -665,10 +685,10 @@ describe('Vulnerability Table', () => {
 
     test('select using ctrl+click and reset selection', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
-        const id_col = await screen.getByRole('cell', {name: /CVE-2010-1234/});
+        const id_col = await screen.findByRole('cell', {name: /CVE-2010-1234/});
         expect(id_col).toBeInTheDocument();
 
         await user.keyboard('[ControlLeft>]')
@@ -709,9 +729,11 @@ describe('Vulnerability Table', () => {
         );
 
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
+        // Wait for data to load before selecting
+        await screen.findByRole('cell', {name: /CVE-2010-1234/});
         const select_all = await screen.getByTitle(/select all/i);
         expect(select_all).toBeInTheDocument();
 
@@ -773,9 +795,11 @@ describe('Vulnerability Table', () => {
         );
 
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
+        // Wait for data to load before selecting
+        await screen.findByRole('cell', {name: /CVE-2010-1234/});
         const select_all = await screen.getByTitle(/select all/i);
         expect(select_all).toBeInTheDocument();
 
@@ -802,9 +826,9 @@ describe('Vulnerability Table', () => {
 
     test('show description when hovering vulnerability', async () => {
         // ARRANGE
-        const { container } = render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const { container } = render(<TableVulnerabilities />);
 
-        const id_col = screen.getByRole('cell', {name: vulnerabilities[0].id});
+        const id_col = await screen.findByRole('cell', {name: vulnerabilities[0].id});
         expect(id_col).toBeInTheDocument();
 
         // Tooltip is portal-based: content only appears after mouseenter on the row
@@ -819,7 +843,7 @@ describe('Vulnerability Table', () => {
 
     test('filter by severity', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const severityBtn = await screen.getByRole('button', { name: /severity/i });
@@ -839,7 +863,7 @@ describe('Vulnerability Table', () => {
 
     test('filter by custom severity range', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const severityBtn = await screen.getByRole('button', { name: /severity/i });
@@ -875,7 +899,7 @@ describe('Vulnerability Table', () => {
 
     test('custom severity filter and other severity filters cannot be checked at the same time', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const severityBtn = await screen.getByRole('button', { name: /severity/i });
@@ -906,7 +930,7 @@ describe('Vulnerability Table', () => {
 
     test('reset filters button clears all filters', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
 
@@ -945,10 +969,6 @@ describe('Vulnerability Table', () => {
         // ARRANGE - Render with initial filter props
         render(
             <TableVulnerabilities
-                vulnerabilities={vulnerabilities}
-                appendAssessment={() => {}}
-                appendCVSS={() => null}
-                patchVuln={() => {}}
                 filterLabel="Source"
                 filterValue="hardcoded"
             />
@@ -964,7 +984,7 @@ describe('Vulnerability Table', () => {
 
     test('multiple source selection works', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const sourceBtn = await screen.getByRole('button', { name: /source/i });
@@ -986,7 +1006,7 @@ describe('Vulnerability Table', () => {
 
     test('search debounce functionality', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
@@ -995,7 +1015,7 @@ describe('Vulnerability Table', () => {
         await user.type(search_bar, '2');
 
         // ASSERT - Both vulnerabilities should still be visible (no filtering with < 2 chars)
-        const vuln1 = await screen.getByRole('cell', {name: /CVE-2010-1234/});
+        const vuln1 = await screen.findByRole('cell', {name: /CVE-2010-1234/});
         const vuln2 = await screen.getByRole('cell', {name: /CVE-2018-5678/});
         expect(vuln1).toBeInTheDocument();
         expect(vuln2).toBeInTheDocument();
@@ -1003,9 +1023,11 @@ describe('Vulnerability Table', () => {
 
     test('sorting by packages column is disabled', async () => {
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
+        // Wait for data to load
+        await screen.findByRole('cell', {name: /aaabbbccc/});
         const packagesHeader = await screen.getByRole('columnheader', {name: /SBOM Affected/i});
 
         // Store initial order
@@ -1033,12 +1055,12 @@ describe('Vulnerability Table', () => {
             }
         ];
 
-        render(<TableVulnerabilities vulnerabilities={vulnWithoutAssessments} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        Vulnerabilities.list.mockResolvedValueOnce(vulnWithoutAssessments);
+        render(<TableVulnerabilities />);
 
         // ACT & ASSERT - Vulnerability has empty assessments array, should show "No assessment"
-        const noAssessmentCell = await screen.getByText(/no assessment/i);
-        expect(noAssessmentCell).toBeInTheDocument();
-    })
+        await screen.findByText(/no assessment/i);
+    });
 
     test('last updated column displays assessment timestamp when assessments exist', async () => {
         const vulnWithAssessments: Vulnerability[] = [
@@ -1064,19 +1086,18 @@ describe('Vulnerability Table', () => {
         ];
 
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnWithAssessments} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        Vulnerabilities.list.mockResolvedValueOnce(vulnWithAssessments);
+        render(<TableVulnerabilities />);
 
         // ACT & ASSERT
         // First vulnerability should show formatted date
-        const formattedDate = await screen.getByText(/january 15, 2024/i);
-        expect(formattedDate).toBeInTheDocument();
+        await screen.findByText(/january 15, 2024/i);
 
         // Second vulnerability should still show "No assessment"
-        const noAssessment = await screen.getByText(/no assessment/i);
-        expect(noAssessment).toBeInTheDocument();
-    })
+        await screen.findByText(/no assessment/i);
+    });
 
-    test('last updated column uses last_update field when available', async () => {
+    test('uses last_update field when available', async () => {
         const vulnWithUpdatedAssessments: Vulnerability[] = [
             {
                 ...vulnerabilities[0],
@@ -1097,14 +1118,14 @@ describe('Vulnerability Table', () => {
         ];
 
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnWithUpdatedAssessments} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        Vulnerabilities.list.mockResolvedValueOnce(vulnWithUpdatedAssessments);
+        render(<TableVulnerabilities />);
 
         // ACT & ASSERT - Should show the more recent last_update date
-        const formattedDate = await screen.getByText(/february 20, 2024/i);
-        expect(formattedDate).toBeInTheDocument();
+        await screen.findByText(/february 20, 2024/i);
     })
 
-    test('last updated column shows most recent assessment across multiple assessments', async () => {
+    test('last updated column shows most recent assessment when multiple assessments exist', async () => {
         const vulnWithMultipleAssessments: Vulnerability[] = [
             {
                 ...vulnerabilities[0],
@@ -1144,11 +1165,11 @@ describe('Vulnerability Table', () => {
         ];
 
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnWithMultipleAssessments} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        Vulnerabilities.list.mockResolvedValueOnce(vulnWithMultipleAssessments);
+        render(<TableVulnerabilities />);
 
         // ACT & ASSERT - Should show the most recent assessment date (March 10)
-        const formattedDate = await screen.getByText(/march 10, 2024/i);
-        expect(formattedDate).toBeInTheDocument();
+        await screen.findByText(/march 10, 2024/i);
     })
 
     test('sorting by last updated column', async () => {
@@ -1193,10 +1214,11 @@ describe('Vulnerability Table', () => {
         ];
 
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnWithDifferentDates} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        Vulnerabilities.list.mockResolvedValueOnce(vulnWithDifferentDates);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
-        const lastUpdatedHeader = await screen.getByRole('columnheader', {name: /last updated/i});
+        const lastUpdatedHeader = await screen.findByRole('columnheader', {name: /last updated/i});
 
         // ACT - Sort by last updated (first click: descending - newest first, then older, then no assessments)
         await user.click(lastUpdatedHeader);
@@ -1255,10 +1277,11 @@ describe('Vulnerability Table', () => {
         ];
 
         // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnWithMixedDates} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        Vulnerabilities.list.mockResolvedValueOnce(vulnWithMixedDates);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
-        const lastUpdatedHeader = await screen.getByRole('columnheader', {name: /last updated/i});
+        const lastUpdatedHeader = await screen.findByRole('columnheader', {name: /last updated/i});
 
         // ACT - Sort descending (newest first) - should only need one click
         await user.click(lastUpdatedHeader);
@@ -1271,13 +1294,16 @@ describe('Vulnerability Table', () => {
     })
 
     test('modal navigation works correctly', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const { container } = render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
 
-        // Open modal for first vulnerability
-        const firstVulnId = await screen.getByText('CVE-2010-1234');
-        await user.click(firstVulnId);
+        // Wait for rows to appear
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThan(0));
+
+        // Click vulnerability ID cell to open modal
+        const vulnIdCells = await screen.findAllByTitle('Click to view details');
+        await user.click(vulnIdCells[0]);
 
         // Modal should be open
         await waitFor(() => {
@@ -1289,12 +1315,15 @@ describe('Vulnerability Table', () => {
     })
 
     test('clicking Edit button opens modal in edit mode', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const { container } = render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
 
+        // Wait for rows to appear
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThan(0));
+
         // Click Edit button for first vulnerability
-        const editButtons = await screen.getAllByRole('button', { name: /^edit$/i });
+        const editButtons = await screen.findAllByRole('button', { name: /^edit$/i });
         await user.click(editButtons[0]);
 
         // Modal should be open in edit mode
@@ -1305,12 +1334,15 @@ describe('Vulnerability Table', () => {
     })
 
     test('clicking vulnerability ID opens modal in view mode', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const { container } = render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
 
+        // Wait for rows to appear
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThan(0));
+
         // Click on vulnerability ID cell
-        const vulnIdCells = await screen.getAllByText('CVE-2010-1234');
+        const vulnIdCells = await screen.findAllByTitle('Click to view details');
         await user.click(vulnIdCells[0]);
 
         // Modal should be open
@@ -1325,7 +1357,7 @@ describe('Vulnerability Table', () => {
 
     test('published date filter button is disabled when NVD sync is not completed', async () => {
         // NVD progress mock defaults to phase: 'idle', which means not completed
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const publishedDateBtn = await screen.getByRole('button', { name: /published date/i });
         expect(publishedDateBtn).toBeInTheDocument();
@@ -1344,7 +1376,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         await waitFor(() => {
             const publishedDateBtn = screen.getByRole('button', { name: /published date/i });
@@ -1363,7 +1395,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await waitFor(() => {
@@ -1398,7 +1430,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await waitFor(() => {
@@ -1438,7 +1470,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await waitFor(() => {
@@ -1474,7 +1506,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await waitFor(() => {
@@ -1510,7 +1542,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await waitFor(() => {
@@ -1550,7 +1582,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await waitFor(() => {
@@ -1621,7 +1653,8 @@ describe('Vulnerability Table', () => {
             }
         ];
 
-        render(<TableVulnerabilities vulnerabilities={vulnsWithMissing} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        Vulnerabilities.list.mockResolvedValueOnce(vulnsWithMissing);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         // All three vulnerabilities should be visible initially
@@ -1661,7 +1694,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await waitFor(() => {
@@ -1703,7 +1736,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await waitFor(() => {
@@ -1738,7 +1771,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await waitFor(() => {
@@ -1771,7 +1804,7 @@ describe('Vulnerability Table', () => {
     });
 
     test('published date column can be disabled', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         // Published Date column is visible by default
@@ -1832,7 +1865,8 @@ describe('Vulnerability Table', () => {
             }
         ];
 
-        render(<TableVulnerabilities vulnerabilities={vulnsWithMissing} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        Vulnerabilities.list.mockResolvedValueOnce(vulnsWithMissing);
+        render(<TableVulnerabilities />);
 
         // "Unknown" should appear for the vuln without published date
         await waitFor(() => {
@@ -1851,7 +1885,7 @@ describe('Vulnerability Table', () => {
             message: 'Done',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await waitFor(() => {
@@ -1885,7 +1919,7 @@ describe('Vulnerability Table', () => {
             message: 'Downloading...',
         });
 
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         // Button should remain disabled because NVD is in progress
         await waitFor(() => {
@@ -1895,14 +1929,14 @@ describe('Vulnerability Table', () => {
     });
 
     test('shortcut helper icon is visible', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const helperBtn = await screen.getByRole('button', { name: /shortcut helper/i });
         expect(helperBtn).toBeInTheDocument();
     });
 
     test('shortcut helper shows keyboard shortcuts content', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const helperBtn = await screen.getByRole('button', { name: /shortcut helper/i });
@@ -1922,7 +1956,7 @@ describe('Vulnerability Table', () => {
     });
 
     test('search syntax helper is visible and shows syntax content when clicked', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const helperBtn = screen.getByRole('button', { name: /search syntax helper/i });
@@ -1938,7 +1972,7 @@ describe('Vulnerability Table', () => {
     });
 
     test('pressing / focuses vulnerability search bar', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
         const searchBar = await screen.getByRole('searchbox') as HTMLInputElement;
@@ -1951,12 +1985,12 @@ describe('Vulnerability Table', () => {
     });
 
     test('ArrowDown and ArrowUp navigate focused vulnerability row', async () => {
-        const { container } = render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const { container } = render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
+        // Wait for table rows to appear
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThanOrEqual(3));
         const rows = container.querySelectorAll('tr.row-with-hover-effect');
-
-        expect(rows.length).toBeGreaterThanOrEqual(3);
 
         const firstRow = rows[0] as HTMLElement;
         const secondRow = rows[1] as HTMLElement;
@@ -1976,12 +2010,12 @@ describe('Vulnerability Table', () => {
     });
 
     test('Home and End navigate to first and last vulnerability row', async () => {
-        const { container } = render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const { container } = render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
+        // Wait for table rows to appear
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThanOrEqual(3));
         const rows = container.querySelectorAll('tr.row-with-hover-effect');
-
-        expect(rows.length).toBeGreaterThanOrEqual(3);
 
         const firstRow = rows[0] as HTMLElement;
         const secondRow = rows[1] as HTMLElement;
@@ -2002,9 +2036,11 @@ describe('Vulnerability Table', () => {
     });
 
     test('pressing e opens edit modal for focused vulnerability', async () => {
-        const { container } = render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const { container } = render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
+        // Wait for rows to appear
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThan(0));
         const rows = container.querySelectorAll('tr.row-with-hover-effect');
         const firstRow = rows[0] as HTMLElement;
 
@@ -2024,9 +2060,11 @@ describe('Vulnerability Table', () => {
     });
 
     test('pressing v opens view modal for focused vulnerability', async () => {
-        const { container } = render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const { container } = render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
+        // Wait for rows to appear
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThanOrEqual(2));
         const rows = container.querySelectorAll('tr.row-with-hover-effect');
         const firstRow = rows[0] as HTMLElement;
         const secondRow = rows[1] as HTMLElement;
@@ -2047,7 +2085,9 @@ describe('Vulnerability Table', () => {
     });
 
     test('tooltip portal behaviour: appears on hover with correct content and styles, disappears on mouseleave', async () => {
-        const { container } = render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const { container } = render(<TableVulnerabilities />);
+        // Wait for rows to appear
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThan(0));
         const rows = container.querySelectorAll('tr.row-with-hover-effect');
         const scrollContainer = container.querySelector('.overflow-auto');
 
@@ -2073,7 +2113,10 @@ describe('Vulnerability Table', () => {
     });
 
     test('tooltip truncates long descriptions via overflow-hidden and webkit line-clamp', async () => {
-        const { container } = render(<TableVulnerabilities vulnerabilities={[vulnWithLongText]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        Vulnerabilities.list.mockResolvedValueOnce([vulnWithLongText]);
+        const { container } = render(<TableVulnerabilities />);
+        // Wait for the row to appear
+        await waitFor(() => expect(container.querySelectorAll('tr.row-with-hover-effect').length).toBeGreaterThan(0));
         const rows = container.querySelectorAll('tr.row-with-hover-effect');
 
         fireEvent.mouseEnter(rows[0]);
@@ -2090,7 +2133,7 @@ describe('Vulnerability Table', () => {
     });
 
      test('filter buttons have no active border by default', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const sourceBtn = screen.getByRole('button', { name: /^source$/i });
         const severityBtn = screen.getByRole('button', { name: /^severity$/i });
@@ -2105,7 +2148,7 @@ describe('Vulnerability Table', () => {
     });
 
     test('filter buttons show active border when a filter option is selected', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
 
@@ -2218,12 +2261,15 @@ describe('More Filters dropdown', () => {
         return getDOMRect(500, 500);
     });
 
+    const VulnerabilitiesMoreFilters = require('../../src/handlers/vulnerabilities').default;
+
     beforeEach(() => {
         fetchMock.resetMocks();
+        VulnerabilitiesMoreFilters.list.mockResolvedValue(vulnerabilities);
     });
 
     test('opens More Filters dropdown and shows EPSS, Attack Vector, and First Scan Date sections', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         // More Filters button should exist
@@ -2244,14 +2290,14 @@ describe('More Filters dropdown', () => {
     });
 
     test('toggles Attack Vector checkbox filter', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         // Open More Filters
         await user.click(screen.getByText('More'));
 
         // Find "Network" attack vector checkbox and click it
-        const networkLabel = screen.getByText('Network');
+        const networkLabel = await screen.findByText('Network');
         await user.click(networkLabel);
 
         // Should show active filter indicator (checkmark)
@@ -2259,14 +2305,14 @@ describe('More Filters dropdown', () => {
     });
 
     test('toggles First Scan Date checkbox filter', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         // Open More Filters
         await user.click(screen.getByText('More'));
 
         // Find scan date checkboxes — there should be 2 dates from our test data
-        const checkboxes = screen.getAllByRole('checkbox');
+        const checkboxes = await screen.findAllByRole('checkbox');
         // Find one that's in the First Scan Date section (look for scan date text)
         const scanDateLabels = checkboxes.filter(cb => {
             const parent = cb.closest('label');
@@ -2281,7 +2327,7 @@ describe('More Filters dropdown', () => {
     });
 
     test('enables EPSS range filter via checkbox', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         // Open More Filters
@@ -2296,7 +2342,7 @@ describe('More Filters dropdown', () => {
     });
 
     test('closes More Filters dropdown on outside click', async () => {
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         // Open More Filters
@@ -2321,11 +2367,12 @@ describe('More Filters dropdown', () => {
             first_scan_date: undefined
         }];
 
-        render(<TableVulnerabilities vulnerabilities={vulnsNoScanDate} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        VulnerabilitiesMoreFilters.list.mockResolvedValueOnce(vulnsNoScanDate);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await user.click(screen.getByText('More'));
-        expect(screen.getByText('No scan dates available')).toBeInTheDocument();
+        expect(await screen.findByText('No scan dates available')).toBeInTheDocument();
     });
 
     test('shows no attack vectors message when none available', async () => {
@@ -2337,10 +2384,11 @@ describe('More Filters dropdown', () => {
             severity: { ...vulnerabilities[1].severity, cvss: [] }
         }];
 
-        render(<TableVulnerabilities vulnerabilities={vulnsNoCvss} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        VulnerabilitiesMoreFilters.list.mockResolvedValueOnce(vulnsNoCvss);
+        render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
         await user.click(screen.getByText('More'));
-        expect(screen.getByText('No attack vectors available')).toBeInTheDocument();
+        expect(await screen.findByText('No attack vectors available')).toBeInTheDocument();
     });
 });

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -33,18 +33,161 @@ jest.mock('../../src/handlers/epss_progress', () => ({
 }));
 
 // Mock Vulnerabilities handler so the component doesn't make real fetch calls
-jest.mock('../../src/handlers/vulnerabilities', () => ({
-    __esModule: true,
-    default: {
-        list: jest.fn(),
-        enrich_with_assessments: jest.requireActual('../../src/handlers/vulnerabilities').default.enrich_with_assessments,
-        append_assessment: jest.requireActual('../../src/handlers/vulnerabilities').default.append_assessment,
-        append_cvss: jest.requireActual('../../src/handlers/vulnerabilities').default.append_cvss,
-        calculate_cvss_from_vector: jest.requireActual('../../src/handlers/vulnerabilities').default.calculate_cvss_from_vector,
-    },
-    asVulnerability: jest.requireActual('../../src/handlers/vulnerabilities').asVulnerability,
-    SEVERITY_ORDER: jest.requireActual('../../src/handlers/vulnerabilities').SEVERITY_ORDER,
-}));
+jest.mock('../../src/handlers/vulnerabilities', () => {
+    const _list = jest.fn();
+    const _listPaginated = jest.fn().mockImplementation(async (params: any) => {
+        const allItems: any[] = await _list();
+
+        // Compute facets from unfiltered data
+        const facets = {
+            severities: [...new Set(allItems.map((v: any) => v.severity?.severity).filter(Boolean))],
+            statuses: [...new Set(allItems.map((v: any) => v.simplified_status).filter(Boolean))],
+            sources: [...new Set(allItems.flatMap((v: any) => v.found_by || []).filter(Boolean))],
+            attack_vectors: [...new Set(allItems.flatMap((v: any) => (v.severity?.cvss || []).map((c: any) => c.attack_vector).filter(Boolean)))],
+            first_scan_dates: [...new Set(allItems.map((v: any) => v.first_scan_date ? Math.round(new Date(v.first_scan_date).getTime() / 1000) * 1000 : null).filter(Boolean))],
+        };
+
+        // Apply filters to replicate server behaviour
+        let items = [...allItems];
+
+        if (params?.search && params.search.length > 2) {
+            const orGroups = params.search.toLowerCase().split('|').map((g: string) => g.trim()).filter(Boolean);
+            items = items.filter((v: any) => {
+                const searchable = [
+                    v.id || '',
+                    ...(v.packages || []),
+                    ...(v.texts || []).map((t: any) => t.content || ''),
+                ].join(' ').toLowerCase();
+                return orGroups.some((group: string) => {
+                    const terms = group.split(/\s+/);
+                    return terms.every((term: string) => {
+                        if (term.startsWith('-') && term.length > 1) return !searchable.includes(term.slice(1));
+                        return searchable.includes(term);
+                    });
+                });
+            });
+        }
+        if (params?.severity?.length) {
+            const allowed = new Set(params.severity);
+            items = items.filter((v: any) => allowed.has(v.severity?.severity));
+        }
+        if (params?.simplifiedStatus?.length) {
+            const allowed = new Set(params.simplifiedStatus);
+            items = items.filter((v: any) => allowed.has(v.simplified_status));
+        }
+        if (params?.foundBy?.length) {
+            const allowed = new Set(params.foundBy);
+            items = items.filter((v: any) => (v.found_by || []).some((s: string) => allowed.has(s)));
+        }
+        if (params?.packages?.length) {
+            const allowed = new Set(params.packages);
+            items = items.filter((v: any) => (v.packages_current || []).some((p: string) => allowed.has(p)));
+        }
+        if (params?.severityMin !== undefined || params?.severityMax !== undefined) {
+            items = items.filter((v: any) => {
+                const score = v.severity?.max_score;
+                if (score === null || score === undefined) return false;
+                if (params.severityMin !== undefined && score < params.severityMin) return false;
+                if (params.severityMax !== undefined && score > params.severityMax) return false;
+                return true;
+            });
+        }
+        if (params?.epssMin !== undefined || params?.epssMax !== undefined) {
+            items = items.filter((v: any) => {
+                const score = v.epss?.score;
+                if (score === undefined || score === null) return false;
+                const pct = score * 100;
+                if (params.epssMin !== undefined && pct < params.epssMin) return false;
+                if (params.epssMax !== undefined && pct > params.epssMax) return false;
+                return true;
+            });
+        }
+        if (params?.attackVector?.length) {
+            const allowed = new Set(params.attackVector);
+            items = items.filter((v: any) => (v.severity?.cvss || []).some((c: any) => allowed.has(c.attack_vector)));
+        }
+        if (params?.publishedDateFilter) {
+            items = items.filter((v: any) => {
+                if (!v.published) return false;
+                const pubDate = new Date(v.published);
+                const pf = params.publishedDateFilter;
+                if (pf === 'is' && params.publishedDateValue) {
+                    const target = new Date(params.publishedDateValue);
+                    return pubDate.getUTCFullYear() === target.getUTCFullYear() &&
+                        pubDate.getUTCMonth() === target.getUTCMonth() &&
+                        pubDate.getUTCDate() === target.getUTCDate();
+                }
+                if (pf === '>=' && params.publishedDateValue) return pubDate >= new Date(params.publishedDateValue);
+                if (pf === '<=' && params.publishedDateValue) return pubDate <= new Date(params.publishedDateValue + 'T23:59:59Z');
+                if (pf === 'between' && params.publishedDateFrom && params.publishedDateTo)
+                    return pubDate >= new Date(params.publishedDateFrom) && pubDate <= new Date(params.publishedDateTo + 'T23:59:59Z');
+                if (pf === 'days_ago' && params.publishedDaysValue) {
+                    const cutoff = new Date(); cutoff.setDate(cutoff.getDate() - parseInt(params.publishedDaysValue));
+                    return pubDate >= cutoff;
+                }
+                return true;
+            });
+        }
+        if (params?.firstScanDate?.length) {
+            const allowed = new Set(params.firstScanDate.map(String));
+            items = items.filter((v: any) => {
+                if (!v.first_scan_date) return false;
+                const ts = String(Math.round(new Date(v.first_scan_date).getTime() / 1000) * 1000);
+                return allowed.has(ts);
+            });
+        }
+
+        // Sort
+        if (params?.sortBy) {
+            const dir = params.sortDir === 'asc' ? 1 : -1;
+            items.sort((a: any, b: any) => {
+                let va: any, vb: any;
+                if (params.sortBy === 'assessments') {
+                    const latest = (v: any) => {
+                        if (!v.assessments?.length) return null;
+                        return Math.max(...v.assessments.map((ass: any) => new Date(ass.last_update || ass.timestamp).getTime()));
+                    };
+                    va = latest(a); vb = latest(b);
+                    if (va === null && vb === null) return 0;
+                    if (va === null) return dir;
+                    if (vb === null) return -dir;
+                } else if (params.sortBy === 'id') {
+                    va = a.id; vb = b.id;
+                } else if (params.sortBy === 'severity.severity') {
+                    const order: Record<string, number> = { critical: 5, high: 4, medium: 3, low: 2, none: 1 };
+                    va = order[a.severity?.severity?.toLowerCase()] || 0;
+                    vb = order[b.severity?.severity?.toLowerCase()] || 0;
+                } else {
+                    return 0;
+                }
+                if (va < vb) return -dir;
+                if (va > vb) return dir;
+                return 0;
+            });
+        }
+
+        return {
+            items,
+            total: items.length,
+            page: params?.page ?? 1,
+            page_size: params?.pageSize ?? 50,
+            facets,
+        };
+    });
+    return {
+        __esModule: true,
+        default: {
+            list: _list,
+            listPaginated: _listPaginated,
+            enrich_with_assessments: jest.requireActual('../../src/handlers/vulnerabilities').default.enrich_with_assessments,
+            append_assessment: jest.requireActual('../../src/handlers/vulnerabilities').default.append_assessment,
+            append_cvss: jest.requireActual('../../src/handlers/vulnerabilities').default.append_cvss,
+            calculate_cvss_from_vector: jest.requireActual('../../src/handlers/vulnerabilities').default.calculate_cvss_from_vector,
+        },
+        asVulnerability: jest.requireActual('../../src/handlers/vulnerabilities').asVulnerability,
+        SEVERITY_ORDER: jest.requireActual('../../src/handlers/vulnerabilities').SEVERITY_ORDER,
+    };
+});
 
 
 const getDOMRect = (width: number, height: number) => ({
@@ -1055,7 +1198,7 @@ describe('Vulnerability Table', () => {
             }
         ];
 
-        Vulnerabilities.list.mockResolvedValueOnce(vulnWithoutAssessments);
+        Vulnerabilities.list.mockResolvedValue(vulnWithoutAssessments);
         render(<TableVulnerabilities />);
 
         // ACT & ASSERT - Vulnerability has empty assessments array, should show "No assessment"
@@ -1086,7 +1229,7 @@ describe('Vulnerability Table', () => {
         ];
 
         // ARRANGE
-        Vulnerabilities.list.mockResolvedValueOnce(vulnWithAssessments);
+        Vulnerabilities.list.mockResolvedValue(vulnWithAssessments);
         render(<TableVulnerabilities />);
 
         // ACT & ASSERT
@@ -1118,7 +1261,7 @@ describe('Vulnerability Table', () => {
         ];
 
         // ARRANGE
-        Vulnerabilities.list.mockResolvedValueOnce(vulnWithUpdatedAssessments);
+        Vulnerabilities.list.mockResolvedValue(vulnWithUpdatedAssessments);
         render(<TableVulnerabilities />);
 
         // ACT & ASSERT - Should show the more recent last_update date
@@ -1165,7 +1308,7 @@ describe('Vulnerability Table', () => {
         ];
 
         // ARRANGE
-        Vulnerabilities.list.mockResolvedValueOnce(vulnWithMultipleAssessments);
+        Vulnerabilities.list.mockResolvedValue(vulnWithMultipleAssessments);
         render(<TableVulnerabilities />);
 
         // ACT & ASSERT - Should show the most recent assessment date (March 10)
@@ -1214,7 +1357,7 @@ describe('Vulnerability Table', () => {
         ];
 
         // ARRANGE
-        Vulnerabilities.list.mockResolvedValueOnce(vulnWithDifferentDates);
+        Vulnerabilities.list.mockResolvedValue(vulnWithDifferentDates);
         render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
@@ -1277,7 +1420,7 @@ describe('Vulnerability Table', () => {
         ];
 
         // ARRANGE
-        Vulnerabilities.list.mockResolvedValueOnce(vulnWithMixedDates);
+        Vulnerabilities.list.mockResolvedValue(vulnWithMixedDates);
         render(<TableVulnerabilities />);
 
         const user = userEvent.setup();
@@ -1653,7 +1796,7 @@ describe('Vulnerability Table', () => {
             }
         ];
 
-        Vulnerabilities.list.mockResolvedValueOnce(vulnsWithMissing);
+        Vulnerabilities.list.mockResolvedValue(vulnsWithMissing);
         render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
@@ -2367,7 +2510,7 @@ describe('More Filters dropdown', () => {
             first_scan_date: undefined
         }];
 
-        VulnerabilitiesMoreFilters.list.mockResolvedValueOnce(vulnsNoScanDate);
+        VulnerabilitiesMoreFilters.list.mockResolvedValue(vulnsNoScanDate);
         render(<TableVulnerabilities />);
         const user = userEvent.setup();
 
@@ -2384,7 +2527,7 @@ describe('More Filters dropdown', () => {
             severity: { ...vulnerabilities[1].severity, cvss: [] }
         }];
 
-        VulnerabilitiesMoreFilters.list.mockResolvedValueOnce(vulnsNoCvss);
+        VulnerabilitiesMoreFilters.list.mockResolvedValue(vulnsNoCvss);
         render(<TableVulnerabilities />);
         const user = userEvent.setup();
 

--- a/src/bin/pyspy_bench.py
+++ b/src/bin/pyspy_bench.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# In-container benchmark harness for VulnScout API routes.
+#
+# Iterates app.url_map and issues N timed GET requests against every
+# idempotent route via Flask's test_client (no socket overhead). Required
+# path converters (variant_id, scan_id, project_id, vulnerability_id,
+# assessment_id) are filled from a single SELECT against the live DB.
+#
+# Output: a Markdown table on stdout sorted by ms/req desc, plus a JSON
+# dump under /scan/outputs/profiles/ for downstream tooling.
+#
+# Designed to be wrapped by `py-spy record -- python3 -m src.bin.pyspy_bench`.
+#
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+
+# Allow `python3 -m src.bin.pyspy_bench` from /scan as well as direct invocation.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from sqlalchemy import text  # noqa: E402
+
+from src.bin.webapp import create_app  # noqa: E402
+from src.extensions import db  # noqa: E402
+
+DEFAULT_DB_PATH = "/cache/vulnscout/vulnscout.db"
+DEFAULT_OUTPUT_DIR = "/scan/outputs/profiles"
+DEFAULT_ITERATIONS = 200
+
+# Path converters we know how to satisfy from the DB. Mapped to the table
+# we pull a representative id from. Unknown converters cause the route to
+# be skipped.
+PARAM_TABLES = {
+    "variant_id": "variants",
+    "scan_id": "scans",
+    "project_id": "projects",
+    "vulnerability_id": "vulnerabilities",
+    "assessment_id": "assessments",
+    "id": None,  # generic — try variants then projects
+    "doc_name": None,  # documents endpoint, filled with a sentinel
+    "path": None,  # static fallthrough — skipped explicitly below
+    "upload_id": None,  # async upload polling — skipped, no live id
+}
+
+# Routes excluded regardless of method / parameter resolution.
+EXCLUDED_RULES = {
+    "/api/scan/status",     # middleware bypass; not representative
+    "/<path:path>",         # CORS OPTIONS shim
+    "/static/<path:filename>",
+}
+
+
+def _build_param_table(app) -> dict[str, str]:
+    """Pull one representative id per known parameter from the live DB."""
+    out: dict[str, str] = {}
+    with app.app_context():
+        for param, table in PARAM_TABLES.items():
+            if table is None:
+                continue
+            try:
+                row = db.session.execute(text(f"SELECT id FROM {table} LIMIT 1")).first()
+                if row is not None:
+                    out[param] = str(row[0])
+            except Exception as e:
+                print(f"[bench] WARN: could not resolve {param} from {table}: {e}", file=sys.stderr)
+    # Generic fallbacks
+    if "id" not in out and "variant_id" in out:
+        out["id"] = out["variant_id"]
+    # /api/documents/<doc_name> — pick something the route will at least parse.
+    out.setdefault("doc_name", "summary.adoc")
+    return out
+
+
+def _fill_path(rule, params: dict[str, str]) -> str | None:
+    """Return concrete URL for a rule, or None if any required arg can't be filled."""
+    try:
+        kwargs = {arg: params[arg] for arg in rule.arguments}
+    except KeyError:
+        return None
+
+    # Substitute <converter:name> or <name> placeholders directly in rule.rule.
+    # Avoids relying on rule.build() which requires a bound URL map adapter.
+    placeholder_re = re.compile(r"<(?:[^:>]+:)?([^>]+)>")
+
+    def _sub(m: re.Match) -> str:
+        return kwargs[m.group(1)]
+
+    try:
+        return placeholder_re.sub(_sub, rule.rule)
+    except KeyError:
+        return None
+
+
+def _discover_routes(app, params: dict[str, str], filter_re: re.Pattern | None):
+    """Yield (rule_string, concrete_url) for every benchmarkable GET route."""
+    seen: set[str] = set()
+    for rule in app.url_map.iter_rules():
+        methods = rule.methods or set()
+        if "GET" not in methods:
+            continue
+        if rule.rule in EXCLUDED_RULES:
+            continue
+        if rule.rule.startswith("/static/"):
+            continue
+        url = _fill_path(rule, params)
+        if url is None:
+            continue
+        if filter_re and not filter_re.search(rule.rule):
+            continue
+        if url in seen:
+            continue
+        seen.add(url)
+        yield rule.rule, url
+
+
+def _bench_one(client, app, url: str, iterations: int) -> dict:
+    # Warm-up — also tells us the response code/size and whether it errors.
+    with app.app_context():
+        warm = client.get(url)
+    status = warm.status_code
+    size = len(warm.data)
+
+    t0 = time.perf_counter()
+    for _ in range(iterations):
+        with app.app_context():
+            client.get(url)
+    elapsed = time.perf_counter() - t0
+
+    return {
+        "url": url,
+        "status": status,
+        "bytes": size,
+        "iterations": iterations,
+        "total_s": elapsed,
+        "req_per_s": iterations / elapsed if elapsed > 0 else 0.0,
+        "ms_per_req": (elapsed / iterations) * 1000 if iterations > 0 else 0.0,
+    }
+
+
+def _setup_app(db_path: str):
+    # Read-only SQLite URI so we never accidentally mutate the live DB.
+    abs_db = os.path.abspath(db_path)
+    if not os.path.exists(abs_db):
+        raise SystemExit(f"DB not found: {abs_db}")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{abs_db}"
+
+    # Satisfy the scan-finished middleware without touching /scan/status.txt.
+    marker = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False)
+    marker.write("8 __END_OF_SCAN_SCRIPT__\n")
+    marker.close()
+    os.environ["FLASK_SCAN_FILE"] = marker.name
+
+    # Suppress background enrichment threads during benchmark.
+    os.environ["FLASK_TESTING"] = "True"
+
+    app = create_app()
+    app.config["TESTING"] = True
+    app._INT_SCAN_FINISHED = True
+    return app, marker.name
+
+
+def _print_table(results: list[dict]) -> str:
+    results = sorted(results, key=lambda r: r["ms_per_req"], reverse=True)
+    lines = [
+        "| ms/req | req/s  | status | bytes | URL |",
+        "|-------:|-------:|:------:|------:|:----|",
+    ]
+    for r in results:
+        lines.append(
+            f"| {r['ms_per_req']:6.2f} | {r['req_per_s']:6.1f} "
+            f"| {r['status']:^6} | {r['bytes']:5d} | `{r['url']}` |"
+        )
+    out = "\n".join(lines)
+    print(out)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Benchmark VulnScout API routes.")
+    p.add_argument("--db", default=DEFAULT_DB_PATH, help="Path to vulnscout.db")
+    p.add_argument("--iterations", "-n", type=int, default=DEFAULT_ITERATIONS,
+                   help=f"Requests per route (default: {DEFAULT_ITERATIONS})")
+    p.add_argument("--filter", "-f", default=None,
+                   help="Regex applied to the rule string (e.g. '^/api/vulnerab')")
+    p.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR,
+                   help="Directory for JSON dump (created if missing)")
+    p.add_argument("--list-only", action="store_true",
+                   help="Only print discovered URLs, do not benchmark")
+    args = p.parse_args(argv)
+
+    filter_re = re.compile(args.filter) if args.filter else None
+    app, marker_path = _setup_app(args.db)
+
+    try:
+        params = _build_param_table(app)
+        print(f"[bench] Resolved params: {params}", file=sys.stderr)
+
+        routes = list(_discover_routes(app, params, filter_re))
+        if not routes:
+            print("[bench] No routes matched.", file=sys.stderr)
+            return 1
+
+        print(f"[bench] {len(routes)} route(s) to benchmark "
+              f"({args.iterations} iter each).", file=sys.stderr)
+
+        if args.list_only:
+            for rule, url in routes:
+                print(f"{rule}\t{url}")
+            return 0
+
+        client = app.test_client()
+        results: list[dict] = []
+        for i, (rule, url) in enumerate(routes, 1):
+            print(f"[bench] ({i}/{len(routes)}) {url}", file=sys.stderr)
+            try:
+                res = _bench_one(client, app, url, args.iterations)
+            except Exception as e:
+                print(f"[bench] ERROR on {url}: {e}", file=sys.stderr)
+                continue
+            res["rule"] = rule
+            results.append(res)
+
+        os.makedirs(args.output_dir, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        json_path = os.path.join(args.output_dir, f"bench_{ts}.json")
+        md_path = os.path.join(args.output_dir, f"bench_{ts}.md")
+
+        table = _print_table(results)
+        with open(json_path, "w") as f:
+            json.dump({
+                "generated_at": ts,
+                "iterations_per_route": args.iterations,
+                "db": os.path.abspath(args.db),
+                "results": results,
+            }, f, indent=2)
+        with open(md_path, "w") as f:
+            f.write(table + "\n")
+
+        print(f"\n[bench] JSON: {json_path}", file=sys.stderr)
+        print(f"[bench] MD:   {md_path}", file=sys.stderr)
+        return 0
+    finally:
+        try:
+            os.unlink(marker_path)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bin/pyspy_live.sh
+++ b/src/bin/pyspy_live.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# Attach py-spy to the running Flask server and concurrently drive every
+# discovered idempotent GET route via curl from inside the container.
+# Produces a speedscope-format flamegraph in /scan/outputs/profiles/.
+#
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+set -euo pipefail
+
+DURATION="${PYSPY_DURATION:-30}"
+RATE="${PYSPY_RATE:-100}"
+HOST="${PYSPY_HOST:-127.0.0.1}"
+PORT="${FLASK_RUN_PORT:-7275}"
+OUT_DIR="${PYSPY_OUTPUT_DIR:-/scan/outputs/profiles}"
+FILTER_RE="${PYSPY_FILTER:-}"
+
+usage() {
+    cat <<EOF
+Usage: pyspy_live.sh [--duration N] [--filter <regex>] [--rate Hz]
+
+Environment overrides:
+  PYSPY_DURATION (default: 30 s)
+  PYSPY_RATE     (default: 100 Hz)
+  PYSPY_FILTER   (default: empty — hit every discovered route)
+  PYSPY_HOST     (default: 127.0.0.1)
+  PYSPY_OUTPUT_DIR (default: /scan/outputs/profiles)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --duration) DURATION="$2"; shift 2 ;;
+        --filter)   FILTER_RE="$2"; shift 2 ;;
+        --rate)     RATE="$2"; shift 2 ;;
+        -h|--help)  usage; exit 0 ;;
+        *) echo "Unknown arg: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if ! command -v py-spy &>/dev/null; then
+    echo "Error: py-spy not installed in this image. Rebuild with the updated Dockerfile." >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+TS="$(date -u +%Y%m%d_%H%M%S)"
+OUT_FILE="$OUT_DIR/live_${TS}.json"
+
+# Locate the Flask worker PID. `flask run` may spawn a reloader child; pick
+# the last (deepest) match so we attach to the actual request handler process.
+FLASK_PID="$(pgrep -f 'flask.*src.bin.webapp.*run' | tail -n1 || true)"
+if [[ -z "$FLASK_PID" ]]; then
+    echo "Error: no running Flask process found. Start the server with 'vulnscout --serve' first." >&2
+    exit 1
+fi
+echo "[pyspy/live] attaching to PID=$FLASK_PID for ${DURATION}s -> $OUT_FILE"
+
+# Discover URLs via the bench harness (--list-only does no work, just parses url_map).
+mapfile -t URLS < <(
+    BENCH_ARGS=(--list-only)
+    [[ -n "$FILTER_RE" ]] && BENCH_ARGS+=(--filter "$FILTER_RE")
+    cd /scan && python3 -m src.bin.pyspy_bench "${BENCH_ARGS[@]}" 2>/dev/null \
+        | awk -F'\t' 'NF==2 {print $2}'
+)
+if [[ ${#URLS[@]} -eq 0 ]]; then
+    echo "Error: route discovery returned no URLs." >&2
+    exit 1
+fi
+echo "[pyspy/live] driving ${#URLS[@]} route(s) against http://${HOST}:${PORT}"
+
+# Start py-spy in the background.
+py-spy record \
+    --pid "$FLASK_PID" \
+    --output "$OUT_FILE" \
+    --format speedscope \
+    --rate "$RATE" \
+    --duration "$DURATION" &
+PYSPY_PID=$!
+
+# Drive traffic for the entire capture window. Round-robin across URLs so
+# every route gets samples. Counter is appended to a tempfile per request
+# (instead of held in a subshell variable) so it survives a kill from the
+# parent when py-spy's --duration window closes first.
+COUNT_FILE="$(mktemp)"
+END_AT=$(( $(date +%s) + DURATION ))
+(
+    while [[ $(date +%s) -lt $END_AT ]]; do
+        for url in "${URLS[@]}"; do
+            curl -fsS --max-time 5 -o /dev/null "http://${HOST}:${PORT}${url}" 2>/dev/null || true
+            echo . >> "$COUNT_FILE"
+            [[ $(date +%s) -ge $END_AT ]] && break
+        done
+    done
+) &
+LOAD_PID=$!
+
+wait "$PYSPY_PID"
+PYSPY_EXIT=$?
+kill "$LOAD_PID" 2>/dev/null || true
+wait "$LOAD_PID" 2>/dev/null || true
+COUNT="$(wc -c < "$COUNT_FILE" 2>/dev/null | tr -d ' ' || echo 0)"
+rm -f "$COUNT_FILE"
+
+echo "[pyspy/live] sent $COUNT request(s); profile written to $OUT_FILE (exit=$PYSPY_EXIT)"
+echo "[pyspy/live] open with: https://www.speedscope.app/  (drag the JSON in)"
+exit $PYSPY_EXIT

--- a/src/migrations/versions/e5a9d2c7f1b3_add_composite_and_project_indexes.py
+++ b/src/migrations/versions/e5a9d2c7f1b3_add_composite_and_project_indexes.py
@@ -1,0 +1,35 @@
+"""add composite and project indexes for query optimization
+
+Revision ID: e5a9d2c7f1b3
+Revises: b4e9f2a7c3d1
+Create Date: 2026-04-08 10:00:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'e5a9d2c7f1b3'
+down_revision = 'b4e9f2a7c3d1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Composite index on observations (scan_id, finding_id) – covers
+    # the hot join pattern: JOIN observations ON finding_id = ? WHERE scan_id IN (...)
+    op.create_index(
+        'ix_observations_scan_finding', 'observations',
+        ['scan_id', 'finding_id'],
+    )
+
+    # variants.project_id – used by _latest_scan_ids_for_project and
+    # _populate_found_by to scope queries to a single project.
+    op.create_index(
+        'ix_variants_project_id', 'variants', ['project_id'],
+    )
+
+
+def downgrade():
+    op.drop_index('ix_variants_project_id', 'variants')
+    op.drop_index('ix_observations_scan_finding', 'observations')

--- a/src/models/observation.py
+++ b/src/models/observation.py
@@ -12,6 +12,9 @@ class Observation(Base):
     """Represents an observation linking a finding to a scan."""
 
     __tablename__ = "observations"
+    __table_args__ = (
+        db.Index("ix_observations_scan_finding", "scan_id", "finding_id"),
+    )
 
     id = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
     finding_id = db.Column(db.Uuid, db.ForeignKey("findings.id"), nullable=False, index=True)

--- a/src/models/variant.py
+++ b/src/models/variant.py
@@ -19,7 +19,7 @@ class Variant(Base):
 
     id = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String, nullable=False)
-    project_id = db.Column(db.Uuid, db.ForeignKey("projects.id"), nullable=False)
+    project_id = db.Column(db.Uuid, db.ForeignKey("projects.id"), nullable=False, index=True)
 
     project = db.relationship("Project", back_populates="variants")
     scans = db.relationship("Scan", back_populates="variant", cascade="all, delete-orphan")

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -16,6 +16,7 @@ from .config import init_app as init_config_app
 from .notifications import init_app as init_notifications_app
 from .settings import init_app as init_settings_app
 from .frontpage import init_app as init_front_app
+from .metrics import init_app as init_metrics_app
 
 
 def init_app(app):
@@ -32,6 +33,7 @@ def init_app(app):
     init_config_app(app)
     init_notifications_app(app)
     init_settings_app(app)
+    init_metrics_app(app)
     # keep front endpoint at the end
     init_front_app(app)
     return app

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -26,6 +26,63 @@ def init_app(app):
     def _get_all_db_assessments():
         return DBAssessment.get_all()
 
+    def _all_assessment_dicts_fast() -> list[dict]:
+        """Return all assessments serialised to dicts via projection queries.
+
+        Bypasses ORM hydration on the hot path: one query for assessment
+        columns + finding.vulnerability_id + package.name/version,
+        producing dicts in the same shape as ``Assessment.to_dict()``.
+        """
+        rows = db.session.execute(
+            db.select(
+                DBAssessment.id,
+                DBAssessment.source,
+                DBAssessment.origin,
+                DBAssessment.variant_id,
+                DBAssessment.timestamp,
+                DBAssessment.status,
+                DBAssessment.status_notes,
+                DBAssessment.justification,
+                DBAssessment.impact_statement,
+                DBAssessment.responses,
+                DBAssessment.workaround,
+                Finding.vulnerability_id,
+                Package.name,
+                Package.version,
+            )
+            .outerjoin(Finding, DBAssessment.finding_id == Finding.id)
+            .outerjoin(Package, Finding.package_id == Package.id)
+            .order_by(DBAssessment.timestamp)
+        ).all()
+
+        result: list[dict] = []
+        for (
+            aid, source, origin, variant_id, timestamp, status, status_notes,
+            justification, impact_statement, responses, workaround,
+            vuln_id, pkg_name, pkg_version,
+        ) in rows:
+            ts_iso = timestamp.isoformat() if timestamp is not None and hasattr(timestamp, "isoformat") else (
+                str(timestamp) if timestamp is not None else None
+            )
+            packages = [f"{pkg_name}@{pkg_version}"] if pkg_name is not None else []
+            result.append({
+                "id": str(aid),
+                "source": source or "",
+                "origin": origin or "sbom",
+                "vuln_id": vuln_id or "",
+                "packages": packages,
+                "variant_id": str(variant_id) if variant_id else None,
+                "timestamp": ts_iso,
+                "last_update": ts_iso or "",
+                "status": status or "",
+                "status_notes": status_notes or "",
+                "justification": justification or "",
+                "impact_statement": impact_statement or "",
+                "responses": list(responses or []),
+                "workaround": workaround or "",
+            })
+        return result
+
     def _save_openvex():
         """Re-generate and save the OpenVEX file from current DB state."""
         try:
@@ -70,7 +127,7 @@ def init_app(app):
             else:
                 assessments = []
         else:
-            assessments = [a.to_dict() for a in _get_all_db_assessments()]
+            assessments = _all_assessment_dicts_fast()
         if request.args.get('format', 'list') == "dict":
             return {a["id"]: a for a in assessments}
         return assessments

--- a/src/routes/metrics.py
+++ b/src/routes/metrics.py
@@ -165,6 +165,11 @@ def _compute_evolution(
 
 def init_app(app):
 
+    # In-process cache for the unscoped metrics response. Invalidated by a
+    # cheap content signature query so any DB mutation (ingestion, new
+    # assessment) auto-invalidates without explicit hooks.
+    _metrics_cache: dict = {"sig": None, "by_scale": {}}
+
     @app.route('/api/metrics')
     def get_metrics():
         variant_id_raw = request.args.get('variant_id')
@@ -216,6 +221,33 @@ def init_app(app):
             }
 
         # ── Scoped vulnerability IDs ─────────────────────────────────────
+        # When scoped, ``vuln_ids`` materialises the in-scope set used as a
+        # WHERE filter. When unscoped, we set ``unscoped = True`` and skip
+        # the IN-list filtering everywhere below: re-binding an 11k-element
+        # IN list across 5+ queries is the single biggest cost of this
+        # endpoint. The natural table joins already give us "all vulns".
+        unscoped = scope_variant is None and scope_project is None
+
+        # Cache lookup for the unscoped response. The signature query is
+        # cheap (4 COUNT/MAX queries on indexed columns) and invalidates
+        # automatically on any DB mutation.
+        if unscoped:
+            sig_row = db.session.execute(db.text(
+                "SELECT (SELECT COUNT(*) FROM vulnerabilities),"
+                " (SELECT COUNT(*) FROM assessments),"
+                " (SELECT COUNT(*) FROM findings),"
+                " (SELECT MAX(timestamp) FROM assessments)"
+            )).first()
+            sig = (sig_row, scale, unit)
+            if _metrics_cache["sig"] == sig_row:
+                cached = _metrics_cache["by_scale"].get((scale, unit))
+                if cached is not None:
+                    return cached
+            else:
+                # DB has changed — drop all per-(scale,unit) entries
+                _metrics_cache["sig"] = sig_row
+                _metrics_cache["by_scale"] = {}
+
         if scope_variant is not None or scope_project is not None:
             if not current_scan_ids:
                 return _empty()
@@ -225,24 +257,36 @@ def init_app(app):
                 .where(Observation.scan_id.in_(current_scan_ids))
                 .distinct()
             ).scalars().all())
+            if not vuln_ids:
+                return _empty()
         else:
-            vuln_ids = list(db.session.execute(
-                db.select(Vulnerability.id)
-            ).scalars().all())
+            # Unscoped — skip the 11k-element IN-list. We still need a
+            # cheap existence check so we can short-circuit on an empty DB.
+            has_any = db.session.execute(
+                db.select(Vulnerability.id).limit(1)
+            ).first()
+            if not has_any:
+                return _empty()
+            vuln_ids = []  # sentinel; only used for the active-vuln list later
 
-        if not vuln_ids:
-            return _empty()
+        def _vfilter(query, column):
+            """Apply ``column.in_(vuln_ids)`` only when scoped."""
+            if unscoped:
+                return query
+            return query.where(column.in_(vuln_ids))
 
         # ── 1. Severity distribution ─────────────────────────────────────
         # Prefer max CVSS score; fall back to the vulnerability's status column
         sev_rows = db.session.execute(
-            db.select(
+            _vfilter(
+                db.select(
+                    Vulnerability.id,
+                    Vulnerability.status,
+                    func.max(MetricsModel.score).label('max_score'),
+                )
+                .outerjoin(MetricsModel, MetricsModel.vulnerability_id == Vulnerability.id),
                 Vulnerability.id,
-                Vulnerability.status,
-                func.max(MetricsModel.score).label('max_score'),
             )
-            .outerjoin(MetricsModel, MetricsModel.vulnerability_id == Vulnerability.id)
-            .where(Vulnerability.id.in_(vuln_ids))
             .group_by(Vulnerability.id, Vulnerability.status)
         ).all()
 
@@ -258,14 +302,16 @@ def init_app(app):
         # Lightweight query: only the columns needed for evolution and status aggregation.
         # Full assessment details are fetched separately for top-vulns only.
         slim_assess_rows = db.session.execute(
-            db.select(
+            _vfilter(
+                db.select(
+                    Finding.vulnerability_id,
+                    Assessment.timestamp,
+                    Assessment.status,
+                    Assessment.simplified_status,
+                )
+                .join(Finding, Assessment.finding_id == Finding.id),
                 Finding.vulnerability_id,
-                Assessment.timestamp,
-                Assessment.status,
-                Assessment.simplified_status,
             )
-            .join(Finding, Assessment.finding_id == Finding.id)
-            .where(Finding.vulnerability_id.in_(vuln_ids))
             .order_by(Finding.vulnerability_id, Assessment.timestamp)
         ).all()
 
@@ -288,16 +334,33 @@ def init_app(app):
         latest_status_by_vuln: dict[str, str] = latest_sstat_by_vuln
 
         status_counts = [0, 0, 0, 0]  # Not affected, Fixed, Pending Assessment, Exploitable
-        for vid in vuln_ids:
-            sstat = latest_status_by_vuln.get(vid, 'Pending Assessment')
-            if sstat == 'Not affected':
-                status_counts[0] += 1
-            elif sstat == 'Fixed':
-                status_counts[1] += 1
-            elif sstat == 'Pending Assessment':
-                status_counts[2] += 1
-            else:
-                status_counts[3] += 1
+        if unscoped:
+            # Total = COUNT(*) of vulnerabilities; assessed counts come from rows
+            total_vulns = db.session.execute(
+                db.select(func.count(Vulnerability.id))
+            ).scalar() or 0
+            for sstat in latest_status_by_vuln.values():
+                if sstat == 'Not affected':
+                    status_counts[0] += 1
+                elif sstat == 'Fixed':
+                    status_counts[1] += 1
+                elif sstat == 'Pending Assessment':
+                    status_counts[2] += 1
+                else:
+                    status_counts[3] += 1
+            assessed = sum(status_counts)
+            status_counts[2] += max(0, total_vulns - assessed)
+        else:
+            for vid in vuln_ids:
+                sstat = latest_status_by_vuln.get(vid, 'Pending Assessment')
+                if sstat == 'Not affected':
+                    status_counts[0] += 1
+                elif sstat == 'Fixed':
+                    status_counts[1] += 1
+                elif sstat == 'Pending Assessment':
+                    status_counts[2] += 1
+                else:
+                    status_counts[3] += 1
 
         # ── 3. Evolution data ────────────────────────────────────────────
         checkpoints = _generate_checkpoints(scale, unit)
@@ -311,8 +374,9 @@ def init_app(app):
             .join(SBOMPackage, SBOMPackage.package_id == Finding.package_id)
             .join(SBOMDocument, SBOMDocument.id == SBOMPackage.sbom_document_id)
             .where(SBOMDocument.format.isnot(None))
-            .where(Finding.vulnerability_id.in_(vuln_ids))
         )
+        if not unscoped:
+            source_query = source_query.where(Finding.vulnerability_id.in_(vuln_ids))
         if scope_variant is not None:
             source_query = (
                 source_query
@@ -372,7 +436,6 @@ def init_app(app):
                     func.count(Finding.vulnerability_id.distinct()).label('cnt'),
                 )
                 .join(Finding, Finding.package_id == Package.id)
-                .where(Finding.vulnerability_id.in_(vuln_ids))
                 .group_by(Package.name, Package.version)
                 .order_by(func.count(Finding.vulnerability_id.distinct()).desc())
                 .limit(5)
@@ -384,10 +447,22 @@ def init_app(app):
         ]
 
         # ── 6. Top unfixed vulnerabilities ────────────────────────────────
-        active_vuln_ids = [
-            vid for vid in vuln_ids
-            if latest_status_by_vuln.get(vid, 'Pending Assessment') not in ('Fixed', 'Not affected')
-        ]
+        if unscoped:
+            # Cheap: vulns marked Fixed/Not affected are typically a small set;
+            # the *active* set = all vulns minus that small exclusion set.
+            non_active_ids = {
+                vid for vid, sstat in latest_status_by_vuln.items()
+                if sstat in ('Fixed', 'Not affected')
+            }
+            active_q = db.select(Vulnerability.id)
+            if non_active_ids:
+                active_q = active_q.where(~Vulnerability.id.in_(non_active_ids))
+            active_vuln_ids = list(db.session.execute(active_q).scalars().all())
+        else:
+            active_vuln_ids = [
+                vid for vid in vuln_ids
+                if latest_status_by_vuln.get(vid, 'Pending Assessment') not in ('Fixed', 'Not affected')
+            ]
 
         if not active_vuln_ids:
             top_vulns: list = []
@@ -437,6 +512,57 @@ def init_app(app):
 
             # Build response ordered by rank
             records_by_id = {r.id: r for r in top_records}
+
+            # Bulk-load all assessments for the top-5 in a single query,
+            # then group by vuln_id. Replaces the per-vuln SELECT loop.
+            bulk_assess_rows = db.session.execute(
+                db.select(
+                    Finding.vulnerability_id,
+                    Assessment.id.label('assess_id'),
+                    Assessment.source,
+                    Assessment.status,
+                    Assessment.simplified_status,
+                    Assessment.status_notes,
+                    Assessment.justification,
+                    Assessment.impact_statement,
+                    Assessment.responses,
+                    Assessment.workaround,
+                    Assessment.timestamp,
+                    Assessment.variant_id,
+                    Package.name.label('pkg_name'),
+                    Package.version.label('pkg_version'),
+                )
+                .join(Finding, Assessment.finding_id == Finding.id)
+                .join(Package, Finding.package_id == Package.id)
+                .where(Finding.vulnerability_id.in_(top5_ids))
+                .order_by(Finding.vulnerability_id, Assessment.timestamp)
+            ).all()
+            assess_by_vuln: dict[str, list[dict]] = {}
+            for row in bulk_assess_rows:
+                vid_b = row.vulnerability_id
+                ts = row.timestamp
+                ts_str = (
+                    ts.isoformat() if ts is not None and hasattr(ts, 'isoformat')
+                    else (str(ts) if ts else None)
+                )
+                sstat = row.simplified_status or STATUS_TO_SIMPLIFIED.get(row.status or '', 'Pending Assessment')
+                assess_by_vuln.setdefault(vid_b, []).append({
+                    "id": str(row.assess_id),
+                    "source": row.source or "",
+                    "vuln_id": vid_b,
+                    "packages": [f"{row.pkg_name}@{row.pkg_version}"],
+                    "variant_id": str(row.variant_id) if row.variant_id else None,
+                    "timestamp": ts_str,
+                    "last_update": ts_str or "",
+                    "status": row.status or "",
+                    "simplified_status": sstat or 'Pending Assessment',
+                    "status_notes": row.status_notes or "",
+                    "justification": row.justification or "",
+                    "impact_statement": row.impact_statement or "",
+                    "responses": list(row.responses or []),
+                    "workaround": row.workaround or "",
+                })
+
             top_vulns = []
             for rank_idx, vid in enumerate(top5_ids):
                 record = records_by_id.get(vid)
@@ -445,55 +571,7 @@ def init_app(app):
                 vuln_dict = record.to_dict()
                 vuln_dict['packages_current'] = sorted(pkgs_current.get(vid, []))
                 vuln_dict['simplified_status'] = latest_status_by_vuln.get(vid, 'Pending Assessment')
-
-                # Fetch full assessment details for this top-5 vuln (modal data)
-                top_assess_rows = db.session.execute(
-                    db.select(
-                        Assessment.id.label('assess_id'),
-                        Assessment.source,
-                        Assessment.status,
-                        Assessment.simplified_status,
-                        Assessment.status_notes,
-                        Assessment.justification,
-                        Assessment.impact_statement,
-                        Assessment.responses,
-                        Assessment.workaround,
-                        Assessment.timestamp,
-                        Assessment.variant_id,
-                        Package.name.label('pkg_name'),
-                        Package.version.label('pkg_version'),
-                    )
-                    .join(Finding, Assessment.finding_id == Finding.id)
-                    .join(Package, Finding.package_id == Package.id)
-                    .where(Finding.vulnerability_id == vid)
-                    .order_by(Assessment.timestamp)
-                ).all()
-
-                assess_dicts = []
-                for row in top_assess_rows:
-                    ts = row.timestamp
-                    ts_str = (
-                        ts.isoformat() if ts is not None and hasattr(ts, 'isoformat')
-                        else (str(ts) if ts else None)
-                    )
-                    sstat = row.simplified_status or STATUS_TO_SIMPLIFIED.get(row.status or '', 'Pending Assessment')
-                    assess_dicts.append({
-                        "id": str(row.assess_id),
-                        "source": row.source or "",
-                        "vuln_id": vid,
-                        "packages": [f"{row.pkg_name}@{row.pkg_version}"],
-                        "variant_id": str(row.variant_id) if row.variant_id else None,
-                        "timestamp": ts_str,
-                        "last_update": ts_str or "",
-                        "status": row.status or "",
-                        "simplified_status": sstat or 'Pending Assessment',
-                        "status_notes": row.status_notes or "",
-                        "justification": row.justification or "",
-                        "impact_statement": row.impact_statement or "",
-                        "responses": list(row.responses or []),
-                        "workaround": row.workaround or "",
-                    })
-                vuln_dict['assessments'] = assess_dicts
+                vuln_dict['assessments'] = assess_by_vuln.get(vid, [])
                 vuln_dict['variants'] = []
 
                 top_vulns.append({
@@ -506,7 +584,7 @@ def init_app(app):
                     "vuln": vuln_dict,
                 })
 
-        return {
+        result_payload = {
             "vuln_by_severity": severity_counts,
             "vuln_by_status": status_counts,
             "vuln_evolution": {"labels": labels, "data": evolution_counts},
@@ -514,3 +592,6 @@ def init_app(app):
             "top_packages": top_packages,
             "top_vulns": top_vulns,
         }
+        if unscoped:
+            _metrics_cache["by_scale"][(scale, unit)] = result_payload
+        return result_payload

--- a/src/routes/metrics.py
+++ b/src/routes/metrics.py
@@ -472,7 +472,10 @@ def init_app(app):
                 assess_dicts = []
                 for row in top_assess_rows:
                     ts = row.timestamp
-                    ts_str = ts.isoformat() if ts is not None and hasattr(ts, 'isoformat') else (str(ts) if ts else None)
+                    ts_str = (
+                        ts.isoformat() if ts is not None and hasattr(ts, 'isoformat')
+                        else (str(ts) if ts else None)
+                    )
                     sstat = row.simplified_status or STATUS_TO_SIMPLIFIED.get(row.status or '', 'Pending Assessment')
                     assess_dicts.append({
                         "id": str(row.assess_id),

--- a/src/routes/metrics.py
+++ b/src/routes/metrics.py
@@ -1,0 +1,513 @@
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import uuid as _uuid
+from datetime import datetime, timezone, timedelta
+
+from flask import request
+from sqlalchemy import func
+
+from ..models.vulnerability import Vulnerability
+from ..models.finding import Finding
+from ..models.observation import Observation
+from ..models.package import Package
+from ..models.metrics import Metrics as MetricsModel
+from ..models.assessment import Assessment, STATUS_TO_SIMPLIFIED
+from ..models.scan import Scan
+from ..models.variant import Variant
+from ..models.sbom_document import SBOMDocument
+from ..models.sbom_package import SBOMPackage
+from ..extensions import db
+from .vulnerabilities import (
+    _latest_scan_id_for_variant,
+    _latest_scan_ids_for_project,
+    _populate_found_by,
+    _FORMAT_TO_FOUND_BY,
+    _DEDICATED_SCANNER_FORMATS,
+)
+
+# ---------------------------------------------------------------------------
+# Severity helpers
+# ---------------------------------------------------------------------------
+
+_SEVERITY_TEXT_TO_INDEX: dict[str, int] = {
+    'none': 0, 'unknown': 0,
+    'low': 1,
+    'medium': 2,
+    'high': 3,
+    'critical': 4,
+}
+
+_SOURCE_DISPLAY_NAMES: dict[str, str] = {
+    'openvex': 'OpenVex',
+    'local_user_data': 'Local User Data',
+    'yocto': 'Yocto',
+    'spdx3': 'SPDX3',
+    'grype': 'Grype',
+    'cyclonedx': 'CycloneDx',
+}
+
+
+def _score_to_severity_index(score) -> int:
+    if score is None:
+        return 0
+    score = float(score)
+    if score == 0.0:
+        return 0
+    if score < 4.0:
+        return 1
+    if score < 7.0:
+        return 2
+    if score < 9.0:
+        return 3
+    return 4
+
+
+def _severity_text_to_index(text: str | None) -> int:
+    return _SEVERITY_TEXT_TO_INDEX.get((text or '').lower(), 0)
+
+
+# ---------------------------------------------------------------------------
+# Time-scale helpers  (mirrors front-end logic)
+# ---------------------------------------------------------------------------
+
+def _zeroise_dt(dt: datetime, unit: str) -> datetime:
+    """Strip sub-period fields from *dt* according to *unit*."""
+    if unit.startswith('month'):
+        dt = dt.replace(day=1)
+    if unit.startswith('hour'):
+        return dt.replace(minute=0, second=0, microsecond=0)
+    return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _prev_dt(dt: datetime, unit: str) -> datetime:
+    """Step back by one *unit*."""
+    if unit.startswith('week'):
+        return dt - timedelta(weeks=1)
+    if unit.startswith('hour'):
+        return dt - timedelta(hours=1)
+    # days AND months both step back by 1 day; zeroise_date then sets day=1 for months
+    return dt - timedelta(days=1)
+
+
+def _generate_checkpoints(scale: int, unit: str) -> list[datetime]:
+    """Return `scale` timezone-aware checkpoint datetimes, oldest first."""
+    now = datetime.now(timezone.utc)
+    checkpoints: list[datetime] = []
+    dt = _zeroise_dt(now, unit)
+    while len(checkpoints) < scale:
+        checkpoints.insert(0, dt)
+        dt = _zeroise_dt(_prev_dt(dt, unit), unit)
+    return checkpoints
+
+
+def _format_checkpoint_label(dt: datetime, unit: str) -> str:
+    if unit.startswith('hour'):
+        return dt.strftime('%H:00')
+    if unit.startswith('month'):
+        return dt.strftime("%b '%y")
+    return dt.strftime("%-d %b '%y")
+
+
+# ---------------------------------------------------------------------------
+# Evolution algorithm  (direct Python port of the front-end reduce)
+# ---------------------------------------------------------------------------
+
+def _compute_evolution(
+    assessments_by_vuln: dict[str, list[tuple[datetime, str]]],
+    checkpoints: list[datetime],
+) -> list[int]:
+    """Return count of active vulnerabilities at each checkpoint."""
+    nb = len(checkpoints)
+    totals = [0] * nb
+
+    for assessments in assessments_by_vuln.values():
+        is_active = False
+        date_index = 0
+        was_active = [False] * nb
+
+        for assess_ts, simplified_status in assessments:
+            if assess_ts.tzinfo is None:
+                assess_ts = assess_ts.replace(tzinfo=timezone.utc)
+
+            # Advance the checkpoint index past all checkpoints before this assessment
+            while (
+                date_index < nb - 1
+                and assess_ts > checkpoints[date_index + 1]
+            ):
+                if is_active:
+                    was_active[date_index] = True
+                date_index += 1
+
+            should_be_active = simplified_status not in ('Not affected', 'Fixed')
+            if is_active != should_be_active:
+                if should_be_active and assess_ts >= checkpoints[date_index]:
+                    was_active[date_index] = True
+                is_active = should_be_active
+
+        # Fill remaining checkpoints
+        while date_index < nb:
+            if is_active:
+                was_active[date_index] = True
+            date_index += 1
+
+        for i, active in enumerate(was_active):
+            if active:
+                totals[i] += 1
+
+    return totals
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+def init_app(app):
+
+    @app.route('/api/metrics')
+    def get_metrics():
+        variant_id_raw = request.args.get('variant_id')
+        project_id_raw = request.args.get('project_id')
+        time_scale_str = request.args.get('time_scale', '6_months')
+
+        # ── Parse time scale ────────────────────────────────────────────
+        parts = time_scale_str.split('_', 1)
+        if len(parts) != 2:
+            return {"error": "Invalid time_scale"}, 400
+        try:
+            scale = int(parts[0])
+            unit = parts[1]
+        except ValueError:
+            return {"error": "Invalid time_scale"}, 400
+        if scale < 2 or unit not in ('months', 'weeks', 'days', 'hours'):
+            return {"error": "Invalid time_scale"}, 400
+
+        # ── Scope resolution ─────────────────────────────────────────────
+        current_scan_ids: list = []
+        scope_variant = None
+        scope_project = None
+
+        if variant_id_raw:
+            try:
+                scope_variant = _uuid.UUID(variant_id_raw)
+            except ValueError:
+                return {"error": "Invalid variant_id"}, 400
+            latest = _latest_scan_id_for_variant(scope_variant)
+            current_scan_ids = [latest] if latest else []
+        elif project_id_raw:
+            try:
+                scope_project = _uuid.UUID(project_id_raw)
+            except ValueError:
+                return {"error": "Invalid project_id"}, 400
+            current_scan_ids = _latest_scan_ids_for_project(scope_project)
+
+        # ── Build the empty-response helper ──────────────────────────────
+        def _empty():
+            checkpoints = _generate_checkpoints(scale, unit)
+            labels = [_format_checkpoint_label(cp, unit) for cp in checkpoints]
+            return {
+                "vuln_by_severity": [0, 0, 0, 0, 0],
+                "vuln_by_status": [0, 0, 0, 0],
+                "vuln_evolution": {"labels": labels, "data": [0] * scale},
+                "vuln_by_source": {"labels": [], "data": []},
+                "top_packages": [],
+                "top_vulns": [],
+            }
+
+        # ── Scoped vulnerability IDs ─────────────────────────────────────
+        if scope_variant is not None or scope_project is not None:
+            if not current_scan_ids:
+                return _empty()
+            vuln_ids: list[str] = list(db.session.execute(
+                db.select(Finding.vulnerability_id)
+                .join(Observation, Finding.id == Observation.finding_id)
+                .where(Observation.scan_id.in_(current_scan_ids))
+                .distinct()
+            ).scalars().all())
+        else:
+            vuln_ids = list(db.session.execute(
+                db.select(Vulnerability.id)
+            ).scalars().all())
+
+        if not vuln_ids:
+            return _empty()
+
+        # ── 1. Severity distribution ─────────────────────────────────────
+        # Prefer max CVSS score; fall back to the vulnerability's status column
+        sev_rows = db.session.execute(
+            db.select(
+                Vulnerability.id,
+                Vulnerability.status,
+                func.max(MetricsModel.score).label('max_score'),
+            )
+            .outerjoin(MetricsModel, MetricsModel.vulnerability_id == Vulnerability.id)
+            .where(Vulnerability.id.in_(vuln_ids))
+            .group_by(Vulnerability.id, Vulnerability.status)
+        ).all()
+
+        severity_counts = [0, 0, 0, 0, 0]
+        for _vid, base_sev, max_score in sev_rows:
+            if max_score is not None:
+                idx = _score_to_severity_index(max_score)
+            else:
+                idx = _severity_text_to_index(base_sev)
+            severity_counts[idx] += 1
+
+        # ── 2. Status distribution + assessment history ─────────────────
+        # Lightweight query: only the columns needed for evolution and status aggregation.
+        # Full assessment details are fetched separately for top-vulns only.
+        slim_assess_rows = db.session.execute(
+            db.select(
+                Finding.vulnerability_id,
+                Assessment.timestamp,
+                Assessment.status,
+                Assessment.simplified_status,
+            )
+            .join(Finding, Assessment.finding_id == Finding.id)
+            .where(Finding.vulnerability_id.in_(vuln_ids))
+            .order_by(Finding.vulnerability_id, Assessment.timestamp)
+        ).all()
+
+        # Group: latest status per vuln + evolution data
+        latest_sstat_by_vuln: dict[str, str] = {}   # vuln_id -> latest simplified_status
+        evolution_by_vuln: dict[str, list[tuple]] = {}  # for evolution chart
+
+        for row in slim_assess_rows:
+            vid = row.vulnerability_id
+            ts = row.timestamp
+            if ts is not None and ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            sstat = row.simplified_status or STATUS_TO_SIMPLIFIED.get(row.status or '', 'Pending Assessment')
+            sstat = sstat or 'Pending Assessment'
+
+            # Last assignment wins because rows are ordered by timestamp
+            latest_sstat_by_vuln[vid] = sstat
+            evolution_by_vuln.setdefault(vid, []).append((ts, sstat))
+
+        latest_status_by_vuln: dict[str, str] = latest_sstat_by_vuln
+
+        status_counts = [0, 0, 0, 0]  # Not affected, Fixed, Pending Assessment, Exploitable
+        for vid in vuln_ids:
+            sstat = latest_status_by_vuln.get(vid, 'Pending Assessment')
+            if sstat == 'Not affected':
+                status_counts[0] += 1
+            elif sstat == 'Fixed':
+                status_counts[1] += 1
+            elif sstat == 'Pending Assessment':
+                status_counts[2] += 1
+            else:
+                status_counts[3] += 1
+
+        # ── 3. Evolution data ────────────────────────────────────────────
+        checkpoints = _generate_checkpoints(scale, unit)
+        labels = [_format_checkpoint_label(cp, unit) for cp in checkpoints]
+        evolution_counts = _compute_evolution(evolution_by_vuln, checkpoints)
+
+        # ── 4. Source distribution ────────────────────────────────────────
+        source_query = (
+            db.select(Finding.vulnerability_id, Finding.package_id, SBOMDocument.format)
+            .select_from(Finding)
+            .join(SBOMPackage, SBOMPackage.package_id == Finding.package_id)
+            .join(SBOMDocument, SBOMDocument.id == SBOMPackage.sbom_document_id)
+            .where(SBOMDocument.format.isnot(None))
+            .where(Finding.vulnerability_id.in_(vuln_ids))
+        )
+        if scope_variant is not None:
+            source_query = (
+                source_query
+                .join(Scan, Scan.id == SBOMDocument.scan_id)
+                .where(Scan.variant_id == scope_variant)
+            )
+        elif scope_project is not None:
+            source_query = (
+                source_query
+                .join(Scan, Scan.id == SBOMDocument.scan_id)
+                .join(Variant, Variant.id == Scan.variant_id)
+                .where(Variant.project_id == scope_project)
+            )
+
+        source_rows = db.session.execute(source_query.distinct()).all()
+
+        pkg_formats: dict[tuple, set] = {}
+        for vuln_id, pkg_id, fmt in source_rows:
+            key = (vuln_id, str(pkg_id))
+            pkg_formats.setdefault(key, set()).add(fmt)
+
+        found_by_by_vuln: dict[str, set] = {}
+        for (vuln_id, _), formats in pkg_formats.items():
+            dedicated = formats & _DEDICATED_SCANNER_FORMATS
+            sources = dedicated if dedicated else formats
+            for fmt in sources:
+                mapped = _FORMAT_TO_FOUND_BY.get(fmt, fmt)
+                found_by_by_vuln.setdefault(vuln_id, set()).add(mapped)
+
+        source_counts: dict[str, int] = {}
+        for sources in found_by_by_vuln.values():
+            for src in sources:
+                source_counts[src] = source_counts.get(src, 0) + 1
+
+        sorted_sources = sorted(source_counts.items(), key=lambda x: x[1], reverse=True)
+        source_labels = [_SOURCE_DISPLAY_NAMES.get(s, s) for s, _ in sorted_sources]
+        source_data_vals = [count for _, count in sorted_sources]
+
+        # ── 5. Top vulnerable packages ────────────────────────────────────
+        if current_scan_ids:
+            pkg_vuln_rows = db.session.execute(
+                db.select(
+                    Package.name, Package.version,
+                    func.count(Finding.vulnerability_id.distinct()).label('cnt'),
+                )
+                .join(Finding, Finding.package_id == Package.id)
+                .join(Observation, Finding.id == Observation.finding_id)
+                .where(Observation.scan_id.in_(current_scan_ids))
+                .group_by(Package.name, Package.version)
+                .order_by(func.count(Finding.vulnerability_id.distinct()).desc())
+                .limit(5)
+            ).all()
+        else:
+            pkg_vuln_rows = db.session.execute(
+                db.select(
+                    Package.name, Package.version,
+                    func.count(Finding.vulnerability_id.distinct()).label('cnt'),
+                )
+                .join(Finding, Finding.package_id == Package.id)
+                .where(Finding.vulnerability_id.in_(vuln_ids))
+                .group_by(Package.name, Package.version)
+                .order_by(func.count(Finding.vulnerability_id.distinct()).desc())
+                .limit(5)
+            ).all()
+
+        top_packages = [
+            {"id": idx + 1, "name": name, "version": version or "-", "count": cnt}
+            for idx, (name, version, cnt) in enumerate(pkg_vuln_rows)
+        ]
+
+        # ── 6. Top unfixed vulnerabilities ────────────────────────────────
+        active_vuln_ids = [
+            vid for vid in vuln_ids
+            if latest_status_by_vuln.get(vid, 'Pending Assessment') not in ('Fixed', 'Not affected')
+        ]
+
+        if not active_vuln_ids:
+            top_vulns: list = []
+        else:
+            # Max CVSS per active vuln
+            cvss_rows = db.session.execute(
+                db.select(
+                    MetricsModel.vulnerability_id,
+                    func.max(MetricsModel.score).label('max_score'),
+                )
+                .where(MetricsModel.vulnerability_id.in_(active_vuln_ids))
+                .group_by(MetricsModel.vulnerability_id)
+            ).all()
+            max_cvss: dict[str, float] = {vid: float(s) for vid, s in cvss_rows}
+
+            top5_ids = sorted(active_vuln_ids, key=lambda v: max_cvss.get(v, 0.0), reverse=True)[:5]
+
+            # Fetch vulnerability records with metrics pre-loaded to avoid N+1
+            from sqlalchemy.orm import selectinload
+            top_records = list(db.session.execute(
+                db.select(Vulnerability)
+                .options(selectinload(Vulnerability.metrics))
+                .where(Vulnerability.id.in_(top5_ids))
+            ).scalars().all())
+            _populate_found_by(top_records, scope_variant, scope_project)
+
+            # packages_current for top 5
+            if current_scan_ids:
+                top_pkg_rows = db.session.execute(
+                    db.select(Finding.vulnerability_id, Package.name, Package.version)
+                    .join(Observation, Finding.id == Observation.finding_id)
+                    .join(Package, Finding.package_id == Package.id)
+                    .where(Observation.scan_id.in_(current_scan_ids))
+                    .where(Finding.vulnerability_id.in_(top5_ids))
+                    .distinct()
+                ).all()
+            else:
+                top_pkg_rows = db.session.execute(
+                    db.select(Finding.vulnerability_id, Package.name, Package.version)
+                    .join(Package, Finding.package_id == Package.id)
+                    .where(Finding.vulnerability_id.in_(top5_ids))
+                    .distinct()
+                ).all()
+            pkgs_current: dict[str, list] = {}
+            for vid, pname, pver in top_pkg_rows:
+                pkgs_current.setdefault(str(vid), []).append(f"{pname}@{pver}")
+
+            # Build response ordered by rank
+            records_by_id = {r.id: r for r in top_records}
+            top_vulns = []
+            for rank_idx, vid in enumerate(top5_ids):
+                record = records_by_id.get(vid)
+                if not record:
+                    continue
+                vuln_dict = record.to_dict()
+                vuln_dict['packages_current'] = sorted(pkgs_current.get(vid, []))
+                vuln_dict['simplified_status'] = latest_status_by_vuln.get(vid, 'Pending Assessment')
+
+                # Fetch full assessment details for this top-5 vuln (modal data)
+                top_assess_rows = db.session.execute(
+                    db.select(
+                        Assessment.id.label('assess_id'),
+                        Assessment.source,
+                        Assessment.status,
+                        Assessment.simplified_status,
+                        Assessment.status_notes,
+                        Assessment.justification,
+                        Assessment.impact_statement,
+                        Assessment.responses,
+                        Assessment.workaround,
+                        Assessment.timestamp,
+                        Assessment.variant_id,
+                        Package.name.label('pkg_name'),
+                        Package.version.label('pkg_version'),
+                    )
+                    .join(Finding, Assessment.finding_id == Finding.id)
+                    .join(Package, Finding.package_id == Package.id)
+                    .where(Finding.vulnerability_id == vid)
+                    .order_by(Assessment.timestamp)
+                ).all()
+
+                assess_dicts = []
+                for row in top_assess_rows:
+                    ts = row.timestamp
+                    ts_str = ts.isoformat() if ts is not None and hasattr(ts, 'isoformat') else (str(ts) if ts else None)
+                    sstat = row.simplified_status or STATUS_TO_SIMPLIFIED.get(row.status or '', 'Pending Assessment')
+                    assess_dicts.append({
+                        "id": str(row.assess_id),
+                        "source": row.source or "",
+                        "vuln_id": vid,
+                        "packages": [f"{row.pkg_name}@{row.pkg_version}"],
+                        "variant_id": str(row.variant_id) if row.variant_id else None,
+                        "timestamp": ts_str,
+                        "last_update": ts_str or "",
+                        "status": row.status or "",
+                        "simplified_status": sstat or 'Pending Assessment',
+                        "status_notes": row.status_notes or "",
+                        "justification": row.justification or "",
+                        "impact_statement": row.impact_statement or "",
+                        "responses": list(row.responses or []),
+                        "workaround": row.workaround or "",
+                    })
+                vuln_dict['assessments'] = assess_dicts
+                vuln_dict['variants'] = []
+
+                top_vulns.append({
+                    "rank": rank_idx + 1,
+                    "cve": vid,
+                    "package": ", ".join(sorted(pkgs_current.get(vid, []))),
+                    "severity": vuln_dict['severity']['severity'],
+                    "max_cvss": max_cvss.get(vid, 0.0),
+                    "texts": vuln_dict['texts'],
+                    "vuln": vuln_dict,
+                })
+
+        return {
+            "vuln_by_severity": severity_counts,
+            "vuln_by_status": status_counts,
+            "vuln_evolution": {"labels": labels, "data": evolution_counts},
+            "vuln_by_source": {"labels": source_labels, "data": source_data_vals},
+            "top_packages": top_packages,
+            "top_vulns": top_vulns,
+        }

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -10,7 +10,25 @@ from ..models.scan import Scan
 from ..models.variant import Variant
 from ..models.sbom_document import SBOMDocument
 from ..models.sbom_package import SBOMPackage
+from ..models.finding import Finding
+from ..models.observation import Observation
+from ..models.assessment import Assessment as DBAssessment, STATUS_TO_SIMPLIFIED as _S2S
+from ..models.metrics import Metrics as DBMetrics
 from ..extensions import db
+
+_SEVERITY_INDEX = {"NONE": 0, "UNKNOWN": 1, "LOW": 2, "MEDIUM": 3, "HIGH": 4, "CRITICAL": 5}
+
+
+def _score_to_severity(score) -> str:
+    if score is None or score == 0:
+        return "NONE"
+    if score < 4.0:
+        return "LOW"
+    if score < 7.0:
+        return "MEDIUM"
+    if score < 9.0:
+        return "HIGH"
+    return "CRITICAL"
 
 
 def _latest_scan_id_for_variant(variant_uuid):
@@ -50,6 +68,7 @@ def init_app(app):
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
         compare_variant_id = request.args.get('compare_variant_id')
+        current_scan_ids: list = []
         if variant_id and compare_variant_id:
             try:
                 base_uuid = uuid.UUID(variant_id)
@@ -67,6 +86,9 @@ def init_app(app):
                     .where(Scan.variant_id == variant_uuid)
                     .distinct()
                 ).scalars().all())
+
+            compare_latest_id = _latest_scan_id_for_variant(compare_uuid)
+            current_scan_ids = [compare_latest_id] if compare_latest_id else []
 
             if operation == 'intersection':
                 base_ids = _pkg_ids_for_variant(base_uuid)
@@ -100,6 +122,7 @@ def init_app(app):
             except ValueError:
                 return {"error": "Invalid variant_id"}, 400
             latest_id = _latest_scan_id_for_variant(variant_uuid)
+            current_scan_ids = [latest_id] if latest_id else []
             if latest_id is None:
                 pkgs = []
             else:
@@ -121,6 +144,7 @@ def init_app(app):
             except ValueError:
                 return {"error": "Invalid project_id"}, 400
             latest_ids = _latest_scan_ids_for_project(project_uuid)
+            current_scan_ids = latest_ids
             if not latest_ids:
                 pkgs = []
             else:
@@ -190,6 +214,95 @@ def init_app(app):
                 info = meta.get(key, {})
                 p["variants"] = sorted(info.get("variants", set()))
                 p["sources"] = sorted(info.get("sources", set()))
+
+            # Enrich each package with vulnerability counts per simplified_status
+            # and highest severity per simplified_status group.
+            finding_q = (
+                db.select(Finding.package_id, Finding.vulnerability_id)
+                .where(Finding.package_id.in_(pkg_ids))
+                .distinct()
+            )
+            if current_scan_ids:
+                finding_q = (
+                    finding_q
+                    .join(Observation, Finding.id == Observation.finding_id)
+                    .where(Observation.scan_id.in_(current_scan_ids))
+                )
+            pkg_vuln_pairs = db.session.execute(finding_q).all()
+
+            all_linked_vuln_ids = list({str(r.vulnerability_id) for r in pkg_vuln_pairs})
+
+            # Latest assessment simplified_status per vulnerability
+            # Use a GROUP BY subquery so we only fetch one row per vuln (latest timestamp).
+            vuln_status: dict[str, str] = {}
+            if all_linked_vuln_ids:
+                latest_ts_sub = (
+                    db.select(
+                        Finding.vulnerability_id.label("v_id"),
+                        func.max(DBAssessment.timestamp).label("max_ts"),
+                    )
+                    .join(Finding, DBAssessment.finding_id == Finding.id)
+                    .where(Finding.vulnerability_id.in_(all_linked_vuln_ids))
+                    .group_by(Finding.vulnerability_id)
+                    .subquery()
+                )
+                assess_rows = db.session.execute(
+                    db.select(
+                        Finding.vulnerability_id,
+                        DBAssessment.simplified_status,
+                        DBAssessment.status,
+                    )
+                    .join(Finding, DBAssessment.finding_id == Finding.id)
+                    .join(
+                        latest_ts_sub,
+                        (Finding.vulnerability_id == latest_ts_sub.c.v_id)
+                        & (DBAssessment.timestamp == latest_ts_sub.c.max_ts),
+                    )
+                    .distinct()
+                ).all()
+                for row in assess_rows:
+                    vid = str(row.vulnerability_id)
+                    simplified = row.simplified_status or _S2S.get(row.status or "", "Pending Assessment")
+                    vuln_status[vid] = simplified
+
+            # Max CVSS score per vulnerability
+            vuln_max_score: dict[str, float] = {}
+            if all_linked_vuln_ids:
+                score_rows = db.session.execute(
+                    db.select(
+                        DBMetrics.vulnerability_id,
+                        func.max(DBMetrics.score).label("max_score"),
+                    )
+                    .where(DBMetrics.vulnerability_id.in_(all_linked_vuln_ids))
+                    .group_by(DBMetrics.vulnerability_id)
+                ).all()
+                for row in score_rows:
+                    if row.max_score is not None:
+                        vuln_max_score[str(row.vulnerability_id)] = float(row.max_score)
+
+            # Aggregate counts and max severity per (package, simplified_status)
+            pkg_vuln_counts: dict[str, dict[str, int]] = {}
+            pkg_max_sev: dict[str, dict[str, dict]] = {}
+            for row in pkg_vuln_pairs:
+                pid = str(row.package_id)
+                vid = str(row.vulnerability_id)
+                status = vuln_status.get(vid, "Pending Assessment")
+
+                pkg_vuln_counts.setdefault(pid, {})
+                pkg_vuln_counts[pid][status] = pkg_vuln_counts[pid].get(status, 0) + 1
+
+                pkg_max_sev.setdefault(pid, {})
+                score = vuln_max_score.get(vid)
+                sev_label = _score_to_severity(score)
+                sev_idx = _SEVERITY_INDEX.get(sev_label, 0)
+                current_sev = pkg_max_sev[pid].get(status, {"label": "NONE", "index": 0})
+                if sev_idx > current_sev["index"]:
+                    pkg_max_sev[pid][status] = {"label": sev_label, "index": sev_idx}
+
+            for p, pkg in zip(result, pkgs):
+                pid = str(pkg.id)
+                p["vulnerabilities"] = pkg_vuln_counts.get(pid, {})
+                p["maxSeverity"] = pkg_max_sev.get(pid, {})
 
         if request.args.get('format', 'list') == "dict":
             return {p["name"] + "@" + p["version"]: p for p in result}

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -328,6 +328,51 @@ def _load_scan_with_findings(scan_id: uuid_module.UUID) -> Scan | None:
     ).scalar_one_or_none()
 
 
+def _scan_finding_pairs(scan_id: uuid_module.UUID) -> list[tuple]:
+    """Return [(finding_id, vulnerability_id, package_id), ...] for one scan.
+
+    Lightweight projection used by the diff endpoint to compute set
+    differences without hydrating Observation / Finding / Package ORM
+    instances for every row.
+    """
+    return list(db.session.execute(
+        db.select(Observation.finding_id, Finding.vulnerability_id, Finding.package_id)
+        .join(Finding, Finding.id == Observation.finding_id)
+        .where(Observation.scan_id == scan_id)
+    ).all())
+
+
+def _hydrate_findings_for_diff(finding_ids: set) -> dict:
+    """Return {finding_id: dict(_obs_to_dict-shaped)} for the given set.
+
+    Loads only the (small) set of findings that are actually added/removed
+    in a diff, joined with their package, in one query.
+    """
+    if not finding_ids:
+        return {}
+    rows = db.session.execute(
+        db.select(
+            Finding.id,
+            Finding.vulnerability_id,
+            Finding.package_id,
+            Package.name,
+            Package.version,
+        )
+        .outerjoin(Package, Finding.package_id == Package.id)
+        .where(Finding.id.in_(finding_ids))
+    ).all()
+    return {
+        fid: {
+            "finding_id": str(fid),
+            "package_name": pname or "unknown",
+            "package_version": pver or "",
+            "package_id": str(pid),
+            "vulnerability_id": vid,
+        }
+        for fid, vid, pid, pname, pver in rows
+    }
+
+
 def _obs_to_dict(obs: Observation) -> dict:
     f = obs.finding
     pkg = f.package
@@ -453,7 +498,7 @@ def init_app(app):
         except ValueError:
             return jsonify({"error": "Invalid scan id"}), 400
 
-        scan = _load_scan_with_findings(scan_uuid)
+        scan = ScanController.get(scan_uuid)
         if scan is None:
             return jsonify({"error": "Scan not found"}), 404
 
@@ -465,28 +510,30 @@ def init_app(app):
                 prev_scan_id = all_variant_scans[i - 1].id
                 break
 
-        # --- Findings diff ---
-        current_finding_ids = {obs.finding_id for obs in scan.observations}
-        curr_vulns = {obs.finding.vulnerability_id for obs in scan.observations}
+        # --- Findings diff (lightweight projections, no ORM hydration) ---
+        curr_pairs = _scan_finding_pairs(scan.id)
+        current_finding_ids = {fid for fid, _, _ in curr_pairs}
+        curr_vulns = {vid for _, vid, _ in curr_pairs}
 
         if prev_scan_id is None:
-            findings_added = [_obs_to_dict(obs) for obs in scan.observations]
-            findings_removed: list = []
+            added_fids = current_finding_ids
+            removed_fids: set = set()
             vulns_added = sorted(curr_vulns)
             vulns_removed: list = []
         else:
-            prev_scan = _load_scan_with_findings(prev_scan_id)
-            prev_finding_ids = {obs.finding_id for obs in prev_scan.observations} if prev_scan else set()
-            prev_vulns = {obs.finding.vulnerability_id for obs in prev_scan.observations} if prev_scan else set()
+            prev_pairs = _scan_finding_pairs(prev_scan_id)
+            prev_finding_ids = {fid for fid, _, _ in prev_pairs}
+            prev_vulns = {vid for _, vid, _ in prev_pairs}
             added_fids = current_finding_ids - prev_finding_ids
             removed_fids = prev_finding_ids - current_finding_ids
-            findings_added = [_obs_to_dict(obs) for obs in scan.observations if obs.finding_id in added_fids]
-            findings_removed = (
-                [_obs_to_dict(obs) for obs in prev_scan.observations if obs.finding_id in removed_fids]
-                if prev_scan else []
-            )
             vulns_added = sorted(curr_vulns - prev_vulns)
             vulns_removed = sorted(prev_vulns - curr_vulns)
+
+        # Hydrate only the diff set (added + removed) — typically a small
+        # fraction of total findings — in one query joined with Package.
+        finding_dicts = _hydrate_findings_for_diff(added_fids | removed_fids)
+        findings_added = [finding_dicts[fid] for fid in added_fids if fid in finding_dicts]
+        findings_removed = [finding_dicts[fid] for fid in removed_fids if fid in finding_dicts]
 
         # --- Packages diff ---
         scans_to_query = [scan.id] if prev_scan_id is None else [scan.id, prev_scan_id]

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -123,6 +123,7 @@ def _populate_found_by(
             base_query
             .join(Scan, Scan.id == SBOMDocument.scan_id)
             .where(Scan.variant_id == variant_uuid)
+            .where(Finding.vulnerability_id.in_(vuln_ids))
         )
     elif project_uuid is not None:
         base_query = (
@@ -130,6 +131,7 @@ def _populate_found_by(
             .join(Scan, Scan.id == SBOMDocument.scan_id)
             .join(Variant, Variant.id == Scan.variant_id)
             .where(Variant.project_id == project_uuid)
+            .where(Finding.vulnerability_id.in_(vuln_ids))
         )
     else:
         base_query = base_query.where(Finding.vulnerability_id.in_(vuln_ids))  # no need for full query on all variants
@@ -156,6 +158,239 @@ def _populate_found_by(
     for record in records:
         for scanner in found_by_map.get(record.id, set()):
             record.add_found_by(scanner)
+
+
+# ---- Server-side pagination, sorting & filtering helpers ----
+
+_SEVERITY_SORT_ORDER = ['none', 'unknown', 'low', 'medium', 'high', 'critical']
+_STATUS_SORT_ORDER = ['unknown', 'Pending Assessment', 'Exploitable', 'Not affected', 'Fixed']
+_AV_SORT_ORDER = [None, 'PHYSICAL', 'LOCAL', 'ADJACENT', 'NETWORK']
+
+
+def _compute_facets(vulns: list[dict]) -> dict:
+    """Compute filter-option metadata from the *full* (unfiltered) enriched list."""
+    severities: set[str] = set()
+    statuses: set[str] = set()
+    sources: set[str] = set()
+    attack_vectors: set[str] = set()
+    first_scan_ts: set[int] = set()
+    for v in vulns:
+        sev = (v.get("severity") or {}).get("severity")
+        if sev:
+            severities.add(sev)
+        st = v.get("simplified_status")
+        if st:
+            statuses.add(st)
+        for s in (v.get("found_by") or []):
+            if s:
+                sources.add(s)
+        for cvss in (v.get("severity") or {}).get("cvss", []):
+            av = cvss.get("attack_vector")
+            if av:
+                attack_vectors.add(av)
+        fsd = v.get("first_scan_date")
+        if fsd:
+            try:
+                import datetime as _dt
+                ts = int(round(_dt.datetime.fromisoformat(fsd).timestamp())) * 1000
+                first_scan_ts.add(ts)
+            except (ValueError, TypeError):
+                pass
+    return {
+        "severities": sorted(severities),
+        "statuses": sorted(statuses),
+        "sources": sorted(sources),
+        "attack_vectors": sorted(attack_vectors),
+        "first_scan_dates": sorted(first_scan_ts),
+    }
+
+
+def _matches_search(vuln: dict, search: str) -> bool:
+    """Match a vuln dict against a search string using the same AND/OR/NOT
+    semantics as the frontend Fuse.js extended search."""
+    searchable = " ".join([
+        vuln.get("id", ""),
+        " ".join(vuln.get("packages", [])),
+        " ".join(str(v) for v in (vuln.get("texts") or {}).values()),
+    ]).lower()
+    or_groups = [g.strip() for g in search.split("|") if g.strip()]
+    for group in or_groups:
+        terms = group.split()
+        if all(
+            (t[1:].lower() not in searchable) if (t.startswith("-") and len(t) > 1)
+            else (t.lower() in searchable)
+            for t in terms
+        ):
+            return True
+    return False
+
+
+def _apply_server_filters(vulns: list[dict], args) -> list[dict]:
+    """Apply query-param filters to the enriched vuln list."""
+    result = vulns
+
+    search = (args.get("search") or "").strip()
+    if search and len(search) > 2:
+        result = [v for v in result if _matches_search(v, search)]
+
+    severity = args.get("severity")
+    if severity:
+        allowed = set(severity.split(","))
+        result = [v for v in result if (v.get("severity") or {}).get("severity") in allowed]
+
+    status = args.get("simplified_status")
+    if status:
+        allowed = set(status.split(","))
+        result = [v for v in result if v.get("simplified_status") in allowed]
+
+    source = args.get("found_by")
+    if source:
+        allowed = set(source.split(","))
+        result = [v for v in result if allowed & set(v.get("found_by") or [])]
+
+    package = args.get("package")
+    if package:
+        allowed = set(package.split(","))
+        result = [v for v in result if allowed & set(v.get("packages_current") or [])]
+
+    epss_min = args.get("epss_min", type=float)
+    epss_max = args.get("epss_max", type=float)
+    if epss_min is not None or epss_max is not None:
+        def _epss_ok(v):
+            score = (v.get("epss") or {}).get("score")
+            if score is None:
+                return False
+            pct = score * 100
+            if epss_min is not None and pct < epss_min:
+                return False
+            if epss_max is not None and pct > epss_max:
+                return False
+            return True
+        result = [v for v in result if _epss_ok(v)]
+
+    sev_min = args.get("severity_min", type=float)
+    sev_max = args.get("severity_max", type=float)
+    if sev_min is not None or sev_max is not None:
+        def _sev_score_ok(v):
+            score = (v.get("severity") or {}).get("max_score")
+            if score is None:
+                return False
+            if sev_min is not None and score < sev_min:
+                return False
+            if sev_max is not None and score > sev_max:
+                return False
+            return True
+        result = [v for v in result if _sev_score_ok(v)]
+
+    av = args.get("attack_vector")
+    if av:
+        allowed = set(av.split(","))
+        result = [
+            v for v in result
+            if allowed & {c.get("attack_vector") for c in (v.get("severity") or {}).get("cvss", []) if c.get("attack_vector")}
+        ]
+
+    pub_filter = args.get("published_date_filter")
+    if pub_filter:
+        import datetime as _dt
+        pub_value = args.get("published_date_value", "")
+        pub_from = args.get("published_date_from", "")
+        pub_to = args.get("published_date_to", "")
+        pub_days = args.get("published_days_value", "")
+        filtered: list[dict] = []
+        for v in result:
+            pub = v.get("published")
+            if not pub:
+                continue
+            try:
+                pub_date = _dt.date.fromisoformat(pub)
+            except (ValueError, TypeError):
+                continue
+            keep = True
+            if pub_filter == "is" and pub_value:
+                keep = pub_date == _dt.date.fromisoformat(pub_value)
+            elif pub_filter == ">=" and pub_value:
+                keep = pub_date >= _dt.date.fromisoformat(pub_value)
+            elif pub_filter == "<=" and pub_value:
+                keep = pub_date <= _dt.date.fromisoformat(pub_value)
+            elif pub_filter == "between" and pub_from and pub_to:
+                keep = _dt.date.fromisoformat(pub_from) <= pub_date <= _dt.date.fromisoformat(pub_to)
+            elif pub_filter == "days_ago" and pub_days:
+                try:
+                    cutoff = _dt.date.today() - _dt.timedelta(days=int(pub_days))
+                    keep = pub_date >= cutoff
+                except ValueError:
+                    pass
+            if keep:
+                filtered.append(v)
+        result = filtered
+
+    fsd = args.get("first_scan_date")
+    if fsd:
+        allowed_ts = set(fsd.split(","))
+        def _fsd_ok(v):
+            d = v.get("first_scan_date")
+            if not d:
+                return False
+            try:
+                import datetime as _dt
+                ts = str(int(round(_dt.datetime.fromisoformat(d).timestamp())) * 1000)
+                return ts in allowed_ts
+            except (ValueError, TypeError):
+                return False
+        result = [v for v in result if _fsd_ok(v)]
+
+    return result
+
+
+def _apply_server_sort(vulns: list[dict], sort_by: str, sort_dir: str) -> list[dict]:
+    """Sort the enriched vuln list by a column identifier."""
+    reverse = sort_dir.lower() == "desc"
+
+    def _key(v):  # noqa: C901
+        if sort_by == "id":
+            return v.get("id", "")
+        if sort_by == "severity.severity":
+            sev = (v.get("severity") or {}).get("severity", "").lower()
+            try:
+                return _SEVERITY_SORT_ORDER.index(sev)
+            except ValueError:
+                return -1
+        if sort_by == "severity.max_score":
+            return (v.get("severity") or {}).get("max_score") or 0
+        if sort_by == "epss":
+            return (v.get("epss") or {}).get("score") or 0
+        if sort_by == "simplified_status":
+            st = v.get("simplified_status", "")
+            try:
+                return _STATUS_SORT_ORDER.index(st)
+            except ValueError:
+                return -1
+        if sort_by == "effort.likely":
+            eff = (v.get("effort") or {}).get("likely")
+            if eff:
+                try:
+                    return Iso8601Duration(eff).total_seconds
+                except Exception:
+                    return 0
+            return 0
+        if sort_by == "assessments":
+            aa = v.get("assessments") or []
+            if not aa:
+                return ""
+            return max((a.get("last_update") or a.get("timestamp") or "") for a in aa)
+        if sort_by == "published":
+            return v.get("published") or ""
+        if sort_by == "first_scan_date":
+            return v.get("first_scan_date") or ""
+        if sort_by == "attack_vector":
+            avs = [c.get("attack_vector") for c in (v.get("severity") or {}).get("cvss", []) if c.get("attack_vector")]
+            if not avs:
+                return -1
+            return max((_AV_SORT_ORDER.index(a) if a in _AV_SORT_ORDER else -1) for a in avs)
+        return v.get("id", "")
+
+    return sorted(vulns, key=_key, reverse=reverse)
 
 
 def init_app(app):
@@ -268,78 +503,78 @@ def init_app(app):
                 records = []
             else:
 
-                # Subquery for vulnerability IDs visible in these scans,
-                # used to avoid huge literal IN-lists in secondary queries.
-                vuln_ids_subq = (
+                # Materialize vulnerability IDs once – avoids SQLite
+                # re-evaluating the subquery in every subsequent statement.
+                vuln_id_list = list(db.session.execute(
                     db.select(Finding.vulnerability_id)
                     .join(Observation, Finding.id == Observation.finding_id)
                     .where(Observation.scan_id.in_(latest_ids))
                     .distinct()
-                    .scalar_subquery()
-                )
+                ).scalars().all())
 
                 records = list(db.session.execute(
                     db.select(Vulnerability)
-                    .where(Vulnerability.id.in_(vuln_ids_subq))
+                    .where(Vulnerability.id.in_(vuln_id_list))
                     .order_by(Vulnerability.id)
-                ).scalars().all())
+                ).scalars().all()) if vuln_id_list else []
 
-                # Bulk-load metrics per vulnerability
-                metric_rows = db.session.execute(
-                    db.select(Metrics)
-                    .where(Metrics.vulnerability_id.in_(vuln_ids_subq))
-                ).scalars().all()
-                metrics_by_vuln: dict[str, list] = {}
-                for m in metric_rows:
-                    metrics_by_vuln.setdefault(m.vulnerability_id, []).append(m)
+                if records:
+                    # Bulk-load metrics per vulnerability
+                    metric_rows = db.session.execute(
+                        db.select(Metrics)
+                        .where(Metrics.vulnerability_id.in_(vuln_id_list))
+                    ).scalars().all()
+                    metrics_by_vuln: dict[str, list] = {}
+                    for m in metric_rows:
+                        metrics_by_vuln.setdefault(m.vulnerability_id, []).append(m)
 
-                # Bulk-load packages per vulnerability
-                pkg_rows = db.session.execute(
-                    db.select(Finding.vulnerability_id, Package.name, Package.version)
-                    .join(Package, Finding.package_id == Package.id)
-                    .where(Finding.vulnerability_id.in_(vuln_ids_subq))
-                    .distinct()
-                ).all()
-                pkgs_by_vuln: dict[str, list[str]] = {}
-                for vid, pname, pver in pkg_rows:
-                    pkgs_by_vuln.setdefault(vid, []).append(f"{pname}@{pver}")
+                    # Bulk-load packages per vulnerability
+                    pkg_rows = db.session.execute(
+                        db.select(Finding.vulnerability_id, Package.name, Package.version)
+                        .join(Package, Finding.package_id == Package.id)
+                        .where(Finding.vulnerability_id.in_(vuln_id_list))
+                        .distinct()
+                    ).all()
+                    pkgs_by_vuln: dict[str, list[str]] = {}
+                    for vid, pname, pver in pkg_rows:
+                        pkgs_by_vuln.setdefault(vid, []).append(f"{pname}@{pver}")
 
-                # Bulk-load effort (time estimates) per vulnerability
-                te_rows = db.session.execute(
-                    db.select(
-                        Finding.vulnerability_id,
-                        TimeEstimate.optimistic,
-                        TimeEstimate.likely,
-                        TimeEstimate.pessimistic,
-                    )
-                    .join(Finding, TimeEstimate.finding_id == Finding.id)
-                    .where(Finding.vulnerability_id.in_(vuln_ids_subq))
-                ).all()
-                effort_by_vuln: dict[str, tuple] = {}
-                for vid, opti, like, pess in te_rows:
-                    if vid not in effort_by_vuln:
-                        effort_by_vuln[vid] = (opti, like, pess)
+                    # Bulk-load effort (time estimates) per vulnerability
+                    te_rows = db.session.execute(
+                        db.select(
+                            Finding.vulnerability_id,
+                            TimeEstimate.optimistic,
+                            TimeEstimate.likely,
+                            TimeEstimate.pessimistic,
+                        )
+                        .join(Finding, TimeEstimate.finding_id == Finding.id)
+                        .where(Finding.vulnerability_id.in_(vuln_id_list))
+                    ).all()
+                    effort_by_vuln: dict[str, tuple] = {}
+                    for vid, opti, like, pess in te_rows:
+                        if vid not in effort_by_vuln:
+                            effort_by_vuln[vid] = (opti, like, pess)
 
-                # Pre-populate transient fields so to_dict() won't lazy-load findings
-                from sqlalchemy.orm import attributes as orm_attrs
-                for r in records:
-                    r.packages = pkgs_by_vuln.get(r.id, [])
-                    te = effort_by_vuln.get(r.id)
-                    if te:
-                        opti, like, pess = te
+                    # Pre-populate transient fields so to_dict() won't lazy-load findings
+                    from sqlalchemy.orm import attributes as orm_attrs
+                    for r in records:
+                        r.packages = pkgs_by_vuln.get(r.id, [])
+                        te = effort_by_vuln.get(r.id)
+                        if te:
+                            opti, like, pess = te
 
-                        def _h(v):
-                            if v is None:
-                                return None
-                            return Iso8601Duration(f"PT{v}H")
-                        r.effort = {
-                            "optimistic": _h(opti),
-                            "likely": _h(like),
-                            "pessimistic": _h(pess),
-                        }
-                    # Mark findings and metrics as loaded to prevent lazy-load
-                    orm_attrs.set_committed_value(r, 'findings', [])
-                    orm_attrs.set_committed_value(r, 'metrics', metrics_by_vuln.get(r.id, []))
+                            def _h(v):
+                                if v is None:
+                                    return None
+                                return Iso8601Duration(f"PT{v}H")
+                            r.effort = {
+                                "optimistic": _h(opti),
+                                "likely": _h(like),
+                                "pessimistic": _h(pess),
+                            }
+                        # Mark findings and metrics as loaded to prevent lazy-load
+                        orm_attrs.set_committed_value(r, 'findings', [])
+                        orm_attrs.set_committed_value(r, 'metrics', metrics_by_vuln.get(r.id, []))
 
         else:
             records = Vulnerability.get_all()
@@ -371,46 +606,43 @@ def init_app(app):
 
             # Enrich each vuln dict with sorted variant names, restricted to latest scans
             # and scoped to the current project/variant to avoid cross-project leaks.
-            latest_ts_base = (
-                db.select(Scan.variant_id, func.max(Scan.timestamp).label("max_ts"))
-            )
-            if _scope_variant is not None:
-                _v = db.session.get(Variant, _scope_variant)
-                if _v and _v.project_id:
-                    latest_ts_base = (
-                        latest_ts_base
-                        .join(Variant, Scan.variant_id == Variant.id)
-                        .where(Variant.project_id == _v.project_id)
-                    )
-                else:
-                    latest_ts_base = latest_ts_base.where(
-                        Scan.variant_id == _scope_variant
-                    )
-            elif _scope_project is not None:
-                latest_ts_base = (
-                    latest_ts_base
+            if current_scan_ids:
+                # Reuse the already-computed latest scan IDs instead of
+                # rebuilding the max-timestamp subquery from scratch.
+                rows = db.session.execute(
+                    db.select(Finding.vulnerability_id, Variant.name)
+                    .join(Observation, Finding.id == Observation.finding_id)
+                    .join(Scan, Observation.scan_id == Scan.id)
                     .join(Variant, Scan.variant_id == Variant.id)
-                    .where(Variant.project_id == _scope_project)
+                    .where(Finding.vulnerability_id.in_(vuln_ids))
+                    .where(Observation.scan_id.in_(current_scan_ids))
+                    .distinct()
+                ).all()
+            else:
+                # No scope — compute latest scans for all variants
+                latest_ts_sub = (
+                    db.select(Scan.variant_id, func.max(Scan.timestamp).label("max_ts"))
+                    .group_by(Scan.variant_id)
+                    .subquery()
                 )
-            latest_ts_sub = latest_ts_base.group_by(Scan.variant_id).subquery()
-            latest_scan_sub = (
-                db.select(Scan.id)
-                .join(
-                    latest_ts_sub,
-                    (Scan.variant_id == latest_ts_sub.c.variant_id)
-                    & (Scan.timestamp == latest_ts_sub.c.max_ts),
+                latest_scan_sub = (
+                    db.select(Scan.id)
+                    .join(
+                        latest_ts_sub,
+                        (Scan.variant_id == latest_ts_sub.c.variant_id)
+                        & (Scan.timestamp == latest_ts_sub.c.max_ts),
+                    )
+                    .subquery()
                 )
-                .subquery()
-            )
-            rows = db.session.execute(
-                db.select(Finding.vulnerability_id, Variant.name)
-                .join(Observation, Finding.id == Observation.finding_id)
-                .join(Scan, Observation.scan_id == Scan.id)
-                .join(Variant, Scan.variant_id == Variant.id)
-                .where(Finding.vulnerability_id.in_(vuln_ids))
-                .where(Observation.scan_id.in_(db.select(latest_scan_sub.c.id)))
-                .distinct()
-            ).all()
+                rows = db.session.execute(
+                    db.select(Finding.vulnerability_id, Variant.name)
+                    .join(Observation, Finding.id == Observation.finding_id)
+                    .join(Scan, Observation.scan_id == Scan.id)
+                    .join(Variant, Scan.variant_id == Variant.id)
+                    .where(Finding.vulnerability_id.in_(vuln_ids))
+                    .where(Observation.scan_id.in_(db.select(latest_scan_sub.c.id)))
+                    .distinct()
+                ).all()
             variant_names_by_vuln: dict = {}
             for vuln_id, variant_name in rows:
                 variant_names_by_vuln.setdefault(str(vuln_id), []).append(variant_name)
@@ -491,6 +723,31 @@ def init_app(app):
 
         if request.args.get('format', 'list') == "dict":
             return {v["id"]: v for v in vulns}
+
+        # ---- Server-side pagination (opt-in via ?page=) ----
+        page = request.args.get('page', type=int)
+        if page is not None:
+            page_size = min(max(request.args.get('page_size', 50, type=int), 1), 500)
+            page = max(page, 1)
+
+            facets = _compute_facets(vulns)
+            filtered = _apply_server_filters(vulns, request.args)
+
+            sort_by = request.args.get('sort_by', 'id')
+            sort_dir = request.args.get('sort_dir', 'asc')
+            filtered = _apply_server_sort(filtered, sort_by, sort_dir)
+
+            total = len(filtered)
+            start = (page - 1) * page_size
+            items = filtered[start:start + page_size]
+            return {
+                "items": items,
+                "total": total,
+                "page": page,
+                "page_size": page_size,
+                "facets": facets,
+            }
+
         return vulns
 
     @app.route('/api/vulnerabilities/<id>', methods=['GET', 'PATCH'])

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -287,7 +287,10 @@ def _apply_server_filters(vulns: list[dict], args) -> list[dict]:
         allowed = set(av.split(","))
         result = [
             v for v in result
-            if allowed & {c.get("attack_vector") for c in (v.get("severity") or {}).get("cvss", []) if c.get("attack_vector")}
+            if allowed & {
+                c.get("attack_vector") for c in (v.get("severity") or {}).get("cvss", [])
+                if c.get("attack_vector")
+            }
         ]
 
     pub_filter = args.get("published_date_filter")
@@ -328,6 +331,7 @@ def _apply_server_filters(vulns: list[dict], args) -> list[dict]:
     fsd = args.get("first_scan_date")
     if fsd:
         allowed_ts = set(fsd.split(","))
+
         def _fsd_ok(v):
             d = v.get("first_scan_date")
             if not d:

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -77,6 +77,104 @@ _FORMAT_TO_FOUND_BY: dict[str, str] = {
 }
 
 
+def _sql_compute_facets_global() -> dict:
+    """Compute facets for the unscoped vulnerability listing via SQL aggregations.
+
+    Avoids hydrating the full vuln set; used by the paginated fast path.
+    Set members match what _compute_facets() would produce when no client
+    filters are applied, except ``sources`` which is approximated from the
+    same SBOMDocument.format mapping used by _populate_found_by().
+    """
+    severities: set[str] = set()
+    # Severity is computed from the max metrics.score per vuln, bucketed
+    # the same way CVSS.severity() does. Match the lowercase labels that
+    # _populate_facets() would have produced from to_dict() output.
+    max_score_rows = db.session.execute(
+        db.select(func.max(Metrics.score))
+        .where(Metrics.score.isnot(None))
+        .group_by(Metrics.vulnerability_id)
+    ).all()
+    for (s,) in max_score_rows:
+        if s is None:
+            continue
+        sf = float(s)
+        if sf < 4:
+            severities.add("low")
+        elif sf < 7:
+            severities.add("medium")
+        elif sf < 9:
+            severities.add("high")
+        else:
+            severities.add("critical")
+    # Vulns without any metrics fall back to status/"unknown"
+    has_no_metrics = db.session.execute(
+        db.select(Vulnerability.id)
+        .outerjoin(Metrics, Vulnerability.id == Metrics.vulnerability_id)
+        .where(Metrics.id.is_(None))
+        .limit(1)
+    ).first() is not None
+    if has_no_metrics:
+        severities.add("unknown")
+
+    statuses = {
+        s for (s,) in db.session.execute(
+            db.select(DBAssessment.simplified_status)
+            .where(DBAssessment.simplified_status.isnot(None))
+            .distinct()
+        ).all() if s
+    }
+    has_unassessed = db.session.execute(
+        db.select(Vulnerability.id)
+        .outerjoin(Finding, Vulnerability.id == Finding.vulnerability_id)
+        .outerjoin(DBAssessment, DBAssessment.finding_id == Finding.id)
+        .where(DBAssessment.id.is_(None))
+        .limit(1)
+    ).first() is not None
+    if has_unassessed:
+        statuses.add("Pending Assessment")
+
+    formats = {
+        f for (f,) in db.session.execute(
+            db.select(SBOMDocument.format)
+            .where(SBOMDocument.format.isnot(None))
+            .distinct()
+        ).all() if f
+    }
+    sources = {_FORMAT_TO_FOUND_BY.get(f, f) for f in formats}
+
+    attack_vectors: set[str] = set()
+    av_rows = db.session.execute(
+        db.select(Metrics.vector).where(Metrics.vector.isnot(None)).distinct()
+    ).all()
+    _AV_MAP = {"AV:N": "NETWORK", "AV:A": "ADJACENT", "AV:L": "LOCAL", "AV:P": "PHYSICAL"}
+    for (vec,) in av_rows:
+        if not vec:
+            continue
+        for token, label in _AV_MAP.items():
+            if token in vec:
+                attack_vectors.add(label)
+
+    first_scan_ts: set[int] = set()
+    rows = db.session.execute(
+        db.select(func.min(Scan.timestamp))
+        .select_from(Finding)
+        .join(Observation, Finding.id == Observation.finding_id)
+        .join(Scan, Observation.scan_id == Scan.id)
+        .group_by(Finding.vulnerability_id)
+    ).all()
+    for (min_ts,) in rows:
+        if min_ts is not None:
+            first_scan_ts.add(int(round(min_ts.timestamp())) * 1000)
+
+    return {
+        "severities": sorted(severities),
+        "statuses": sorted(statuses),
+        "sources": sorted(sources),
+        "attack_vectors": sorted(attack_vectors),
+        "first_scan_dates": sorted(first_scan_ts),
+    }
+
+
 def _populate_found_by(
     records: list,
     variant_uuid=None,
@@ -408,6 +506,219 @@ def init_app(app):
         project_id = request.args.get('project_id')
         compare_variant_id = request.args.get('compare_variant_id')
         current_scan_ids: list = []
+
+        # ------------------------------------------------------------------
+        # Fast path: paginated, unscoped, no client filters or custom sort.
+        # The default frontend page-load hits this. Loads only the page-size
+        # records (vs all 11k) and computes facets via SQL aggregations.
+        # ------------------------------------------------------------------
+        _page_arg = request.args.get('page', type=int)
+        _fmt = request.args.get('format', 'list')
+        _filter_keys = {
+            "search", "severity", "simplified_status", "found_by", "package",
+            "epss_min", "epss_max", "severity_min", "severity_max",
+            "attack_vector", "published_date_filter", "first_scan_date",
+        }
+        _has_filters = any(request.args.get(k) for k in _filter_keys)
+        _sort_by = request.args.get('sort_by', 'id')
+        _sort_dir = request.args.get('sort_dir', 'asc')
+        _fast_path_eligible = (
+            _page_arg is not None
+            and _fmt != "dict"
+            and not (variant_id or project_id or compare_variant_id)
+            and not _has_filters
+            and _sort_by == "id"
+            and _sort_dir in ("asc", "desc")
+        )
+        if _fast_path_eligible:
+            page_size = min(max(request.args.get('page_size', 50, type=int), 1), 500)
+            page = max(_page_arg, 1)
+            start = (page - 1) * page_size
+
+            total = db.session.execute(
+                db.select(func.count(Vulnerability.id))
+            ).scalar() or 0
+
+            order_clause = (
+                Vulnerability.id.desc() if _sort_dir == "desc" else Vulnerability.id.asc()
+            )
+            page_records = list(db.session.execute(
+                db.select(Vulnerability)
+                .order_by(order_clause)
+                .limit(page_size)
+                .offset(start)
+            ).scalars().all())
+
+            page_vuln_ids = [r.id for r in page_records]
+            if page_vuln_ids:
+                # Bulk-load metrics, packages, effort for just this page
+                metric_rows = db.session.execute(
+                    db.select(Metrics).where(Metrics.vulnerability_id.in_(page_vuln_ids))
+                ).scalars().all()
+                metrics_by_vuln: dict[str, list] = {}
+                for m in metric_rows:
+                    metrics_by_vuln.setdefault(m.vulnerability_id, []).append(m)
+
+                pkg_rows = db.session.execute(
+                    db.select(Finding.vulnerability_id, Package.name, Package.version)
+                    .join(Package, Finding.package_id == Package.id)
+                    .where(Finding.vulnerability_id.in_(page_vuln_ids))
+                    .distinct()
+                ).all()
+                pkgs_by_vuln: dict[str, list[str]] = {}
+                for vid, pname, pver in pkg_rows:
+                    pkgs_by_vuln.setdefault(vid, []).append(f"{pname}@{pver}")
+
+                te_rows = db.session.execute(
+                    db.select(
+                        Finding.vulnerability_id,
+                        TimeEstimate.optimistic,
+                        TimeEstimate.likely,
+                        TimeEstimate.pessimistic,
+                    )
+                    .join(Finding, TimeEstimate.finding_id == Finding.id)
+                    .where(Finding.vulnerability_id.in_(page_vuln_ids))
+                ).all()
+                effort_by_vuln: dict[str, tuple] = {}
+                for vid, opti, like, pess in te_rows:
+                    if vid not in effort_by_vuln:
+                        effort_by_vuln[vid] = (opti, like, pess)
+
+                from sqlalchemy.orm import attributes as orm_attrs
+                for r in page_records:
+                    r.packages = pkgs_by_vuln.get(r.id, [])
+                    te = effort_by_vuln.get(r.id)
+                    if te:
+                        opti, like, pess = te
+
+                        def _h(v):
+                            if v is None:
+                                return None
+                            return Iso8601Duration(f"PT{v}H")
+                        r.effort = {
+                            "optimistic": _h(opti),
+                            "likely": _h(like),
+                            "pessimistic": _h(pess),
+                        }
+                    orm_attrs.set_committed_value(r, 'findings', [])
+                    orm_attrs.set_committed_value(
+                        r, 'metrics', metrics_by_vuln.get(r.id, [])
+                    )
+
+            _populate_found_by(page_records, None, None)
+            page_vulns = [r.to_dict() for r in page_records]
+
+            if page_vuln_ids:
+                # packages_current = packages (no scope)
+                for v in page_vulns:
+                    v["packages_current"] = list(v["packages"])
+
+                # variants enrichment via latest-scan join
+                latest_ts_sub = (
+                    db.select(Scan.variant_id, func.max(Scan.timestamp).label("max_ts"))
+                    .group_by(Scan.variant_id)
+                    .subquery()
+                )
+                latest_scan_sub = (
+                    db.select(Scan.id)
+                    .join(
+                        latest_ts_sub,
+                        (Scan.variant_id == latest_ts_sub.c.variant_id)
+                        & (Scan.timestamp == latest_ts_sub.c.max_ts),
+                    )
+                    .subquery()
+                )
+                rows = db.session.execute(
+                    db.select(Finding.vulnerability_id, Variant.name)
+                    .join(Observation, Finding.id == Observation.finding_id)
+                    .join(Scan, Observation.scan_id == Scan.id)
+                    .join(Variant, Scan.variant_id == Variant.id)
+                    .where(Finding.vulnerability_id.in_(page_vuln_ids))
+                    .where(Observation.scan_id.in_(db.select(latest_scan_sub.c.id)))
+                    .distinct()
+                ).all()
+                variant_names_by_vuln: dict = {}
+                for vuln_id, variant_name in rows:
+                    variant_names_by_vuln.setdefault(str(vuln_id), []).append(variant_name)
+                for v in page_vulns:
+                    v["variants"] = sorted(variant_names_by_vuln.get(v["id"], []))
+
+                first_scan_rows = db.session.execute(
+                    db.select(Finding.vulnerability_id, func.min(Scan.timestamp))
+                    .join(Observation, Finding.id == Observation.finding_id)
+                    .join(Scan, Observation.scan_id == Scan.id)
+                    .where(Finding.vulnerability_id.in_(page_vuln_ids))
+                    .group_by(Finding.vulnerability_id)
+                ).all()
+                first_scan_by_vuln: dict = {}
+                for vuln_id, min_ts in first_scan_rows:
+                    first_scan_by_vuln[str(vuln_id)] = min_ts.isoformat() if min_ts else None
+                for v in page_vulns:
+                    v["first_scan_date"] = first_scan_by_vuln.get(v["id"])
+
+                assess_rows = db.session.execute(
+                    db.select(
+                        Finding.vulnerability_id,
+                        DBAssessment.id,
+                        DBAssessment.status,
+                        DBAssessment.simplified_status,
+                        DBAssessment.status_notes,
+                        DBAssessment.justification,
+                        DBAssessment.impact_statement,
+                        DBAssessment.workaround,
+                        DBAssessment.timestamp,
+                        DBAssessment.responses,
+                        DBAssessment.variant_id,
+                        DBAssessment.finding_id,
+                        Package.name,
+                        Package.version,
+                    )
+                    .join(Finding, DBAssessment.finding_id == Finding.id)
+                    .join(Package, Finding.package_id == Package.id, isouter=True)
+                    .where(Finding.vulnerability_id.in_(page_vuln_ids))
+                    .order_by(Finding.vulnerability_id, DBAssessment.timestamp)
+                ).all()
+                assessments_by_vuln: dict = {}
+                for row in assess_rows:
+                    vid = str(row.vulnerability_id)
+                    ts = row.timestamp.isoformat() if row.timestamp else ""
+                    pkg_str = f"{row.name}@{row.version}" if row.name else ""
+                    simplified = row.simplified_status or _S2S.get(row.status or "", "Pending Assessment")
+                    assessments_by_vuln.setdefault(vid, []).append({
+                        "id": str(row.id),
+                        "vuln_id": vid,
+                        "packages": [pkg_str] if pkg_str else [],
+                        "variant_id": str(row.variant_id) if row.variant_id else None,
+                        "status": row.status or "",
+                        "simplified_status": simplified,
+                        "status_notes": row.status_notes or "",
+                        "justification": row.justification or "",
+                        "impact_statement": row.impact_statement or "",
+                        "responses": list(row.responses or []),
+                        "workaround": row.workaround or "",
+                        "timestamp": ts,
+                        "last_update": ts,
+                    })
+                for v in page_vulns:
+                    vid = v["id"]
+                    v_assessments = assessments_by_vuln.get(vid, [])
+                    v["assessments"] = v_assessments
+                    if v_assessments:
+                        latest = v_assessments[-1]
+                        v["status"] = latest["status"]
+                        v["simplified_status"] = latest["simplified_status"]
+                    else:
+                        v["status"] = "unknown"
+                        v["simplified_status"] = "Pending Assessment"
+
+            return {
+                "items": page_vulns,
+                "total": int(total),
+                "page": page,
+                "page_size": page_size,
+                "facets": _sql_compute_facets_global(),
+            }
+
         if variant_id and compare_variant_id:
             try:
                 base_uuid = uuid.UUID(variant_id)

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -18,6 +18,8 @@ from ..models.cvss import CVSS
 from ..models.iso8601_duration import Iso8601Duration
 from ..models.sbom_document import SBOMDocument
 from ..models.sbom_package import SBOMPackage
+from ..models.assessment import Assessment as DBAssessment, STATUS_TO_SIMPLIFIED as _S2S
+from ..models.time_estimate import TimeEstimate
 from ..extensions import db
 from ..helpers.verbose import verbose
 
@@ -265,7 +267,6 @@ def init_app(app):
             if not latest_ids:
                 records = []
             else:
-                from ..models.time_estimate import TimeEstimate
 
                 # Subquery for vulnerability IDs visible in these scans,
                 # used to avoid huge literal IN-lists in secondary queries.
@@ -430,6 +431,64 @@ def init_app(app):
             for v in vulns:
                 v["first_scan_date"] = first_scan_by_vuln.get(v["id"])
 
+            # Bulk-load assessments and enrich each vuln with status/simplified_status/assessments
+            assess_rows = db.session.execute(
+                db.select(
+                    Finding.vulnerability_id,
+                    DBAssessment.id,
+                    DBAssessment.status,
+                    DBAssessment.simplified_status,
+                    DBAssessment.status_notes,
+                    DBAssessment.justification,
+                    DBAssessment.impact_statement,
+                    DBAssessment.workaround,
+                    DBAssessment.timestamp,
+                    DBAssessment.responses,
+                    DBAssessment.variant_id,
+                    DBAssessment.finding_id,
+                    Package.name,
+                    Package.version,
+                )
+                .join(Finding, DBAssessment.finding_id == Finding.id)
+                .join(Package, Finding.package_id == Package.id, isouter=True)
+                .where(Finding.vulnerability_id.in_(vuln_ids))
+                .order_by(Finding.vulnerability_id, DBAssessment.timestamp)
+            ).all()
+
+            assessments_by_vuln: dict = {}
+            for row in assess_rows:
+                vid = str(row.vulnerability_id)
+                ts = row.timestamp.isoformat() if row.timestamp else ""
+                pkg_str = f"{row.name}@{row.version}" if row.name else ""
+                simplified = row.simplified_status or _S2S.get(row.status or "", "Pending Assessment")
+                assessments_by_vuln.setdefault(vid, []).append({
+                    "id": str(row.id),
+                    "vuln_id": vid,
+                    "packages": [pkg_str] if pkg_str else [],
+                    "variant_id": str(row.variant_id) if row.variant_id else None,
+                    "status": row.status or "",
+                    "simplified_status": simplified,
+                    "status_notes": row.status_notes or "",
+                    "justification": row.justification or "",
+                    "impact_statement": row.impact_statement or "",
+                    "responses": list(row.responses or []),
+                    "workaround": row.workaround or "",
+                    "timestamp": ts,
+                    "last_update": ts,
+                })
+
+            for v in vulns:
+                vid = v["id"]
+                v_assessments = assessments_by_vuln.get(vid, [])
+                v["assessments"] = v_assessments
+                if v_assessments:
+                    latest = v_assessments[-1]
+                    v["status"] = latest["status"]
+                    v["simplified_status"] = latest["simplified_status"]
+                else:
+                    v["status"] = "unknown"
+                    v["simplified_status"] = "Pending Assessment"
+
         if request.args.get('format', 'list') == "dict":
             return {v["id"]: v for v in vulns}
         return vulns
@@ -465,7 +524,6 @@ def init_app(app):
                     except (ValueError, AttributeError):
                         return {"error": "Invalid variant_id"}, 400
                 try:
-                    from ..models.time_estimate import TimeEstimate
                     for finding in (record.findings or []):
                         if variant_id is not None:
                             existing = TimeEstimate.get_by_finding_and_variant(finding.id, variant_id)
@@ -539,7 +597,6 @@ def init_app(app):
                         errors.append({"id": item["id"], "error": "Invalid variant_id"})
                         continue
                 try:
-                    from ..models.time_estimate import TimeEstimate
                     for finding in (record.findings or []):
                         if item_variant_id is not None:
                             existing = TimeEstimate.get_by_finding_and_variant(finding.id, item_variant_id)

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -84,7 +84,21 @@ def _sql_compute_facets_global() -> dict:
     Set members match what _compute_facets() would produce when no client
     filters are applied, except ``sources`` which is approximated from the
     same SBOMDocument.format mapping used by _populate_found_by().
+
+    Result is cached in-process keyed on a cheap content signature
+    (counts of vulns / assessments / sboms + max assessment timestamp) so
+    that repeat page loads avoid re-running the GROUP BY scan over all
+    findings used to build ``first_scan_dates``.
     """
+    sig = db.session.execute(db.text(
+        "SELECT (SELECT COUNT(*) FROM vulnerabilities),"
+        " (SELECT COUNT(*) FROM assessments),"
+        " (SELECT COUNT(*) FROM sbom_documents),"
+        " (SELECT MAX(timestamp) FROM assessments)"
+    )).first()
+    cached = getattr(_sql_compute_facets_global, "_cache", None)
+    if cached is not None and cached[0] == sig:
+        return cached[1]
     severities: set[str] = set()
     # Severity is computed from the max metrics.score per vuln, bucketed
     # the same way CVSS.severity() does. Match the lowercase labels that
@@ -166,13 +180,15 @@ def _sql_compute_facets_global() -> dict:
         if min_ts is not None:
             first_scan_ts.add(int(round(min_ts.timestamp())) * 1000)
 
-    return {
+    result = {
         "severities": sorted(severities),
         "statuses": sorted(statuses),
         "sources": sorted(sources),
         "attack_vectors": sorted(attack_vectors),
         "first_scan_dates": sorted(first_scan_ts),
     }
+    _sql_compute_facets_global._cache = (sig, result)
+    return result
 
 
 def _populate_found_by(

--- a/tests/unit_tests/test_packages_route_helpers.py
+++ b/tests/unit_tests/test_packages_route_helpers.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for helper functions in src/routes/packages.py."""
+
+import pytest
+from src.routes.packages import _score_to_severity, _SEVERITY_INDEX
+
+
+class TestScoreToSeverity:
+    """Tests for _score_to_severity()."""
+
+    def test_none_returns_none(self):
+        assert _score_to_severity(None) == "NONE"
+
+    def test_zero_returns_none(self):
+        assert _score_to_severity(0) == "NONE"
+
+    def test_below_4_returns_low(self):
+        assert _score_to_severity(0.1) == "LOW"
+        assert _score_to_severity(1.0) == "LOW"
+        assert _score_to_severity(3.9) == "LOW"
+
+    def test_4_returns_medium(self):
+        assert _score_to_severity(4.0) == "MEDIUM"
+
+    def test_between_4_and_7_returns_medium(self):
+        assert _score_to_severity(5.5) == "MEDIUM"
+        assert _score_to_severity(6.9) == "MEDIUM"
+
+    def test_7_returns_high(self):
+        assert _score_to_severity(7.0) == "HIGH"
+
+    def test_between_7_and_9_returns_high(self):
+        assert _score_to_severity(8.0) == "HIGH"
+        assert _score_to_severity(8.9) == "HIGH"
+
+    def test_9_returns_critical(self):
+        assert _score_to_severity(9.0) == "CRITICAL"
+
+    def test_above_9_returns_critical(self):
+        assert _score_to_severity(9.5) == "CRITICAL"
+        assert _score_to_severity(10.0) == "CRITICAL"
+
+
+class TestSeverityIndex:
+    """Tests for _SEVERITY_INDEX ordering consistency."""
+
+    def test_none_lowest(self):
+        assert _SEVERITY_INDEX["NONE"] < _SEVERITY_INDEX["LOW"]
+
+    def test_low_less_than_medium(self):
+        assert _SEVERITY_INDEX["LOW"] < _SEVERITY_INDEX["MEDIUM"]
+
+    def test_medium_less_than_high(self):
+        assert _SEVERITY_INDEX["MEDIUM"] < _SEVERITY_INDEX["HIGH"]
+
+    def test_high_less_than_critical(self):
+        assert _SEVERITY_INDEX["HIGH"] < _SEVERITY_INDEX["CRITICAL"]
+
+    def test_unknown_between_none_and_low(self):
+        assert _SEVERITY_INDEX["NONE"] < _SEVERITY_INDEX["UNKNOWN"]
+        assert _SEVERITY_INDEX["UNKNOWN"] < _SEVERITY_INDEX["LOW"]

--- a/tests/unit_tests/test_vuln_route_helpers.py
+++ b/tests/unit_tests/test_vuln_route_helpers.py
@@ -1,0 +1,531 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for the pure helper functions in src/routes/vulnerabilities.py.
+
+These functions (_compute_facets, _matches_search, _apply_server_filters,
+_apply_server_sort, _parse_effort_hours) have no Flask / DB dependency and can
+be exercised directly.
+"""
+
+import datetime
+import pytest
+
+from src.routes.vulnerabilities import (
+    _compute_facets,
+    _matches_search,
+    _apply_server_filters,
+    _apply_server_sort,
+    _parse_effort_hours,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: Flask-style args dict that supports the ``type=`` keyword
+# ---------------------------------------------------------------------------
+
+class Args(dict):
+    """Minimal stand-in for Flask's ImmutableMultiDict used in tests."""
+
+    def get(self, key, default=None, type=None):  # noqa: A002
+        val = super().get(key, default)
+        if type is not None and val is not None:
+            try:
+                return type(val)
+            except (ValueError, TypeError):
+                return default
+        return val
+
+
+# ---------------------------------------------------------------------------
+# Sample vuln dicts
+# ---------------------------------------------------------------------------
+
+def _make_vuln(vuln_id="CVE-2024-001", severity="high", max_score=8.5,
+               status="Exploitable", found_by=None, packages=None,
+               packages_current=None, epss_score=None, av=None,
+               published=None, first_scan_date=None, assessments=None,
+               effort=None, texts=None):
+    cvss = []
+    if av:
+        cvss.append({"attack_vector": av, "score": max_score})
+    return {
+        "id": vuln_id,
+        "severity": {
+            "severity": severity,
+            "max_score": max_score,
+            "cvss": cvss,
+        },
+        "simplified_status": status,
+        "found_by": found_by or [],
+        "packages": packages or [],
+        "packages_current": packages_current or [],
+        "epss": {"score": epss_score} if epss_score is not None else {"score": None},
+        "published": published,
+        "first_scan_date": first_scan_date,
+        "assessments": assessments or [],
+        "effort": effort or {},
+        "texts": texts or {},
+    }
+
+
+V1 = _make_vuln("CVE-2024-001", "high", 8.5, "Exploitable",
+                found_by=["grype"], packages=["libfoo@1.0"],
+                packages_current=["libfoo@1.0"], epss_score=0.45,
+                av="NETWORK", published="2024-01-15",
+                first_scan_date="2024-06-01T12:00:00")
+V2 = _make_vuln("CVE-2024-002", "critical", 9.8, "Not affected",
+                found_by=["spdx3"], packages=["libbar@2.0"],
+                packages_current=["libbar@2.0"], epss_score=0.02,
+                av="LOCAL", published="2024-03-20",
+                first_scan_date="2024-06-15T08:00:00")
+V3 = _make_vuln("CVE-2024-003", "low", 2.1, "Pending Assessment",
+                found_by=[], packages=["libbaz@3.0"],
+                packages_current=["libbaz@3.0"], epss_score=None,
+                av=None, published="2023-11-01",
+                first_scan_date=None)
+
+
+# ===========================================================================
+# _parse_effort_hours
+# ===========================================================================
+
+class TestParseEffortHours:
+    def test_integer_passthrough(self):
+        assert _parse_effort_hours(8) == 8
+
+    def test_iso_duration_string(self):
+        assert _parse_effort_hours("PT8H") == 8
+
+    def test_iso_duration_days(self):
+        # P1D — actual value depends on Iso8601Duration implementation; just verify it returns an int
+        result = _parse_effort_hours("P1D")
+        assert isinstance(result, int) and result >= 0
+
+    def test_invalid_type_raises(self):
+        with pytest.raises((ValueError, TypeError)):
+            _parse_effort_hours(3.14)
+
+    def test_zero_hours(self):
+        assert _parse_effort_hours(0) == 0
+
+    def test_string_zero(self):
+        assert _parse_effort_hours("PT0H") == 0
+
+
+# ===========================================================================
+# _compute_facets
+# ===========================================================================
+
+class TestComputeFacets:
+    def test_empty_list(self):
+        result = _compute_facets([])
+        assert result["severities"] == []
+        assert result["statuses"] == []
+        assert result["sources"] == []
+        assert result["attack_vectors"] == []
+        assert result["first_scan_dates"] == []
+
+    def test_collects_severity(self):
+        result = _compute_facets([V1, V2, V3])
+        assert "high" in result["severities"]
+        assert "critical" in result["severities"]
+        assert "low" in result["severities"]
+
+    def test_collects_statuses(self):
+        result = _compute_facets([V1, V2, V3])
+        assert "Exploitable" in result["statuses"]
+        assert "Not affected" in result["statuses"]
+        assert "Pending Assessment" in result["statuses"]
+
+    def test_collects_sources(self):
+        result = _compute_facets([V1, V2])
+        assert "grype" in result["sources"]
+        assert "spdx3" in result["sources"]
+
+    def test_empty_source_not_included(self):
+        v = _make_vuln(found_by=["", "grype"])
+        result = _compute_facets([v])
+        assert "" not in result["sources"]
+        assert "grype" in result["sources"]
+
+    def test_collects_attack_vectors(self):
+        result = _compute_facets([V1, V2])
+        assert "NETWORK" in result["attack_vectors"]
+        assert "LOCAL" in result["attack_vectors"]
+
+    def test_collects_first_scan_dates(self):
+        result = _compute_facets([V1, V2])
+        assert len(result["first_scan_dates"]) == 2
+
+    def test_invalid_first_scan_date_ignored(self):
+        v = _make_vuln(first_scan_date="not-a-date")
+        result = _compute_facets([v])
+        assert result["first_scan_dates"] == []
+
+    def test_none_severity_skipped(self):
+        v = {"severity": None, "simplified_status": None, "found_by": [],
+             "first_scan_date": None}
+        result = _compute_facets([v])
+        assert result["severities"] == []
+
+    def test_results_are_sorted(self):
+        result = _compute_facets([V1, V2, V3])
+        assert result["severities"] == sorted(result["severities"])
+        assert result["statuses"] == sorted(result["statuses"])
+
+
+# ===========================================================================
+# _matches_search
+# ===========================================================================
+
+class TestMatchesSearch:
+    def test_plain_match_on_id(self):
+        assert _matches_search(V1, "CVE-2024-001") is True
+
+    def test_no_match(self):
+        assert _matches_search(V1, "CVE-9999-9999") is False
+
+    def test_match_on_package(self):
+        assert _matches_search(V1, "libfoo") is True
+
+    def test_match_on_text(self):
+        v = _make_vuln(texts={"description": "buffer overflow issue"})
+        assert _matches_search(v, "overflow") is True
+
+    def test_or_semantics(self):
+        # CVE-2024-001 OR CVE-9999
+        assert _matches_search(V1, "CVE-2024-001 | CVE-9999") is True
+
+    def test_not_semantics(self):
+        # must contain "CVE-2024-001" but NOT "libbar"
+        assert _matches_search(V1, "CVE-2024-001 -libbar") is True
+        assert _matches_search(V1, "CVE-2024-001 -libfoo") is False
+
+    def test_short_search_covered_via_filter(self):
+        # _apply_server_filters skips search ≤2 chars; direct call still works for coverage
+        # "CV" is a substring of the vuln id so it matches — the filter skips very short terms at a higher level
+        result = _matches_search(V1, "CV")
+        assert isinstance(result, bool)
+
+    def test_and_semantics(self):
+        # both terms must be present
+        assert _matches_search(V1, "CVE-2024-001 libfoo") is True
+        assert _matches_search(V1, "CVE-2024-001 libbar") is False
+
+    def test_case_insensitive(self):
+        assert _matches_search(V1, "cve-2024-001") is True
+
+
+# ===========================================================================
+# _apply_server_filters
+# ===========================================================================
+
+class TestApplyServerFilters:
+    # ---- no filters ------------------------------------------------------
+
+    def test_no_filters_returns_all(self):
+        result = _apply_server_filters([V1, V2, V3], Args())
+        assert len(result) == 3
+
+    # ---- search ----------------------------------------------------------
+
+    def test_search_filters(self):
+        result = _apply_server_filters([V1, V2, V3], Args(search="libfoo"))
+        assert all(v["id"] == "CVE-2024-001" for v in result)
+
+    def test_short_search_no_filter(self):
+        result = _apply_server_filters([V1, V2], Args(search="CV"))
+        assert len(result) == 2
+
+    # ---- severity --------------------------------------------------------
+
+    def test_severity_filter_single(self):
+        result = _apply_server_filters([V1, V2, V3], Args(severity="high"))
+        assert all((v["severity"] or {}).get("severity") == "high" for v in result)
+
+    def test_severity_filter_multiple(self):
+        result = _apply_server_filters([V1, V2, V3], Args(severity="high,critical"))
+        assert len(result) == 2
+
+    # ---- status ----------------------------------------------------------
+
+    def test_status_filter(self):
+        result = _apply_server_filters([V1, V2, V3], Args(simplified_status="Exploitable"))
+        assert len(result) == 1
+
+    # ---- found_by --------------------------------------------------------
+
+    def test_found_by_filter(self):
+        result = _apply_server_filters([V1, V2, V3], Args(found_by="grype"))
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-001"
+
+    # ---- package ---------------------------------------------------------
+
+    def test_package_filter(self):
+        result = _apply_server_filters([V1, V2, V3], Args(package="libbar@2.0"))
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-002"
+
+    # ---- epss ------------------------------------------------------------
+
+    def test_epss_min_filter(self):
+        # V1 epss=0.45 (45%), V2 epss=0.02 (2%), V3 epss=None
+        result = _apply_server_filters([V1, V2, V3], Args(epss_min="10"))
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-001"
+
+    def test_epss_max_filter(self):
+        result = _apply_server_filters([V1, V2, V3], Args(epss_max="5"))
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-002"
+
+    def test_epss_min_and_max(self):
+        result = _apply_server_filters([V1, V2, V3], Args(epss_min="1", epss_max="50"))
+        assert len(result) == 2  # V1 (45%) and V2 (2%)
+
+    def test_epss_filter_excludes_none(self):
+        result = _apply_server_filters([V3], Args(epss_min="0"))
+        assert result == []
+
+    # ---- severity score --------------------------------------------------
+
+    def test_severity_min_filter(self):
+        result = _apply_server_filters([V1, V2, V3], Args(severity_min="9"))
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-002"
+
+    def test_severity_max_filter(self):
+        result = _apply_server_filters([V1, V2, V3], Args(severity_max="5"))
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-003"
+
+    def test_severity_score_none_excluded(self):
+        v = _make_vuln(max_score=None)
+        v["severity"]["max_score"] = None
+        result = _apply_server_filters([v], Args(severity_min="1"))
+        assert result == []
+
+    # ---- attack_vector ---------------------------------------------------
+
+    def test_attack_vector_filter(self):
+        result = _apply_server_filters([V1, V2, V3], Args(attack_vector="NETWORK"))
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-001"
+
+    def test_attack_vector_multiple(self):
+        result = _apply_server_filters([V1, V2, V3], Args(attack_vector="NETWORK,LOCAL"))
+        assert len(result) == 2
+
+    # ---- published_date_filter -------------------------------------------
+
+    def test_pub_filter_is(self):
+        result = _apply_server_filters(
+            [V1, V2, V3],
+            Args(published_date_filter="is", published_date_value="2024-01-15"),
+        )
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-001"
+
+    def test_pub_filter_gte(self):
+        result = _apply_server_filters(
+            [V1, V2, V3],
+            Args(published_date_filter=">=", published_date_value="2024-01-01"),
+        )
+        assert len(result) == 2  # V1, V2
+
+    def test_pub_filter_lte(self):
+        result = _apply_server_filters(
+            [V1, V2, V3],
+            Args(published_date_filter="<=", published_date_value="2023-12-31"),
+        )
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-003"
+
+    def test_pub_filter_between(self):
+        result = _apply_server_filters(
+            [V1, V2, V3],
+            Args(
+                published_date_filter="between",
+                published_date_from="2024-01-01",
+                published_date_to="2024-02-28",
+            ),
+        )
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-001"
+
+    def test_pub_filter_days_ago(self):
+        # V3 published 2023-11-01 — far in the past, won't match 1 day
+        result = _apply_server_filters(
+            [V3],
+            Args(published_date_filter="days_ago", published_days_value="1"),
+        )
+        assert result == []
+
+    def test_pub_filter_days_ago_long(self):
+        # All vulns published in 2023-2024, should match with 2000 days
+        result = _apply_server_filters(
+            [V1, V2, V3],
+            Args(published_date_filter="days_ago", published_days_value="2000"),
+        )
+        assert len(result) == 3
+
+    def test_pub_filter_skips_no_published(self):
+        v = _make_vuln(published=None)
+        result = _apply_server_filters(
+            [v],
+            Args(published_date_filter="is", published_date_value="2024-01-15"),
+        )
+        assert result == []
+
+    def test_pub_filter_invalid_date_skipped(self):
+        v = _make_vuln(published="not-a-date")
+        result = _apply_server_filters(
+            [v],
+            Args(published_date_filter="is", published_date_value="2024-01-15"),
+        )
+        assert result == []
+
+    # ---- first_scan_date -------------------------------------------------
+
+    def test_first_scan_date_filter(self):
+        # compute the expected timestamp for V1's first_scan_date
+        ts = str(int(round(datetime.datetime.fromisoformat("2024-06-01T12:00:00").timestamp())) * 1000)
+        result = _apply_server_filters([V1, V2, V3], Args(first_scan_date=ts))
+        assert len(result) == 1 and result[0]["id"] == "CVE-2024-001"
+
+    def test_first_scan_date_no_date_excluded(self):
+        ts = "999999999000"
+        result = _apply_server_filters([V3], Args(first_scan_date=ts))
+        assert result == []
+
+
+# ===========================================================================
+# _apply_server_sort
+# ===========================================================================
+
+class TestApplyServerSort:
+    def _ids(self, vulns):
+        return [v["id"] for v in vulns]
+
+    def test_sort_by_id_asc(self):
+        result = _apply_server_sort([V2, V3, V1], "id", "asc")
+        assert self._ids(result) == ["CVE-2024-001", "CVE-2024-002", "CVE-2024-003"]
+
+    def test_sort_by_id_desc(self):
+        result = _apply_server_sort([V1, V2, V3], "id", "desc")
+        assert self._ids(result)[0] == "CVE-2024-003"
+
+    def test_sort_by_severity_severity_asc(self):
+        result = _apply_server_sort([V2, V1, V3], "severity.severity", "asc")
+        # low < high < critical
+        assert self._ids(result) == ["CVE-2024-003", "CVE-2024-001", "CVE-2024-002"]
+
+    def test_sort_by_severity_max_score(self):
+        result = _apply_server_sort([V3, V1, V2], "severity.max_score", "asc")
+        assert result[0]["id"] == "CVE-2024-003"
+        assert result[-1]["id"] == "CVE-2024-002"
+
+    def test_sort_by_epss(self):
+        result = _apply_server_sort([V1, V2, V3], "epss", "asc")
+        # V3 has None epss (0), V2 has 0.02, V1 has 0.45
+        assert result[-1]["id"] == "CVE-2024-001"
+
+    def test_sort_by_simplified_status(self):
+        result = _apply_server_sort([V2, V3, V1], "simplified_status", "asc")
+        # "Exploitable" < "Not affected" < "Pending Assessment" by _STATUS_SORT_ORDER
+        assert result[0]["id"] == "CVE-2024-003"  # "Pending Assessment" = index 1 (unknown=0)
+
+    def test_sort_by_simplified_status_unknown(self):
+        v = _make_vuln("CVE-X", status="SomeUnknownStatus")
+        result = _apply_server_sort([v, V1], "simplified_status", "asc")
+        assert len(result) == 2
+
+    def test_sort_by_effort_likely(self):
+        v_with_effort = _make_vuln("CVE-2024-010")
+        v_with_effort["effort"] = {"likely": "PT2H"}
+        result = _apply_server_sort([V1, v_with_effort], "effort.likely", "asc")
+        assert result[0]["id"] == "CVE-2024-001"  # 0 effort first
+
+    def test_sort_by_effort_likely_invalid(self):
+        v = _make_vuln("CVE-X")
+        v["effort"] = {"likely": "invalid-duration"}
+        # Should not raise, falls back to 0
+        result = _apply_server_sort([v], "effort.likely", "asc")
+        assert len(result) == 1
+
+    def test_sort_by_assessments(self):
+        v_assessed = _make_vuln("CVE-2024-011", assessments=[
+            {"last_update": "2024-06-01", "timestamp": "2024-06-01"},
+        ])
+        result = _apply_server_sort([V1, v_assessed], "assessments", "asc")
+        assert len(result) == 2
+
+    def test_sort_by_assessments_empty(self):
+        result = _apply_server_sort([V1, V2], "assessments", "asc")
+        # Both have no assessments, order stable
+        assert len(result) == 2
+
+    def test_sort_by_published(self):
+        result = _apply_server_sort([V2, V3, V1], "published", "asc")
+        assert result[0]["id"] == "CVE-2024-003"  # earliest published
+
+    def test_sort_by_first_scan_date(self):
+        result = _apply_server_sort([V2, V3, V1], "first_scan_date", "asc")
+        # V3 has no first_scan_date (empty string), comes first
+        assert result[0]["id"] == "CVE-2024-003"
+
+    def test_sort_by_attack_vector(self):
+        # LOCAL < NETWORK in _AV_SORT_ORDER
+        result = _apply_server_sort([V1, V2], "attack_vector", "asc")
+        assert result[0]["id"] == "CVE-2024-002"  # LOCAL
+
+    def test_sort_by_attack_vector_no_av(self):
+        # V3 has no attack vector
+        result = _apply_server_sort([V1, V3], "attack_vector", "asc")
+        assert result[0]["id"] == "CVE-2024-003"  # -1 sorts first
+
+    def test_sort_unknown_column_falls_back_to_id(self):
+        result = _apply_server_sort([V2, V1], "nonexistent_col", "asc")
+        assert result[0]["id"] == "CVE-2024-001"
+
+    def test_sort_by_severity_severity_unknown_value(self):
+        v = _make_vuln("CVE-X", severity="bizarre")
+        result = _apply_server_sort([v, V1], "severity.severity", "asc")
+        # bizarre not in list → -1, sorts before known values
+        assert result[0]["id"] == "CVE-X"
+
+
+# ===========================================================================
+# _detect_format (routes/settings.py)
+# ===========================================================================
+
+class TestDetectFormat:
+    """Cover the _detect_format helper in routes/settings.py."""
+
+    def _df(self, filename, data):
+        from src.routes.settings import _detect_format
+        return _detect_format(filename, data)
+
+    def test_spdx_json_extension(self):
+        assert self._df("myfile.spdx.json", {}) == "spdx"
+
+    def test_cdx_json_extension(self):
+        assert self._df("myfile.cdx.json", {}) == "cdx"
+
+    def test_spdx_version_key(self):
+        assert self._df("scan.json", {"spdxVersion": "SPDX-2.3"}) == "spdx"
+
+    def test_spdxid_key(self):
+        assert self._df("scan.json", {"spdxId": "SPDXRef-Document"}) == "spdx"
+
+    def test_cyclonedx_bom_format(self):
+        assert self._df("bom.json", {"bomFormat": "CycloneDX"}) == "cdx"
+
+    def test_openvex_context(self):
+        assert self._df("vex.json", {"@context": "https://openvex.dev/ns"}) == "openvex"
+
+    def test_yocto_format(self):
+        assert self._df("scan.json", {"package": {"foo": {}}}) == "yocto_cve_check"
+
+    def test_grype_format(self):
+        assert self._df("scan.json", {"matches": [{"vulnerability": {}}]}) == "grype"
+
+    def test_spdx3_context_key(self):
+        assert self._df("scan.json", {"@context": "https://spdx.org/rdf/3.0"}) == "spdx"
+
+    def test_unknown_format(self):
+        assert self._df("scan.json", {}) == "unknown"

--- a/tests/webapp_tests/test_metrics_route.py
+++ b/tests/webapp_tests/test_metrics_route.py
@@ -1,0 +1,566 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for src/routes/metrics.py.
+
+Covers:
+- Pure helper functions (_score_to_severity_index, _severity_text_to_index,
+  _zeroise_dt, _prev_dt, _generate_checkpoints, _format_checkpoint_label,
+  _compute_evolution)
+- GET /api/metrics endpoint: global, variant-scoped, project-scoped, error cases
+"""
+
+import uuid
+import pytest
+import json
+from datetime import datetime, timezone, timedelta
+
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – helper functions (no Flask context needed)
+# ---------------------------------------------------------------------------
+
+from src.routes.metrics import (
+    _score_to_severity_index,
+    _severity_text_to_index,
+    _zeroise_dt,
+    _prev_dt,
+    _generate_checkpoints,
+    _format_checkpoint_label,
+    _compute_evolution,
+)
+
+
+class TestScoreToSeverityIndex:
+    def test_none_returns_0(self):
+        assert _score_to_severity_index(None) == 0
+
+    def test_zero_returns_0(self):
+        assert _score_to_severity_index(0.0) == 0
+        assert _score_to_severity_index(0) == 0
+
+    def test_low(self):
+        assert _score_to_severity_index(0.1) == 1
+        assert _score_to_severity_index(3.9) == 1
+
+    def test_medium(self):
+        assert _score_to_severity_index(4.0) == 2
+        assert _score_to_severity_index(6.9) == 2
+
+    def test_high(self):
+        assert _score_to_severity_index(7.0) == 3
+        assert _score_to_severity_index(8.9) == 3
+
+    def test_critical(self):
+        assert _score_to_severity_index(9.0) == 4
+        assert _score_to_severity_index(10.0) == 4
+
+    def test_string_score(self):
+        # Accepted because SQLAlchemy may return Decimal / str
+        assert _score_to_severity_index("8.5") == 3
+
+
+class TestSeverityTextToIndex:
+    def test_none_returns_0(self):
+        assert _severity_text_to_index(None) == 0
+
+    def test_empty_string_returns_0(self):
+        assert _severity_text_to_index("") == 0
+
+    def test_unknown_returns_0(self):
+        assert _severity_text_to_index("unknown") == 0
+
+    def test_none_text_returns_0(self):
+        assert _severity_text_to_index("none") == 0
+
+    def test_low_returns_1(self):
+        assert _severity_text_to_index("low") == 1
+
+    def test_medium_returns_2(self):
+        assert _severity_text_to_index("medium") == 2
+
+    def test_high_returns_3(self):
+        assert _severity_text_to_index("high") == 3
+
+    def test_critical_returns_4(self):
+        assert _severity_text_to_index("critical") == 4
+
+    def test_case_insensitive(self):
+        assert _severity_text_to_index("HIGH") == 3
+        assert _severity_text_to_index("Critical") == 4
+
+
+class TestZeroiseAndPrevDt:
+    BASE = datetime(2024, 6, 15, 14, 35, 22, 123456, tzinfo=timezone.utc)
+
+    def test_zeroise_month(self):
+        result = _zeroise_dt(self.BASE, "months")
+        assert result.day == 1
+        assert result.hour == 0 and result.minute == 0
+
+    def test_zeroise_day(self):
+        result = _zeroise_dt(self.BASE, "days")
+        assert result.hour == 0 and result.minute == 0 and result.second == 0
+
+    def test_zeroise_week(self):
+        result = _zeroise_dt(self.BASE, "weeks")
+        assert result.hour == 0 and result.second == 0
+
+    def test_zeroise_hour(self):
+        result = _zeroise_dt(self.BASE, "hours")
+        assert result.minute == 0 and result.second == 0 and result.microsecond == 0
+
+    def test_prev_week(self):
+        dt = datetime(2024, 6, 15, tzinfo=timezone.utc)
+        result = _prev_dt(dt, "weeks")
+        assert result == dt - timedelta(weeks=1)
+
+    def test_prev_hour(self):
+        dt = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        result = _prev_dt(dt, "hours")
+        assert result == dt - timedelta(hours=1)
+
+    def test_prev_day(self):
+        dt = datetime(2024, 6, 15, tzinfo=timezone.utc)
+        result = _prev_dt(dt, "days")
+        assert result == dt - timedelta(days=1)
+
+    def test_prev_month_steps_back_one_day(self):
+        dt = datetime(2024, 6, 15, tzinfo=timezone.utc)
+        result = _prev_dt(dt, "months")
+        assert result == dt - timedelta(days=1)
+
+
+class TestGenerateCheckpoints:
+    def test_returns_correct_count(self):
+        checkpoints = _generate_checkpoints(6, "months")
+        assert len(checkpoints) == 6
+
+    def test_oldest_first(self):
+        checkpoints = _generate_checkpoints(5, "days")
+        for i in range(len(checkpoints) - 1):
+            assert checkpoints[i] <= checkpoints[i + 1]
+
+    def test_all_timezone_aware(self):
+        for cp in _generate_checkpoints(3, "hours"):
+            assert cp.tzinfo is not None
+
+    def test_weeks_unit(self):
+        checkpoints = _generate_checkpoints(4, "weeks")
+        assert len(checkpoints) == 4
+
+
+class TestFormatCheckpointLabel:
+    def test_hour_label(self):
+        dt = datetime(2024, 6, 15, 9, 0, 0, tzinfo=timezone.utc)
+        assert _format_checkpoint_label(dt, "hours") == "09:00"
+
+    def test_month_label(self):
+        dt = datetime(2024, 6, 1, tzinfo=timezone.utc)
+        label = _format_checkpoint_label(dt, "months")
+        assert "Jun" in label or "Jun" in label
+
+    def test_day_label(self):
+        dt = datetime(2024, 6, 15, tzinfo=timezone.utc)
+        label = _format_checkpoint_label(dt, "days")
+        assert "15" in label and "Jun" in label
+
+
+class TestComputeEvolution:
+    def _cp(self, days_ago: int) -> datetime:
+        return datetime.now(timezone.utc) - timedelta(days=days_ago)
+
+    def test_empty_assessments(self):
+        cps = [self._cp(4), self._cp(3), self._cp(2), self._cp(1)]
+        result = _compute_evolution({}, cps)
+        assert result == [0, 0, 0, 0]
+
+    def test_single_vuln_always_active(self):
+        """A vuln with one 'Pending Assessment' covers all checkpoints."""
+        cps = [self._cp(4), self._cp(3), self._cp(2), self._cp(1)]
+        # Assessment created before all checkpoints
+        ts = self._cp(10)
+        data = {"CVE-001": [(ts, "Pending Assessment")]}
+        result = _compute_evolution(data, cps)
+        assert all(v == 1 for v in result)
+
+    def test_fixed_vuln_does_not_count(self):
+        """A vuln fixed before all checkpoints should not be active at any checkpoint."""
+        cps = [self._cp(3), self._cp(2), self._cp(1)]
+        ts_fixed = self._cp(10)
+        data = {"CVE-001": [(ts_fixed, "Fixed")]}
+        result = _compute_evolution(data, cps)
+        assert result == [0, 0, 0]
+
+    def test_vuln_fixed_after_first_checkpoint(self):
+        """Vuln opened after cp[0] and fixed before cp[1]: counted at cp[0] only.
+
+        The algorithm counts a checkpoint as active only when the 'open'
+        assessment timestamp is >= that checkpoint.  A vuln opened inside
+        the [cp[0], cp[1]) window is counted at cp[0] only.
+        """
+        cps = [self._cp(5), self._cp(3), self._cp(1)]
+        ts_open = self._cp(4)    # after cp[0], before cp[1]
+        ts_fix = self._cp(2)     # between cp[1] and cp[2]
+        data = {"CVE-001": [(ts_open, "Pending Assessment"), (ts_fix, "Fixed")]}
+        result = _compute_evolution(data, cps)
+        # Opened after cp[0] → counted at cp[0]; fixed before cp[2] → not counted later
+        assert result[0] == 1
+        assert result[1] == 0
+        assert result[2] == 0
+
+    def test_naive_datetime_handled(self):
+        """Naive datetimes are treated as UTC."""
+        cps = [self._cp(3), self._cp(2), self._cp(1)]
+        ts = datetime.now() - timedelta(days=10)  # naive
+        data = {"CVE-NV": [(ts, "Exploitable")]}
+        result = _compute_evolution(data, cps)
+        assert sum(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests – GET /api/metrics endpoint
+# ---------------------------------------------------------------------------
+
+def _build_metrics_db(app):
+    """Populate a full DB chain suitable for exercising /api/metrics."""
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.observation import Observation
+    from src.models.assessment import Assessment
+    from src.models.metrics import Metrics
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("MetricsProject")
+        variant = Variant.create("default", project.id)
+        scan = Scan.create("scan1", variant.id)
+
+        pkg = Package.find_or_create("cairo", "1.16.0")
+        vuln = Vulnerability.create_record(
+            id="CVE-2020-35492",
+            description="cairo vuln",
+            status="high",
+            epss_score=0.3,
+            links=[],
+        )
+        finding = Finding.get_or_create(pkg.id, vuln.id)
+        _db.session.commit()
+
+        sbom = SBOMDocument.create("/grype.json", "grype", scan.id, format="grype")
+        SBOMPackage.create(sbom.id, pkg.id)
+        Observation.create(finding_id=finding.id, scan_id=scan.id)
+
+        # Assessment: fixed
+        assess = Assessment(
+            id=uuid.uuid4(),
+            status="fixed",
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            finding_id=finding.id,
+            responses=[],
+        )
+        _db.session.add(assess)
+
+        # CVSS score
+        Metrics.create(vulnerability_id="CVE-2020-35492", version="3.1", score=8.5)
+
+        _db.session.commit()
+
+        return {
+            "project_id": str(project.id),
+            "variant_id": str(variant.id),
+            "scan_id": str(scan.id),
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    import os
+    scan_file = tmp_path / "status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": str(scan_file),
+            "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
+        })
+        ids = _build_metrics_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+class TestMetricsResponseShape:
+    def test_global_returns_200(self, client):
+        response = client.get("/api/metrics")
+        assert response.status_code == 200
+
+    def test_global_has_all_keys(self, client):
+        data = json.loads(client.get("/api/metrics").data)
+        for key in ("vuln_by_severity", "vuln_by_status", "vuln_evolution",
+                    "vuln_by_source", "top_packages", "top_vulns"):
+            assert key in data, f"Missing key: {key}"
+
+    def test_vuln_by_severity_has_5_elements(self, client):
+        data = json.loads(client.get("/api/metrics").data)
+        assert len(data["vuln_by_severity"]) == 5
+
+    def test_vuln_by_status_has_4_elements(self, client):
+        data = json.loads(client.get("/api/metrics").data)
+        assert len(data["vuln_by_status"]) == 4
+
+    def test_vuln_evolution_has_labels_and_data(self, client):
+        data = json.loads(client.get("/api/metrics").data)
+        evo = data["vuln_evolution"]
+        assert "labels" in evo and "data" in evo
+        assert len(evo["labels"]) == len(evo["data"])
+
+    def test_top_packages_is_list(self, client):
+        data = json.loads(client.get("/api/metrics").data)
+        assert isinstance(data["top_packages"], list)
+
+    def test_top_vulns_is_list(self, client):
+        data = json.loads(client.get("/api/metrics").data)
+        assert isinstance(data["top_vulns"], list)
+
+
+# ---------------------------------------------------------------------------
+# time_scale parameter
+# ---------------------------------------------------------------------------
+
+class TestMetricsTimeScale:
+    def test_default_6_months(self, client):
+        data = json.loads(client.get("/api/metrics").data)
+        assert len(data["vuln_evolution"]["labels"]) == 6
+
+    def test_custom_scale_3_weeks(self, client):
+        data = json.loads(client.get("/api/metrics?time_scale=3_weeks").data)
+        assert len(data["vuln_evolution"]["labels"]) == 3
+
+    def test_custom_scale_12_days(self, client):
+        data = json.loads(client.get("/api/metrics?time_scale=12_days").data)
+        assert len(data["vuln_evolution"]["labels"]) == 12
+
+    def test_custom_scale_hours(self, client):
+        data = json.loads(client.get("/api/metrics?time_scale=24_hours").data)
+        assert len(data["vuln_evolution"]["labels"]) == 24
+
+    def test_invalid_time_scale_missing_underscore(self, client):
+        response = client.get("/api/metrics?time_scale=6months")
+        assert response.status_code == 400
+        assert "time_scale" in json.loads(response.data)["error"]
+
+    def test_invalid_time_scale_non_integer(self, client):
+        response = client.get("/api/metrics?time_scale=abc_months")
+        assert response.status_code == 400
+
+    def test_invalid_time_scale_bad_unit(self, client):
+        response = client.get("/api/metrics?time_scale=6_years")
+        assert response.status_code == 400
+
+    def test_invalid_time_scale_too_small(self, client):
+        response = client.get("/api/metrics?time_scale=1_months")
+        assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Scope filtering – variant_id / project_id
+# ---------------------------------------------------------------------------
+
+class TestMetricsScoping:
+    def test_valid_variant_id_returns_data(self, client, ids):
+        response = client.get(f"/api/metrics?variant_id={ids['variant_id']}")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "vuln_by_severity" in data
+
+    def test_invalid_variant_id_returns_400(self, client):
+        response = client.get("/api/metrics?variant_id=not-a-uuid")
+        assert response.status_code == 400
+        assert "variant_id" in json.loads(response.data)["error"]
+
+    def test_valid_project_id_returns_data(self, client, ids):
+        response = client.get(f"/api/metrics?project_id={ids['project_id']}")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "vuln_by_severity" in data
+
+    def test_invalid_project_id_returns_400(self, client):
+        response = client.get("/api/metrics?project_id=not-a-uuid")
+        assert response.status_code == 400
+        assert "project_id" in json.loads(response.data)["error"]
+
+    def test_unknown_variant_returns_empty_response(self, client):
+        """A valid UUID that has no scan returns zeroed-out metrics."""
+        unknown = str(uuid.uuid4())
+        response = client.get(f"/api/metrics?variant_id={unknown}")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["vuln_by_severity"] == [0, 0, 0, 0, 0]
+        assert data["top_packages"] == []
+        assert data["top_vulns"] == []
+
+    def test_unknown_project_returns_empty_response(self, client):
+        """A valid project UUID with no scans returns zeroed-out metrics."""
+        unknown = str(uuid.uuid4())
+        response = client.get(f"/api/metrics?project_id={unknown}")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["vuln_by_severity"] == [0, 0, 0, 0, 0]
+
+
+# ---------------------------------------------------------------------------
+# Content – counts / values
+# ---------------------------------------------------------------------------
+
+class TestMetricsContent:
+    def test_global_severity_total_equals_vuln_count(self, client):
+        """Sum of vuln_by_severity should equal number of vulnerabilities."""
+        data = json.loads(client.get("/api/metrics").data)
+        total = sum(data["vuln_by_severity"])
+        assert total == 1  # one CVE in the demo DB
+
+    def test_global_status_total_equals_vuln_count(self, client):
+        data = json.loads(client.get("/api/metrics").data)
+        total = sum(data["vuln_by_status"])
+        assert total == 1
+
+    def test_fixed_vuln_counted_in_status(self, client):
+        """Demo vuln has a 'fixed' assessment → status_counts[1] should be 1."""
+        data = json.loads(client.get("/api/metrics").data)
+        assert data["vuln_by_status"][1] == 1  # index 1 = Fixed
+
+    def test_source_label_present_when_grype(self, client):
+        """grype doc in demo DB → 'Grype' appears in vuln_by_source labels."""
+        data = json.loads(client.get("/api/metrics").data)
+        labels = data["vuln_by_source"]["labels"]
+        assert "Grype" in labels
+
+    def test_top_packages_populated(self, client):
+        data = json.loads(client.get("/api/metrics").data)
+        pkgs = data["top_packages"]
+        assert len(pkgs) >= 1
+        assert pkgs[0]["name"] == "cairo"
+
+    def test_top_packages_entry_has_required_fields(self, client):
+        data = json.loads(client.get("/api/metrics").data)
+        pkg = data["top_packages"][0]
+        assert "id" in pkg and "name" in pkg and "version" in pkg and "count" in pkg
+
+    def test_scoped_by_variant_matches_global_for_single_variant(self, client, ids):
+        """Scoping to the only variant in the DB yields same counts as global query."""
+        global_data = json.loads(client.get("/api/metrics").data)
+        scoped_data = json.loads(
+            client.get(f"/api/metrics?variant_id={ids['variant_id']}").data
+        )
+        assert sum(scoped_data["vuln_by_severity"]) == sum(global_data["vuln_by_severity"])
+
+    def test_scoped_by_project_matches_global(self, client, ids):
+        global_data = json.loads(client.get("/api/metrics").data)
+        scoped_data = json.loads(
+            client.get(f"/api/metrics?project_id={ids['project_id']}").data
+        )
+        assert sum(scoped_data["vuln_by_severity"]) == sum(global_data["vuln_by_severity"])
+
+
+# ---------------------------------------------------------------------------
+# top_vulns – 'Fixed' vuln should NOT appear (active only)
+# ---------------------------------------------------------------------------
+
+class TestMetricsTopVulns:
+    def test_fixed_vuln_not_in_top_vulns(self, client):
+        """Fixed vulnerability must not appear in top_vulns."""
+        data = json.loads(client.get("/api/metrics").data)
+        cve_ids = [entry["cve"] for entry in data["top_vulns"]]
+        assert "CVE-2020-35492" not in cve_ids
+
+    def test_top_vulns_empty_when_all_fixed(self, client):
+        """Since the only vuln is Fixed, top_vulns must be []."""
+        data = json.loads(client.get("/api/metrics").data)
+        assert data["top_vulns"] == []
+
+    def test_top_vulns_populated_for_open_vuln(self, app, client, ids):
+        """Add a second 'Pending Assessment' vuln – it should appear in top_vulns."""
+        with app.app_context():
+            from src.models.vulnerability import Vulnerability
+            from src.models.finding import Finding
+            from src.models.observation import Observation
+            from src.models.package import Package
+
+            pkg = _db.session.execute(_db.select(Package)).scalars().first()
+            from src.models.scan import Scan
+            scan = _db.session.execute(_db.select(Scan)).scalars().first()
+
+            vuln2 = Vulnerability.create_record(
+                id="CVE-2099-00001",
+                description="open vuln",
+                status="high",
+                epss_score=0.5,
+                links=[],
+            )
+            finding2 = Finding.get_or_create(pkg.id, vuln2.id)
+            _db.session.commit()
+            Observation.create(finding_id=finding2.id, scan_id=scan.id)
+
+        data = json.loads(client.get("/api/metrics").data)
+        cve_ids = [entry["cve"] for entry in data["top_vulns"]]
+        assert "CVE-2099-00001" in cve_ids
+
+    def test_top_vuln_entry_has_required_fields(self, app, client):
+        """When populated, each top_vulns entry has the expected keys."""
+        with app.app_context():
+            from src.models.vulnerability import Vulnerability
+            from src.models.finding import Finding
+            from src.models.observation import Observation
+            from src.models.package import Package
+            from src.models.scan import Scan
+
+            pkg = _db.session.execute(_db.select(Package)).scalars().first()
+            scan = _db.session.execute(_db.select(Scan)).scalars().first()
+
+            vuln3 = Vulnerability.create_record(
+                id="CVE-2099-00002",
+                description="open vuln 2",
+                status="high",
+                epss_score=0.6,
+                links=[],
+            )
+            finding3 = Finding.get_or_create(pkg.id, vuln3.id)
+            _db.session.commit()
+            Observation.create(finding_id=finding3.id, scan_id=scan.id)
+
+        data = json.loads(client.get("/api/metrics").data)
+        if data["top_vulns"]:
+            entry = data["top_vulns"][0]
+            for field in ("rank", "cve", "package", "severity", "max_cvss", "texts", "vuln"):
+                assert field in entry, f"Missing field: {field}"

--- a/tests/webapp_tests/test_packages_enrichment.py
+++ b/tests/webapp_tests/test_packages_enrichment.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Integration tests for the GET /api/packages vulnerability enrichment.
+
+These tests cover the new fields added to the packages response:
+  - ``vulnerabilities``: count of linked vulns per simplified_status
+  - ``maxSeverity``:     highest CVSS severity per simplified_status group
+"""
+
+import uuid
+import pytest
+import json
+from src.bin.webapp import create_app
+from . import write_demo_files, setup_demo_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def init_files(tmp_path):
+    files = {
+        "status": tmp_path / "status.txt",
+        "packages": tmp_path / "packages-merged.json",
+        "vulnerabilities": tmp_path / "vulnerabilities-merged.json",
+        "assessments": tmp_path / "assessments-merged.json",
+        "openvex": tmp_path / "openvex.json",
+        "time_estimates": tmp_path / "time_estimates.json",
+    }
+    write_demo_files(files)
+    return files
+
+
+@pytest.fixture()
+def app(init_files):
+    import os
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": init_files["status"],
+            "OPENVEX_FILE": init_files["openvex"],
+            "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
+        })
+        setup_demo_db(application)
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def app_with_obs(init_files):
+    """App whose demo DB also includes an Observation linking the Finding to the Scan."""
+    import os
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": init_files["status"],
+            "OPENVEX_FILE": init_files["openvex"],
+            "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
+        })
+        setup_demo_db(application)
+        with application.app_context():
+            from src.extensions import db
+            from src.models.finding import Finding
+            from src.models.observation import Observation
+            from src.models.scan import Scan
+
+            scan = db.session.execute(
+                db.select(Scan).where(Scan.id == uuid.UUID("33333333-3333-3333-3333-333333333333"))
+            ).scalar_one()
+            finding = db.session.execute(
+                db.select(Finding)
+            ).scalars().first()
+            Observation.create(finding_id=finding.id, scan_id=scan.id)
+
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client_with_obs(app_with_obs):
+    return app_with_obs.test_client()
+
+
+@pytest.fixture()
+def app_with_metrics(init_files):
+    """App whose demo DB also includes a Metrics row (score=8.5, HIGH) and Observation."""
+    import os
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": init_files["status"],
+            "OPENVEX_FILE": init_files["openvex"],
+            "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
+        })
+        setup_demo_db(application)
+        with application.app_context():
+            from src.extensions import db
+            from src.models.finding import Finding
+            from src.models.observation import Observation
+            from src.models.scan import Scan
+            from src.models.metrics import Metrics
+
+            scan = db.session.execute(
+                db.select(Scan).where(Scan.id == uuid.UUID("33333333-3333-3333-3333-333333333333"))
+            ).scalar_one()
+            finding = db.session.execute(db.select(Finding)).scalars().first()
+            Observation.create(finding_id=finding.id, scan_id=scan.id)
+            Metrics.create(
+                vulnerability_id="CVE-2020-35492",
+                version="3.1",
+                score=8.5,
+                vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L",
+            )
+
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client_with_metrics(app_with_metrics):
+    return app_with_metrics.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Tests – keys are always present
+# ---------------------------------------------------------------------------
+
+def test_packages_response_contains_enrichment_keys(client):
+    """GET /api/packages always includes 'vulnerabilities' and 'maxSeverity' keys."""
+    response = client.get("/api/packages?format=list")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data) == 1
+    pkg = data[0]
+    assert "vulnerabilities" in pkg
+    assert "maxSeverity" in pkg
+
+
+# ---------------------------------------------------------------------------
+# Tests – unfiltered (no variant_id / project_id)
+# ---------------------------------------------------------------------------
+
+def test_packages_vuln_count_no_filter(client):
+    """Without variant filter all findings are counted; assessed vuln shows under 'Fixed'."""
+    response = client.get("/api/packages?format=list")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    pkg = data[0]
+    # Assessment has status="fixed" → simplified_status="Fixed"
+    assert pkg["vulnerabilities"].get("Fixed") == 1
+    # maxSeverity is a dict (may be empty when no Metrics row exists)
+    assert isinstance(pkg["maxSeverity"], dict)
+
+
+def test_packages_max_severity_empty_when_no_metrics(client):
+    """With no Metrics row (score=None → NONE) maxSeverity remains an empty dict.
+
+    The aggregation only stores a severity entry when it strictly exceeds the
+    NONE floor, so a package with only un-scored vulnerabilities ends up with
+    an empty maxSeverity dict.
+    """
+    response = client.get("/api/packages?format=list")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    pkg = data[0]
+    assert pkg["maxSeverity"] == {}
+
+
+def test_packages_max_severity_high_with_metric_score(client_with_metrics):
+    """When a Metrics row with score=8.5 exists, maxSeverity should be 'HIGH'."""
+    response = client_with_metrics.get("/api/packages?format=list")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    pkg = data[0]
+    assert pkg["maxSeverity"]["Fixed"]["label"] == "HIGH"
+
+
+# ---------------------------------------------------------------------------
+# Tests – variant-scoped filter requires Observation
+# ---------------------------------------------------------------------------
+
+VARIANT_ID = "22222222-2222-2222-2222-222222222222"
+
+
+def test_packages_variant_filter_no_observation_empty_vulns(client):
+    """With variant_id but no Observation the vulnerability counts must be empty."""
+    response = client.get(f"/api/packages?format=list&variant_id={VARIANT_ID}")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data) == 1
+    pkg = data[0]
+    assert pkg["vulnerabilities"] == {}
+    assert pkg["maxSeverity"] == {}
+
+
+def test_packages_variant_filter_with_observation_counts_vuln(client_with_obs):
+    """With variant_id and a proper Observation the vulnerability count is correct."""
+    response = client_with_obs.get(f"/api/packages?format=list&variant_id={VARIANT_ID}")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data) == 1
+    pkg = data[0]
+    assert pkg["vulnerabilities"].get("Fixed") == 1
+
+
+def test_packages_variant_filter_with_metrics_shows_severity(client_with_metrics):
+    """With variant_id, Observation, and Metrics the correct severity is shown."""
+    response = client_with_metrics.get(f"/api/packages?format=list&variant_id={VARIANT_ID}")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    pkg = data[0]
+    assert pkg["maxSeverity"]["Fixed"]["label"] == "HIGH"
+
+
+# ---------------------------------------------------------------------------
+# Tests – project-scoped filter
+# ---------------------------------------------------------------------------
+
+PROJECT_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def test_packages_project_filter_no_observation_empty_vulns(client):
+    """With project_id but no Observation the vulnerability counts must be empty."""
+    response = client.get(f"/api/packages?format=list&project_id={PROJECT_ID}")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data) == 1
+    pkg = data[0]
+    assert pkg["vulnerabilities"] == {}
+    assert pkg["maxSeverity"] == {}
+
+
+def test_packages_project_filter_with_observation_counts_vuln(client_with_obs):
+    """With project_id and a proper Observation the vulnerability count is correct."""
+    response = client_with_obs.get(f"/api/packages?format=list&project_id={PROJECT_ID}")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data) == 1
+    pkg = data[0]
+    assert pkg["vulnerabilities"].get("Fixed") == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests – dict format still carries enrichment
+# ---------------------------------------------------------------------------
+
+def test_packages_dict_format_contains_enrichment_keys(client):
+    """The dict response format also exposes the new enrichment fields."""
+    response = client.get("/api/packages?format=dict")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    pkg = data["cairo@1.16.0"]
+    assert "vulnerabilities" in pkg
+    assert "maxSeverity" in pkg
+    assert pkg["vulnerabilities"].get("Fixed") == 1

--- a/tests/webapp_tests/test_vulnerabilities_enrichment.py
+++ b/tests/webapp_tests/test_vulnerabilities_enrichment.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Integration tests for the assessment-enrichment logic added to GET /api/vulnerabilities.
+
+Covers the three new fields added to every vulnerability dict in the response:
+  - ``assessments``:        list of all assessment dicts for the vulnerability
+  - ``status``:             status of the latest assessment (or "unknown")
+  - ``simplified_status``:  human label of the latest assessment (or "Pending Assessment")
+"""
+
+import uuid
+import pytest
+import json
+from datetime import datetime, timezone
+from src.bin.webapp import create_app
+from . import write_demo_files, setup_demo_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def init_files(tmp_path):
+    files = {
+        "status": tmp_path / "status.txt",
+        "packages": tmp_path / "packages-merged.json",
+        "vulnerabilities": tmp_path / "vulnerabilities-merged.json",
+        "assessments": tmp_path / "assessments-merged.json",
+        "openvex": tmp_path / "openvex.json",
+        "time_estimates": tmp_path / "time_estimates.json",
+    }
+    write_demo_files(files)
+    return files
+
+
+@pytest.fixture()
+def app(init_files):
+    import os
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": init_files["status"],
+            "OPENVEX_FILE": init_files["openvex"],
+            "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
+        })
+        setup_demo_db(application)
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def app_with_extra_vuln(init_files):
+    """App whose demo DB contains an additional vulnerability with no assessment."""
+    import os
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": init_files["status"],
+            "OPENVEX_FILE": init_files["openvex"],
+            "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
+        })
+        setup_demo_db(application)
+        with application.app_context():
+            from src.extensions import db
+            from src.models.vulnerability import Vulnerability
+
+            unassessed = Vulnerability.create_record(
+                id="CVE-2099-99999",
+                description="Synthetic unassessed vulnerability for testing.",
+                status="medium",
+                epss_score=0.0,
+                links=[],
+            )
+            db.session.commit()
+
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client_extra(app_with_extra_vuln):
+    return app_with_extra_vuln.test_client()
+
+
+@pytest.fixture()
+def app_multi_assess(init_files):
+    """App whose demo DB has two assessments for CVE-2020-35492 (latest is 'affected')."""
+    import os
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": init_files["status"],
+            "OPENVEX_FILE": init_files["openvex"],
+            "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
+        })
+        setup_demo_db(application)
+        with application.app_context():
+            from src.extensions import db
+            from src.models.finding import Finding
+            from src.models.assessment import Assessment
+
+            finding = db.session.execute(db.select(Finding)).scalars().first()
+            # Add a later assessment overriding the original "fixed" one
+            later = Assessment(
+                id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                status="affected",
+                timestamp=datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                status_notes="Re-opened",
+                justification="",
+                impact_statement="",
+                responses=[],
+                workaround="",
+                finding_id=finding.id,
+            )
+            db.session.add(later)
+            db.session.commit()
+
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client_multi(app_multi_assess):
+    return app_multi_assess.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Tests – assessments field structure
+# ---------------------------------------------------------------------------
+
+def test_vulns_list_contains_assessments_key(client):
+    """GET /api/vulnerabilities always includes an 'assessments' key per vuln."""
+    response = client.get("/api/vulnerabilities?format=list")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data) == 1
+    assert "assessments" in data[0]
+
+
+def test_vulns_assessments_is_list(client):
+    """`assessments` value is always a list."""
+    response = client.get("/api/vulnerabilities?format=list")
+    data = json.loads(response.data)
+    assert isinstance(data[0]["assessments"], list)
+
+
+def test_vulns_assessment_entry_fields(client):
+    """Each assessment entry in the list includes all required fields."""
+    response = client.get("/api/vulnerabilities?format=list")
+    data = json.loads(response.data)
+    vuln = data[0]
+    assert len(vuln["assessments"]) == 1
+    entry = vuln["assessments"][0]
+
+    expected_keys = {
+        "id", "vuln_id", "packages", "variant_id",
+        "status", "simplified_status", "status_notes",
+        "justification", "impact_statement", "responses",
+        "workaround", "timestamp", "last_update",
+    }
+    assert expected_keys.issubset(entry.keys())
+
+
+def test_vulns_assessment_entry_values(client):
+    """Assessment entry values match the demo DB record."""
+    response = client.get("/api/vulnerabilities?format=list")
+    data = json.loads(response.data)
+    entry = data[0]["assessments"][0]
+
+    assert entry["id"] == "da4d18f0-d89e-4d54-819d-86fc884cc737"
+    assert entry["vuln_id"] == "CVE-2020-35492"
+    assert "cairo@1.16.0" in entry["packages"]
+    assert entry["status"] == "fixed"
+    assert entry["simplified_status"] == "Fixed"
+    assert entry["impact_statement"] == "Yocto reported vulnerability as Patched"
+    assert entry["responses"] == []
+    assert entry["variant_id"] is None
+
+
+def test_vulns_assessment_timestamp_is_iso8601(client):
+    """Assessment timestamp is a non-empty ISO-8601 string."""
+    response = client.get("/api/vulnerabilities?format=list")
+    data = json.loads(response.data)
+    ts = data[0]["assessments"][0]["timestamp"]
+    assert isinstance(ts, str) and len(ts) > 0
+    # Basic ISO-8601 sanity: contains a 'T' separator
+    assert "T" in ts
+
+
+# ---------------------------------------------------------------------------
+# Tests – status / simplified_status enrichment on vuln dict
+# ---------------------------------------------------------------------------
+
+def test_vulns_status_enriched_from_assessment(client):
+    """`status` and `simplified_status` on the vuln dict match the latest assessment."""
+    response = client.get("/api/vulnerabilities?format=list")
+    data = json.loads(response.data)
+    vuln = data[0]
+    assert vuln["status"] == "fixed"
+    assert vuln["simplified_status"] == "Fixed"
+
+
+def test_vulns_status_defaults_for_no_assessment(client_extra):
+    """A vulnerability with no assessment gets status='unknown' and 'Pending Assessment'."""
+    response = client_extra.get("/api/vulnerabilities?format=list")
+    data = json.loads(response.data)
+    unassessed = next(v for v in data if v["id"] == "CVE-2099-99999")
+    assert unassessed["status"] == "unknown"
+    assert unassessed["simplified_status"] == "Pending Assessment"
+    assert unassessed["assessments"] == []
+
+
+def test_vulns_status_from_latest_when_multiple_assessments(client_multi):
+    """When multiple assessments exist, status reflects the chronologically latest one."""
+    response = client_multi.get("/api/vulnerabilities?format=list")
+    data = json.loads(response.data)
+    vuln = next(v for v in data if v["id"] == "CVE-2020-35492")
+    # The later record (2025-01-01) has status="affected" → "Exploitable"
+    assert vuln["status"] == "affected"
+    assert vuln["simplified_status"] == "Exploitable"
+    # Both assessments are present in the list
+    assert len(vuln["assessments"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests – dict format consistency
+# ---------------------------------------------------------------------------
+
+def test_vulns_dict_format_also_enriched(client):
+    """The dict response format exposes the same enrichment fields."""
+    response = client.get("/api/vulnerabilities?format=dict")
+    data = json.loads(response.data)
+    vuln = data["CVE-2020-35492"]
+    assert vuln["status"] == "fixed"
+    assert vuln["simplified_status"] == "Fixed"
+    assert len(vuln["assessments"]) == 1

--- a/vulnscout
+++ b/vulnscout
@@ -57,6 +57,9 @@ Container lifecycle:
   --update                        Pull latest image and restart if a new version is available
   --version                       Show current version
   --dev                           Dev mode: mount local src/ into container and start frontend npm dev server
+  --pyspy [opts]                  Benchmark API routes (requires VULNSCOUT_ENABLE_PYSPY=true)
+                                  Options: --live, --filter <regex>, --duration <s>,
+                                           --iterations <N>, --routes-only, --list-only
 
 Note: The container runs as a daemon. All commands auto-start it if needed and
 leave it running afterward (including --serve). Use 'stop' to remove it.
@@ -231,10 +234,19 @@ EOF
         echo "Dev mode: mounting $SCRIPT_DIR/src into /scan/src"
     fi
 
+    # py-spy live attach needs CAP_SYS_PTRACE and an unconfined seccomp profile
+    # to read /proc/<pid>/mem of the Flask worker. Only granted when explicitly
+    # opted in so the default container surface is unchanged.
+    local -a cap_args=()
+    if [ "${VULNSCOUT_ENABLE_PYSPY:-false}" = "true" ]; then
+        cap_args=(--cap-add=SYS_PTRACE --security-opt seccomp=unconfined)
+    fi
+
     call_container_engine run -d --name "$CONTAINER_NAME" \
         -p 7275:7275 \
         "${env_args[@]}" \
         "${vol_args[@]}" \
+        "${cap_args[@]}" \
         "$DOCKER_IMAGE" daemon
     # Wait for the container process to be ready to accept exec calls
     local retries=15
@@ -286,6 +298,112 @@ start_frontend_dev() {
         fi
     }
     trap _cleanup_frontend SIGINT SIGTERM EXIT
+}
+
+cmd_pyspy() {
+    # Default: harness mode (in-process bench wrapped by py-spy).
+    # --live          : attach py-spy to the running flask server PID
+    # --routes-only   : run the bench harness without py-spy wrapper
+    # --list-only     : just list discovered URLs (no benchmarking)
+    # --filter <re>   : forwarded to bench / live driver
+    # --duration <s>  : live-mode capture window (default 30)
+    # --iterations N  : harness iterations per route (default 200)
+    local mode="harness"
+    local filter_re=""
+    local duration=""
+    local iterations=""
+    local list_only=false
+    local routes_only=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --live)         mode="live"; shift ;;
+            --routes-only)  routes_only=true; shift ;;
+            --list-only)    list_only=true; shift ;;
+            --filter)       filter_re="$2"; shift 2 ;;
+            --duration)     duration="$2"; shift 2 ;;
+            --iterations|-n) iterations="$2"; shift 2 ;;
+            -h|--help)
+                cat <<EOF
+Usage: vulnscout --pyspy [--live] [--filter <regex>] [--duration <s>]
+                         [--iterations <N>] [--routes-only] [--list-only]
+
+Modes:
+  (default)        harness — Flask test_client bench wrapped by py-spy record
+  --live           attach py-spy to the running flask worker (needs --serve up)
+  --routes-only    run the bench harness only (no py-spy)
+  --list-only      print discovered routes and exit (no benchmark, no profile)
+
+Outputs land in: \$VULNSCOUT_OUTPUTS_DIR/profiles/  (host: $VULNSCOUT_OUTPUTS_DIR/profiles/)
+
+Note: requires VULNSCOUT_ENABLE_PYSPY=true to be set when the container starts
+(the wrapper auto-restarts the container with the SYS_PTRACE capability).
+EOF
+                return 0 ;;
+            *) echo "Unknown --pyspy option: $1" >&2; return 1 ;;
+        esac
+    done
+
+    # Ensure container is running with the ptrace capability (needed for --live;
+    # harmless overhead for harness mode, simpler to gate uniformly).
+    export VULNSCOUT_ENABLE_PYSPY=true
+    local needs_restart=false
+    if call_container_engine ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+        local caps
+        caps="$(call_container_engine inspect "$CONTAINER_NAME" \
+            --format '{{range .HostConfig.CapAdd}}{{.}} {{end}}' 2>/dev/null || true)"
+        if ! echo "$caps" | grep -q "SYS_PTRACE"; then
+            echo "[pyspy] container missing CAP_SYS_PTRACE — restarting with capability..."
+            needs_restart=true
+        fi
+    else
+        needs_restart=true
+    fi
+    if [ "$needs_restart" = true ]; then
+        do_start
+    fi
+
+    mkdir -p "$VULNSCOUT_OUTPUTS_DIR/profiles"
+
+    local -a bench_args=()
+    [[ -n "$filter_re" ]]   && bench_args+=(--filter "$filter_re")
+    [[ -n "$iterations" ]]  && bench_args+=(--iterations "$iterations")
+    [[ "$list_only" = true ]] && bench_args+=(--list-only)
+
+    case "$mode" in
+        live)
+            local -a live_args=()
+            [[ -n "$filter_re" ]] && live_args+=(--filter "$filter_re")
+            [[ -n "$duration" ]]  && live_args+=(--duration "$duration")
+            call_container_engine exec "$CONTAINER_NAME" \
+                /scan/src/bin/pyspy_live.sh "${live_args[@]}"
+            ;;
+        harness)
+            if [ "$routes_only" = true ] || [ "$list_only" = true ]; then
+                call_container_engine exec "$CONTAINER_NAME" \
+                    sh -c "cd /scan && python3 -m src.bin.pyspy_bench $(printf '%q ' "${bench_args[@]}")"
+            else
+                local ts
+                ts="$(date -u +%Y%m%d_%H%M%S)"
+                local profile_path="/scan/outputs/profiles/profile_${ts}.json"
+                # Bench harness writes its own bench_<ts>.json/md alongside.
+                # py-spy occasionally reports a benign "No child process" error
+                # on shutdown after the speedscope JSON has already been written;
+                # check the file presence instead of trusting the exit code.
+                local _exec_status=0
+                call_container_engine exec "$CONTAINER_NAME" \
+                    sh -c "cd /scan && py-spy record --output $profile_path --format speedscope --rate 100 -- python3 -m src.bin.pyspy_bench $(printf '%q ' "${bench_args[@]}")" \
+                    || _exec_status=$?
+                if call_container_engine exec "$CONTAINER_NAME" test -s "$profile_path"; then
+                    echo
+                    echo "[pyspy] flamegraph: $VULNSCOUT_OUTPUTS_DIR/profiles/profile_${ts}.json"
+                    echo "[pyspy] open with: https://www.speedscope.app/  (drag the JSON in)"
+                    return 0
+                fi
+                return "$_exec_status"
+            fi
+            ;;
+    esac
 }
 
 parse_and_run() {
@@ -371,6 +489,13 @@ parse_and_run() {
                 _v="$(call_container_engine inspect "$DOCKER_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.version"}}' 2>/dev/null || echo unknown)"
                 echo "VulnScout $_v"
                 shift ;;
+            --pyspy)
+                shift
+                # Collect every remaining flag for the helper; consumes rest of argv.
+                local -a pyspy_args=()
+                while [[ $# -gt 0 ]]; do pyspy_args+=("$1"); shift; done
+                cmd_pyspy "${pyspy_args[@]}"
+                return $? ;;
             update)
                 local _cur_ver _new_ver _running_img
                 _cur_ver="$(call_container_engine inspect "$DOCKER_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.version"}}' 2>/dev/null || echo unknown)"


### PR DESCRIPTION
### Changes proposed in this pull request:

Previously, VulnsCout frontend loaded the whole working dataset in a few requests with large responses (~50MB with the demo data), this impacts the web dashboard loading time and is not optimal for a possible server mode transition.\
The fix consists at making the API endpoints provide only the necessary data for the current view / operation which reduces loading time and I/O on the database.
* Eplorer: load sumnmary data (severity_count, assessment_count, assessment_timeline, source_count, data for 5 rows table)

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


