### PR TITLE
feat: scan management commands

### DIFF
--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -60,6 +60,7 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 | `--export-custom-assessments` | Export custom (review) assessments as `.tar.gz` to `/scan/outputs/` |
 | `--import-custom-assessments <path>` | Import custom assessments from `.json` or `.tar.gz` |
 | `--match-condition <expr>` | Exit with code 2 if expression matches any vulnerability. Incompatible with `--serve` |
+| `--delete-scan <id>` | Delete a past scan by its ID |
 
 ### Data Retrieval Commands
 

--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -61,6 +61,14 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 | `--import-custom-assessments <path>` | Import custom assessments from `.json` or `.tar.gz` |
 | `--match-condition <expr>` | Exit with code 2 if expression matches any vulnerability. Incompatible with `--serve` |
 
+### Data Retrieval Commands
+
+| Flag | Description |
+|------|-------------|
+| `--list-projects` | List all projects and their variants |
+| `--list-scans` | List all past scans |
+| `--json` | Output objects in JSON format |
+
 ### Configuration Commands
 
 | Flag | Description |
@@ -75,7 +83,6 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 |------|-------------|
 | `--help`, `-h` | Show help message |
 | `--version` | Print the VulnScout version |
-| `--list-projects` | List all projects in the database |
 | `daemon` | Enter daemon mode (default when no arguments are given) |
 
 ---

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -30,12 +30,14 @@ from ..models.sbom_document import SBOMDocument
 from ..models.scan import Scan as ScanModel
 from ..models.finding import Finding as FindingModel
 from ..models.observation import Observation
+from ..models.project import Project as ProjectModel
 from ..helpers.verbose import verbose
 from ..helpers.env_vars import get_bool_env
 from ..extensions import batch_session, db as _db
 import click
 import json
 import os
+import typing
 from flask.cli import with_appcontext
 from sqlalchemy import and_, exists
 
@@ -372,6 +374,8 @@ def init_app(app) -> None:
     app.cli.add_command(export_command)
     app.cli.add_command(export_custom_assessments_command)
     app.cli.add_command(import_custom_assessments_command)
+    app.cli.add_command(list_projects_command)
+    app.cli.add_command(list_scans_command)
 
 
 @click.command("export")
@@ -936,6 +940,54 @@ def import_custom_assessments_command(file_path: str) -> None:
         f"Imported {len(total_created)} assessments"
         f" ({total_skipped} skipped as duplicates)"
     )
+
+
+_T = typing.TypeVar("_T")
+
+
+def _echo_object_list(
+    json_format: bool,
+    objects: list[_T],
+    pretty_format: typing.Callable[[_T], str],
+    to_dict: typing.Callable[[_T], dict],
+):
+    if json_format:
+        # cannot use a generator here since the json library cannot dump an
+        # array "lazily"
+        click.echo_via_pager(json.dumps(
+            [to_dict(obj) for obj in objects],
+            indent=4)
+        )
+    else:
+        click.echo_via_pager(pretty_format(obj) for obj in objects)
+
+
+@click.command("list-projects")
+@click.option("--json", "json_format", is_flag=True)
+@with_appcontext
+def list_projects_command(json_format: bool):
+    def _format_project_pretty(project: ProjectModel) -> str:
+        variants_string = ", ".join(v.name for v in project.variants)
+        return (f"{project.name} ({project.id}), "
+                f"{len(project.variants)} variants: {variants_string}\n")
+
+    projects = ProjectController.get_all()
+    _echo_object_list(json_format, projects, _format_project_pretty, ProjectModel.to_dict)
+
+
+@click.command("list-scans")
+@click.option("--json", "json_format", is_flag=True)
+@with_appcontext
+def list_scans_command(json_format: bool = False):
+    def _format_scan_pretty(scan: ScanModel) -> str:
+        return (f"{scan.id} ({scan.description}) at {scan.timestamp}, "
+                f"project {scan.variant.project.name}, "
+                f"variant {scan.variant.name}, "
+                f"{len(scan.sbom_documents)} SBOMs, "
+                f"{len(scan.observations)} observations\n")
+
+    scans = ScanController.get_all()
+    _echo_object_list(json_format, scans, _format_scan_pretty, ScanModel.to_dict)
 
 
 def main() -> dict:

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -38,6 +38,7 @@ import click
 import json
 import os
 import typing
