### PR TITLE
fix: upgrade cyclonedx-python-lib to 11.7.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-cyclonedx-python-lib==7.5.0
+cyclonedx-python-lib==11.7.0
 Flask==3.0.3
 jinja2==3.1.4
 pyparsing==3.1.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,4 @@
-cyclonedx-python-lib==7.5.0
+cyclonedx-python-lib==11.7.0
 flake8==7.0.0
 Flask==3.0.3
 Flask-SQLAlchemy==3.1.1

--- a/src/views/cyclonedx.py
+++ b/src/views/cyclonedx.py
@@ -182,10 +182,20 @@ class CycloneDx:
             for reference in vulnerability.references:
                 vuln.add_alias(reference.id)
             for rating in vulnerability.ratings:
-                if rating.method and rating.score and rating.method.startswith('CVSSv'):
+                method_value = rating.method.value if rating.method else ""
+                if rating.method and rating.score and method_value.startswith('CVSSv'):
+                    version = method_value.replace("CVSSv", "").replace("31", "3.1")
+                    # The library normalises the vector by stripping the
+                    # "CVSS:X.X/" prefix – reconstruct the full form.
+                    vector = rating.vector or ""
+                    if vector and not vector.startswith("CVSS:"):
+                        if version in ("3.0", "3", "3.1"):
+                            vector = f"CVSS:{version}/{vector}"
+                        elif version in ("4.0", "4"):
+                            vector = f"CVSS:{version}/{vector}"
                     cvss = CVSS(
-                        str(rating.method.replace("CVSSv", "").replace("31", "3.1")),
-                        rating.vector,
+                        version,
+                        vector,
                         rating.source.name if rating.source and rating.source.name else 'unknown',
                         float(rating.score),
                         0.0,
@@ -309,7 +319,10 @@ class CycloneDx:
             for alias in vuln.aliases:
                 vuln_obj.references.add(
                     cyclonedx.model.vulnerability.VulnerabilityReference(
-                        id=alias
+                        id=alias,
+                        source=cyclonedx.model.vulnerability.VulnerabilitySource(
+                            name=vuln.namespace,
+                        )
                     )
                 )
             have_custom_severity = vuln.severity_max_score is not None

--- a/tests/integration_tests/test_cyclonedx_export.py
+++ b/tests/integration_tests/test_cyclonedx_export.py
@@ -145,10 +145,9 @@ def test_export_vulnerabilities_json(cdx_exporter):
             "references": [
                 {
                     "id": "CVE-2018-99999",
-                    # "source": {
-                    #     "name": "NVD",
-                    #     "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-99999"
-                    # }
+                    "source": {
+                        "name": "NVD",
+                    }
                 }
             ],
             "advisories": [
@@ -161,10 +160,9 @@ def test_export_vulnerabilities_json(cdx_exporter):
                     "method": "CVSSv31",
                     "source": {
                         "name": "NVD",
-                        # "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-35492"
                     },
                     "score": 7.8,
-                    "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                    "vector": "AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
                     "severity": "high"
                 },
                 {


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

Resolving the PR: https://github.com/savoirfairelinux/vulnscout/issues/265

### Changes proposed in this pull request:

* Modern CycloneDX SBOMs weren't parsed correctly leading to a VulnScout crash.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1- Checkout on this PR and build the corresponding docker image

```
docker build -t sfl:fix_cdx .
```

2- Export the `VULNSCOUT_IMAGE` variable: 

```
export VULNSCOUT_IMAGE="sfl:fix_cdx"
```

3- Build the project and start the web interface:

```
./vulnscout --serve --dev --add-cdx path_to_file/docker_bom.json
```
