### PR TITLE
entrypoint: --add-grype flag

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -121,6 +121,9 @@ VulnScout accepts multiple input file types. Commands can be chained and will au
 
 # OpenVEX file
 ./vulnscout --add-openvex <path>
+
+# Grype file
+./vulnscout --add-grype <path>
 ----
 
 Multiple inputs can be chained in a single command:
@@ -138,6 +141,7 @@ Multiple inputs can be chained in a single command:
 - `.tar`, `.tar.gz`, `.tar.zst` archives are supported as SPDX 2 input.
 - `.spdx` files (tag-value format) are supported as SPDX 2 input.
 - `.spdx.json` is supported as SPDX 3 input.
+- Grype scan files should end with `.grype.json`.
 - To ignore parsing errors for malformed SBOMs, set: `IGNORE_PARSING_ERRORS=true`
 ====
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -34,6 +34,7 @@ Input commands:
   --add-cve-check <path>    Add a Yocto CVE check JSON file
   --add-openvex <path>      Add an OpenVEX JSON file
   --add-cdx <path>          Add a CycloneDX file
+  --add-grype <path>        Add a Grype results file
   --add-report-template <path>  Add a custom report template to /scan/templates/
   --perform-grype-scan      Perform a Grype scan on the added inputs
 
@@ -503,6 +504,8 @@ while [[ $# -gt 0 ]]; do
             cmd_add_file openvex "$2"; INPUTS_ADDED=true; SCAN_REQUIRED=true; shift 2 ;;
         --add-cdx)
             cmd_add_file cdx "$2"; INPUTS_ADDED=true; SCAN_REQUIRED=true; shift 2 ;;
+        --add-grype)
+            cmd_add_file grype "$2"; INPUTS_ADDED=true; SCAN_REQUIRED=true; shift 2 ;;
         --perform-grype-scan)
             GRYPE_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --clear-inputs)

--- a/vulnscout
+++ b/vulnscout
@@ -43,6 +43,7 @@ declare -A INPUT_PATHS=(
     [add-cve-check]="yocto_cve_check"
     [add-openvex]="openvex"
     [add-cdx]="cdx"
+    [add-grype]="grype"
 )
 
 show_help() {
@@ -70,6 +71,7 @@ Input commands (can be chained, triggers scan automatically):
   --add-cve-check <path>          Add a Yocto CVE check JSON file
   --add-openvex <path>            Add an OpenVEX JSON file
   --add-cdx <path>                Add a CycloneDX file
+  --add-grype <path>              Add a Grype results file
   --perform-grype-scan            Run Grype on the current DB content (after merging any added inputs)
 
 Scan & output commands:
@@ -304,7 +306,7 @@ parse_and_run() {
                 VARIANT="$2"; shift 2 ;;
             --match-condition)
                 MATCH_CONDITION="$2"; shift 2 ;;
-            add-spdx|--add-spdx|add-cve-check|--add-cve-check|add-openvex|--add-openvex|add-cdx|--add-cdx)
+            add-spdx|--add-spdx|add-cve-check|--add-cve-check|add-openvex|--add-openvex|add-cdx|--add-cdx|add-grype|--add-grype)
                 ensure_running; add_input "${1#--}" "$2"; shift 2 ;;
             perform-grype-scan|--perform-grype-scan)
                 ensure_running; PENDING_ARGS+=(--perform-grype-scan); shift ;;


### PR DESCRIPTION
Added ability to directly input Grype results JSON file. This allows us to have more control on the Grype scanning process externally to VulnScout and then feed VS with the scanned results.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [ ] Added necessary reviewers