+import uuid
 from flask.cli import with_appcontext
 from sqlalchemy import and_, exists
 
@@ -376,6 +377,7 @@ def init_app(app) -> None:
     app.cli.add_command(import_custom_assessments_command)
     app.cli.add_command(list_projects_command)
     app.cli.add_command(list_scans_command)
+    app.cli.add_command(delete_scan_command)
 
 
 @click.command("export")
@@ -988,6 +990,14 @@ def list_scans_command(json_format: bool = False):
 
     scans = ScanController.get_all()
     _echo_object_list(json_format, scans, _format_scan_pretty, ScanModel.to_dict)
+
+
+@click.command("delete-scan")
+@click.argument("scan-id", type=click.UUID)
+@with_appcontext
+def delete_scan_command(scan_id: uuid.UUID):
+    ScanController.delete(scan_id)
+    click.echo(f"Successfully deleted scan {scan_id}")
 
 
 def main() -> dict:

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -47,6 +47,7 @@ Scan & output commands:
   --export-custom-assessments  Export custom (review) assessments as tar.gz to /scan/outputs/
   --import-custom-assessments <path>  Import custom assessments from .json or .tar.gz
   --match-condition <expr>  Exit code 2 if condition met (e.g. "cvss >= 9.0")
+  --delete-scan <id>        Delete a past scan by its ID
 
 Data retrieval commands:
   --list-projects           List all projects and their variants
@@ -426,6 +427,11 @@ cmd_do_get_data() {
     flask --app src.bin.webapp "${DATA_REQUESTED#--}" "${data_args[@]}"
 }
 
+cmd_delete_scan() {
+    scan_id="$1"
+    flask --app src.bin.webapp delete-scan "$scan_id"
+}
+
 cmd_daemon() {
     setup_user
     echo "VulnScout ready. Use '/scan/src/entrypoint.sh --help' for available commands."
@@ -553,6 +559,8 @@ while [[ $# -gt 0 ]]; do
             GRYPE_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --clear-inputs)
             cmd_clear_inputs; shift ;;
+        --delete-scan)
+            cmd_delete_scan "$2"; shift 2 ;;
         --serve)
             if [[ -n "$MATCH_CONDITION" ]]; then
                 echo "Error: --serve and --match-condition are incompatible."; exit 1

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -40,13 +40,18 @@ Input commands:
 Scan & output commands:
   --serve                   Run scan then start interactive web UI (port 7275)
   --report <template>       Generate a report from a template in /scan/templates/
-  --report <path>           Stage a local report template file and generate a report from it 
+  --report <path>           Stage a local report template file and generate a report from it
   --export-spdx             Export project as SPDX 3.0 SBOM to /scan/outputs/
   --export-cdx              Export project as CycloneDX 1.6 SBOM to /scan/outputs/
   --export-openvex          Export project as OpenVEX document to /scan/outputs/
   --export-custom-assessments  Export custom (review) assessments as tar.gz to /scan/outputs/
   --import-custom-assessments <path>  Import custom assessments from .json or .tar.gz
   --match-condition <expr>  Exit code 2 if condition met (e.g. "cvss >= 9.0")
+
+Data retrieval commands:
+  --list-projects           List all projects and their variants
+  --list-scans              List all past scans
+  --json                    Output objects in JSON format
 
 Configuration commands:
   --config <key> <value>    Set a persistent config value
@@ -399,9 +404,26 @@ cmd_config_clear() {
     fi
 }
 
