### PR TITLE
Fix: db lock after few assessments due to NVD taking control of the DB

### DIFF
--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -65,9 +65,8 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         .then((patchData) => {
             setPatchInfo(patchData);
         })
-        .catch((err) => {
-            console.error(err);
-            triggerBanner("Failed to load patch data", "error");
+        .catch((_err) => {
+            // patch-finder feature may be disabled — fail silently
         });
     }, []);
 
@@ -88,9 +87,8 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                 setPatchDbReady(false);
             }
         })
-        .catch((err) => {
-            console.error(err);
-            triggerBanner("Failed to load patch data", "error");
+        .catch((_err) => {
+            // patch-finder feature may be disabled — fail silently
         })
     }, [loadPatchData]);
 

--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -9,7 +9,7 @@
 
 from ..helpers.add_middleware import FlaskWithMiddleware as Flask
 from ..helpers.env_vars import get_bool_env
-from ..extensions import db, migrate
+from ..extensions import db, migrate, setup_write_serialization
 from ..routes import init_app
 from .. import models  # noqa: F401
 from .merger_ci import init_app as init_merger_cli, post_treatment
@@ -32,6 +32,11 @@ def _launch_enrichment(app):
     """
     def _enrich_epss():
         with app.app_context():
+            # Disable autoflush: without this, every SELECT triggers a flush
+            # which acquires the write-lock and holds it across the slow HTTP
+            # calls until the next explicit commit().  With autoflush=False
+            # the lock is only held during commit() itself (milliseconds).
+            db.session.autoflush = False
             try:
                 from ..controllers.packages import PackagesController
                 from ..controllers.vulnerabilities import VulnerabilitiesController
@@ -43,6 +48,7 @@ def _launch_enrichment(app):
 
     def _enrich_nvd():
         with app.app_context():
+            db.session.autoflush = False
             try:
                 from ..controllers.packages import PackagesController
                 from ..controllers.vulnerabilities import VulnerabilitiesController
@@ -96,6 +102,10 @@ def create_app():
                 db.session.commit()
             except Exception:
                 pass
+            # Serialise write transactions across threads so that
+            # concurrent enrichment / request commits never trigger
+            # "database is locked".
+            setup_write_serialization(db.session)
 
     # Ensure every new SQLite connection inherits the busy timeout so that
     # concurrent writes from background threads don't immediately fail.

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -1,11 +1,9 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy import event
 from contextlib import contextmanager
-import logging
-import time
-
-logger = logging.getLogger(__name__)
+import threading
 
 
 class Base(DeclarativeBase):
@@ -17,39 +15,141 @@ db = SQLAlchemy(model_class=Base)
 
 migrate = Migrate()
 
-#: Maximum number of times to retry a flush/commit that fails with
-#: "database is locked" before giving up.
-_MAX_RETRIES = 5
-_RETRY_DELAY = 1.0  # seconds between retries
+# ---------------------------------------------------------------------------
+# SQLite write serialisation — priority lock
+# ---------------------------------------------------------------------------
+# SQLite only supports one writer at a time, even with WAL journal mode.
+# When multiple threads (EPSS enrichment, NVD enrichment, Flask requests)
+# try to write concurrently, "database is locked" errors occur because the
+# busy_timeout expires while another thread holds a write transaction.
+#
+# The lock below serialises all write *transactions*.  It is acquired
+# transparently on the first ``Session.flush()`` that contains pending
+# writes and released on ``commit()`` or ``rollback()``.  Read-only
+# sessions never touch the lock.
+#
+# Priority order (highest first):
+#   0 — Flask request handlers             (interactive, latency-sensitive)
+#   1 — EPSS enrichment thread             (fast API, small payloads)
+#   2 — NVD enrichment thread              (slow API, can take minutes)
+#
+# When the lock is released and several threads are waiting, the one with
+# the highest priority (lowest number) is woken first.
+# ---------------------------------------------------------------------------
 
 
-def _is_locked_error(exc: BaseException) -> bool:
-    """Return True when *exc* (or its chain) wraps a SQLite
-    ``database is locked`` error."""
-    cur: BaseException | None = exc
-    while cur is not None:
-        if "database is locked" in str(cur):
-            return True
-        cur = cur.__cause__ or cur.__context__  # type: ignore[assignment]
-    return False
+class _PriorityWriteLock:
+    """Write lock that wakes the highest-priority waiter first.
+
+    Priority is auto-detected from ``threading.current_thread().name``.
+    The interface (``acquire`` / ``release``) mirrors ``threading.Lock``
+    so it can be used as a drop-in replacement.
+    """
+
+    _FLASK = 0
+    _EPSS = 1
+    _NVD = 2
+
+    def __init__(self):
+        self._mutex = threading.Lock()
+        self._held = False
+        self._waiters: list = []  # [(priority, Event)]
+
+    # ---- priority detection ------------------------------------------------
+
+    @staticmethod
+    def _thread_priority() -> int:
+        name = threading.current_thread().name
+        if "enrichment-nvd" in name:
+            return _PriorityWriteLock._NVD
+        if "enrichment-epss" in name:
+            return _PriorityWriteLock._EPSS
+        return _PriorityWriteLock._FLASK
+
+    # ---- public API --------------------------------------------------------
+
+    def acquire(self):
+        priority = self._thread_priority()
+        evt = threading.Event()
+        with self._mutex:
+            if not self._held:
+                self._held = True
+                return
+            self._waiters.append((priority, evt))
+            self._waiters.sort(key=lambda w: w[0])
+        evt.wait()  # block until release() hands ownership to us
+
+    def release(self):
+        with self._mutex:
+            if not self._held:
+                return
+            if self._waiters:
+                _prio, evt = self._waiters.pop(0)
+                # _held stays True — ownership transfers to the woken thread
+                evt.set()
+            else:
+                self._held = False
+
+
+_db_write_lock = _PriorityWriteLock()
+
+# Per-thread flag that tracks whether the *current thread* holds the write
+# lock.  Using ``threading.local`` instead of a session attribute avoids the
+# stale-session problem: in tests each ``create_app()`` yields a fresh
+# Session, but the old Session's ``_holds_write_lock`` is lost while the
+# module-level ``_db_write_lock._held`` stays True → deadlock on the next
+# acquire in the same (single-threaded) test run.
+_write_lock_state = threading.local()
+
+# Guard so that listeners are registered exactly once, no matter how many
+# times ``create_app()`` is called (each test fixture calls it).
+_write_serialization_initialized = False
+
+
+def setup_write_serialization(session_factory):
+    """Register SQLAlchemy session events that serialise SQLite writes.
+
+    Call once after ``db.init_app(app)`` when the engine is SQLite.  The
+    events are registered on *session_factory* (typically ``db.session``,
+    a ``scoped_session``).  Subsequent calls are no-ops.
+    """
+    global _write_serialization_initialized
+    if _write_serialization_initialized:
+        return
+    _write_serialization_initialized = True
+
+    def _release_lock(*_args, **_kwargs):
+        if getattr(_write_lock_state, "held", False):
+            _write_lock_state.held = False
+            _db_write_lock.release()
+
+    @event.listens_for(session_factory, "before_flush")
+    def _before_flush(session, flush_context, instances):
+        # Only acquire if there are actual pending writes.
+        if not (session.new or session.dirty or session.deleted):
+            return
+        if not getattr(_write_lock_state, "held", False):
+            _db_write_lock.acquire()
+            _write_lock_state.held = True
+
+    @event.listens_for(session_factory, "after_commit")
+    def _after_commit(session):
+        _release_lock()
+
+    @event.listens_for(session_factory, "after_soft_rollback")
+    def _after_soft_rollback(session, previous_transaction):
+        _release_lock()
 
 
 @contextmanager
 def batch_session():
-    """Context manager that defers all ``db.session.commit()`` calls to a
-    single commit at the end of the block.  Inside the block every
-    ``commit()`` is silently replaced by ``flush()`` so that
-    auto-generated PKs are available but no individual SQLite transaction
-    is opened per row.
+    """Context manager that defers all ``db.session.commit()`` calls to a single
+    commit at the end of the block.  Inside the block every ``commit()`` is
+    silently replaced by ``flush()`` so that auto-generated PKs are available
+    but no individual SQLite transaction is opened per row.
 
-    When no Flask application context is active (e.g. during direct
-    ``main()`` invocation in e2e tests) the body executes normally
-    without batching.
-
-    If a flush or the final commit fails with *database is locked*
-    (SQLite contention with the background enrichment thread), the
-    session is rolled back, all pending objects are re-added, and the
-    operation is retried up to ``_MAX_RETRIES`` times.
+    When no Flask application context is active (e.g. during direct ``main()``
+    invocation in e2e tests) the body executes normally without batching.
 
     Usage::
 
@@ -59,78 +159,23 @@ def batch_session():
         # a single COMMIT happens here
     """
     try:
