### PR TITLE
fix: strip staging prefix from filename

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -371,6 +371,15 @@ cmd_export_custom_assessments() {
 cmd_import_custom_assessments() {
     local file="$1"
     cd "$BASE_DIR"
+    local raw_basename dest_name dest_file
+    raw_basename="$(basename "$file")"
+    dest_name="${raw_basename#vulnscout_stage_}"
+    if [[ "$dest_name" != "$raw_basename" ]]; then
+        dest_file="$(dirname "$file")/$dest_name"
+        mv "$file" "$dest_file"
+        file="$dest_file"
+    fi
+
     flask --app src.bin.webapp db upgrade
     flask --app src.bin.webapp import-custom-assessments "$file"
     setup_user


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

Reference: https://github.com/savoirfairelinux/vulnscout/issues/281

### Changes proposed in this pull request:

The vulnscout wrapper stages files into the container as /tmp/vulnscout_stage_<basename>. When running
--import-custom-assessments MyVariant.json, the CLI command extracted the variant name from the staged filename, producing 'vulnscout_stage_MyVariant' instead of 'MyVariant', causing a "no variant found matching filename" error.

Strip the vulnscout_stage_ prefix in cmd_import_custom_assessments(), consistent with how cmd_add_report_template() already handles it.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1- Export the assessments:  

```
 ./vulnscout --export-custom-assessments
```

2- Import the assessments back:

```
/vulnscout --import-custom-assessments .vulnscout/outputs/default.json 
```

Result: 

```
vboudevin@vboudevin-pc:~/Documents/vs/vulnscout$ .
Successfully copied 3.07kB to vulnscout:/tmp/vulnscout_stage_default.json
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Imported 0 assessments (1 skipped as duplicates)
```

Previous wrong result:

```
Successfully copied 3.07kB to vulnscout:/tmp/vulnscout_stage_default.json
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Error: no variant found matching filename 'vulnscout_stage_default'. The JSON filename must correspond to an existing variant name.
```