-cmd_list_projects() {
-    cd /scan/src
-    flask --app bin.webapp list-projects
+# Process the arguments of a --list-xxx or --get-xxx command but do NOT do the
+# operation right away so it waits until all arguments are processed before
+# actually getting the data (in cmd_do_get_data).
+# This way, all arguments are parsed first, especially the ones that the get
+# data operations depend on (e.g. --json).
+cmd_get_data() {
+    flag="$1"
+    if [[ "$DATA_REQUESTED" != "" ]]; then
+        # Only 1 --list-xxx or --get-xxx command is allowed at the same time
+        echo "Cannot use $flag and $DATA_REQUESTED together"
+        exit 1
+    fi
+    DATA_REQUESTED="$flag"
+}
+
+cmd_do_get_data() {
+    data_args=()
+    if [[ "$JSON_OUTPUT" == true ]]; then data_args+=("--json"); fi
+
+    flask --app src.bin.webapp "${DATA_REQUESTED#--}" "${data_args[@]}"
 }
 
 cmd_daemon() {
@@ -440,6 +462,8 @@ GRYPE_SCAN_REQUESTED=false
 REPORT_TEMPLATES=()
 EXPORT_FORMATS=()
 SCAN_REQUIRED=false
+JSON_OUTPUT=false
+DATA_REQUESTED=""
 
 # ---------------------------------------------------------------------------
 # Legacy setup detection: if an openvex.json output exists but no database,
@@ -508,6 +532,8 @@ while [[ $# -gt 0 ]]; do
             PROJECT_NAME="$2"; shift 2 ;;
         --variant)
             VARIANT_NAME="$2"; shift 2 ;;
+        --json)
+            JSON_OUTPUT=true; shift ;;
         --match-condition)
             if [[ "$SERVE_REQUESTED" == "true" ]]; then
                 echo "Error: --serve and --match-condition are incompatible."; exit 1
@@ -548,8 +574,8 @@ while [[ $# -gt 0 ]]; do
             EXPORT_CUSTOM_ASSESSMENTS=true; shift ;;
         --import-custom-assessments)
             IMPORT_CUSTOM_ASSESSMENTS_FILE="$2"; shift 2 ;;
-        --list-projects)
-            cmd_list_projects; exit 0 ;;
+        --list-projects|--list-scans)
+            cmd_get_data "$1"; shift ;;
         --config)
             cmd_config_set "$2" "$3"; shift 3 ;;
         --config-list)
@@ -561,7 +587,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Step 1: Scan the new inputs/match condition if any 
+# Step 1: Scan the new inputs/match condition if any
 match_exit=0
 if [[ "$SCAN_REQUIRED" == "true" ]]; then
     cmd_scan || match_exit=$?
@@ -590,6 +616,11 @@ if [[ "${EXPORT_CUSTOM_ASSESSMENTS:-false}" == "true" ]]; then
 fi
 if [[ -n "${IMPORT_CUSTOM_ASSESSMENTS_FILE:-}" ]]; then
     cmd_import_custom_assessments "$IMPORT_CUSTOM_ASSESSMENTS_FILE"
+fi
+
+# Step 5: Get data
+if [[ "$DATA_REQUESTED" != "" ]]; then
+    cmd_do_get_data
 fi
 
 exit $match_exit

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -33,6 +33,16 @@ class Project(Base):
     def __repr__(self) -> str:
         return f"<Project id={self.id} name={self.name!r}>"
 
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "name": self.name,
+            "variants": [{
+                "id": str(variant.id),
+                "name": variant.name
+            } for variant in self.variants],
+        }
+
     # ------------------------------------------------------------------
     # CRUD helpers
     # ------------------------------------------------------------------

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -4,9 +4,15 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import uuid
-from typing import Optional
-from sqlalchemy.exc import IntegrityError
+import typing
+
 from ..extensions import db, Base
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Mapped
+
+if typing.TYPE_CHECKING:
+    from .variant import Variant
 
 
 class Project(Base):
@@ -15,10 +21,14 @@ class Project(Base):
     __tablename__ = "projects"
     __table_args__ = (db.UniqueConstraint("name", name="uq_projects_name"),)
 
-    id = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
-    name = db.Column(db.String, nullable=False)
+    id: Mapped[uuid.UUID] = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = db.Column(db.String, nullable=False)
 
