### PR TITLE
fix: Remove API GET request per CVE on Review

### DIFF
--- a/frontend/src/handlers/assessments.ts
+++ b/frontend/src/handlers/assessments.ts
@@ -26,6 +26,7 @@ type Assessment = {
     timestamp: string;
     last_update?: string;
     responses: string[];
+    vuln_texts?: Record<string, string>;
 };
 
 export type { Assessment };
@@ -67,6 +68,7 @@ const asAssessment = (data: any): Assessment | [] => {
     if (typeof data?.workaround === "string") item.workaround = data.workaround;
     if (typeof data?.workaround_timestamp === "string") item.workaround_timestamp = data.workaround_timestamp;
     if (typeof data?.last_update === "string") item.last_update = data.last_update;
+    if (typeof data?.vuln_texts === "object" && data.vuln_texts !== null) item.vuln_texts = data.vuln_texts;
     return item
 }
 

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -133,31 +133,17 @@ function Review({ variantId, projectId }: Readonly<Props>) {
             .then(data => {
                 setAssessments(groupAssessments(data));
                 setLoading(false);
-                // Fetch vulnerability descriptions for hover tooltips
-                const vulnIds = [...new Set(data.map(a => a.vuln_id))];
-                if (vulnIds.length > 0) {
-                    Promise.all(
-                        vulnIds.map(vid =>
-                            fetch(`${import.meta.env.VITE_API_URL}/api/vulnerabilities/${encodeURIComponent(vid)}`, { mode: 'cors' })
-                                .then(r => r.ok ? r.json() : null)
-                                .then(d => {
-                                    if (!d) return null;
-                                    const v = asVulnerability(d);
-                                    if (Array.isArray(v)) return null;
-                                    return v;
-                                })
-                                .catch(() => null)
-                        )
-                    ).then(results => {
-                        const descMap: Record<string, { title: string; content: string }[]> = {};
-                        for (const v of results) {
-                            if (v) {
-                                descMap[v.id] = v.texts.length > 0 ? v.texts : [{ title: "description", content: "No description available" }];
-                            }
-                        }
-                        setVulnDescriptions(descMap);
-                    });
+                // Build tooltip descriptions from vuln_texts included in the response
+                const descMap: Record<string, { title: string; content: string }[]> = {};
+                for (const a of data) {
+                    if (a.vuln_id && !descMap[a.vuln_id] && a.vuln_texts) {
+                        const entries = Object.entries(a.vuln_texts);
+                        descMap[a.vuln_id] = entries.length > 0
+                            ? entries.map(([title, content]) => ({ title, content }))
+                            : [{ title: "description", content: "No description available" }];
+                    }
                 }
+                setVulnDescriptions(descMap);
             })
             .catch(err => {
                 console.error(err);

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -77,7 +77,12 @@ def init_app(app):
 
     @app.route('/api/assessments/review')
     def review_assessments():
-        """Return assessments not linked to any scan (handmade via the web UI)."""
+        """Return assessments not linked to any scan (handmade via the web UI).
+
+        Each assessment dict is enriched with a ``vuln_texts`` key mapping to the
+        vulnerability's ``texts`` dict so the front-end can display tooltips
+        without extra requests.
+        """
         import uuid as _uuid
         from ..models.variant import Variant as DBVariant
         variant_id = request.args.get('variant_id')
@@ -100,6 +105,17 @@ def init_app(app):
                 assessments.extend(a.to_dict() for a in DBAssessment.get_handmade(v.id))
         else:
             assessments = [a.to_dict() for a in DBAssessment.get_handmade()]
+
+        # Enrich with vulnerability texts for front-end tooltips (single DB pass)
+        vuln_ids = {a["vuln_id"] for a in assessments if a.get("vuln_id")}
+        vuln_texts: dict[str, dict] = {}
+        for vid_str in vuln_ids:
+            vuln = DBVuln.get_by_id(vid_str)
+            if vuln is not None:
+                vuln_texts[vid_str] = dict(vuln.texts or {})
+        for a in assessments:
+            a["vuln_texts"] = vuln_texts.get(a.get("vuln_id", ""), {})
+
         return assessments
 
     @app.route('/api/assessments/review/export')


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The Review page previously fired one GET /api/vulnerabilities/<id> request per distinct CVE to fetch tooltip descriptions, causing performance degradation and potential crashes with large datasets.

Instead, enrich the /api/assessments/review backend response with a vuln_texts field containing each vulnerability's description texts (single DB pass over distinct vuln_ids). The frontend now reads descriptions directly from the response — zero extra requests.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1- Assess 100 CVEs

2-Go in `Review` tab.

Without this change: one GET request per CVE & long loading:

```
172.17.0.1 - - [16/Apr/2026 20:54:07] "GET /api/variants HTTP/1.1" 200 -
172.17.0.1 - - [16/Apr/2026 20:54:09] "GET /api/assessments/review?project_id=483b647a-93bc-4da0-9ef6-c14559187ab8 HTTP/1.1" 200 -
172.17.0.1 - - [16/Apr/2026 20:54:11] "GET /api/assessments/review?project_id=483b647a-93bc-4da0-9ef6-c14559187ab8 HTTP/1.1" 200 -
172.17.0.1 - - [16/Apr/2026 20:54:16] "GET /api/vulnerabilities/CVE-2003-0956 HTTP/1.1" 200 -
172.17.0.1 - - [16/Apr/2026 20:54:16] "GET /api/vulnerabilities/CVE-2003-0859 HTTP/1.1" 200 -
172.17.0.1 - - [16/Apr/2026 20:54:16] "GET /api/vulnerabilities/CVE-2000-0344 HTTP/1.1" 200 -
```

With this change. No loading delay for description & no GET request required anymore.