### PR TITLE
fix: Update the README to remove cqfd command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,36 +79,7 @@ It is also possible to add sources files on a specific project and variant with 
 
 == :book: Documentation
 
-Full documentation is available in the `doc/` directory as a Sphinx project.
-
-=== Building the documentation
-
-Install the required Python packages:
-
-[source,bash]
-----
-pip install sphinx myst-parser sphinx-rtd-theme
-----
-
-Then build the HTML documentation:
-
-[source,bash]
-----
-make -C doc html
-----
-
-The generated pages are in `doc/build/html/`. Open `doc/build/html/index.html` in your browser.
-
-==== Building with CQFD
-
-If you use CQFD, you can build the documentation inside the CQFD container:
-
-[source,bash]
-----
-cqfd -b documentation
-----
-
-The generated documentation will be available in `doc/build/html/` on the host.
+Full documentation is available at https://vulnscout.readthedocs.io/
 
 ===  Container Lifecycle
 

--- a/doc/source/dev_guide.md
+++ b/doc/source/dev_guide.md
@@ -248,6 +248,38 @@ This helps enforce code quality and consistency across all contributions.
 
 ---
 
+## Building the Documentation
+
+Full documentation is available in the `doc/` directory as a Sphinx project.
+
+### Local Build
+
+Install the required Python packages:
+
+```bash
+pip install sphinx myst-parser sphinx-rtd-theme
+```
+
+Then build the HTML documentation:
+
+```bash
+make -C doc html
+```
+
+The generated pages are in `doc/build/html/`. Open `doc/build/html/index.html` in your browser.
+
+### Building with CQFD
+
+If you use CQFD, you can build the documentation inside the CQFD container:
+
+```bash
+cqfd -b documentation
+```
+
+The generated documentation will be available in `doc/build/html/` on the host.
+
+---
+
 ## Release Process
 
 VulnScout follows a semantic versioning strategy with development versions between releases.


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

No need to ask the user to compile the documentation anymore. As it is available online: https://vulnscout.readthedocs.io/

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Read the Readme.adoc