-    variants = db.relationship("Variant", back_populates="project", cascade="all, delete-orphan")
+    variants: Mapped[list["Variant"]] = db.relationship(  # type: ignore
+        "Variant",
+        back_populates="project",
+        cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:
         return f"<Project id={self.id} name={self.name!r}>"
@@ -36,7 +46,7 @@ class Project(Base):
         return project
 
     @staticmethod
-    def get_by_id(project_id: uuid.UUID) -> Optional["Project"]:
+    def get_by_id(project_id: uuid.UUID) -> "Project | None":
         """Return the project matching *project_id*, or ``None`` if not found."""
         return db.session.get(Project, project_id)
 

--- a/src/models/scan.py
+++ b/src/models/scan.py
@@ -51,6 +51,21 @@ class Scan(Base):
     def __repr__(self) -> str:
         return f"<Scan id={self.id} timestamp={self.timestamp}>"
 
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "description": self.description,
+            "timestamp": self.timestamp.isoformat(),
+            "variant": {
+                "id": str(self.variant.id),
+                "name": self.variant.name,
+                "project": {
+                    "id": str(self.variant.project.id),
+                    "name": self.variant.project.name,
+                }
+            }
+        }
+
     # ------------------------------------------------------------------
     # CRUD helpers
     # ------------------------------------------------------------------

--- a/src/models/scan.py
+++ b/src/models/scan.py
@@ -3,11 +3,19 @@
 # Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
-from typing import Optional
+import typing
 import uuid
 from datetime import datetime, timezone
+
 from ..extensions import db, Base
 from .variant import Variant
+
+from sqlalchemy.orm import Mapped
+
+if typing.TYPE_CHECKING:
+    # avoid circular imports, https://stackoverflow.com/a/79601366
+    from .sbom_document import SBOMDocument
+    from .observation import Observation
 
 
 class Scan(Base):
@@ -15,18 +23,30 @@ class Scan(Base):
 
     __tablename__ = "scans"
 
-    id = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
-    description = db.Column(db.Text, nullable=True)
-    timestamp = db.Column(
+    id: Mapped[uuid.UUID] = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
+    description: Mapped[str | None] = db.Column(db.Text, nullable=True)
+    timestamp: Mapped[datetime] = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    variant_id = db.Column(db.Uuid, db.ForeignKey("variants.id"), nullable=False, index=True)
+    variant_id: Mapped[uuid.UUID] = db.Column(db.Uuid, db.ForeignKey("variants.id"), nullable=False, index=True)
 
-    variant = db.relationship("Variant", back_populates="scans")
-    sbom_documents = db.relationship("SBOMDocument", back_populates="scan", cascade="all, delete-orphan")
-    observations = db.relationship("Observation", back_populates="scan", cascade="all, delete-orphan")
+    # Flask-SQLAlchemy has typing issues, see https://github.com/pallets-eco/flask-sqlalchemy/issues/1318
+    variant: Mapped[Variant] = db.relationship(  # type: ignore
+        "Variant",
+        back_populates="scans"
+    )
+    sbom_documents: Mapped[list["SBOMDocument"]] = db.relationship(  # type: ignore
+        "SBOMDocument",
+        back_populates="scan",
+        cascade="all, delete-orphan"
+    )
+    observations: Mapped[list["Observation"]] = db.relationship(  # type: ignore
+        "Observation",
+        back_populates="scan",
+        cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:
         return f"<Scan id={self.id} timestamp={self.timestamp}>"
@@ -44,7 +64,7 @@ class Scan(Base):
         return scan
 
     @staticmethod
-    def get_by_id(scan_id: uuid.UUID) -> Optional["Scan"]:
+    def get_by_id(scan_id: uuid.UUID) -> "Scan | None":
         """Return the scan matching *scan_id*, or ``None`` if not found."""
         return db.session.get(Scan, scan_id)
 
@@ -73,7 +93,7 @@ class Scan(Base):
         ).scalars().all())
 
     @staticmethod
-    def get_latest() -> Optional["Scan"]:
+    def get_latest() -> "Scan | None":
         """Return the most recently created scan, or ``None`` if no scans exist."""
         result = db.session.execute(
             db.select(Scan).order_by(Scan.timestamp.desc()).limit(1)

--- a/src/models/variant.py
+++ b/src/models/variant.py
@@ -4,9 +4,18 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import uuid
-from typing import Optional
-from sqlalchemy.exc import IntegrityError
+import typing
+
 from ..extensions import db, Base
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Mapped
+
+if typing.TYPE_CHECKING:
+    from .project import Project
+    from .scan import Scan
+    from .assessment import Assessment
+    from .time_estimate import TimeEstimate
 
 
 class Variant(Base):
@@ -17,14 +26,25 @@ class Variant(Base):
         db.UniqueConstraint("name", "project_id", name="uq_variants_name_project"),
     )
 
