### PR TITLE
bugfix: Update Intialization message to get URL

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -317,15 +317,15 @@ cmd_scan() {
     fi
 
     if [[ "${INTERACTIVE_MODE}" == "true" ]]; then
+        local _port="${FLASK_RUN_PORT:-7275}"
+        local _host="${FLASK_RUN_HOST:-localhost}"
+        # 0.0.0.0 means "all interfaces" — show localhost in the URL instead
+        [[ "$_host" == "0.0.0.0" ]] && _host="localhost"
+        local _url="http://${_host}:${_port}"
         set_status "2" "<!-- __END_OF_SCAN_SCRIPT__ -->"
         echo "------------------------------------------------------------------------------"
-        echo "------------------------------------------------------------------------------"
-        echo "------------------------------------------------------------------------------"
-        echo "------------------------------------------------------------------------------"
-        echo "---------- Initialization Done - Loading is over and WebUI is ready ----------"
-        echo "------------------------------------------------------------------------------"
-        echo "------------------------------------------------------------------------------"
-        echo "------------------------------------------------------------------------------"
+        echo "Initialization Done - Loading is over and WebUI is ready !!!"
+        echo "Open  $_url in your browser to access VulnScout"
         echo "------------------------------------------------------------------------------"
         fg %?flask 2>/dev/null || true # Bring back process named 'flask' (flask run) to foreground.
     fi


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Resolve the git issue:
https://github.com/savoirfairelinux/vulnscout/issues/273

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

```
./vulnscout --serve
```

Output: 

```
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Step (1/2): No new input files to merge, skipping
Step (2/2): <!-- __END_OF_SCAN_SCRIPT__ -->
------------------------------------------------------------------------------
Initialization Done - Loading is over and WebUI is ready !!!
Open  http://localhost:7275 in your browser to access VulnScout
------------------------------------------------------------------------------
( cd "$BASE_DIR" && flask "${FLASK_ARGS[@]}" )
```