+        # Force the scoped-session proxy to resolve — this will raise
+        # RuntimeError when there is no Flask app context.
         session = db.session
         session.get_bind()
         original_commit = session.commit
     except (RuntimeError, Exception):
+        # No Flask app context or no DB binding — run the block without batching
         yield None
         return
 
     def _deferred_commit():
-        """Replace ``commit()`` with ``flush()`` inside the batch block.
-
-        On *database is locked* we snapshot ``session.new`` / dirty
-        objects, rollback (which evicts them), re-``add`` them, wait,
-        and retry.
-        """
-        for attempt in range(_MAX_RETRIES):
-            # Snapshot objects that would be lost on rollback.
-            pending_new = list(session.new)
-            pending_dirty = [
-                (obj, {
-                    attr.key: attr.history
-                    for attr in db.inspect(obj).attrs
-                    if attr.history.has_changes()
-                })
-                for obj in session.dirty
-            ]
-            try:
-                session.flush()
-                return
-            except Exception as exc:
-                if _is_locked_error(exc) \
-                        and attempt < _MAX_RETRIES - 1:
-                    logger.warning(
-                        "database is locked during flush, "
-                        "retrying (%d/%d)",
-                        attempt + 1, _MAX_RETRIES,
-                    )
-                    session.rollback()
-                    # Re-attach evicted objects.
-                    for obj in pending_new:
-                        session.add(obj)
-                    for obj, _ in pending_dirty:
-                        session.add(obj)
-                    time.sleep(_RETRY_DELAY)
-                    continue
-                raise
+        session.flush()
 
     session.commit = _deferred_commit  # type: ignore[assignment]
     try:
         yield session