-    id = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
-    name = db.Column(db.String, nullable=False)
-    project_id = db.Column(db.Uuid, db.ForeignKey("projects.id"), nullable=False)
+    id: Mapped[uuid.UUID] = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = db.Column(db.String, nullable=False)
+    project_id: Mapped[uuid.UUID] = db.Column(db.Uuid, db.ForeignKey("projects.id"), nullable=False)
 
-    project = db.relationship("Project", back_populates="variants")
-    scans = db.relationship("Scan", back_populates="variant", cascade="all, delete-orphan")
-    assessments = db.relationship("Assessment", back_populates="variant", cascade="all, delete-orphan")
-    time_estimates = db.relationship("TimeEstimate", back_populates="variant", cascade="all, delete-orphan")
+    project: Mapped["Project"] = db.relationship(  # type: ignore
+        back_populates="variants"
+    )
+    scans: Mapped[list["Scan"]] = db.relationship(  # type: ignore
+        back_populates="variant",
+        cascade="all, delete-orphan"
+    )
+    assessments: Mapped[list["Assessment"]] = db.relationship(  # type: ignore
+        back_populates="variant",
+        cascade="all, delete-orphan"
+    )
+    time_estimates: Mapped[list["TimeEstimate"]] = db.relationship(  # type: ignore
+        back_populates="variant",
+        cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:
         return f"<Variant id={self.id} name={self.name!r}>"
@@ -42,7 +62,7 @@ class Variant(Base):
         return variant
 
     @staticmethod
-    def get_by_id(variant_id: uuid.UUID) -> Optional["Variant"]:
+    def get_by_id(variant_id: uuid.UUID) -> "Variant | None":
         """Return the variant matching *variant_id*, or ``None`` if not found."""
         return db.session.get(Variant, variant_id)
 

--- a/tests/end_to_end_tests/test_merger_ci.py
+++ b/tests/end_to_end_tests/test_merger_ci.py
@@ -15,6 +15,10 @@ import pytest
 import io
 import json
 import os
+
+from flask.testing import FlaskCliRunner
+from click.testing import Result as CliResult
+
 from src.bin.merger_ci import _run_main, _ts_key, post_treatment, main
 from . import write_demo_files
 
@@ -56,7 +60,7 @@ def app(init_files, monkeypatch):
         result = runner.invoke(args=[
             "merge",
             "--project", "TestProject",
-            "--variant", "default",
+            "--variant", "TestVariant",
             "--cdx", str(init_files["CDX_PATH"]),
             "--spdx", str(init_files["SPDX_PATH"]),
             "--grype", str(init_files["GRYPE_CDX_PATH"]),
@@ -67,6 +71,11 @@ def app(init_files, monkeypatch):
         assert result.exit_code == 0, result.output
         yield application
         _db.drop_all()
+
+
+@pytest.fixture()
+def cli_runner(app) -> FlaskCliRunner:
+    return app.test_cli_runner()
 
 
 # ---------------------------------------------------------------------------
@@ -514,7 +523,7 @@ def test_import_custom_assessments_json_unknown_variant(app, tmp_path):
 
 def test_import_custom_assessments_json_invalid_json(app, tmp_path):
     """Import a .json with invalid JSON exits with error code 1."""
-    json_file = tmp_path / "default.json"
+    json_file = tmp_path / "TestVariant.json"
     json_file.write_text("{invalid json")
     with app.app_context():
         runner = app.test_cli_runner()
@@ -527,7 +536,7 @@ def test_import_custom_assessments_json_invalid_json(app, tmp_path):
 
 def test_import_custom_assessments_json_not_openvex(app, tmp_path):
     """Import a .json that is not OpenVEX exits with error code 1."""
-    json_file = tmp_path / "default.json"
+    json_file = tmp_path / "TestVariant.json"
     json_file.write_text(json.dumps({"hello": "world"}))
     with app.app_context():
         runner = app.test_cli_runner()
@@ -549,7 +558,7 @@ def test_import_custom_assessments_json_success(app, tmp_path):
             "status_notes": "imported via CLI",
         }],
     }
