### PR TITLE
fix: multiedit correct vulnerability count

### DIFF
--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -198,8 +198,9 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                     }
                 }
 
+                const vulnCount = data.vuln_count ?? data.count;
                 const errorMsg = data.error_count ? ` (${data.error_count} failed)` : '';
-                triggerBanner(`Successfully added assessments to ${data.count} vulnerabilities${errorMsg}`, 'success');
+                triggerBanner(`Successfully added assessments to ${vulnCount} vulnerabilities${errorMsg}`, 'success');
                 resetVulns();
             } else {
                 const errorMsg = data?.errors?.length

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -622,10 +622,12 @@ def init_app(app):
                     except Exception as e:
                         errors.append({"vuln_id": vuln_id, "error": str(e)})
 
+        distinct_vulns = len({r.get("vuln_id") for r in results if r.get("vuln_id")})
         response = {
             "status": "success" if results else "error",
             "assessments": results,
-            "count": len(results)
+            "count": len(results),
+            "vuln_count": distinct_vulns
         }
         if errors:
             response["errors"] = errors

--- a/tests/webapp_tests/test_assessments_coverage.py
+++ b/tests/webapp_tests/test_assessments_coverage.py
@@ -174,6 +174,7 @@ def test_post_assessments_batch_all_valid(client):
     data = json.loads(response.data)
     assert data["status"] == "success"
     assert data["count"] == 2
+    assert data["vuln_count"] == 2
     assert len(data["assessments"]) == 2
 
 
@@ -201,6 +202,7 @@ def test_post_assessments_batch_mixed_validity(client):
     assert response.status_code == 200
     data = json.loads(response.data)
     assert data["count"] == 1
+    assert data["vuln_count"] == 1
     assert data["error_count"] == 2
     assert len(data["errors"]) == 2
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The batch assessment endpoint creates one record per (vulnerability, package) pair, so count was inflated when vulnerabilities had multiple packages. Add vuln_count (distinct vuln IDs) to the API response and use it in the frontend banner.
### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Use MultiEdit on a batch of CVE (e.g. 53 vulnerabilities). The report count display should be correct

<img width="448" height="74" alt="image" src="https://github.com/user-attachments/assets/e03de97a-a4ff-43ff-89c4-e22238f81aeb" />


