### PR TITLE
bugfix: Error 500 setting a custom assessment

### DIFF
--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -400,7 +400,6 @@ class VulnerabilitiesController:
                     print(f"=== EPSS: committed {processed}/{total}", flush=True)
                 except Exception as e:
                     verbose(f"[fetch_epss_scores commit at {processed}] {e}")
-
                     db.session.rollback()
 
         # Final commit for any remaining deferred EPSS updates.

--- a/src/models/assessment.py
+++ b/src/models/assessment.py
@@ -762,6 +762,7 @@ class Assessment(Base):
             self.workaround = workaround
         if responses is not None:
             self.responses = responses
+        self.timestamp = datetime.now(timezone.utc)
         db.session.commit()
         return self
 

--- a/src/models/finding.py
+++ b/src/models/finding.py
@@ -135,7 +135,7 @@ class Finding(Base):
         if existing is None:
             try:
                 with db.session.begin_nested():
-                    existing = Finding.create(package_id, vulnerability_id)
+                    existing = Finding.create(package_id, vulnerability_id, commit=False)
             except Exception as e:
                 verbose(f"[Finding.get_or_create race {vulnerability_id!r}] {e}")
                 existing = Finding.get_by_package_and_vulnerability(package_id, vulnerability_id)

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -12,7 +12,7 @@ from ..controllers.packages import PackagesController
 from ..controllers.vulnerabilities import VulnerabilitiesController
 from ..controllers.assessments import AssessmentsController
 from ..helpers.verbose import verbose
-from ..extensions import db
+from ..extensions import db, batch_session
 from ..models.vulnerability import Vulnerability as DBVuln
 
 OPENVEX_FILE = "/scan/outputs/openvex.json"
@@ -511,34 +511,35 @@ def init_app(app):
         from datetime import datetime as _dt, timezone as _tz
         shared_timestamp = getattr(assessment, 'timestamp', None) or _dt.now(_tz.utc)
         created = []
-        for pkg_string_id in (assessment.packages or []):
-            try:
-                # find_or_create handles both lookup and creation in one query
-                name, version = pkg_string_id.rsplit("@", 1) if "@" in pkg_string_id else (pkg_string_id, "")
-                db_pkg = Package.find_or_create(name, version)
-                # Ensure vulnerability record exists before creating Finding (FK constraint)
-                DBVuln.get_or_create(vuln_id)
-                finding = Finding.get_or_create(db_pkg.id, vuln_id)
-                # Always create a new record — never merge with an existing one.
-                # from_vuln_assessment does a find-or-update which would overwrite
-                # previous user assessments on the same (finding, variant).
-                db_a = DBAssessment.create(
-                    status=assessment.status,
-                    simplified_status=STATUS_TO_SIMPLIFIED.get(assessment.status, "Pending Assessment"),
-                    finding_id=finding.id,
-                    variant_id=variant_id,
-                    origin="custom",
-                    status_notes=assessment.status_notes,
-                    justification=assessment.justification,
-                    impact_statement=assessment.impact_statement,
-                    workaround=getattr(assessment, "workaround", None),
-                    responses=list(assessment.responses) if assessment.responses else [],
-                    timestamp=shared_timestamp,
-                    commit=True,
-                )
-                created.append(db_a.to_dict())
-            except Exception as e:
-                return {"error": f"DB error: {e}"}, 500
+        try:
+            with batch_session():
+                for pkg_string_id in (assessment.packages or []):
+                    # find_or_create handles both lookup and creation in one query
+                    name, version = pkg_string_id.rsplit("@", 1) if "@" in pkg_string_id else (pkg_string_id, "")
+                    db_pkg = Package.find_or_create(name, version)
+                    # Ensure vulnerability record exists before creating Finding (FK constraint)
+                    DBVuln.get_or_create(vuln_id)
+                    finding = Finding.get_or_create(db_pkg.id, vuln_id)
+                    # Always create a new record — never merge with an existing one.
+                    # from_vuln_assessment does a find-or-update which would overwrite
+                    # previous user assessments on the same (finding, variant).
+                    db_a = DBAssessment.create(
+                        status=assessment.status,
+                        simplified_status=STATUS_TO_SIMPLIFIED.get(assessment.status, "Pending Assessment"),
+                        finding_id=finding.id,
+                        variant_id=variant_id,
+                        origin="custom",
+                        status_notes=assessment.status_notes,
+                        justification=assessment.justification,
+                        impact_statement=assessment.impact_statement,
+                        workaround=getattr(assessment, "workaround", None),
+                        responses=list(assessment.responses) if assessment.responses else [],
+                        timestamp=shared_timestamp,
+                        commit=True,
+                    )
+                    created.append(db_a.to_dict())
+        except Exception as e:
+            return {"error": f"DB error: {e}"}, 500
 
         if not created:
             return {"error": "No valid package found"}, 400
@@ -559,64 +560,67 @@ def init_app(app):
         pkg_cache: dict = {}
         finding_cache: dict = {}
 
-        for item in payload_data["assessments"]:
-            if not isinstance(item, dict) or "vuln_id" not in item:
-                errors.append({"error": "Invalid assessment data", "item": item})
-                continue
-
-            assessment, status = payload_to_assessment(item)
-            if status != 200:
-                errors.append({"vuln_id": item.get("vuln_id"), "error": assessment.get("error", "Unknown error")})
-                continue
-
-            vuln_id = assessment.vuln_id
-            # Parse optional variant_id from the raw item
-            variant_id_raw = item.get('variant_id') or None
-            variant_id = None
-            if variant_id_raw:
-                try:
-                    import uuid as _uuid
-                    variant_id = _uuid.UUID(variant_id_raw)
-                except (ValueError, AttributeError):
-                    errors.append({"vuln_id": vuln_id, "error": "Invalid variant_id"})
+        with batch_session():
+            for item in payload_data["assessments"]:
+                if not isinstance(item, dict) or "vuln_id" not in item:
+                    errors.append({"error": "Invalid assessment data", "item": item})
                     continue