-    json_file = tmp_path / "default.json"
+    json_file = tmp_path / "TestVariant.json"
     json_file.write_text(json.dumps(doc))
     with app.app_context():
         runner = app.test_cli_runner()
@@ -647,8 +656,8 @@ def test_import_custom_assessments_targz_invalid_json_inside(
 
     buf = io.BytesIO()
     with _tf.open(fileobj=buf, mode='w:gz') as tar:
-        content = b"{not valid json"
-        info = _tf.TarInfo(name="default.json")
+        content = b"{"
+        info = _tf.TarInfo(name="TestVariant.json")
         info.size = len(content)
         tar.addfile(info, io.BytesIO(content))
 
@@ -672,7 +681,7 @@ def test_import_custom_assessments_targz_not_openvex_inside(
     buf = io.BytesIO()
     with _tf.open(fileobj=buf, mode='w:gz') as tar:
         content = json.dumps({"hello": "world"}).encode()
-        info = _tf.TarInfo(name="default.json")
+        info = _tf.TarInfo(name="TestVariant.json")
         info.size = len(content)
         tar.addfile(info, io.BytesIO(content))
 
@@ -685,3 +694,112 @@ def test_import_custom_assessments_targz_not_openvex_inside(
             "import-custom-assessments", str(archive),
         ])
     assert result.exit_code == 1
+
+
+def test_list_projects(cli_runner):
+    out: CliResult = cli_runner.invoke(args=[
+        "list-projects"
+    ])
+
+    assert out.exit_code == 0
+    assert "TestProject" in out.stdout
+    assert "TestVariant" in out.stdout
+
+
+def test_list_projects_json(cli_runner):
+    out: CliResult = cli_runner.invoke(args=[
+        "list-projects",
+        "--json"
+    ])
+
+    assert out.exit_code == 0
+
+    data = json.loads(out.stdout)
+    assert isinstance(data, list)
+    assert len(data) == 1
+
+    project = data[0]
+    assert isinstance(project, dict)
+    assert project["name"] == "TestProject"
+
+    variants = project["variants"]
+    assert isinstance(variants, list)
+    assert len(variants) == 1
+
+    variant = variants[0]
+    assert variant["name"] == "TestVariant"
+
+
+def test_list_scans(cli_runner):
+    out: CliResult = cli_runner.invoke(args=[
+        "list-scans"
+    ])
+
+    assert out.exit_code == 0
+    assert "TestProject" in out.stdout
+    assert "TestVariant" in out.stdout
+
+
+def test_list_scans_json(cli_runner):
+    out: CliResult = cli_runner.invoke(args=[
+        "list-scans",
+        "--json"
+    ])
+
+    from datetime import datetime
+
+    assert out.exit_code == 0
+
+    data = json.loads(out.stdout)
+    assert isinstance(data, list)
+    assert len(data) == 1
+
+    scan = data[0]
+    assert isinstance(scan, dict)
+    scan_timestamp = datetime.fromisoformat(scan["timestamp"])
+    assert scan_timestamp is not None
+    # cannot test that the timestamp is recent bc of timezone issues
+
+    variant = scan["variant"]
+    assert isinstance(variant, dict)
+    assert variant["name"] == "TestVariant"
+
+    project = variant["project"]
+    assert isinstance(project, dict)
+    assert project["name"] == "TestProject"
+
+
+def test_delete_scan(cli_runner):
+    out: CliResult = cli_runner.invoke(args=[
+        "list-scans",
+        "--json"
+    ])
+
+    scan_id = json.loads(out.stdout)[0]["id"]
+
+    out = cli_runner.invoke(args=[
+        "delete-scan",
+        scan_id
+    ])
+
+    assert out.exit_code == 0
+    assert "deleted scan" in out.stdout
+
+
+def test_delete_unknown_scan(cli_runner):
+    import uuid
+
+    out: CliResult = cli_runner.invoke(args=[
+        "delete-scan",
+        str(uuid.uuid4())
+    ])
+
+    assert out.exit_code != 0
+    assert "Scan not found" in str(out.exception)
+
+    out = cli_runner.invoke(args=[
+        "list-scans",
+        "--json"
+    ])
+
+    assert len(json.loads(out.stdout)) == 1, "The scan has been deleted"

--- a/vulnscout
+++ b/vulnscout
@@ -83,6 +83,7 @@ Scan & output commands:
   --export-openvex                Export project as OpenVEX document
   --export-custom-assessments     Export custom (review) assessments as tar.gz
   --import-custom-assessments <path>  Import custom assessments from .json or .tar.gz
+  --delete-scan <id>                Delete a past scan by its ID
 
 Data retrieval commands:
   list-projects                   List all projects and their variants
@@ -332,6 +333,10 @@ parse_and_run() {
                 local import_staged="/tmp/vulnscout_stage_$(basename "$import_file")"
                 call_container_engine cp "$import_file" "$CONTAINER_NAME:$import_staged"
                 EXPORT_ARGS+=(--import-custom-assessments "$import_staged")
+                shift 2 ;;
+            --delete-scan)
+                ensure_running
+                exec_container --delete-scan "$2"
                 shift 2 ;;
             serve|--serve)
                 SERVE_REQUESTED=true; shift ;;

