### PR TITLE
docs: add Read the Docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: doc/source/conf.py
+
+python:
+  install:
+    - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+myst_parser
+sphinx_rtd_theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,3 +24,8 @@ exclude_patterns = []
 
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
+
+# Set intersphinx mapping with meta-vulnscout documentation.
+intersphinx_mapping = {
+    "meta-vulnscout": ("https://meta-vulnscout.readthedocs.io/en/latest/", None),
+}

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,3 +13,4 @@ VulnScout Documentation
    ci_conditions
    api
    dev_guide
+   yocto-integration

--- a/doc/source/yocto-integration.md
+++ b/doc/source/yocto-integration.md
@@ -1,0 +1,24 @@
+# Yocto Integration
+
+VulnScout can be integrated into your Yocto/OpenEmbedded build workflow using the
+**meta-vulnscout** BSP layer.
+
+## meta-vulnscout
+
+The `meta-vulnscout` layer provides recipes and classes to automatically run
+VulnScout vulnerability analysis as part of your Yocto build process. It handles
+SBOM generation, vulnerability scanning, and report collection.
+
+### Features
+
+- Automatic SBOM extraction from Yocto builds
+- Integration with the VulnScout scanning pipeline
+- Support for SPDX 2 and SPDX 3 SBOM formats
+- CI/CD-ready with configurable fail conditions
+
+### Getting Started
+
+Full documentation, installation instructions, and configuration options are
+available on the meta-vulnscout documentation site:
+
+> **[meta-vulnscout documentation](https://meta-vulnscout.readthedocs.io/en/latest/)**


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Add RTD yaml configuration file and an intersphinx mapping to meta-vulnscout documentation.  Documentation will be available on vulnscout.readthedocs.io

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

You can't :)
Just read the code