-        # Final commit — same retry logic.
-        for attempt in range(_MAX_RETRIES):
-            pending_new = list(session.new)
-            pending_dirty = list(session.dirty)
-            try:
-                original_commit()
-                break
-            except Exception as exc:
-                if _is_locked_error(exc) \
-                        and attempt < _MAX_RETRIES - 1:
-                    logger.warning(
-                        "database is locked during commit, "
-                        "retrying (%d/%d)",
-                        attempt + 1, _MAX_RETRIES,
-                    )
-                    session.rollback()
-                    for obj in pending_new:
-                        session.add(obj)
-                    for obj in pending_dirty:
-                        session.add(obj)
-                    time.sleep(_RETRY_DELAY)
-                    continue
-                raise
+        original_commit()  # single real commit
     except Exception:
         try:
             session.rollback()

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -2,6 +2,10 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from sqlalchemy.orm import DeclarativeBase
 from contextlib import contextmanager
+import logging
+import time
+
+logger = logging.getLogger(__name__)
 
 
 class Base(DeclarativeBase):
@@ -13,16 +17,39 @@ db = SQLAlchemy(model_class=Base)
 
 migrate = Migrate()
 
+#: Maximum number of times to retry a flush/commit that fails with
+#: "database is locked" before giving up.
+_MAX_RETRIES = 5
+_RETRY_DELAY = 1.0  # seconds between retries
+
+
+def _is_locked_error(exc: BaseException) -> bool:
+    """Return True when *exc* (or its chain) wraps a SQLite
+    ``database is locked`` error."""
+    cur: BaseException | None = exc
+    while cur is not None:
+        if "database is locked" in str(cur):
+            return True
+        cur = cur.__cause__ or cur.__context__  # type: ignore[assignment]
+    return False
+
 
 @contextmanager
 def batch_session():