-            pkg_list = assessment.packages or []
-            if not pkg_list:
-                errors.append({"vuln_id": vuln_id, "error": "No valid package found"})
-                continue
-            for pkg_string_id in pkg_list:
-                try:
-                    # Resolve package from cache first, then DB
-                    db_pkg = pkg_cache.get(pkg_string_id)
-                    if db_pkg is None:
-                        name, version = pkg_string_id.rsplit("@", 1) if "@" in pkg_string_id else (pkg_string_id, "")
-                        db_pkg = Package.find_or_create(name, version)
-                        pkg_cache[pkg_string_id] = db_pkg
-                    # Ensure vulnerability record exists before creating Finding (FK constraint)
-                    DBVuln.get_or_create(vuln_id)
-                    # Resolve finding from cache first, then DB
-                    f_key = (db_pkg.id, vuln_id)
-                    finding = finding_cache.get(f_key)
-                    if finding is None:
-                        finding = Finding.get_or_create(db_pkg.id, vuln_id)
-                        finding_cache[f_key] = finding
-                    # Always create a new record — never overwrite an existing assessment
-                    db_a = DBAssessment.create(
-                        status=assessment.status,
-                        simplified_status=STATUS_TO_SIMPLIFIED.get(assessment.status, "Pending Assessment"),
-                        finding_id=finding.id,
-                        variant_id=variant_id,
-                        origin="custom",
-                        status_notes=assessment.status_notes,
-                        justification=assessment.justification,
-                        impact_statement=assessment.impact_statement,
-                        workaround=getattr(assessment, "workaround", None),
-                        responses=list(assessment.responses) if assessment.responses else [],
-                        commit=True,
-                    )
-                    results.append(db_a.to_dict())
-                except Exception as e:
-                    errors.append({"vuln_id": vuln_id, "error": str(e)})
+
+                assessment, status = payload_to_assessment(item)
+                if status != 200:
+                    errors.append({"vuln_id": item.get("vuln_id"), "error": assessment.get("error", "Unknown error")})
+                    continue
+
+                vuln_id = assessment.vuln_id
+                # Parse optional variant_id from the raw item
+                variant_id_raw = item.get('variant_id') or None
+                variant_id = None
+                if variant_id_raw:
+                    try:
+                        import uuid as _uuid
+                        variant_id = _uuid.UUID(variant_id_raw)
+                    except (ValueError, AttributeError):
+                        errors.append({"vuln_id": vuln_id, "error": "Invalid variant_id"})
+                        continue
+                pkg_list = assessment.packages or []
+                if not pkg_list:
+                    errors.append({"vuln_id": vuln_id, "error": "No valid package found"})
+                    continue
+                for pkg_string_id in pkg_list:
+                    try:
+                        # Resolve package from cache first, then DB
+                        db_pkg = pkg_cache.get(pkg_string_id)
+                        if db_pkg is None:
+                            name, version = (pkg_string_id.rsplit("@", 1)
+                                             if "@" in pkg_string_id
+                                             else (pkg_string_id, ""))
+                            db_pkg = Package.find_or_create(name, version)
+                            pkg_cache[pkg_string_id] = db_pkg
+                        # Ensure vulnerability record exists before creating Finding (FK constraint)
+                        DBVuln.get_or_create(vuln_id)
+                        # Resolve finding from cache first, then DB
+                        f_key = (db_pkg.id, vuln_id)
+                        finding = finding_cache.get(f_key)
+                        if finding is None:
+                            finding = Finding.get_or_create(db_pkg.id, vuln_id)
+                            finding_cache[f_key] = finding
+                        # Always create a new record — never overwrite an existing assessment
+                        db_a = DBAssessment.create(
+                            status=assessment.status,
+                            simplified_status=STATUS_TO_SIMPLIFIED.get(assessment.status, "Pending Assessment"),
+                            finding_id=finding.id,
+                            variant_id=variant_id,
+                            origin="custom",
+                            status_notes=assessment.status_notes,
+                            justification=assessment.justification,
+                            impact_statement=assessment.impact_statement,
+                            workaround=getattr(assessment, "workaround", None),
+                            responses=list(assessment.responses) if assessment.responses else [],
+                            commit=True,
+                        )
+                        results.append(db_a.to_dict())
+                    except Exception as e:
+                        errors.append({"vuln_id": vuln_id, "error": str(e)})
 
         response = {
             "status": "success" if results else "error",


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Custom assessment while fetching the NVD raised an issue 500 "Failed to add assessment: HTTP code 500".

Wrap assessment creation routes in batch_session() to collapse multiple DB commits into one, minimizing SQLite write-lock contention with background enrichment threads. Fix Finding.get_or_create commit inside savepoint.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1- Checkout on this PR and build the corresponding docker image

```
docker build -t sfl:fix_assess .
```

2- Export the `VULNSCOUT_IMAGE` variable: 

```
export VULNSCOUT_IMAGE="sfl:fix_assess"
```

3- Build the project and start the web interface:

```
./vulnscout --serve --add-spdx $(pwd)/example/spdx3/core-image-minimal-qemux86-64.rootfs.spdx.json \
--add-cve-check $(pwd)/example/spdx3/core-image-minimal-qemux86-64.rootfs.json
```

4- Try to do some custom assessments - Shouldn't crash