### PR TITLE
fix:SBOM tab shows packages with 0 vulnerabilities

### DIFF
--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -38,6 +38,12 @@ const asPackage = (data: any): Package | [] => {
     if (Array.isArray(data?.purl)) {
         for (const purl of data.purl) if (typeof purl === "string") pkg.purl.push(purl);
     }
+    if (Array.isArray(data?.variants)) {
+        for (const v of data.variants) if (typeof v === "string") pkg.variants.push(v);
+    }
+    if (Array.isArray(data?.sources)) {
+        for (const s of data.sources) if (typeof s === "string") pkg.source.push(s);
+    }
     return pkg
 };
 
@@ -97,8 +103,8 @@ class Packages {
                 ...pkg,
                 vulnerabilities: counts,
                 maxSeverity: severities,
-                source: [...new Set(vulnerabilities.map((vuln) => vuln.found_by).flat())],
-                variants: [...new Set(vulnerabilities.flatMap((vuln) => vuln.variants || []))],
+                source: [...new Set([...pkg.source, ...vulnerabilities.map((vuln) => vuln.found_by).flat()])],
+                variants: [...new Set([...pkg.variants, ...vulnerabilities.flatMap((vuln) => vuln.variants || [])])],
             };
         });
     }

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -6,10 +6,10 @@ import uuid
 
 from sqlalchemy import func
 from ..models.package import Package
-from ..models.finding import Finding
-from ..models.observation import Observation
 from ..models.scan import Scan
 from ..models.variant import Variant
+from ..models.sbom_document import SBOMDocument
+from ..models.sbom_package import SBOMPackage
 from ..extensions import db
 
 
@@ -61,9 +61,9 @@ def init_app(app):
             def _pkg_ids_for_variant(variant_uuid):
                 return set(db.session.execute(
                     db.select(Package.id)
-                    .join(Finding, Package.id == Finding.package_id)
-                    .join(Observation, Finding.id == Observation.finding_id)
-                    .join(Scan, Observation.scan_id == Scan.id)
+                    .join(SBOMPackage, Package.id == SBOMPackage.package_id)
+                    .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+                    .join(Scan, SBOMDocument.scan_id == Scan.id)
                     .where(Scan.variant_id == variant_uuid)
                     .distinct()
                 ).scalars().all())