-    """Context manager that defers all ``db.session.commit()`` calls to a single
-    commit at the end of the block.  Inside the block every ``commit()`` is
-    silently replaced by ``flush()`` so that auto-generated PKs are available
-    but no individual SQLite transaction is opened per row.
+    """Context manager that defers all ``db.session.commit()`` calls to a
+    single commit at the end of the block.  Inside the block every
+    ``commit()`` is silently replaced by ``flush()`` so that
+    auto-generated PKs are available but no individual SQLite transaction
+    is opened per row.
 
-    When no Flask application context is active (e.g. during direct ``main()``
-    invocation in e2e tests) the body executes normally without batching.
+    When no Flask application context is active (e.g. during direct
+    ``main()`` invocation in e2e tests) the body executes normally
+    without batching.
+
+    If a flush or the final commit fails with *database is locked*
+    (SQLite contention with the background enrichment thread), the
+    session is rolled back, all pending objects are re-added, and the
+    operation is retried up to ``_MAX_RETRIES`` times.
 
     Usage::
 
@@ -32,23 +59,78 @@ def batch_session():
         # a single COMMIT happens here
     """
     try:
-        # Force the scoped-session proxy to resolve — this will raise
-        # RuntimeError when there is no Flask app context.
         session = db.session
         session.get_bind()
         original_commit = session.commit
     except (RuntimeError, Exception):
-        # No Flask app context or no DB binding — run the block without batching
         yield None
         return
 
     def _deferred_commit():
-        session.flush()
+        """Replace ``commit()`` with ``flush()`` inside the batch block.
+
+        On *database is locked* we snapshot ``session.new`` / dirty
+        objects, rollback (which evicts them), re-``add`` them, wait,
+        and retry.
+        """
+        for attempt in range(_MAX_RETRIES):
+            # Snapshot objects that would be lost on rollback.
+            pending_new = list(session.new)
+            pending_dirty = [
+                (obj, {
+                    attr.key: attr.history
+                    for attr in db.inspect(obj).attrs
+                    if attr.history.has_changes()
+                })
+                for obj in session.dirty
+            ]
+            try:
+                session.flush()
+                return
+            except Exception as exc:
+                if _is_locked_error(exc) \
+                        and attempt < _MAX_RETRIES - 1:
+                    logger.warning(
+                        "database is locked during flush, "
+                        "retrying (%d/%d)",
+                        attempt + 1, _MAX_RETRIES,
+                    )
+                    session.rollback()
+                    # Re-attach evicted objects.
+                    for obj in pending_new:
+                        session.add(obj)
+                    for obj, _ in pending_dirty:
+                        session.add(obj)
+                    time.sleep(_RETRY_DELAY)
+                    continue
+                raise
 
     session.commit = _deferred_commit  # type: ignore[assignment]
     try:
         yield session
-        original_commit()  # single real commit
+        # Final commit — same retry logic.
+        for attempt in range(_MAX_RETRIES):
+            pending_new = list(session.new)
+            pending_dirty = list(session.dirty)
+            try:
+                original_commit()
+                break
+            except Exception as exc:
+                if _is_locked_error(exc) \
+                        and attempt < _MAX_RETRIES - 1:
+                    logger.warning(
+                        "database is locked during commit, "
+                        "retrying (%d/%d)",
+                        attempt + 1, _MAX_RETRIES,
+                    )
+                    session.rollback()
+                    for obj in pending_new:
+                        session.add(obj)
+                    for obj in pending_dirty:
+                        session.add(obj)
+                    time.sleep(_RETRY_DELAY)
+                    continue
+                raise
     except Exception:
         try:
             session.rollback()

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -6,7 +6,6 @@ from .packages import init_app as init_pkg_app
 from .vulnerabilities import init_app as init_vuln_app
 from .assessments import init_app as init_assess_app
 from .documents import init_app as init_doc_app
-# from .patch_finder import init_app as init_patch_finder_app  # disabled — feature on standby
 from .nvd_progress import init_app as init_nvd_progress_app
 from .epss_progress import init_app as init_epss_progress_app
 from .project import init_app as init_project_app
@@ -23,7 +22,6 @@ def init_app(app):
     init_vuln_app(app)
     init_assess_app(app)
     init_doc_app(app)
-    # init_patch_finder_app(app)  # disabled — feature on standby
     init_nvd_progress_app(app)
     init_epss_progress_app(app)
     init_project_app(app)

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -6,7 +6,7 @@ from .packages import init_app as init_pkg_app
 from .vulnerabilities import init_app as init_vuln_app
 from .assessments import init_app as init_assess_app
 from .documents import init_app as init_doc_app
-from .patch_finder import init_app as init_patch_finder_app
+# from .patch_finder import init_app as init_patch_finder_app  # disabled — feature on standby
 from .nvd_progress import init_app as init_nvd_progress_app
 from .epss_progress import init_app as init_epss_progress_app
 from .project import init_app as init_project_app
@@ -23,7 +23,7 @@ def init_app(app):
     init_vuln_app(app)
     init_assess_app(app)
     init_doc_app(app)
-    init_patch_finder_app(app)
+    # init_patch_finder_app(app)  # disabled — feature on standby
     init_nvd_progress_app(app)
     init_epss_progress_app(app)
     init_project_app(app)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,7 +8,7 @@ test: test_backend test_frontend test_ci
 test_backend:
 	flake8 $(SRC_DIR) --config ../tox.ini
 	mypy --config-file ../tox.ini $(SRC_DIR)
-	pytest --cov-report term-missing --cov-report html --cov=$(SRC_DIR) --cov-fail-under=95
+	pytest --cov-config=../tox.ini --cov-report term-missing --cov-report html --cov=$(SRC_DIR) --cov-fail-under=95
 	pdoc $(SRC_DIR) -o ./htmldocs
 	find . -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
 

--- a/tests/unit_tests/test_priority_write_lock.py
+++ b/tests/unit_tests/test_priority_write_lock.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for _PriorityWriteLock and setup_write_serialization in extensions.py.
+
+Validates that:
+  - The priority write lock serialises concurrent writers.
+  - Flask threads (priority 0) are woken before EPSS (1) before NVD (2).
+  - SQLAlchemy session events correctly acquire/release the lock.
+  - The lock survives session destruction between test fixtures.
+"""
+
+import os
+import time
+import threading
+import pytest
+
+from src.extensions import (
+    _PriorityWriteLock, _db_write_lock, _write_lock_state,
+)
+from src.extensions import db as _db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def app():
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        from src.bin.webapp import create_app
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": "/dev/null"})
+        with application.app_context():
+            _db.create_all()
+            yield application
+            _db.drop_all()
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture(autouse=True)
+def _release_global_lock():
+    """Safety net: ensure the global write-lock is never left held between tests."""
+    yield
+    # Force-release if still held (prevents cascading deadlocks on failure).
+    if _db_write_lock._held:
+        _db_write_lock._held = False
+    _write_lock_state.__dict__.pop("held", None)
+
+
+@pytest.fixture()
+def lock():
+    """A fresh _PriorityWriteLock for each test (not the global one)."""
+    return _PriorityWriteLock()
+
+
+# ===================================================================
+# _PriorityWriteLock — pure unit tests
+# ===================================================================
+
+class TestPriorityWriteLock:
+
+    # ---- thread-name → priority mapping ----------------------------
+
+    def test_flask_thread_priority(self):
+        """Default / Werkzeug threads get priority 0 (highest)."""
+        assert _PriorityWriteLock._thread_priority() == 0
+
+    def test_epss_thread_priority(self):
+        result = []
+
+        def check():
+            result.append(_PriorityWriteLock._thread_priority())
+
+        t = threading.Thread(target=check, name="enrichment-epss")
+        t.start()
+        t.join()
+        assert result[0] == 1
+
+    def test_nvd_thread_priority(self):
+        result = []
+
+        def check():
+            result.append(_PriorityWriteLock._thread_priority())
+
+        t = threading.Thread(target=check, name="enrichment-nvd")
+        t.start()
+        t.join()
+        assert result[0] == 2
+
+    # ---- basic acquire / release -----------------------------------
+
+    def test_acquire_release(self, lock):
+        """Acquire then release should not deadlock."""
+        lock.acquire()
+        assert lock._held
+        lock.release()
+        assert not lock._held
+
+    def test_double_release_is_safe(self, lock):
+        """Releasing an un-held lock is a no-op."""
+        lock.release()                  # not held — no-op
+        lock.acquire()
+        lock.release()
+        lock.release()                  # already released — no-op
+        assert not lock._held
+
+    def test_second_acquire_blocks_until_release(self, lock):
+        """A second acquire blocks until the first holder releases."""
+        lock.acquire()
+        acquired = threading.Event()
+
+        def waiter():
+            lock.acquire()
+            acquired.set()
+            lock.release()
+
+        t = threading.Thread(target=waiter)
+        t.start()
+        # The waiter should be blocked
+        assert not acquired.wait(timeout=0.15)
+        # Release from the main thread — waiter should proceed
+        lock.release()
+        assert acquired.wait(timeout=2)
+        t.join()
+
+    # ---- priority ordering -----------------------------------------
+
+    def test_priority_ordering(self, lock):
+        """When multiple threads wait, highest priority (lowest value) wins.
+
+        Scenario:
+          1. Main thread holds the lock.
+          2. Three threads with different priorities try to acquire.
+          3. After release, they should proceed in priority order:
+             Flask (0) → EPSS (1) → NVD (2).
+        """
+        lock.acquire()                  # main thread holds the lock
+
+        order = []
+        barrier = threading.Barrier(3)  # all waiters line up before competing
+
+        def waiter(label, thread_name):
+            t = threading.current_thread()
+            old_name = t.name
+            t.name = thread_name
+            try:
+                barrier.wait(timeout=5)    # synchronise start
+                lock.acquire()             # block here until released
+                order.append(label)
+                lock.release()
+            finally:
+                t.name = old_name
+
+        threads = [
+            threading.Thread(target=waiter, args=("nvd", "enrichment-nvd")),
+            threading.Thread(target=waiter, args=("epss", "enrichment-epss")),
+            threading.Thread(target=waiter, args=("flask", "werkzeug-thread")),
+        ]
+        for t in threads:
+            t.start()
+
+        # Give waiters time to all reach acquire() and register
+        time.sleep(0.3)
+
+        # Release — the priority queue should wake Flask, then EPSS, then NVD
+        lock.release()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert order == ["flask", "epss", "nvd"], f"Got: {order}"
+
+    def test_same_priority_fifo(self, lock):
+        """Threads with the same priority are served in arrival order (FIFO)
+        because Python's sort is stable.
+        """
+        lock.acquire()
+        order = []
+        barrier = threading.Barrier(3)
+
+        def waiter(idx):
+            barrier.wait(timeout=5)
+            lock.acquire()
+            order.append(idx)
+            lock.release()
+
+        threads = []
+        for i in range(3):
+            t = threading.Thread(target=waiter, args=(i,), name=f"flask-{i}")
+            threads.append(t)
+            t.start()
+
+        # Let all threads reach barrier.wait then acquire()
+        time.sleep(0.3)
+
+        lock.release()    # start servicing
+        for t in threads:
+            t.join(timeout=5)
+
+        # All 3 should eventually run
+        assert sorted(order) == [0, 1, 2]
+
+
+# ===================================================================
+# setup_write_serialization — integration with SQLAlchemy session
+# ===================================================================
+
+class TestWriteSerializationEvents:
+    """Verify that the session events acquire/release the write lock correctly.
+
+    Uses the global ``_db_write_lock._held`` flag and the thread-local
+    ``_write_lock_state.held`` to verify lock state.
+    """
+
+    def test_lock_acquired_on_dirty_flush(self, app):
+        """Flushing dirty data acquires the write lock."""
+        from src.models.project import Project
+        assert not _db_write_lock._held
+
+        p = Project(name="LockTest")
+        _db.session.add(p)
+        _db.session.flush()
+        assert _db_write_lock._held, \
+            "Write lock should be held after flushing dirty data"
+        assert getattr(_write_lock_state, "held", False)
+
+        _db.session.commit()
+        assert not _db_write_lock._held, \
+            "Write lock should be released after commit"
+        assert not getattr(_write_lock_state, "held", False)
+
+    def test_lock_released_on_rollback(self, app):
+        """Rolling back a dirty session releases the write lock."""
+        from src.models.project import Project
+        p = Project(name="RollbackTest")
+        _db.session.add(p)
+        _db.session.flush()
+        assert _db_write_lock._held
+
+        _db.session.rollback()
+        assert not _db_write_lock._held, \
+            "Write lock should be released after rollback"
+
+    def test_no_lock_on_clean_flush(self, app):
+        """Flushing when there are no pending changes should not acquire lock."""
+        _db.session.flush()          # nothing dirty
+        assert not _db_write_lock._held
+
+    def test_lock_not_reacquired_on_second_flush(self, app):
+        """Subsequent flushes within the same transaction don't deadlock."""
+        from src.models.project import Project
+        _db.session.add(Project(name="First"))
+        _db.session.flush()
+        assert _db_write_lock._held
+
+        _db.session.add(Project(name="Second"))
+        _db.session.flush()     # must NOT deadlock (re-entrant flush)
+        assert _db_write_lock._held
+
+        _db.session.commit()
+        assert not _db_write_lock._held
+
+    def test_batch_session_acquires_and_releases(self, app):
+        """batch_session() holds the lock during the block, releases on exit."""
+        from src.extensions import batch_session
+        from src.models.project import Project
+
+        with batch_session():
+            _db.session.add(Project(name="Batch1"))
+            _db.session.commit()     # _deferred_commit → flush only
+            assert _db_write_lock._held, \
+                "Lock should be held inside batch_session after deferred commit"
+
+        # After the block, original_commit() ran → lock released
+        assert not _db_write_lock._held, \
+            "Lock should be released after batch_session exits"
+
+    def test_batch_session_releases_on_error(self, app):
+        """If batch_session throws, the lock is still released via rollback."""
+        from src.extensions import batch_session
+        from src.models.project import Project
+
+        with pytest.raises(ValueError):
+            with batch_session():
+                _db.session.add(Project(name="ErrTest"))
+                _db.session.commit()     # deferred → flush
+                assert _db_write_lock._held
+                raise ValueError("simulated failure")
+
+        assert not _db_write_lock._held, \
+            "Lock should be released after exception in batch_session"
+
+    def test_lock_survives_session_destruction(self, app):
+        """Thread-local flag prevents deadlock when Session objects change.
+
+        begin_nested() acquires the lock on flush, and the savepoint release
+        triggers after_soft_rollback which releases the lock.  A subsequent
+        begin_nested() must re-acquire without deadlocking.
+        """
+        from src.models.project import Project
+
+        # Simulate a begin_nested write (like PackagesController.add)
+        with _db.session.begin_nested():
+            _db.session.add(Project(name="Nested"))
+        # Savepoint released → after_soft_rollback fires → lock released.
+        # This is correct — the write transaction doesn't span savepoints.
+        assert not _db_write_lock._held
+
+        # Another begin_nested in the same thread should work fine.
+        with _db.session.begin_nested():
+            _db.session.add(Project(name="Nested2"))
+        assert not _db_write_lock._held
+
+        # Explicit commit on the outer transaction.
+        _db.session.commit()
+        assert not _db_write_lock._held
+
+
+# ===================================================================
+# Priority works end-to-end with DB writes
+# ===================================================================
+
+class TestPriorityEndToEnd:
+    """Verify that a simulated enrichment thread yields priority to Flask."""
+
+    def test_flask_preempts_nvd(self, app):
+        """When NVD and Flask both wait, Flask always goes first.
+
+        Steps:
+          1. Main thread holds the lock via flush.
+          2. NVD thread and Flask thread both try to flush.
+          3. Main releases → Flask must proceed before NVD.
+        """
+        from src.models.project import Project
+
+        order = []
+        all_registered = threading.Event()
+
+        def nvd_writer():
+            with app.app_context():
+                _db.session.add(Project(name="NVD-proj"))
+                all_registered.wait(timeout=5)
+                _db.session.flush()
+                order.append("nvd")
+                _db.session.commit()
+
+        def flask_writer():
+            with app.app_context():
+                _db.session.add(Project(name="Flask-proj"))
+                all_registered.wait(timeout=5)
+                _db.session.flush()
+                order.append("flask")
+                _db.session.commit()
+
+        # Hold the lock so both writers must queue
+        _db.session.add(Project(name="Holder"))
+        _db.session.flush()
+        assert _db_write_lock._held
+
+        t_nvd = threading.Thread(target=nvd_writer, name="enrichment-nvd")
+        t_flask = threading.Thread(target=flask_writer, name="flask-handler")
+
+        t_nvd.start()
+        t_flask.start()
+
+        # Let both threads reach add + wait on all_registered
+        time.sleep(0.1)
+        all_registered.set()
+        # Let both threads call flush → block on _db_write_lock.acquire()
+        time.sleep(0.3)
+
+        # Release — Flask (priority 0) should go before NVD (priority 2)
+        _db.session.commit()
+        t_flask.join(timeout=5)
+        t_nvd.join(timeout=5)
+
+        assert len(order) == 2, f"Not all writers completed: {order}"
+        assert order[0] == "flask", f"Expected flask first, got: {order}"

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -270,7 +270,7 @@ def test_render_document_invalid_ext(client):
     data = json.loads(response.data)
     assert data["error"] is not None
 
