### PR TITLE
UI bug fixes

### DIFF
--- a/frontend/src/components/ConfirmationModal.tsx
+++ b/frontend/src/components/ConfirmationModal.tsx
@@ -40,7 +40,13 @@ function ConfirmationModal({
 
     return (
         <div
+            data-testid="confirmation-modal-backdrop"
             tabIndex={-1}
+            onMouseDown={(event) => {
+                if (event.target === event.currentTarget) {
+                    onCancel();
+                }
+            }}
             className="fixed top-0 right-0 left-0 z-[100] flex justify-center items-center w-full h-full max-h-full bg-black/50"
         >
             <div className="relative p-4 w-full max-w-md max-h-full">

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -31,10 +31,12 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
     const [isAllVariantsMode, setIsAllVariantsMode] = useState<boolean>(false)
     const loadingLabel = selectedVulns.length === 1 ? 'Editing selected CVE...' : 'Editing selected CVEs...'
 
-    if (selectedVulns.length == 0) {
-        if (panelOpened) setPanelOpened(0)
-        if (isLoading) setIsLoading(false)
-    }
+    useEffect(() => {
+        if (selectedVulns.length === 0) {
+            setPanelOpened(0);
+            setIsLoading(false);
+        }
+    }, [selectedVulns.length]);
 
     // Recompute affected variants whenever the status panel opens or the selection changes
     useEffect(() => {
@@ -180,6 +182,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
 
                 const errorMsg = data.error_count ? ` (${data.error_count} failed)` : '';
                 triggerBanner(`Successfully added assessments to ${data.count} vulnerabilities${errorMsg}`, 'success');
+                resetVulns();
             } else {
                 const errorMsg = data?.errors?.length
                     ? `Errors: ${data.errors.map((e: {error?: string}) => e.error).join(', ')}`
@@ -238,6 +241,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
 
                 const errorMsg = data.error_count ? ` (${data.error_count} failed)` : '';
                 triggerBanner(`Successfully updated time estimates for ${data.count} vulnerabilities${errorMsg}`, 'success');
+                resetVulns();
             } else {
                 const errorMsg = data?.errors?.length
                     ? `Errors: ${data.errors.map((e: {error?: string}) => e.error).join(', ')}`

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -29,6 +29,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
     const [isLoading, setIsLoading] = useState<boolean>(false)
     const [affectedVariantNames, setAffectedVariantNames] = useState<string[]>([])
     const [isAllVariantsMode, setIsAllVariantsMode] = useState<boolean>(false)
+    const loadingLabel = selectedVulns.length === 1 ? 'Editing selected CVE...' : 'Editing selected CVEs...'
 
     if (selectedVulns.length == 0) {
         if (panelOpened) setPanelOpened(0)
@@ -259,7 +260,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                 <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
                     <div className="flex flex-col items-center gap-3 text-white">
                         <div className="w-10 h-10 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
-                        <span className="text-sm font-semibold">Editing multiple CVEs...</span>
+                        <span className="text-sm font-semibold">{loadingLabel}</span>
                     </div>
                 </div>
             )}

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -30,6 +30,9 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
     const [affectedVariantNames, setAffectedVariantNames] = useState<string[]>([])
     const [isAllVariantsMode, setIsAllVariantsMode] = useState<boolean>(false)
     const loadingLabel = selectedVulns.length === 1 ? 'Editing selected CVE...' : 'Editing selected CVEs...'
+    const closePanel = () => {
+        if (!isLoading) setPanelOpened(0)
+    }
 
     useEffect(() => {
         if (selectedVulns.length === 0) {
@@ -37,6 +40,21 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
             setIsLoading(false);
         }
     }, [selectedVulns.length]);
+
+    useEffect(() => {
+        if (panelOpened === 0 || isLoading) return;
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setPanelOpened(0);
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [panelOpened, isLoading]);
 
     // Recompute affected variants whenever the status panel opens or the selection changes
     useEffect(() => {
@@ -258,7 +276,13 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
 
     return (<>
         {selectedVulns.length >= 1 && <>
-            {panelOpened > 0 && <div className="absolute top-0 left-0 right-0 bottom-0 z-30 bg-black/40"></div>}
+            {panelOpened > 0 && (
+                <div
+                    data-testid="multi-edit-backdrop"
+                    className="fixed inset-0 z-30 bg-black/40"
+                    onMouseDown={closePanel}
+                ></div>
+            )}
 
             {isLoading && (
                 <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
@@ -284,7 +308,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
             <div className={[
                 'absolute z-40 p-4 bg-slate-700 shadow-md shadow-slate-400/40 top-48 left-32 w-1/2',
                 panelOpened == 1 ? 'block' : 'hidden'
-            ].join(' ')}>
+            ].join(' ')} data-testid="multi-edit-status-panel">
                 <StatusEditor
                     onAddAssessment={(data) => addAssessment(data)}
                     progressBar={undefined}
@@ -317,7 +341,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
             <div className={[
                 'absolute z-40 p-4 bg-slate-700 shadow-md shadow-slate-400/40 top-48 left-32 w-1/2',
                 panelOpened == 2 ? 'block' : 'hidden'
-            ].join(' ')}>
+            ].join(' ')} data-testid="multi-edit-time-panel">
                 <TimeEstimateEditor
                     onSaveTimeEstimation={(data) => saveTimeEstimation(data)}
                     progressBar={undefined}

--- a/frontend/src/components/PopupExportOptions.tsx
+++ b/frontend/src/components/PopupExportOptions.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type Options = {
     docName: string;
@@ -19,9 +19,28 @@ function PopupExportOptions({docName, extension, onClose = () => {}}: Readonly<O
 
     const onlyMoreRecent = onlyMoreRecentDate != '' ? `${onlyMoreRecentDate}T${onlyMoreRecentTime || '00:00'}` : undefined;
 
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [onClose]);
+
     return (
         <div
+            data-testid="popup-export-backdrop"
             tabIndex={-1}
+            onMouseDown={(event) => {
+                if (event.target === event.currentTarget) {
+                    onClose();
+                }
+            }}
             className="overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-full max-h-full bg-gray-900/90"
         >
             <div className="relative p-4 md:p-32 xl:px-64 h-full">

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -668,7 +668,13 @@ type AssessmentGroup = {
 
     return (
         <div
+            data-testid="vuln-modal-backdrop"
             tabIndex={-1}
+            onMouseDown={(event) => {
+                if (event.target === event.currentTarget) {
+                    handleClose();
+                }
+            }}
             className="overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-full max-h-full bg-gray-900/90"
         >
             {submittingMessage && (

--- a/frontend/tests/unit_tests/test_confirmation_modal.tsx
+++ b/frontend/tests/unit_tests/test_confirmation_modal.tsx
@@ -98,6 +98,15 @@ describe('ConfirmationModal', () => {
         expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
     });
 
+    test('should call onCancel when backdrop is clicked', async () => {
+        const user = userEvent.setup();
+        render(<ConfirmationModal {...defaultProps} />);
+
+        await user.click(screen.getByTestId('confirmation-modal-backdrop'));
+
+        expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+    });
+
     test('should call onCancel when Escape key is pressed', () => {
         // ARRANGE
         render(<ConfirmationModal {...defaultProps} />);

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -105,6 +105,44 @@ describe('MultiEditBar', () => {
         expect(container.firstChild).not.toBeNull();
     });
 
+    test('uses singular loading copy for a single selected vulnerability', async () => {
+        fetchMock.mockImplementation(() => new Promise(() => {}));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-2']
+        };
+
+        const { getByText } = render(<MultiEditBar {...props} />);
+
+        await act(async () => { getByText('Change status').click(); });
+        await act(async () => { getByText('Add assessment').click(); });
+
+        await waitFor(() => {
+            expect(getByText('Editing selected CVE...')).toBeInTheDocument();
+            expect(getByText('Selected vulnerabilities: 1')).toBeInTheDocument();
+        });
+    });
+
+    test('uses plural loading copy for multiple selected vulnerabilities', async () => {
+        fetchMock.mockImplementation(() => new Promise(() => {}));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1', 'vuln-2']
+        };
+
+        const { getByText } = render(<MultiEditBar {...props} />);
+
+        await act(async () => { getByText('Change status').click(); });
+        await act(async () => { getByText('Add assessment').click(); });
+
+        await waitFor(() => {
+            expect(getByText('Editing selected CVEs...')).toBeInTheDocument();
+            expect(getByText('Selected vulnerabilities: 2')).toBeInTheDocument();
+        });
+    });
+
     test('handles same status across vulnerabilities', () => {
         const sameStatusVulns = [
             { ...mockVulnerabilities[0], id: 'vuln-1', status: 'affected' },

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -186,6 +186,24 @@ describe('MultiEditBar', () => {
         expect(statusEditor).toBeTruthy();
     });
 
+    test('clicking the backdrop closes the batch status panel', async () => {
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1']
+        };
+
+        const { getByText, getByTestId } = render(<MultiEditBar {...props} />);
+        await act(async () => { getByText('Change status').click(); });
+
+        expect(getByTestId('multi-edit-status-panel')).toHaveClass('block');
+
+        fireEvent.mouseDown(getByTestId('multi-edit-backdrop'));
+
+        await waitFor(() => {
+            expect(getByTestId('multi-edit-status-panel')).toHaveClass('hidden');
+        });
+    });
+
     test('renders time estimate editor when change time button clicked', () => {
         const props = {
             ...mockProps,
@@ -199,6 +217,25 @@ describe('MultiEditBar', () => {
         // TimeEstimateEditor should be visible (check by finding an input with its placeholder)
         const timeEditor = getByPlaceholderText('shortest estimate [eg: 5h]');
         expect(timeEditor).toBeTruthy();
+    });
+
+    test('pressing escape closes the batch time panel', async () => {
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1']
+        };
+
+        const { getByText, getByPlaceholderText, getByTestId } = render(<MultiEditBar {...props} />);
+        await act(async () => { getByText('Change estimated time').click(); });
+
+        expect(getByPlaceholderText('shortest estimate [eg: 5h]')).toBeInTheDocument();
+        expect(getByTestId('multi-edit-time-panel')).toHaveClass('block');
+
+        fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+
+        await waitFor(() => {
+            expect(getByTestId('multi-edit-time-panel')).toHaveClass('hidden');
+        });
     });
 
     test('calls resetVulns when reset selection button clicked', () => {

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -233,6 +233,7 @@ describe('MultiEditBar', () => {
         const mockTriggerBanner = jest.fn();
         const mockAppendAssessment = jest.fn();
         const mockPatchVuln = jest.fn();
+        const mockResetVulns = jest.fn();
         fetchMock.mockResponseOnce(JSON.stringify([])); // Variants.listByVuln for vuln-1
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
@@ -253,7 +254,8 @@ describe('MultiEditBar', () => {
             selectedVulns: ['vuln-1'],
             triggerBanner: mockTriggerBanner,
             appendAssessment: mockAppendAssessment,
-            patchVuln: mockPatchVuln
+            patchVuln: mockPatchVuln,
+            resetVulns: mockResetVulns
         };
 
         const { getByText } = render(<MultiEditBar {...props} />);
@@ -273,11 +275,13 @@ describe('MultiEditBar', () => {
         });
         expect(mockAppendAssessment).toHaveBeenCalled();
         expect(mockPatchVuln).toHaveBeenCalled();
+        expect(mockResetVulns).toHaveBeenCalledTimes(1);
     });
 
     test('saveTimeEstimation success path: updates vulns and triggers success banner', async () => {
         const mockTriggerBanner = jest.fn();
         const mockPatchVuln = jest.fn();
+        const mockResetVulns = jest.fn();
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
             vulnerabilities: [{
@@ -295,7 +299,8 @@ describe('MultiEditBar', () => {
             ...mockProps,
             selectedVulns: ['vuln-1'],
             triggerBanner: mockTriggerBanner,
-            patchVuln: mockPatchVuln
+            patchVuln: mockPatchVuln,
+            resetVulns: mockResetVulns
         };
 
         const { getByText, getByPlaceholderText } = render(<MultiEditBar {...props} />);
@@ -315,6 +320,7 @@ describe('MultiEditBar', () => {
             );
         });
         expect(mockPatchVuln).toHaveBeenCalled();
+        expect(mockResetVulns).toHaveBeenCalledTimes(1);
     });
 
     test('addAssessment error path: triggers error banner with error details', async () => {

--- a/frontend/tests/unit_tests/test_popup_export_options.tsx
+++ b/frontend/tests/unit_tests/test_popup_export_options.tsx
@@ -109,6 +109,24 @@ describe('PopupExportOptions component', () => {
        expect(mockOnClose).toHaveBeenCalled();
    });
 
+   test('calls onClose when backdrop is clicked', async () => {
+       const mockOnClose = jest.fn();
+       render(<PopupExportOptions docName="report.txt" extension="adoc" onClose={mockOnClose} />);
+
+       await userEvent.click(screen.getByTestId('popup-export-backdrop'));
+
+       expect(mockOnClose).toHaveBeenCalledTimes(1);
+   });
+
+   test('calls onClose when escape is pressed', () => {
+       const mockOnClose = jest.fn();
+       render(<PopupExportOptions docName="report.txt" extension="adoc" onClose={mockOnClose} />);
+
+       fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+
+       expect(mockOnClose).toHaveBeenCalledTimes(1);
+   });
+
    test('renders without onClose prop (uses default)', async () => {
        render(<PopupExportOptions docName="report.txt" extension="adoc" />);
        expect(screen.getByText(/Exporting/i)).toBeInTheDocument();

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -407,6 +407,29 @@ describe('Vulnerability Modal', () => {
         expect(closeCb).toHaveBeenCalledTimes(1);
     });
 
+    test('clicking the backdrop closes modal without unsaved changes', async () => {
+        const closeCb = jest.fn();
+        render(<VulnModal vuln={vulnerability} onClose={closeCb} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const user = userEvent.setup();
+        await user.click(screen.getByTestId('vuln-modal-backdrop'));
+
+        expect(closeCb).toHaveBeenCalledTimes(1);
+    });
+
+    test('clicking the backdrop shows confirmation when unsaved changes exist', async () => {
+        const closeCb = jest.fn();
+        render(<VulnModal vuln={vulnerability} isEditing={true} onClose={closeCb} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const user = userEvent.setup();
+        const optimistic = screen.getByPlaceholderText(/shortest estimate/i);
+        await user.type(optimistic, '5h');
+        await user.click(screen.getByTestId('vuln-modal-backdrop'));
+
+        expect(await screen.findByText(/are you sure you want to close without saving/i)).toBeInTheDocument();
+        expect(closeCb).not.toHaveBeenCalled();
+    });
+
     test('ESC key shows confirmation modal with unsaved changes', async () => {
         const closeCb = jest.fn();
         render(<VulnModal vuln={vulnerability} isEditing={true} onClose={closeCb} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);


### PR DESCRIPTION
- **fix(ui): use singular batch-edit copy for one CVE**
- **fix(ui): clear batch selections after successful edits**
- **fix(ui): allow popups to close on escape and backdrop click**

### Changes proposed in this pull request:

* Fix the vulnerabilities batch-edit bar so single-item selections use singular copy, successful batch edits clear the current selection, and previously edited CVEs cannot be accidentally modified again from stale state.
* Make the relevant UI popups dismissible with `Escape` and backdrop clicks, including the batch status/time panels and the main vulnerability modal, while preserving the existing unsaved-changes confirmation flow.
* Add focused frontend unit coverage for the updated batch-edit and modal dismissal behavior.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Run the frontend tests:
  `cd frontend && npx jest --runInBand --coverage=false tests/unit_tests/test_multi_edit_bar.tsx tests/unit_tests/test_confirmation_modal.tsx tests/unit_tests/test_popup_export_options.tsx tests/unit_tests/test_vuln_modal.tsx`
* In the `Vulnerabilities` view, select exactly one CVE and open batch edit. Confirm the UI uses singular wording for the selection/loading text.
* With a `Status` filter active, select one or more CVEs, batch-change their status, and confirm the selection counter resets to zero after the update completes.
* Repeat a batch edit after the first one and confirm previously edited, now-filtered-out vulnerabilities are not still selected in the background.
* Open the batch status panel, batch time panel, and a vulnerability details modal. Confirm `Escape` closes them and clicking outside the popup closes them as well.
* In the vulnerability details modal, make an unsaved edit and click the backdrop. Confirm you get the unsaved-changes confirmation instead of the modal closing immediately.

### Additional notes

* Note that the tests from these three commits were written by generative AI. The model used was GPT 5.4.

### Related Issue

* N/A

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [/] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [/] Linked relevant issues (if any)
- [ ] Added necessary reviewers