@@ -81,9 +81,9 @@ def init_app(app):
                 exclude_ids = list(_pkg_ids_for_variant(base_uuid))
                 query = (
                     db.select(Package)
-                    .join(Finding, Package.id == Finding.package_id)
-                    .join(Observation, Finding.id == Observation.finding_id)
-                    .join(Scan, Observation.scan_id == Scan.id)
+                    .join(SBOMPackage, Package.id == SBOMPackage.package_id)
+                    .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+                    .join(Scan, SBOMDocument.scan_id == Scan.id)
                     .where(Scan.variant_id == compare_uuid)
                     .distinct()
                     .order_by(Package.name)
@@ -102,9 +102,9 @@ def init_app(app):
             else:
                 pkgs = list(db.session.execute(
                     db.select(Package)
-                    .join(Finding, Package.id == Finding.package_id)
-                    .join(Observation, Finding.id == Observation.finding_id)
-                    .where(Observation.scan_id == latest_id)
+                    .join(SBOMPackage, Package.id == SBOMPackage.package_id)
+                    .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+                    .where(SBOMDocument.scan_id == latest_id)
                     .distinct()
                     .order_by(Package.name)
                 ).scalars().all())
@@ -119,15 +119,52 @@ def init_app(app):
             else:
                 pkgs = list(db.session.execute(
                     db.select(Package)
-                    .join(Finding, Package.id == Finding.package_id)
-                    .join(Observation, Finding.id == Observation.finding_id)
-                    .where(Observation.scan_id.in_(latest_ids))
+                    .join(SBOMPackage, Package.id == SBOMPackage.package_id)
+                    .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+                    .where(SBOMDocument.scan_id.in_(latest_ids))
                     .distinct()
                     .order_by(Package.name)
                 ).scalars().all())
         else:
             pkgs = Package.get_all()
         result = [pkg.to_dict() for pkg in pkgs]
+
+        # Enrich each package with its variants and sources derived from the
+        # SBOMPackage → SBOMDocument → Scan → Variant chain so that the
+        # frontend can display them even for packages with 0 vulnerabilities.
+        pkg_ids = [pkg.id for pkg in pkgs]
+        if pkg_ids:
+            rows = db.session.execute(
+                db.select(
+                    Package.name,
+                    Package.version,
+                    Variant.name.label("variant_name"),
+                    SBOMDocument.format.label("doc_format"),
+                )
+                .join(SBOMPackage, Package.id == SBOMPackage.package_id)
+                .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+                .join(Scan, SBOMDocument.scan_id == Scan.id)
+                .join(Variant, Scan.variant_id == Variant.id)
+                .where(Package.id.in_(pkg_ids))
+            ).all()
+
+            # Build lookup: "name@version" → {variants: set, sources: set}
+            meta: dict = {}
+            for row in rows:
+                key = f"{row.name}@{row.version}"
+                if key not in meta:
+                    meta[key] = {"variants": set(), "sources": set()}
+                if row.variant_name:
+                    meta[key]["variants"].add(row.variant_name)
+                if row.doc_format:
+                    meta[key]["sources"].add(row.doc_format)
+
+            for p in result:
+                key = f"{p['name']}@{p['version']}"
+                info = meta.get(key, {})
+                p["variants"] = sorted(info.get("variants", set()))
+                p["sources"] = sorted(info.get("sources", set()))
+
         if request.args.get('format', 'list') == "dict":
             return {p["name"] + "@" + p["version"]: p for p in result}
         return result

--- a/tests/webapp_tests/test_project_variant_endpoints.py
+++ b/tests/webapp_tests/test_project_variant_endpoints.py
@@ -350,14 +350,16 @@ class TestPackagesFiltering:
         assert "cairo" in names
         assert "busybox" not in names
 
-    def test_packages_filter_variant_b_returns_empty(self, client_and_data):
-        """VariantB has no findings/observations so filtering returns empty."""
+    def test_packages_filter_variant_b_returns_busybox(self, client_and_data):
+        """VariantB has busybox (no vulnerabilities) linked via SBOMPackage."""
         client, data = client_and_data
         variant_b_id = data["variant_b_id"]
         response = client.get(f"/api/packages?variant_id={variant_b_id}&format=list")
         assert response.status_code == 200
         body = json.loads(response.data)
-        assert body == []
+        names = [p["name"] for p in body]
+        assert "busybox" in names
+        assert "cairo" not in names
 
     def test_packages_invalid_variant_uuid(self, client):
         response = client.get("/api/packages?variant_id=not-a-uuid&format=list")
@@ -394,8 +396,8 @@ class TestPackagesFiltering:
         names = [p["name"] for p in body]
         assert "cairo" in names
 
-    def test_packages_compare_difference_empty_when_compare_has_no_unique(self, client_and_data):
-        """difference(base=VA, compare=VB): pkgs in VB but NOT in VA → empty."""
+    def test_packages_compare_difference_returns_busybox(self, client_and_data):
+        """difference(base=VA, compare=VB): pkgs in VB but NOT in VA → busybox."""
         client, data = client_and_data
         variant_a_id = data["variant_a_id"]
         variant_b_id = data["variant_b_id"]
@@ -406,7 +408,9 @@ class TestPackagesFiltering:
         )
         assert response.status_code == 200
         body = json.loads(response.data)
-        assert body == []
+        names = [p["name"] for p in body]
+        assert "busybox" in names
+        assert "cairo" not in names
 
     def test_packages_compare_intersection_empty_when_no_common(self, client_and_data):
         """intersection(VA, VB): no common packages → empty."""


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

Github Issue: https://github.com/savoirfairelinux/vulnscout/issues/255

### Changes proposed in this pull request:

The /api/packages endpoint was querying packages through Finding → Observation joins, which excluded packages without any associated vulnerability.

Replaced with SBOMPackage → SBOMDocument
joins so that all packages registered in the SBOM are returned regardless of vulnerability count.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Load an SBOM with a `Package` containing 0 Vulns. Should correctly appear in the `SBOM` tab.