### PR TITLE
fix: Include UTC offset in serialized timestamps

### DIFF
--- a/src/controllers/scans.py
+++ b/src/controllers/scans.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Optional
 
 from ..models.scan import Scan
+from ..helpers.datetime_utils import ensure_utc_iso
 
 
 class ScanController:
@@ -27,7 +28,7 @@ class ScanController:
         return {
             "id": str(scan.id),
             "description": scan.description,
-            "timestamp": scan.timestamp.isoformat() if scan.timestamp else None,
+            "timestamp": ensure_utc_iso(scan.timestamp),
             "variant_id": str(scan.variant_id),
         }
 

--- a/src/helpers/datetime_utils.py
+++ b/src/helpers/datetime_utils.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+from datetime import timezone
+
+
+def ensure_utc_iso(dt) -> str | None:
+    """Return an ISO 8601 string that always carries the UTC offset.
+
+    SQLite does not preserve timezone info, so datetimes read back from
+    the database are naive even though they were stored as UTC.  This
+    helper re-attaches ``+00:00`` when the offset is missing so that
+    consumers (e.g. JavaScript ``new Date()``) can interpret the value
+    correctly.
+    """
+    if dt is None:
+        return None
+    if not hasattr(dt, "isoformat"):
+        return str(dt)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()

--- a/src/models/assessment.py
+++ b/src/models/assessment.py
@@ -9,6 +9,7 @@ from typing import Optional
 from sqlalchemy import orm
 from sqlalchemy.orm import Mapped, relationship, joinedload
 from ..extensions import db, Base
+from ..helpers.datetime_utils import ensure_utc_iso
 from ..helpers.verbose import verbose
 from .vulnerability import Vulnerability
 from .package import Package
@@ -345,9 +346,7 @@ class Assessment(Base):
     # ==================================================================
 
     def to_dict(self) -> dict:
-        ts = self.timestamp
-        if ts is not None:
-            ts = ts.isoformat() if hasattr(ts, "isoformat") else str(ts)
+        ts = ensure_utc_iso(self.timestamp)
         return {
             "id": str(self.id),
             "source": self.source or "",
@@ -409,9 +408,7 @@ class Assessment(Base):
         if self.justification in VALID_JUSTIFICATION_CDX_VEX and not self.impact_statement:
             openvex_impact = self.justification
 
-        ts = self.timestamp
-        if ts is not None and hasattr(ts, "isoformat"):
-            ts = ts.isoformat()
+        ts = ensure_utc_iso(self.timestamp)
 
         return {
             "vulnerability": {"name": self.vuln_id},
@@ -451,9 +448,7 @@ class Assessment(Base):
         elif self.impact_statement:
             detail = self.impact_statement
 
-        ts = self.timestamp
-        if ts is not None and hasattr(ts, "isoformat"):
-            ts = ts.isoformat()
+        ts = ensure_utc_iso(self.timestamp)
 
         return {
             "workaround": self.workaround or "",

--- a/src/models/scan.py
+++ b/src/models/scan.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime, timezone
 
 from ..extensions import db, Base
+from ..helpers.datetime_utils import ensure_utc_iso
 from .variant import Variant
 
 from sqlalchemy.orm import Mapped
@@ -55,7 +56,7 @@ class Scan(Base):
         return {
             "id": str(self.id),
             "description": self.description,
-            "timestamp": self.timestamp.isoformat(),
+            "timestamp": ensure_utc_iso(self.timestamp),
             "variant": {
                 "id": str(self.variant.id),
                 "name": self.variant.name,

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -12,6 +12,7 @@ from ..models.finding import Finding
 from ..models.observation import Observation
 from ..models.package import Package
 from ..models.scan import Scan
+from ..helpers.datetime_utils import ensure_utc_iso
 from ..models.variant import Variant
 from ..models.metrics import Metrics
 from ..models.cvss import CVSS
@@ -426,7 +427,7 @@ def init_app(app):
             ).all()
             first_scan_by_vuln: dict = {}
             for vuln_id, min_ts in first_scan_rows:
-                first_scan_by_vuln[str(vuln_id)] = min_ts.isoformat() if min_ts else None
+                first_scan_by_vuln[str(vuln_id)] = ensure_utc_iso(min_ts)
             for v in vulns:
                 v["first_scan_date"] = first_scan_by_vuln.get(v["id"])
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Timezone wasn't applied properly on imported documents.

SQLite does not preserve timezone info on datetime columns. When datetimes are read back from the database they become naive, so .isoformat() produces strings without "+00:00". JavaScript's new Date() then interprets them as local time instead of UTC, shifting displayed hours by the user's timezone offset.

Add a shared ensure_utc_iso() helper in src/helpers/datetime_utils.py that re-attaches the UTC offset to naive datetimes before serialization.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Create a new project, assessments should be with the correct hours/min based on the timezone (e.g. Visible on Last Updated column in Vulnerability tab) .

