### PR TITLE
fix: PURL as OpenVEX product @id, not name@version

### DIFF
--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -203,11 +203,12 @@ def init_app(app):
                             name, version = pkg_str.rsplit("@", 1)
                         else:
                             name, version = pkg_str, ""
+                        purl = f"pkg:generic/{name}@{version}"
                         products.append({
-                            "@id": pkg_str,
+                            "@id": purl,
                             "identifiers": {
                                 "cpe23": f"cpe:2.3:*:*:{name}:{version}:*:*:*:*:*:*:*",
-                                "purl": f"pkg:generic/{name}@{version}",
+                                "purl": purl,
                             }
                         })
                     stmt["products"] = products

--- a/src/views/fast_spdx.py
+++ b/src/views/fast_spdx.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 from ..models.package import Package
+from ..controllers.packages import PackagesController
+from ..controllers.vulnerabilities import VulnerabilitiesController
+from ..controllers.assessments import AssessmentsController
 
 
 class FastSPDX ():
@@ -13,51 +16,53 @@ class FastSPDX ():
     """
 
     def __init__(self, controllers):
-        self.packagesCtrl = controllers["packages"]
-        self.vulnerabilitiesCtrl = controllers["vulnerabilities"]
-        self.assessmentsCtrl = controllers["assessments"]
-        self.sbom = None
+        self.packagesCtrl: PackagesController = controllers["packages"]
+        self.vulnerabilitiesCtrl: VulnerabilitiesController = controllers["vulnerabilities"]
+        self.assessmentsCtrl: AssessmentsController = controllers["assessments"]
 
-    def get_field(self, obj: dict, field: list[str]):
-        """Get field from dict or return None."""
-        for f in field:
-            if f in obj:
-                return obj[f]
-        return None
-
-    def check_spdx_version(self):
+    def _check_spdx_version(self, sbom: dict):
         """Check if the SPDX version is supported."""
-        self.version = self.get_field(self.sbom, ["spdxVersion", "SPDXVersion", "spdxversion"])
-        if self.version != "SPDX-2.3" and self.version != "SPDX-2.2":
+        self.version = _get_field(sbom, ["spdxVersion", "SPDXVersion", "spdxversion"])
+        if self.version not in ("SPDX-2.3", "SPDX-2.2"):
             raise ValueError("Unsupported SPDX version")
 
-    def merge_packages(self):
+    def _merge_packages(self, sbom: dict):
         """Merge packages from SPDX SBOM."""
-        if not self.get_field(self.sbom, ["packages", "Packages"]):
-            return
+        for pkg in _get_field(sbom, ["packages", "Packages"]) or []:
+            parsed_package = self._parse_package(pkg)
+            if parsed_package:
+                self.packagesCtrl.add(parsed_package)
 
-        for pkg in self.get_field(self.sbom, ["packages", "Packages"]):
-            name = self.get_field(pkg, ["name", "Name", "packageName", "PackageName"])
-            if name is None:
-                continue
-            version = self.get_field(pkg, ["version", "Version", "packageVersion", "PackageVersion", "versionInfo"])
-            primary_package_purpose = self.get_field(pkg, ["primaryPackagePurpose", "PrimaryPackagePurpose"])
-            licences = self.get_field(pkg, ["licenseDeclared", "LicenseDeclared"])
+    def _parse_package(self, pkg: dict) -> Package | None:
+        name = _get_field(pkg, ["name", "Name", "packageName", "PackageName"])
+        if name is None:
+            return None
+        version = _get_field(pkg, ["version", "Version", "packageVersion", "PackageVersion", "versionInfo"])
+        primary_package_purpose = _get_field(pkg, ["primaryPackagePurpose", "PrimaryPackagePurpose"])
+        licences = _get_field(pkg, ["licenseDeclared", "LicenseDeclared"])
 
-            package = Package(name, version or "", [], [], licences or "")
-            cpe_type = "a"
-            if primary_package_purpose == "OPERATING-SYSTEM" or primary_package_purpose == "OPERATING_SYSTEM":
-                cpe_type = "o"
-            if primary_package_purpose == "DEVICE":
-                cpe_type = "h"
-            package.add_cpe(f"cpe:2.3:{cpe_type}:*:{name}:{version or '*'}:*:*:*:*:*:*:*")
-            package.generate_generic_cpe()
-            package.generate_generic_purl()
+        package = Package(name, version or "", [], [], licences or "")
+        cpe_type = "a"
+        if primary_package_purpose == "OPERATING-SYSTEM" or primary_package_purpose == "OPERATING_SYSTEM":
+            cpe_type = "o"
+        if primary_package_purpose == "DEVICE":
+            cpe_type = "h"
+        package.add_cpe(f"cpe:2.3:{cpe_type}:*:{name}:{version or '*'}:*:*:*:*:*:*:*")
 
-            self.packagesCtrl.add(package)
+        package.generate_generic_cpe()
+        package.generate_generic_purl()
+
+        return package
 
     def parse_from_dict(self, spdx: dict):
         """Read data from SPDX json parsed format."""
-        self.sbom = spdx
-        self.check_spdx_version()
-        self.merge_packages()
+        self._check_spdx_version(spdx)
+        self._merge_packages(spdx)
+
+
+def _get_field(obj: dict, field: list[str]):
+    """Get field from dict or return None."""
+    for f in field:
+        if f in obj:
+            return obj[f]
+    return None

--- a/src/views/fast_spdx.py
+++ b/src/views/fast_spdx.py
@@ -49,6 +49,12 @@ class FastSPDX ():
             cpe_type = "h"
         package.add_cpe(f"cpe:2.3:{cpe_type}:*:{name}:{version or '*'}:*:*:*:*:*:*:*")
 
+        for external_ref in _get_field(pkg, ["externalRefs"]) or []:
+            if _get_field(external_ref, ["referenceType"]) == "purl":
+                purl = _get_field(external_ref, ["referenceLocator"])
+                assert isinstance(purl, str)
+                package.add_purl(purl)
+
         package.generate_generic_cpe()
         package.generate_generic_purl()
 

--- a/src/views/openvex.py
+++ b/src/views/openvex.py
@@ -139,9 +139,6 @@ class OpenVex:
 
             pkg_list = []
             for pkg_id in assess.packages:
-                product = {
-                    "@id": pkg_id
-                }
                 pkg = self.packagesCtrl.get(pkg_id)
 
                 if pkg is not None:
@@ -149,9 +146,16 @@ class OpenVex:
                         pkg.generate_generic_cpe()
                     if len(pkg.purl) < 1:
                         pkg.generate_generic_purl()
-                    product["identifiers"] = {
-                        "cpe23": pkg.cpe[0],
-                        "purl": pkg.purl[0]
+                    product = {
+                        "@id": pkg.purl[0],
+                        "identifiers": {
+                            "cpe23": pkg.cpe[0],
+                            "purl": pkg.purl[0]
+                        }
+                    }
+                else:
+                    product = {
+                        "@id": pkg_id
                     }
 
                 pkg_list.append(product)

--- a/src/views/spdx.py
+++ b/src/views/spdx.py
@@ -69,6 +69,11 @@ class SPDX:
                 license_str = str(license_declared)
                 pkg.licences = license_str
             pkg.add_cpe(f"cpe:2.3:{cpe_type}:*:{package.name or '*'}:{package.version or '*'}:*:*:*:*:*:*:*")
+
+            for external_ref in package.external_references:
+                if external_ref.reference_type == "purl":
+                    pkg.add_purl(external_ref.locator)
+
             pkg.generate_generic_cpe()
             pkg.generate_generic_purl()
 

--- a/tests/integration_tests/test_openvex.py
+++ b/tests/integration_tests/test_openvex.py
@@ -252,7 +252,7 @@ def test_encode_with_data(openvex_parser, pkg_ABC, vuln_123, assesment_123):
     }.items() <= statement["vulnerability"].items()
     assert len(statement["products"]) == 1
     assert {
-        "@id": "abc@1.2.3",
+        "@id": "pkg:generic/abc@1.2.3",
         "identifiers": {
             "cpe23": "cpe:2.3:a:abc:abc:1.2.3:*:*:*:*:*:*:*",
             "purl": "pkg:generic/abc@1.2.3"


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

Reference: https://github.com/savoirfairelinux/vulnscout/issues/276.

### Changes proposed in this pull request:

When multiple distinct BOM components share the same name and version (e.g. perl@5.26.1, util-linux@2.31.1), the generated OpenVEX output collapsed them into the same product identity, making cross-document BOM-VEX matching ambiguous. Use the PURL (already present in identifiers) as the primary product @id to preserve target uniqueness.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1- Checkout on this PR and build the corresponding docker image

```
docker build -t sfl:fix_openvex .
```

2- Export the `VULNSCOUT_IMAGE` variable: 

```
export VULNSCOUT_IMAGE="sfl:fix_openvex"
```


3- Export a project in `OpenVEX` format. Now the `@id` value correspond to the `purl` not `package@version`