### PR TITLE
bugfix: remove deprecated --add-report-templates

### DIFF
--- a/doc/WRITING_REPORT_TEMPLATE.adoc
+++ b/doc/WRITING_REPORT_TEMPLATE.adoc
@@ -20,7 +20,7 @@ Templates can produce any text-based format: AsciiDoc, HTML, Markdown, CSV, plai
 |Built-in templates shipped with VulnScout.
 
 |`/scan/templates/`
-|Custom templates installed into the container (via `--add-report-template`).
+|Custom templates inside the container (staged automatically when a path is passed to `--report`).
 
 |`.vulnscout/templates/`
 |Per-project host-side templates (mounted automatically if the directory exists).
@@ -28,15 +28,7 @@ Templates can produce any text-based format: AsciiDoc, HTML, Markdown, CSV, plai
 
 === Adding a Custom Template
 
-To register and immediately use a local template file:
-
-[source,shell]
-----
-./vulnscout --add-report-template /path/to/my-report.adoc
-./vulnscout --project demo report my-report.adoc
-----
-
-Or pass the file path directly to `report` — it registers and runs the template in one step:
+Pass the file path directly to `report` — it stages and runs the template in one step:
 
 [source,shell]
 ----

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -35,7 +35,6 @@ Input commands:
   --add-openvex <path>      Add an OpenVEX JSON file
   --add-cdx <path>          Add a CycloneDX file
   --add-grype <path>        Add a Grype results file
-  --add-report-template <path>  Add a custom report template to /scan/templates/
   --perform-grype-scan      Perform a Grype scan on the added inputs
 
 Scan & output commands:


### PR DESCRIPTION
## Fixes # by Valentin Boudevin 

### Changes proposed in this pull request:

Remove the `--add-report-template` which was still present in the entrypoint helper and the documentation.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