--- a/vulnscout
+++ b/vulnscout
@@ -84,6 +84,11 @@ Scan & output commands:
   --export-custom-assessments     Export custom (review) assessments as tar.gz
   --import-custom-assessments <path>  Import custom assessments from .json or .tar.gz
 
+Data retrieval commands:
+  list-projects                   List all projects and their variants
+  list-scans                      List all past scans
+  --json                          Output objects in JSON format
+
 Configuration:
   config <key> <value>            Set a config value
   config-list                     Show current configuration
@@ -296,6 +301,8 @@ parse_and_run() {
     local SERVE_REQUESTED=false
     local REPORT_ARGS=()
     local EXPORT_ARGS=()
+    local DATA_REQUESTED=""
+    local DATA_ARGS=()
     while [ $# -gt 0 ]; do
         case "$1" in
             --dev)
@@ -342,6 +349,18 @@ parse_and_run() {
                 fi
                 REPORT_ARGS+=(--report "$tpl")
                 shift 2 ;;
+            list-projects|list-scans)
+                ensure_running
+                command="$1"
+                if [[ "$DATA_REQUESTED" != "" ]]; then
+                    # Only 1 data request command is allowed at the same time
+                    echo "Cannot use $command and $DATA_REQUESTED together"
+                    exit 1
+                fi
+                DATA_REQUESTED="$command"
+                shift ;;
+            --json)
+                DATA_ARGS+=(--json); shift ;;
             start)
                 do_start
                 if [ "$DEV_MODE" = true ]; then
@@ -420,6 +439,8 @@ parse_and_run() {
         local -a scan_args=()
         [ -n "$MATCH_CONDITION" ] && scan_args+=(--match-condition "$MATCH_CONDITION")
         exec_container --project "$PROJECT" --variant "$VARIANT" "${PENDING_ARGS[@]}" "${scan_args[@]}" "${REPORT_ARGS[@]}" "${EXPORT_ARGS[@]}" || _exit=$?
+    elif [[ "$DATA_REQUESTED" != "" ]]; then
+        exec_container "--$DATA_REQUESTED" "${DATA_ARGS[@]}"
     elif [ -n "$MATCH_CONDITION" ] || [ ${#REPORT_ARGS[@]} -gt 0 ] || [ ${#EXPORT_ARGS[@]} -gt 0 ]; then
         # No new inputs but a match-condition, report, or export was given: run against existing DB data
         ensure_running


### PR DESCRIPTION
### Changes proposed in this pull request:

* Properly type hint the models for Scan, Variant and Project
* Add `--list-scans` command with 
* Add `--list-projects` command logic (was present in entrypoint but not implemented)
  * The 2 commands above accept an optional `--json` flag to output in JSON so it can be used in scripts
* Add `--delete-scan` command to drop a scan

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

*Fill out this section so that a reviewer can know how to verify your change.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