-
+@pytest.mark.skip(reason="patch-finder feature on standby")
 def test_get_patch_finder_status(client):
     response = client.get("/api/patch-finder/status")
     assert response.status_code == 200
@@ -400,13 +400,14 @@ def test_documents_list_categories_enrichment(monkeypatch, client):
     assert "vex" in item["category"]
     assert item["category"].count("misc") == 1
 
-
+@pytest.mark.skip(reason="patch-finder feature on standby")
 def test_patch_finder_scan_non_list_payload(client):
     """POST /api/patch-finder/scan with a non-list payload returns 400 (line 45)."""
     response = client.post("/api/patch-finder/scan", json={"not": "a list"})
     assert response.status_code == 400
 
 
+@pytest.mark.skip(reason="patch-finder feature on standby")
 def test_patch_finder_scan_unknown_cve(client):
     """POST /api/patch-finder/scan with an unknown CVE returns 200 with empty dict."""
     response = client.post("/api/patch-finder/scan", json=["CVE-0000-99999"])

--- a/tests/webapp_tests/test_post_endpoints.py
+++ b/tests/webapp_tests/test_post_endpoints.py
@@ -195,7 +195,7 @@ def test_patch_vulnerability_invalids(client):
     })
     assert response.status_code == 400
 
-
+@pytest.mark.skip(reason="patch-finder feature on standby")
 def test_post_scan_patch_finder(client, app):
     from src.models.vulnerability import Vulnerability
     with app.app_context():

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ max-line-length = 120
 exclude = src/migrations/versions
 
 [coverage:run]
-omit = */migrations/env.py
+omit =
+    */migrations/env.py
+    */routes/patch_finder.py
 
 [mypy]
 files = src


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

*fix: serialize SQLite writes with priority lock
*fix: remove patch-finder route usage

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Wait for the NVD/EPSS loading to start and try to assess 10000 cves in one shot several times. Should not crash.