### PR TITLE
Scan: Rework of the feature to include NVD/OSV/GRYPE

### DIFF
--- a/frontend/src/handlers/grypeScanState.ts
+++ b/frontend/src/handlers/grypeScanState.ts
@@ -1,0 +1,142 @@
+/**
+ * Module-level singleton that manages Grype scan state globally.
+ *
+ * Because ScanHistory is conditionally rendered (unmounts on tab change),
+ * the polling and status must live outside the component tree so a scan
+ * keeps running even when the user navigates away from the Scans tab.
+ */
+
+import ScansHandler from "./scans";
+
+// ---- public state shape ----
+export type GrypeState = {
+    status: "idle" | "running" | "done" | "error";
+    error: string | null;
+    progress: string | null;
+    logs: string[];
+    total: number;
+    doneCount: number;
+};
+
+// ---- internal module state ----
+// IMPORTANT: `stateRef` is the object returned by getSnapshot() and must be
+// referentially stable (same object identity) when nothing has changed,
+// because useSyncExternalStore compares with Object.is.
+let stateRef: GrypeState = { status: "idle", error: null, progress: null, logs: [], total: 0, doneCount: 0 };
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let activeVariantIds: string[] = [];
+const listeners = new Set<(s: GrypeState) => void>();
+
+// callback invoked when a scan finishes (allows the consumer to refresh data)
+let onDoneCallback: (() => void) | null = null;
+
+function emit() {
+    listeners.forEach((fn) => fn(stateRef));
+}
+
+function setState(patch: Partial<GrypeState>) {
+    stateRef = { ...stateRef, ...patch };
+    emit();
+}
+
+function stopPolling() {
+    if (pollTimer !== null) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+    }
+}
+
+function startPolling() {
+    stopPolling();
+    pollTimer = setInterval(async () => {
+        try {
+            const statuses = await Promise.all(
+                activeVariantIds.map((vid) => ScansHandler.getGrypeScanStatus(vid))
+            );
+            const anyError = statuses.find((s) => s.status === "error");
+            const allDone = statuses.every(
+                (s) => s.status === "done" || s.status === "idle"
+            );
+
+            // Capture latest progress
+            const running = statuses.find((s) => s.status === "running");
+            if (running && running.progress) {
+                setState({
+                    progress: running.progress,
+                    logs: running.logs ?? stateRef.logs,
+                    total: running.total ?? stateRef.total,
+                    doneCount: running.done_count ?? stateRef.doneCount,
+                });
+            }
+
+            if (anyError) {
+                stopPolling();
+                setState({
+                    status: "error",
+                    error: anyError.error ?? "Grype scan failed",
+                    progress: null,
+                });
+            } else if (allDone && statuses.some((s) => s.status === "done")) {
+                stopPolling();
+                const doneInfo = statuses.find((s) => s.status === "done");
+                setState({
+                    status: "done",
+                    error: null,
+                    progress: doneInfo?.progress ?? null,
+                    logs: doneInfo?.logs ?? stateRef.logs,
+                    total: doneInfo?.total ?? stateRef.total,
+                    doneCount: doneInfo?.done_count ?? stateRef.doneCount,
+                });
+                onDoneCallback?.();
+            }
+        } catch {
+            // network hiccup — keep polling
+        }
+    }, 3000);
+}
+
+// ---- public API ----
+
+/** Subscribe to state changes.  Returns an unsubscribe function. */
+export function subscribe(fn: (s: GrypeState) => void): () => void {
+    listeners.add(fn);
+    return () => {
+        listeners.delete(fn);
+    };
+}
+
+/** Read the current snapshot (must return a referentially stable object). */
+export function getSnapshot(): GrypeState {
+    return stateRef;
+}
+
+/** Register a callback fired once when the running scan finishes. */
+export function setOnDone(cb: (() => void) | null) {
+    onDoneCallback = cb;
+}
+
+/** Dismiss the log panel (reset state to idle). */
+export function dismiss() {
+    stopPolling();
+    setState({ status: "idle", error: null, progress: null, logs: [], total: 0, doneCount: 0 });
+}
+
+/** Trigger Grype scans for the given variant IDs. */
+export async function triggerScan(variantIds: string[]) {
+    if (variantIds.length === 0) return;
+    setState({ status: "running", error: null, progress: "starting", logs: [], total: 0, doneCount: 0 });
+    activeVariantIds = [...variantIds];
+
+    for (const vid of variantIds) {
+        const result = await ScansHandler.triggerGrypeScan(vid);
+        if (!result.ok) {
+            setState({
+                status: "error",
+                error: result.error ?? "Failed to start Grype scan",
+            });
+            return;
+        }
+    }
+
+    startPolling();
+}

--- a/frontend/src/handlers/nvdScanState.ts
+++ b/frontend/src/handlers/nvdScanState.ts
@@ -1,0 +1,134 @@
+/**
+ * Module-level singleton that manages NVD CPE scan state globally.
+ *
+ * Mirrors grypeScanState.ts — polling and status live outside the
+ * component tree so a scan keeps running when the user navigates away.
+ */
+
+import ScansHandler from "./scans";
+
+// ---- public state shape ----
+export type NvdState = {
+    status: "idle" | "running" | "done" | "error";
+    error: string | null;
+    progress: string | null;
+    logs: string[];
+    total: number;
+    doneCount: number;
+};
+
+// ---- internal module state ----
+let stateRef: NvdState = { status: "idle", error: null, progress: null, logs: [], total: 0, doneCount: 0 };
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let activeVariantIds: string[] = [];
+const listeners = new Set<(s: NvdState) => void>();
+
+let onDoneCallback: (() => void) | null = null;
+
+function emit() {
+    listeners.forEach((fn) => fn(stateRef));
+}
+
+function setState(patch: Partial<NvdState>) {
+    stateRef = { ...stateRef, ...patch };
+    emit();
+}
+
+function stopPolling() {
+    if (pollTimer !== null) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+    }
+}
+
+function startPolling() {
+    stopPolling();
+    pollTimer = setInterval(async () => {
+        try {
+            const statuses = await Promise.all(
+                activeVariantIds.map((vid) => ScansHandler.getNvdScanStatus(vid))
+            );
+            const anyError = statuses.find((s) => s.status === "error");
+            const allDone = statuses.every(
+                (s) => s.status === "done" || s.status === "idle"
+            );
+
+            // Capture latest progress string
+            const running = statuses.find((s) => s.status === "running");
+            if (running && running.progress) {
+                setState({
+                    progress: running.progress,
+                    logs: running.logs ?? stateRef.logs,
+                    total: running.total ?? stateRef.total,
+                    doneCount: running.done_count ?? stateRef.doneCount,
+                });
+            }
+
+            if (anyError) {
+                stopPolling();
+                setState({
+                    status: "error",
+                    error: anyError.error ?? "NVD scan failed",
+                    progress: null,
+                });
+            } else if (allDone && statuses.some((s) => s.status === "done")) {
+                stopPolling();
+                const doneInfo = statuses.find((s) => s.status === "done");
+                setState({
+                    status: "done",
+                    error: null,
+                    progress: doneInfo?.progress ?? null,
+                    logs: doneInfo?.logs ?? stateRef.logs,
+                    total: doneInfo?.total ?? stateRef.total,
+                    doneCount: doneInfo?.done_count ?? stateRef.doneCount,
+                });
+                onDoneCallback?.();
+            }
+        } catch {
+            // network hiccup — keep polling
+        }
+    }, 3000);
+}
+
+// ---- public API ----
+
+export function subscribe(fn: (s: NvdState) => void): () => void {
+    listeners.add(fn);
+    return () => {
+        listeners.delete(fn);
+    };
+}
+
+export function getSnapshot(): NvdState {
+    return stateRef;
+}
+
+export function setOnDone(cb: (() => void) | null) {
+    onDoneCallback = cb;
+}
+
+/** Dismiss the log panel (reset state to idle). */
+export function dismiss() {
+    stopPolling();
+    setState({ status: "idle", error: null, progress: null, logs: [], total: 0, doneCount: 0 });
+}
+
+export async function triggerScan(variantIds: string[]) {
+    if (variantIds.length === 0) return;
+    setState({ status: "running", error: null, progress: "starting", logs: [], total: 0, doneCount: 0 });
+    activeVariantIds = [...variantIds];
+
+    for (const vid of variantIds) {
+        const result = await ScansHandler.triggerNvdScan(vid);
+        if (!result.ok) {
+            setState({
+                status: "error",
+                error: result.error ?? "Failed to start NVD scan",
+                progress: null,
+            });
+            return;
+        }
+    }
+
+    startPolling();
+}

--- a/frontend/src/handlers/osvScanState.ts
+++ b/frontend/src/handlers/osvScanState.ts
@@ -1,0 +1,134 @@
+/**
+ * Module-level singleton that manages OSV PURL scan state globally.
+ *
+ * Mirrors nvdScanState.ts — polling and status live outside the
+ * component tree so a scan keeps running when the user navigates away.
+ */
+
+import ScansHandler from "./scans";
+
+// ---- public state shape ----
+export type OsvState = {
+    status: "idle" | "running" | "done" | "error";
+    error: string | null;
+    progress: string | null;
+    logs: string[];
+    total: number;
+    doneCount: number;
+};
+
+// ---- internal module state ----
+let stateRef: OsvState = { status: "idle", error: null, progress: null, logs: [], total: 0, doneCount: 0 };
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let activeVariantIds: string[] = [];
+const listeners = new Set<(s: OsvState) => void>();
+
+let onDoneCallback: (() => void) | null = null;
+
+function emit() {
+    listeners.forEach((fn) => fn(stateRef));
+}
+
+function setState(patch: Partial<OsvState>) {
+    stateRef = { ...stateRef, ...patch };
+    emit();
+}
+
+function stopPolling() {
+    if (pollTimer !== null) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+    }
+}
+
+function startPolling() {
+    stopPolling();
+    pollTimer = setInterval(async () => {
+        try {
+            const statuses = await Promise.all(
+                activeVariantIds.map((vid) => ScansHandler.getOsvScanStatus(vid))
+            );
+            const anyError = statuses.find((s) => s.status === "error");
+            const allDone = statuses.every(
+                (s) => s.status === "done" || s.status === "idle"
+            );
+
+            // Capture latest progress string
+            const running = statuses.find((s) => s.status === "running");
+            if (running && running.progress) {
+                setState({
+                    progress: running.progress,
+                    logs: running.logs ?? stateRef.logs,
+                    total: running.total ?? stateRef.total,
+                    doneCount: running.done_count ?? stateRef.doneCount,
+                });
+            }
+
+            if (anyError) {
+                stopPolling();
+                setState({
+                    status: "error",
+                    error: anyError.error ?? "OSV scan failed",
+                    progress: null,
+                });
+            } else if (allDone && statuses.some((s) => s.status === "done")) {
+                stopPolling();
+                const doneInfo = statuses.find((s) => s.status === "done");
+                setState({
+                    status: "done",
+                    error: null,
+                    progress: doneInfo?.progress ?? null,
+                    logs: doneInfo?.logs ?? stateRef.logs,
+                    total: doneInfo?.total ?? stateRef.total,
+                    doneCount: doneInfo?.done_count ?? stateRef.doneCount,
+                });
+                onDoneCallback?.();
+            }
+        } catch {
+            // network hiccup — keep polling
+        }
+    }, 3000);
+}
+
+// ---- public API ----
+
+export function subscribe(fn: (s: OsvState) => void): () => void {
+    listeners.add(fn);
+    return () => {
+        listeners.delete(fn);
+    };
+}
+
+export function getSnapshot(): OsvState {
+    return stateRef;
+}
+
+export function setOnDone(cb: (() => void) | null) {
+    onDoneCallback = cb;
+}
+
+/** Dismiss the log panel (reset state to idle). */
+export function dismiss() {
+    stopPolling();
+    setState({ status: "idle", error: null, progress: null, logs: [], total: 0, doneCount: 0 });
+}
+
+export async function triggerScan(variantIds: string[]) {
+    if (variantIds.length === 0) return;
+    setState({ status: "running", error: null, progress: "starting", logs: [], total: 0, doneCount: 0 });
+    activeVariantIds = [...variantIds];
+
+    for (const vid of variantIds) {
+        const result = await ScansHandler.triggerOsvScan(vid);
+        if (!result.ok) {
+            setState({
+                status: "error",
+                error: result.error ?? "Failed to start OSV scan",
+                progress: null,
+            });
+            return;
+        }
+    }
+
+    startPolling();
+}

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -2,6 +2,7 @@ type Scan = {
     id: string;
     description: string | null;
     scan_type: string;
+    scan_source: string | null;
     timestamp: string;
     variant_id: string;
     variant_name: string | null;
@@ -18,6 +19,15 @@ type Scan = {
     packages_upgraded: number | null;
     vulns_added: number | null;
     vulns_removed: number | null;
+    newly_detected_findings: number | null;
+    newly_detected_vulns: number | null;
+    branch_finding_count: number | null;
+    branch_vuln_count: number | null;
+    branch_package_count: number | null;
+    global_finding_count: number | null;
+    global_vuln_count: number | null;
+    global_package_count: number | null;
+    formats: string[];
 };
 
 type FindingDiffEntry = {
@@ -65,9 +75,45 @@ type ScanDiff = {
     packages_upgraded: PackageUpgradeEntry[];
     vulns_added: string[];
     vulns_removed: string[];
+    newly_detected_findings: number | null;
+    newly_detected_vulns: number | null;
+    newly_detected_findings_list: FindingDiffEntry[] | null;
+    newly_detected_vulns_list: string[] | null;
 };
 
-export type { Scan, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry, ScanDiff };
+type GlobalResultFinding = {
+    finding_id: string;
+    package_name: string;
+    package_version: string;
+    package_id: string;
+    vulnerability_id: string;
+    sources: string[];
+};
+
+type GlobalResultPackage = {
+    package_id: string;
+    package_name: string;
+    package_version: string;
+    sources: string[];
+};
+
+type GlobalResultVuln = {
+    vulnerability_id: string;
+    sources: string[];
+};
+
+type GlobalResult = {
+    scan_id: string;
+    scan_type: string;
+    packages: GlobalResultPackage[];
+    findings: GlobalResultFinding[];
+    vulnerabilities: GlobalResultVuln[];
+    package_count: number;
+    finding_count: number;
+    vuln_count: number;
+};
+
+export type { Scan, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry, ScanDiff, GlobalResult, GlobalResultFinding, GlobalResultPackage, GlobalResultVuln };
 
 class ScansHandler {
     static async list(variantId?: string, projectId?: string): Promise<Scan[]> {
@@ -126,13 +172,75 @@ class ScansHandler {
         return { ok: false, error: data?.error ?? `HTTP ${response.status}` };
     }
 
-    static async getGrypeScanStatus(variantId: string): Promise<{ status: string; error?: string | null }> {
+    static async getGlobalResult(scanId: string): Promise<GlobalResult | null> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/scans/${encodeURIComponent(scanId)}/global-result`,
+            { mode: 'cors' }
+        );
+        if (!response.ok) return null;
+        const data = await response.json();
+        if (typeof data?.scan_id !== 'string') return null;
+        return data as GlobalResult;
+    }
+
+    static async getGrypeScanStatus(variantId: string): Promise<{ status: string; error?: string | null; progress?: string | null; logs?: string[]; total?: number; done_count?: number }> {
         const response = await fetch(
             import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/grype-scan/status`,
             { mode: 'cors' }
         );
         if (!response.ok) return { status: 'unknown' };
         return await response.json();
+    }
+
+    static async triggerNvdScan(variantId: string): Promise<{ ok: boolean; error?: string }> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/nvd-scan`,
+            { method: 'POST', mode: 'cors' }
+        );
+        if (response.ok || response.status === 202) return { ok: true };
+        const data = await response.json().catch(() => ({}));
+        return { ok: false, error: data?.error ?? `HTTP ${response.status}` };
+    }
+
+    static async getNvdScanStatus(variantId: string): Promise<{ status: string; error?: string | null; progress?: string | null; logs?: string[]; total?: number; done_count?: number }> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/nvd-scan/status`,
+            { mode: 'cors' }
+        );
+        if (!response.ok) return { status: 'unknown' };
+        return await response.json();
+    }
+
+    static async triggerOsvScan(variantId: string): Promise<{ ok: boolean; error?: string }> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/osv-scan`,
+            { method: 'POST', mode: 'cors' }
+        );
+        if (response.ok || response.status === 202) return { ok: true };
+        const data = await response.json().catch(() => ({}));
+        return { ok: false, error: data?.error ?? `HTTP ${response.status}` };
+    }
+
+    static async getOsvScanStatus(variantId: string): Promise<{ status: string; error?: string | null; progress?: string | null; logs?: string[]; total?: number; done_count?: number }> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/osv-scan/status`,
+            { mode: 'cors' }
+        );
+        if (!response.ok) return { status: 'unknown' };
+        return await response.json();
+    }
+
+    static async deleteScan(scanId: string): Promise<{ ok: boolean; error?: string; orphaned_findings_removed?: number }> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/scans/${encodeURIComponent(scanId)}`,
+            { method: 'DELETE', mode: 'cors' }
+        );
+        if (response.ok) {
+            const data = await response.json().catch(() => ({}));
+            return { ok: true, orphaned_findings_removed: data?.orphaned_findings_removed };
+        }
+        const data = await response.json().catch(() => ({}));
+        return { ok: false, error: data?.error ?? `HTTP ${response.status}` };
     }
 }
 

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -1,6 +1,7 @@
 type Scan = {
     id: string;
     description: string | null;
+    scan_type: string;
     timestamp: string;
     variant_id: string;
     variant_name: string | null;
@@ -50,6 +51,7 @@ type FindingUpgradeEntry = {
 
 type ScanDiff = {
     scan_id: string;
+    scan_type: string;
     previous_scan_id: string | null;
     is_first: boolean;
     finding_count: number;
@@ -112,6 +114,25 @@ class ScansHandler {
             }
         );
         return response.ok;
+    }
+
+    static async triggerGrypeScan(variantId: string): Promise<{ ok: boolean; error?: string }> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/grype-scan`,
+            { method: 'POST', mode: 'cors' }
+        );
+        if (response.ok || response.status === 202) return { ok: true };
+        const data = await response.json().catch(() => ({}));
+        return { ok: false, error: data?.error ?? `HTTP ${response.status}` };
+    }
+
+    static async getGrypeScanStatus(variantId: string): Promise<{ status: string; error?: string | null }> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/grype-scan/status`,
+            { mode: 'cors' }
+        );
+        if (!response.ok) return { status: 'unknown' };
+        return await response.json();
     }
 }
 

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -19,6 +19,9 @@ type Scan = {
     packages_upgraded: number | null;
     vulns_added: number | null;
     vulns_removed: number | null;
+    vulns_unchanged: number | null;
+    findings_unchanged: number | null;
+    packages_unchanged: number | null;
     newly_detected_findings: number | null;
     newly_detected_vulns: number | null;
     branch_finding_count: number | null;
@@ -58,6 +61,7 @@ type FindingUpgradeEntry = {
     package_name: string;
     old_version: string;
     new_version: string;
+    origin?: string;
 };
 
 type ScanDiff = {
@@ -71,11 +75,14 @@ type ScanDiff = {
     findings_added: FindingDiffEntry[];
     findings_removed: FindingDiffEntry[];
     findings_upgraded: FindingUpgradeEntry[];
+    findings_unchanged: FindingDiffEntry[];
     packages_added: PackageDiffEntry[];
     packages_removed: PackageDiffEntry[];
     packages_upgraded: PackageUpgradeEntry[];
+    packages_unchanged: PackageDiffEntry[];
     vulns_added: string[];
     vulns_removed: string[];
+    vulns_unchanged: string[];
     newly_detected_findings: number | null;
     newly_detected_vulns: number | null;
     newly_detected_findings_list: FindingDiffEntry[] | null;

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -36,6 +36,7 @@ type FindingDiffEntry = {
     package_version: string;
     package_id: string;
     vulnerability_id: string;
+    origin?: string;
 };
 
 type PackageDiffEntry = {

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -152,6 +152,9 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         );
     }, [loadData]);
 
+    const handleScanComplete = useCallback(() => {
+        loadData(currentVariantId, currentVariantId ? undefined : currentProjectId);
+    }, [loadData, currentVariantId, currentProjectId]);
 
 
     function appendAssessment(added: Assessment) {
@@ -304,7 +307,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     compareOperation={currentOperation}
                 />}
                 {tab === 'patch-finder' && <PatchFinder vulnerabilities={vulns} packages={pkgs} patchData={patchInfo} db_ready={patchDbReady} nvdProgress={nvdProgress} />}
-                {tab === 'scans' && <ScanHistory variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} />}
+                {tab === 'scans' && <ScanHistory variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onScanComplete={handleScanComplete} />}
                 {tab === 'review' && <Review variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onAssessmentChanged={handleAssessmentChanged} />}
                 {tab === 'exports' && <Exports />}
                 {tab === 'settings' && <Settings onDataChanged={(message) => {

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import ScansHandler from "../handlers/scans";
 import type { Scan, ScanDiff, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry } from "../handlers/scans";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPencil, faCheck, faXmark } from "@fortawesome/free-solid-svg-icons";
+import { faPencil, faCheck, faXmark, faBug } from "@fortawesome/free-solid-svg-icons";
 
 type Props = {
     variantId?: string;
@@ -306,11 +306,12 @@ function VulnDiffList({ vulns, label, colorClass }: {
 
 type Section = 'packages' | 'findings' | 'vulnerabilities';
 
-function DiffModal({ scanId, onClose }: { scanId: string; onClose: () => void }) {
+function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: string; onClose: () => void }) {
     const [diff, setDiff] = useState<ScanDiff | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-    const [section, setSection] = useState<Section>('packages');
+    const isToolScan = scanType === 'tool';
+    const [section, setSection] = useState<Section>(isToolScan ? 'findings' : 'packages');
     const overlayRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
@@ -357,7 +358,7 @@ function DiffModal({ scanId, onClose }: { scanId: string; onClose: () => void })
                     {/* Header */}
                     <div className="flex items-center justify-between p-4 md:p-5 border-b rounded-t dark:border-gray-600">
                         <h3 className="text-xl font-semibold text-gray-900 dark:text-white">
-                            Scan diff details
+                            {isToolScan ? 'Tool scan diff details' : 'Scan diff details'}
                         </h3>
                         <button
                             onClick={onClose}
@@ -374,6 +375,7 @@ function DiffModal({ scanId, onClose }: { scanId: string; onClose: () => void })
                     {/* Tab bar */}
                     {diff && (
                         <div className="flex border-b dark:border-gray-600 px-4 flex-wrap">
+                            {!isToolScan && (
                             <button className={tabCls('packages')} onClick={() => setSection('packages')}>
                                 Packages
                                 {diff.is_first ? (
@@ -394,6 +396,7 @@ function DiffModal({ scanId, onClose }: { scanId: string; onClose: () => void })
                                     </>
                                 )}
                             </button>
+                            )}
                             <button className={tabCls('findings')} onClick={() => setSection('findings')}>
                                 Findings
                                 {diff.is_first ? (
@@ -543,8 +546,19 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [openDiffId, setOpenDiffId] = useState<string | null>(null);
+    const [openDiffType, setOpenDiffType] = useState<string>('sbom');
     const [editingDescId, setEditingDescId] = useState<string | null>(null);
     const [editingDescValue, setEditingDescValue] = useState<string>('');
+    const [grypeStatus, setGrypeStatus] = useState<string>('idle');
+    const [grypeError, setGrypeError] = useState<string | null>(null);
+
+    const refreshScans = useCallback(() => {
+        ScansHandler.list(variantId, projectId)
+            .then((data) => {
+                setScans([...data].reverse());
+            })
+            .catch(() => {});
+    }, [variantId, projectId]);
 
     async function saveDescription(scanId: string) {
         const ok = await ScansHandler.setDescription(scanId, editingDescValue);
@@ -552,6 +566,45 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
             setScans(prev => prev.map(s => s.id === scanId ? { ...s, description: editingDescValue } : s));
             setEditingDescId(null);
         }
+    }
+
+    // Derive the effective variant IDs to scan: explicit prop or unique IDs from loaded scans
+    const effectiveVariantIds: string[] = variantId
+        ? [variantId]
+        : [...new Set(scans.map(s => s.variant_id))];
+
+    async function handleTriggerGrypeScan() {
+        if (effectiveVariantIds.length === 0) return;
+        setGrypeError(null);
+
+        // Trigger a scan for every variant
+        for (const vid of effectiveVariantIds) {
+            const result = await ScansHandler.triggerGrypeScan(vid);
+            if (!result.ok) {
+                setGrypeError(result.error ?? 'Failed to start Grype scan');
+                return;
+            }
+        }
+
+        setGrypeStatus('running');
+        // Poll all variants until every one is done (or any errors)
+        const interval = setInterval(async () => {
+            const statuses = await Promise.all(
+                effectiveVariantIds.map(vid => ScansHandler.getGrypeScanStatus(vid))
+            );
+            const anyError = statuses.find(s => s.status === 'error');
+            const allDone = statuses.every(s => s.status === 'done' || s.status === 'idle');
+            if (anyError) {
+                clearInterval(interval);
+                setGrypeStatus('error');
+                setGrypeError(anyError.error ?? 'Grype scan failed');
+            } else if (allDone && statuses.some(s => s.status === 'done')) {
+                clearInterval(interval);
+                setGrypeStatus('done');
+                refreshScans();
+                setTimeout(() => setGrypeStatus('idle'), 3000);
+            }
+        }, 3000);
     }
 
     useEffect(() => {
@@ -566,26 +619,70 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
                 setError("Failed to load scan history.");
                 setLoading(false);
             });
-    }, [variantId, projectId]);
+    }, [variantId, projectId, refreshScans]);
+
+    // Build the scan-trigger button (always visible when there are variant(s) to scan)
+    const canTriggerScan = effectiveVariantIds.length > 0 || variantId;
+    const scanButton = canTriggerScan ? (
+        <div className="flex items-center gap-3">
+            {grypeError && (
+                <span className="text-sm text-red-400">{grypeError}</span>
+            )}
+            {grypeStatus === 'done' && (
+                <span className="text-sm text-green-400">Grype scan complete!</span>
+            )}
+            <button
+                onClick={handleTriggerGrypeScan}
+                disabled={grypeStatus === 'running' || loading}
+                className={[
+                    "inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-colors",
+                    grypeStatus === 'running'
+                        ? "bg-purple-800/50 text-purple-300 cursor-wait"
+                        : "bg-purple-700 hover:bg-purple-600 text-white",
+                ].join(' ')}
+            >
+                <FontAwesomeIcon icon={faBug} />
+                {grypeStatus === 'running' ? 'Scanning…' : 'Perform Grype Scan'}
+            </button>
+        </div>
+    ) : null;
 
     if (loading) {
         return (
-            <div className="flex items-center justify-center h-32 text-gray-400">
-                Loading scan history…
+            <div className="max-w-7xl mx-auto py-6">
+                <div className="flex items-center justify-between mb-6">
+                    <h1 className="text-2xl font-bold text-gray-800 dark:text-neutral-100">Scan History</h1>
+                    {scanButton}
+                </div>
+                <div className="flex items-center justify-center h-32 text-gray-400">
+                    Loading scan history…
+                </div>
             </div>
         );
     }
     if (error) {
         return (
-            <div className="flex items-center justify-center h-32 text-red-400">
-                {error}
+            <div className="max-w-7xl mx-auto py-6">
+                <div className="flex items-center justify-between mb-6">
+                    <h1 className="text-2xl font-bold text-gray-800 dark:text-neutral-100">Scan History</h1>
+                    {scanButton}
+                </div>
+                <div className="flex items-center justify-center h-32 text-red-400">
+                    {error}
+                </div>
             </div>
         );
     }
     if (scans.length === 0) {
         return (
-            <div className="flex items-center justify-center h-32 text-gray-400 dark:text-neutral-400">
-                No scans found.
+            <div className="max-w-7xl mx-auto py-6">
+                <div className="flex items-center justify-between mb-6">
+                    <h1 className="text-2xl font-bold text-gray-800 dark:text-neutral-100">Scan History</h1>
+                    {scanButton}
+                </div>
+                <div className="flex items-center justify-center h-32 text-gray-400 dark:text-neutral-400">
+                    No scans found.
+                </div>
             </div>
         );
     }
@@ -593,13 +690,16 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
     return (
         <>
             {openDiffId && (
-                <DiffModal scanId={openDiffId} onClose={() => setOpenDiffId(null)} />
+                <DiffModal scanId={openDiffId} scanType={openDiffType} onClose={() => setOpenDiffId(null)} />
             )}
 
             <div className="max-w-7xl mx-auto py-6">
-                <h1 className="text-2xl font-bold mb-6 text-gray-800 dark:text-neutral-100">
-                    Scan History
-                </h1>
+                <div className="flex items-center justify-between mb-6">
+                    <h1 className="text-2xl font-bold text-gray-800 dark:text-neutral-100">
+                        Scan History
+                    </h1>
+                    {scanButton}
+                </div>
 
                 <ol className="relative border-l-2 border-cyan-700 dark:border-cyan-600">
                     {scans.map((scan, index) => (
@@ -615,19 +715,29 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
                             ].join(' ')} />
 
                             <div className="p-4 bg-white dark:bg-neutral-700 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-600">
-                                {/* Row 1: timestamp */}
-                                <time className="block text-sm font-semibold text-gray-500 dark:text-neutral-400 mb-1">
-                                    {formatDate(scan.timestamp)}
-                                </time>
+                                {/* Row 1: timestamp + scan type badge */}
+                                <div className="flex items-center gap-2 mb-1">
+                                    <time className="text-sm font-semibold text-gray-500 dark:text-neutral-400">
+                                        {formatDate(scan.timestamp)}
+                                    </time>
+                                    {(scan.scan_type || 'sbom') === 'tool' && (
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
+                                            <FontAwesomeIcon icon={faBug} className="mr-1" />
+                                            Tool Scan
+                                        </span>
+                                    )}
+                                </div>
 
                                 {/* Row 2: badges + details button */}
                                 <div className="flex items-center gap-2 flex-wrap mb-1">
                                         {scan.is_first ? (
                                             /* First scan: total counts */
                                             <>
+                                                {(scan.scan_type || 'sbom') !== 'tool' && (
                                                 <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
                                                     {(scan.package_count ?? 0).toLocaleString()} packages
                                                 </span>
+                                                )}
                                                 <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
                                                     {(scan.finding_count ?? 0).toLocaleString()} findings
                                                 </span>
@@ -638,6 +748,8 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
                                         ) : (
                                             /* Subsequent scans: diff badges */
                                             <>
+                                                {(scan.scan_type || 'sbom') !== 'tool' && (
+                                                <>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     +{(scan.packages_added ?? 0).toLocaleString()} packages
                                                 </span>
@@ -647,15 +759,19 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     ↑{(scan.packages_upgraded ?? 0).toLocaleString()} packages upgraded
                                                 </span>
+                                                </>
+                                                )}
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     +{(scan.findings_added ?? 0).toLocaleString()} findings
                                                 </span>
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     −{(scan.findings_removed ?? 0).toLocaleString()} findings
                                                 </span>
+                                                {(scan.scan_type || 'sbom') !== 'tool' && (
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     ↑{(scan.findings_upgraded ?? 0).toLocaleString()} findings upgraded
                                                 </span>
+                                                )}
                                                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
                                                     +{(scan.vulns_added ?? 0).toLocaleString()} vulnerabilities
                                                 </span>
@@ -667,7 +783,7 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
 
                                         {/* Details button */}
                                         <button
-                                            onClick={() => setOpenDiffId(scan.id)}
+                                            onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
                                             className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
                                         >
                                             Details

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -111,12 +111,14 @@ function FindingUpgradeDiffTable({ entries, label, colorClass }: {
     colorClass: string;
 }) {
     const [filter, setFilter] = useState('');
+    const hasOrigin = entries.some(e => !!e.origin);
     const filtered = filter
         ? entries.filter(e =>
             e.package_name.toLowerCase().includes(filter.toLowerCase()) ||
             e.vulnerability_id.toLowerCase().includes(filter.toLowerCase()) ||
             e.old_version.toLowerCase().includes(filter.toLowerCase()) ||
-            e.new_version.toLowerCase().includes(filter.toLowerCase())
+            e.new_version.toLowerCase().includes(filter.toLowerCase()) ||
+            (e.origin || '').toLowerCase().includes(filter.toLowerCase())
         )
         : entries;
 
@@ -145,6 +147,7 @@ function FindingUpgradeDiffTable({ entries, label, colorClass }: {
                                 <th className="px-3 py-2">Old Version</th>
                                 <th className="px-3 py-2">New Version</th>
                                 <th className="px-3 py-2">Vulnerability</th>
+                                {hasOrigin && <th className="px-3 py-2">Origin</th>}
                             </tr>
                         </thead>
                         <tbody>
@@ -154,6 +157,7 @@ function FindingUpgradeDiffTable({ entries, label, colorClass }: {
                                     <td className="px-3 py-1.5 font-mono text-red-400">{e.old_version}</td>
                                     <td className="px-3 py-1.5 font-mono text-green-400">{e.new_version}</td>
                                     <td className="px-3 py-1.5 font-mono">{e.vulnerability_id}</td>
+                                    {hasOrigin && <td className="px-3 py-1.5 text-gray-400">{e.origin ?? ''}</td>}
                                 </tr>
                             ))}
                         </tbody>
@@ -607,6 +611,9 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
                                         <span className={`ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold ${diff.packages_upgraded.length > 0 ? 'bg-yellow-900/40 text-yellow-300' : 'bg-gray-600 text-gray-400'}`}>
                                             ↑{diff.packages_upgraded.length.toLocaleString()}
                                         </span>
+                                        <span className="ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold bg-gray-600 text-gray-400">
+                                            ={diff.packages_unchanged.length.toLocaleString()}
+                                        </span>
                                     </>
                                 )}
                             </button>
@@ -628,6 +635,9 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
                                         <span className={`ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold ${diff.findings_upgraded.length > 0 ? 'bg-yellow-900/40 text-yellow-300' : 'bg-gray-600 text-gray-400'}`}>
                                             ↑{diff.findings_upgraded.length.toLocaleString()}
                                         </span>
+                                        <span className="ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold bg-gray-600 text-gray-400">
+                                            ={diff.findings_unchanged.length.toLocaleString()}
+                                        </span>
                                     </>
                                 )}
                             </button>
@@ -644,6 +654,9 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
                                         </span>
                                         <span className={`ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold ${diff.vulns_removed.length > 0 ? 'bg-red-900/40 text-red-300' : 'bg-gray-600 text-gray-400'}`}>
                                             −{diff.vulns_removed.length.toLocaleString()}
+                                        </span>
+                                        <span className="ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold bg-gray-600 text-gray-400">
+                                            ={diff.vulns_unchanged.length.toLocaleString()}
                                         </span>
                                     </>
                                 )}
@@ -692,6 +705,13 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
                                         colorClass="text-yellow-400"
                                     />
                                 )}
+                                {!diff.is_first && (
+                                    <PackageDiffTable
+                                        entries={diff.packages_unchanged}
+                                        label="Unchanged packages"
+                                        colorClass="text-gray-400"
+                                    />
+                                )}
                             </>
                         )}
                         {diff && section === 'findings' && (
@@ -718,6 +738,13 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
                                         entries={diff.findings_upgraded}
                                         label="Findings on upgraded packages"
                                         colorClass="text-yellow-400"
+                                    />
+                                )}
+                                {!diff.is_first && (
+                                    <FindingDiffTable
+                                        entries={diff.findings_unchanged}
+                                        label="Unchanged findings"
+                                        colorClass="text-gray-400"
                                     />
                                 )}
                             </>
@@ -753,6 +780,13 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
                                         />
                                     );
                                 })()}
+                                {!diff.is_first && (
+                                    <VulnDiffList
+                                        vulns={diff.vulns_unchanged}
+                                        label="Unchanged vulnerabilities"
+                                        colorClass="text-gray-400"
+                                    />
+                                )}
                             </>
                         )}
                         {diff && section === 'newly_detected' && isToolScan && (
@@ -1520,17 +1554,19 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                 {/* Vulnerabilities row */}
                                 <div className="flex items-center gap-2 flex-wrap mb-1">
                                     <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Vulnerabilities:</span>
-                                    {scan.is_first ? (
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
-                                        </span>
-                                    ) : (
+                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                        {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
+                                    </span>
+                                    {!scan.is_first && (
                                         <>
                                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                +{(scan.vulns_added ?? 0).toLocaleString()} vulnerabilities detected
+                                                {(scan.vulns_added ?? 0).toLocaleString()} new vulnerabilities
                                             </span>
                                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                −{(scan.vulns_removed ?? 0).toLocaleString()} vulnerabilities detected
+                                                {(scan.vulns_removed ?? 0).toLocaleString()} vulnerabilities removed
+                                            </span>
+                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
+                                                {(scan.vulns_unchanged ?? 0).toLocaleString()} vulnerabilities unchanged
                                             </span>
                                         </>
                                     )}
@@ -1538,20 +1574,22 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                 {/* Findings row */}
                                 <div className="flex items-center gap-2 flex-wrap mb-1">
                                     <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Findings:</span>
-                                    {scan.is_first ? (
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.finding_count ?? 0).toLocaleString()} findings detected
-                                        </span>
-                                    ) : (
+                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                        {(scan.finding_count ?? 0).toLocaleString()} findings detected
+                                    </span>
+                                    {!scan.is_first && (
                                         <>
                                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                +{(scan.findings_added ?? 0).toLocaleString()} findings detected
+                                                {(scan.findings_added ?? 0).toLocaleString()} new findings
                                             </span>
                                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                −{(scan.findings_removed ?? 0).toLocaleString()} findings detected
+                                                {(scan.findings_removed ?? 0).toLocaleString()} findings removed
                                             </span>
                                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                ↑{(scan.findings_upgraded ?? 0).toLocaleString()} findings upgraded
+                                                {(scan.findings_upgraded ?? 0).toLocaleString()} findings upgraded
+                                            </span>
+                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
+                                                {(scan.findings_unchanged ?? 0).toLocaleString()} findings unchanged
                                             </span>
                                         </>
                                     )}
@@ -1559,20 +1597,22 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                 {/* Packages row */}
                                 <div className="flex items-center gap-2 flex-wrap mb-1">
                                     <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Packages:</span>
-                                    {scan.is_first ? (
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.package_count ?? 0).toLocaleString()} packages
-                                        </span>
-                                    ) : (
+                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                        {(scan.package_count ?? 0).toLocaleString()} packages detected
+                                    </span>
+                                    {!scan.is_first && (
                                         <>
                                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                +{(scan.packages_added ?? 0).toLocaleString()} packages
+                                                {(scan.packages_added ?? 0).toLocaleString()} new packages
                                             </span>
                                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                −{(scan.packages_removed ?? 0).toLocaleString()} packages
+                                                {(scan.packages_removed ?? 0).toLocaleString()} packages removed
                                             </span>
                                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                ↑{(scan.packages_upgraded ?? 0).toLocaleString()} packages upgraded
+                                                {(scan.packages_upgraded ?? 0).toLocaleString()} packages upgraded
+                                            </span>
+                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
+                                                {(scan.packages_unchanged ?? 0).toLocaleString()} packages unchanged
                                             </span>
                                         </>
                                     )}
@@ -1585,17 +1625,17 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                     </button>
                                 </div>
 
-                                {/* SBOM Result row */}
+                                {/* Scan Result row — uses global counts when tool scans exist, else SBOM-only */}
                                 <div className="flex items-center gap-2 flex-wrap mb-1 mt-2 pt-2 border-t border-neutral-300 dark:border-neutral-600">
-                                    <span className="text-xs font-bold text-cyan-400 uppercase tracking-wide">SBOM Result:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.package_count ?? 0).toLocaleString()} packages
+                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Scan Result:</span>
+                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${((scan.global_package_count ?? scan.package_count ?? 0)) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                        {(scan.global_package_count ?? scan.package_count ?? 0).toLocaleString()} packages
                                     </span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.finding_count ?? 0).toLocaleString()} findings detected
+                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${((scan.global_finding_count ?? scan.finding_count ?? 0)) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                        {(scan.global_finding_count ?? scan.finding_count ?? 0).toLocaleString()} findings
                                     </span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
+                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${((scan.global_vuln_count ?? scan.vuln_count ?? 0)) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                        {(scan.global_vuln_count ?? scan.vuln_count ?? 0).toLocaleString()} vulnerabilities
                                     </span>
                                     <button
                                         onClick={() => setOpenGlobalId(scan.id)}
@@ -1604,28 +1644,6 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                         Details
                                     </button>
                                 </div>
-
-                                {/* Scan Result (SBOM ∪ all tool scans) — only when tool scans exist */}
-                                {scan.global_finding_count != null && (
-                                    <div className="flex items-center gap-2 flex-wrap mb-1 mt-2 pt-2 border-t border-neutral-300 dark:border-neutral-600">
-                                        <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Scan Result:</span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_package_count ?? 0).toLocaleString()} packages
-                                        </span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_finding_count ?? 0).toLocaleString()} findings detected
-                                        </span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_vuln_count ?? 0).toLocaleString()} vulnerabilities detected
-                                        </span>
-                                        <button
-                                            onClick={() => setOpenGlobalId(scan.id)}
-                                            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
-                                        >
-                                            Details
-                                        </button>
-                                    </div>
-                                )}
                                 </>
                                 )}
 
@@ -1637,10 +1655,10 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                             {(scan.global_package_count ?? 0).toLocaleString()} packages
                                         </span>
                                         <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_finding_count ?? 0).toLocaleString()} findings detected
+                                            {(scan.global_finding_count ?? 0).toLocaleString()} findings
                                         </span>
                                         <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_vuln_count ?? 0).toLocaleString()} vulnerabilities detected
+                                            {(scan.global_vuln_count ?? 0).toLocaleString()} vulnerabilities
                                         </span>
                                         <button
                                             onClick={() => setOpenGlobalId(scan.id)}

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1,12 +1,31 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useSyncExternalStore } from "react";
 import ScansHandler from "../handlers/scans";
-import type { Scan, ScanDiff, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry } from "../handlers/scans";
+import type { Scan, ScanDiff, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry, GlobalResult } from "../handlers/scans";
+import { subscribe, getSnapshot, setOnDone, triggerScan, dismiss as grypeDismiss, type GrypeState } from "../handlers/grypeScanState";
+import {
+    subscribe as nvdSubscribe,
+    getSnapshot as nvdGetSnapshot,
+    setOnDone as nvdSetOnDone,
+    triggerScan as nvdTriggerScan,
+    dismiss as nvdDismiss,
+    type NvdState,
+} from "../handlers/nvdScanState";
+import {
+    subscribe as osvSubscribe,
+    getSnapshot as osvGetSnapshot,
+    setOnDone as osvSetOnDone,
+    triggerScan as osvTriggerScan,
+    dismiss as osvDismiss,
+    type OsvState,
+} from "../handlers/osvScanState";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPencil, faCheck, faXmark, faBug } from "@fortawesome/free-solid-svg-icons";
+import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash } from "@fortawesome/free-solid-svg-icons";
+import ConfirmationModal from "../components/ConfirmationModal";
 
 type Props = {
     variantId?: string;
     projectId?: string;
+    onScanComplete?: () => void;
 };
 
 function formatDate(iso: string): string {
@@ -304,7 +323,191 @@ function VulnDiffList({ vulns, label, colorClass }: {
     );
 }
 
-type Section = 'packages' | 'findings' | 'vulnerabilities';
+type Section = 'packages' | 'findings' | 'vulnerabilities' | 'newly_detected';
+type GlobalSection = 'packages' | 'findings' | 'vulnerabilities';
+
+// ---------------------------------------------------------------------------
+// Scan Result modal — shows active items (SBOM ∪ Tool scan) with source
+// ---------------------------------------------------------------------------
+
+function GlobalResultModal({ scanId, onClose }: { scanId: string; onClose: () => void }) {
+    const [data, setData] = useState<GlobalResult | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [section, setSection] = useState<GlobalSection>('packages');
+    const [filter, setFilter] = useState('');
+    const overlayRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') { e.preventDefault(); onClose(); }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [onClose]);
+
+    useEffect(() => {
+        ScansHandler.getGlobalResult(scanId)
+            .then(d => {
+                if (d) setData(d);
+                else setError("Failed to load scan result.");
+                setLoading(false);
+            })
+            .catch(() => { setError("Failed to load scan result."); setLoading(false); });
+    }, [scanId]);
+
+    const tabCls = (s: GlobalSection) =>
+        ["px-4 py-2 text-sm font-semibold border-b-2 transition-colors",
+         section === s ? "border-cyan-500 text-cyan-400" : "border-transparent text-gray-400 hover:text-gray-200",
+        ].join(' ');
+
+    const lc = filter.toLowerCase();
+    const filteredPkgs = data ? (lc ? data.packages.filter(p => p.package_name.toLowerCase().includes(lc) || p.package_version.toLowerCase().includes(lc) || p.sources.some(s => s.toLowerCase().includes(lc))) : data.packages) : [];
+    const filteredFindings = data ? (lc ? data.findings.filter(f => f.package_name.toLowerCase().includes(lc) || f.vulnerability_id.toLowerCase().includes(lc) || f.sources.some(s => s.toLowerCase().includes(lc))) : data.findings) : [];
+    const filteredVulns = data ? (lc ? data.vulnerabilities.filter(v => v.vulnerability_id.toLowerCase().includes(lc) || v.sources.some(s => s.toLowerCase().includes(lc))) : data.vulnerabilities) : [];
+
+    return (
+        <div
+            className="overflow-x-hidden fixed top-0 right-0 left-0 z-50 flex items-center justify-center w-full md:inset-0 h-full max-h-full bg-gray-900/90"
+            onClick={e => { if (e.target === overlayRef.current) onClose(); }}
+            ref={overlayRef}
+        >
+            <div className="relative p-16 h-full w-full">
+                <div className="relative rounded-lg shadow bg-gray-700 h-full overflow-y-auto flex flex-col">
+
+                    {/* Header */}
+                    <div className="flex items-center justify-between p-4 md:p-5 border-b rounded-t dark:border-gray-600">
+                        <h3 className="text-xl font-semibold text-white">
+                            Scan Result — Active Items
+                        </h3>
+                        <button onClick={onClose} type="button" className="text-white bg-transparent border border-gray-600 hover:bg-gray-600 hover:border-gray-500 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center transition-colors">
+                            <svg className="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+                                <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+                            </svg>
+                            <span className="sr-only">Close modal</span>
+                        </button>
+                    </div>
+
+                    {/* Tab bar */}
+                    {data && (
+                        <div className="flex border-b dark:border-gray-600 px-4 flex-wrap items-center">
+                            <button className={tabCls('packages')} onClick={() => setSection('packages')}>
+                                Packages
+                                <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold bg-cyan-900/40 text-cyan-300">
+                                    {data.package_count.toLocaleString()}
+                                </span>
+                            </button>
+                            <button className={tabCls('findings')} onClick={() => setSection('findings')}>
+                                Findings
+                                <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold bg-cyan-900/40 text-cyan-300">
+                                    {data.finding_count.toLocaleString()}
+                                </span>
+                            </button>
+                            <button className={tabCls('vulnerabilities')} onClick={() => setSection('vulnerabilities')}>
+                                Vulnerabilities
+                                <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold bg-cyan-900/40 text-cyan-300">
+                                    {data.vuln_count.toLocaleString()}
+                                </span>
+                            </button>
+                            <div className="ml-auto">
+                                <input
+                                    type="text"
+                                    placeholder="Filter…"
+                                    value={filter}
+                                    onChange={e => setFilter(e.target.value)}
+                                    className="text-xs px-2 py-1 rounded border border-gray-600 bg-gray-800 text-gray-200 w-48"
+                                />
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Body */}
+                    <div className="p-4 md:p-5 space-y-4 text-gray-300 flex-1 overflow-auto">
+                        {loading && <p className="text-gray-400">Loading…</p>}
+                        {error && <p className="text-red-400">{error}</p>}
+
+                        {data && section === 'packages' && (
+                            <div className="overflow-auto max-h-[70vh] rounded border border-gray-600">
+                                <table className="w-full text-xs text-left">
+                                    <thead className="sticky top-0 bg-gray-800 text-gray-300 uppercase">
+                                        <tr>
+                                            <th className="px-3 py-2">Package</th>
+                                            <th className="px-3 py-2">Version</th>
+                                            <th className="px-3 py-2">Source</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {filteredPkgs.map(p => (
+                                            <tr key={p.package_id} className="border-t border-gray-600 hover:bg-gray-600/40">
+                                                <td className="px-3 py-1.5 font-mono">{p.package_name}</td>
+                                                <td className="px-3 py-1.5 font-mono text-gray-400">{p.package_version}</td>
+                                                <td className="px-3 py-1.5 text-gray-400">{p.sources.join(', ')}</td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+
+                        {data && section === 'findings' && (
+                            <div className="overflow-auto max-h-[70vh] rounded border border-gray-600">
+                                <table className="w-full text-xs text-left">
+                                    <thead className="sticky top-0 bg-gray-800 text-gray-300 uppercase">
+                                        <tr>
+                                            <th className="px-3 py-2">Package</th>
+                                            <th className="px-3 py-2">Version</th>
+                                            <th className="px-3 py-2">Vulnerability</th>
+                                            <th className="px-3 py-2">Source</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {filteredFindings.map(f => (
+                                            <tr key={f.finding_id} className="border-t border-gray-600 hover:bg-gray-600/40">
+                                                <td className="px-3 py-1.5 font-mono">{f.package_name}</td>
+                                                <td className="px-3 py-1.5 font-mono text-gray-400">{f.package_version}</td>
+                                                <td className="px-3 py-1.5 font-mono">{f.vulnerability_id}</td>
+                                                <td className="px-3 py-1.5 text-gray-400">{f.sources.join(', ')}</td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+
+                        {data && section === 'vulnerabilities' && (
+                            <div className="overflow-auto max-h-[70vh] rounded border border-gray-600">
+                                <table className="w-full text-xs text-left">
+                                    <thead className="sticky top-0 bg-gray-800 text-gray-300 uppercase">
+                                        <tr>
+                                            <th className="px-3 py-2">Vulnerability</th>
+                                            <th className="px-3 py-2">Source</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {filteredVulns.map(v => (
+                                            <tr key={v.vulnerability_id} className="border-t border-gray-600 hover:bg-gray-600/40">
+                                                <td className="px-3 py-1.5 font-mono">{v.vulnerability_id}</td>
+                                                <td className="px-3 py-1.5 text-gray-400">{v.sources.join(', ')}</td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Footer */}
+                    <div className="flex items-center justify-end p-4 md:p-5 border-t border-gray-200 rounded-b dark:border-gray-600">
+                        <button onClick={onClose} type="button" className="py-2.5 px-5 text-sm font-medium text-gray-400 focus:outline-none rounded-lg border border-gray-600 hover:bg-gray-600 hover:text-white focus:z-10 focus:ring-4 focus:ring-blue-500 bg-gray-800">
+                            Close
+                        </button>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    );
+}
 
 function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: string; onClose: () => void }) {
     const [diff, setDiff] = useState<ScanDiff | null>(null);
@@ -434,6 +637,17 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
                                     </>
                                 )}
                             </button>
+                            {isToolScan && diff.newly_detected_findings != null && (
+                            <button className={tabCls('newly_detected')} onClick={() => setSection('newly_detected')}>
+                                New Discovered
+                                <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold bg-green-900/40 text-green-300">
+                                    {(diff.newly_detected_findings ?? 0).toLocaleString()} findings
+                                </span>
+                                <span className="ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-bold bg-green-900/40 text-green-300">
+                                    {(diff.newly_detected_vulns ?? 0).toLocaleString()} vulns
+                                </span>
+                            </button>
+                            )}
                         </div>
                     )}
 
@@ -518,6 +732,31 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
                                 )}
                             </>
                         )}
+                        {diff && section === 'newly_detected' && isToolScan && (
+                            <>
+                                <p className="text-sm text-gray-400 mb-4 italic">
+                                    Findings and vulnerabilities discovered by the tool scan that were <strong className="text-purple-300">not previously known</strong> — they are new items not found in the SBOM or any earlier tool scan.
+                                </p>
+                                {diff.newly_detected_findings_list && diff.newly_detected_findings_list.length > 0 ? (
+                                    <FindingDiffTable
+                                        entries={diff.newly_detected_findings_list}
+                                        label="New findings discovered"
+                                        colorClass="text-green-400"
+                                    />
+                                ) : (
+                                    <p className="text-sm text-gray-400 italic mb-4">No new findings discovered.</p>
+                                )}
+                                {diff.newly_detected_vulns_list && diff.newly_detected_vulns_list.length > 0 ? (
+                                    <VulnDiffList
+                                        vulns={diff.newly_detected_vulns_list}
+                                        label="New vulnerabilities discovered"
+                                        colorClass="text-green-400"
+                                    />
+                                ) : (
+                                    <p className="text-sm text-gray-400 italic">No new vulnerabilities discovered.</p>
+                                )}
+                            </>
+                        )}
                     </div>
 
                     {/* Footer */}
@@ -541,16 +780,38 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
 // Main page
 // ---------------------------------------------------------------------------
 
-function ScanHistory({ variantId, projectId }: Readonly<Props>) {
+function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) {
     const [scans, setScans] = useState<Scan[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [openDiffId, setOpenDiffId] = useState<string | null>(null);
     const [openDiffType, setOpenDiffType] = useState<string>('sbom');
+    const [openGlobalId, setOpenGlobalId] = useState<string | null>(null);
     const [editingDescId, setEditingDescId] = useState<string | null>(null);
     const [editingDescValue, setEditingDescValue] = useState<string>('');
-    const [grypeStatus, setGrypeStatus] = useState<string>('idle');
-    const [grypeError, setGrypeError] = useState<string | null>(null);
+    const [deletingId, setDeletingId] = useState<string | null>(null);
+    const [hideEmptyScans, setHideEmptyScans] = useState(false);
+    const [showGrype, setShowGrype] = useState(true);
+    const [showOsv, setShowOsv] = useState(true);
+    const [showNvd, setShowNvd] = useState(true);
+
+    // Global Grype scan state — survives tab switches
+    const grypeState: GrypeState = useSyncExternalStore(subscribe, getSnapshot);
+    const grypeStatus = grypeState.status;
+    const grypeError = grypeState.error;
+    const grypeProgress = grypeState.progress;
+
+    // Global NVD scan state — survives tab switches
+    const nvdState: NvdState = useSyncExternalStore(nvdSubscribe, nvdGetSnapshot);
+    const nvdStatus = nvdState.status;
+    const nvdError = nvdState.error;
+    const nvdProgress = nvdState.progress;
+
+    // Global OSV scan state — survives tab switches
+    const osvState: OsvState = useSyncExternalStore(osvSubscribe, osvGetSnapshot);
+    const osvStatus = osvState.status;
+    const osvError = osvState.error;
+    const osvProgress = osvState.progress;
 
     const refreshScans = useCallback(() => {
         ScansHandler.list(variantId, projectId)
@@ -568,43 +829,66 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
         }
     }
 
+    async function handleDeleteScan(scanId: string) {
+        const result = await ScansHandler.deleteScan(scanId);
+        if (result.ok) {
+            setDeletingId(null);
+            refreshScans();
+            onScanComplete?.();
+        }
+    }
+
     // Derive the effective variant IDs to scan: explicit prop or unique IDs from loaded scans
     const effectiveVariantIds: string[] = variantId
         ? [variantId]
         : [...new Set(scans.map(s => s.variant_id))];
 
+    // Register the refresh callback so the global store can trigger it on completion
+    useEffect(() => {
+        setOnDone(() => { refreshScans(); onScanComplete?.(); });
+        return () => setOnDone(null);
+    }, [refreshScans, onScanComplete]);
+
+    useEffect(() => {
+        nvdSetOnDone(() => { refreshScans(); onScanComplete?.(); });
+        return () => nvdSetOnDone(null);
+    }, [refreshScans, onScanComplete]);
+
+    useEffect(() => {
+        osvSetOnDone(() => { refreshScans(); onScanComplete?.(); });
+        return () => osvSetOnDone(null);
+    }, [refreshScans, onScanComplete]);
+
+    // If a scan finished while we were away, refresh the list on mount
+    useEffect(() => {
+        if (grypeStatus === 'done') refreshScans();
+        if (nvdStatus === 'done') refreshScans();
+        if (osvStatus === 'done') refreshScans();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     async function handleTriggerGrypeScan() {
         if (effectiveVariantIds.length === 0) return;
-        setGrypeError(null);
+        await triggerScan(effectiveVariantIds);
+    }
 
-        // Trigger a scan for every variant
-        for (const vid of effectiveVariantIds) {
-            const result = await ScansHandler.triggerGrypeScan(vid);
-            if (!result.ok) {
-                setGrypeError(result.error ?? 'Failed to start Grype scan');
-                return;
-            }
-        }
+    async function handleTriggerNvdScan() {
+        if (effectiveVariantIds.length === 0) return;
+        await nvdTriggerScan(effectiveVariantIds);
+    }
 
-        setGrypeStatus('running');
-        // Poll all variants until every one is done (or any errors)
-        const interval = setInterval(async () => {
-            const statuses = await Promise.all(
-                effectiveVariantIds.map(vid => ScansHandler.getGrypeScanStatus(vid))
-            );
-            const anyError = statuses.find(s => s.status === 'error');
-            const allDone = statuses.every(s => s.status === 'done' || s.status === 'idle');
-            if (anyError) {
-                clearInterval(interval);
-                setGrypeStatus('error');
-                setGrypeError(anyError.error ?? 'Grype scan failed');
-            } else if (allDone && statuses.some(s => s.status === 'done')) {
-                clearInterval(interval);
-                setGrypeStatus('done');
-                refreshScans();
-                setTimeout(() => setGrypeStatus('idle'), 3000);
-            }
-        }, 3000);
+    async function handleTriggerOsvScan() {
+        if (effectiveVariantIds.length === 0) return;
+        await osvTriggerScan(effectiveVariantIds);
+    }
+
+    async function handleTriggerAllScans() {
+        if (effectiveVariantIds.length === 0) return;
+        await Promise.all([
+            triggerScan(effectiveVariantIds),
+            nvdTriggerScan(effectiveVariantIds),
+            osvTriggerScan(effectiveVariantIds),
+        ]);
     }
 
     useEffect(() => {
@@ -623,37 +907,353 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
 
     // Build the scan-trigger button (always visible when there are variant(s) to scan)
     const canTriggerScan = effectiveVariantIds.length > 0 || variantId;
-    const scanButton = canTriggerScan ? (
-        <div className="flex items-center gap-3">
-            {grypeError && (
-                <span className="text-sm text-red-400">{grypeError}</span>
-            )}
-            {grypeStatus === 'done' && (
-                <span className="text-sm text-green-400">Grype scan complete!</span>
-            )}
+    const allRunning = grypeStatus === 'running' || nvdStatus === 'running' || osvStatus === 'running';
+
+    // Filter out "empty" scans (no changes) when toggle is active
+    const displayedScans = hideEmptyScans
+        ? scans.filter(s => {
+            if (s.is_first) return true; // first scans always shown
+            const hasChanges =
+                (s.findings_added ?? 0) !== 0 ||
+                (s.findings_removed ?? 0) !== 0 ||
+                (s.findings_upgraded ?? 0) !== 0 ||
+                (s.packages_added ?? 0) !== 0 ||
+                (s.packages_removed ?? 0) !== 0 ||
+                (s.packages_upgraded ?? 0) !== 0 ||
+                (s.vulns_added ?? 0) !== 0 ||
+                (s.vulns_removed ?? 0) !== 0 ||
+                (s.newly_detected_findings ?? 0) !== 0 ||
+                (s.newly_detected_vulns ?? 0) !== 0;
+            return hasChanges;
+        })
+        : scans;
+
+    // Apply scan-source visibility filters
+    const filteredScans = displayedScans.filter((s) => {
+        if ((s.scan_type || 'sbom') !== 'tool') return true; // always show SBOM
+        const src = s.scan_source || 'grype';
+        if (src === 'grype' && !showGrype) return false;
+        if (src === 'osv' && !showOsv) return false;
+        if (src === 'nvd' && !showNvd) return false;
+        return true;
+    });
+
+    // -----------------------------------------------------------------------
+    // Linear timeline — source-to-color mapping for tool scan squares
+    // -----------------------------------------------------------------------
+    const sourceSquareColor: Record<string, string> = {
+        grype: "bg-purple-400",
+        osv: "bg-green-400",
+        nvd: "bg-orange-400",
+    };
+
+    // Column sizing — single lane
+    const LANE_W = 36;            // px – timeline column
+    const mainCX = LANE_W / 2;    // center-x of the lane
+
+    const menuBar = (
+        <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2 flex-wrap">
+            <h1 className="text-lg font-bold">Scan History</h1>
+
+            {/* Hide empty scans toggle */}
             <button
-                onClick={handleTriggerGrypeScan}
-                disabled={grypeStatus === 'running' || loading}
+                onClick={() => setHideEmptyScans(h => !h)}
                 className={[
-                    "inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold transition-colors",
-                    grypeStatus === 'running'
-                        ? "bg-purple-800/50 text-purple-300 cursor-wait"
-                        : "bg-purple-700 hover:bg-purple-600 text-white",
+                    "py-1 px-2 rounded flex items-center gap-1 text-sm font-semibold transition-colors",
+                    hideEmptyScans
+                        ? "bg-sky-950 text-white"
+                        : "bg-sky-900 hover:bg-sky-950 text-white",
                 ].join(' ')}
+                title={hideEmptyScans ? "Showing only scans with changes" : "Showing all scans"}
+            >
+                <FontAwesomeIcon icon={faFilter} />
+                Hide empty scans
+                {hideEmptyScans && <span className="ml-1 bg-sky-700 px-1 rounded text-xs">✓</span>}
+            </button>
+
+            {/* Scan source visibility toggles */}
+            <span className="text-xs text-sky-300 ml-2">Show:</span>
+            <button
+                onClick={() => setShowGrype(v => !v)}
+                className={[
+                    "py-1 px-2 rounded flex items-center gap-1 text-xs font-semibold transition-colors",
+                    showGrype ? "bg-purple-700 text-white" : "bg-sky-900/60 text-sky-400 line-through",
+                ].join(' ')}
+                title={showGrype ? "Grype scans visible" : "Grype scans hidden"}
             >
                 <FontAwesomeIcon icon={faBug} />
-                {grypeStatus === 'running' ? 'Scanning…' : 'Perform Grype Scan'}
+                Grype
             </button>
+            <button
+                onClick={() => setShowOsv(v => !v)}
+                className={[
+                    "py-1 px-2 rounded flex items-center gap-1 text-xs font-semibold transition-colors",
+                    showOsv ? "bg-green-700 text-white" : "bg-sky-900/60 text-sky-400 line-through",
+                ].join(' ')}
+                title={showOsv ? "OSV scans visible" : "OSV scans hidden"}
+            >
+                <FontAwesomeIcon icon={faLeaf} />
+                OSV
+            </button>
+            <button
+                onClick={() => setShowNvd(v => !v)}
+                className={[
+                    "py-1 px-2 rounded flex items-center gap-1 text-xs font-semibold transition-colors",
+                    showNvd ? "bg-orange-700 text-white" : "bg-sky-900/60 text-sky-400 line-through",
+                ].join(' ')}
+                title={showNvd ? "NVD scans visible" : "NVD scans hidden"}
+            >
+                <FontAwesomeIcon icon={faShieldHalved} />
+                NVD
+            </button>
+
+            {/* Right side: status + scan buttons */}
+            <div className="ml-auto flex items-center gap-3">
+                {grypeError && (
+                    <span className="text-sm text-red-400">{grypeError}</span>
+                )}
+                {grypeStatus === 'done' && (
+                    <span className="text-sm text-green-400">Grype scan complete!</span>
+                )}
+                {nvdError && (
+                    <span className="text-sm text-red-400">{nvdError}</span>
+                )}
+                {nvdStatus === 'done' && (
+                    <span className="text-sm text-green-400">NVD scan complete!</span>
+                )}
+                {osvError && (
+                    <span className="text-sm text-red-400">{osvError}</span>
+                )}
+                {osvStatus === 'done' && (
+                    <span className="text-sm text-green-400">OSV scan complete!</span>
+                )}
+                {canTriggerScan && (
+                    <button
+                        onClick={handleTriggerAllScans}
+                        disabled={allRunning || loading}
+                        className={[
+                            "inline-flex items-center gap-2 px-3 py-1 rounded text-sm font-semibold transition-colors",
+                            allRunning
+                                ? "bg-cyan-800/50 text-cyan-300 cursor-wait"
+                                : "bg-cyan-700 hover:bg-cyan-600 text-white",
+                        ].join(' ')}
+                    >
+                        <FontAwesomeIcon icon={faCrosshairs} />
+                        {allRunning ? 'Scanning…' : 'Scan All'}
+                    </button>
+                )}
+                {canTriggerScan && (
+                    <button
+                        onClick={handleTriggerGrypeScan}
+                        disabled={grypeStatus === 'running' || loading}
+                        className={[
+                            "inline-flex items-center gap-2 px-3 py-1 rounded text-sm font-semibold transition-colors",
+                            grypeStatus === 'running'
+                                ? "bg-purple-800/50 text-purple-300 cursor-wait"
+                                : "bg-purple-700 hover:bg-purple-600 text-white",
+                        ].join(' ')}
+                    >
+                        <FontAwesomeIcon icon={faBug} />
+                        {grypeStatus === 'running' ? `Grype Scan… ${grypeProgress ?? ''}` : 'Perform Grype Scan'}
+                    </button>
+                )}
+                {canTriggerScan && (
+                    <button
+                        onClick={handleTriggerNvdScan}
+                        disabled={nvdStatus === 'running' || loading}
+                        className={[
+                            "inline-flex items-center gap-2 px-3 py-1 rounded text-sm font-semibold transition-colors",
+                            nvdStatus === 'running'
+                                ? "bg-orange-800/50 text-orange-300 cursor-wait"
+                                : "bg-orange-700 hover:bg-orange-600 text-white",
+                        ].join(' ')}
+                    >
+                        <FontAwesomeIcon icon={faShieldHalved} />
+                        {nvdStatus === 'running' ? `NVD Scan… ${nvdProgress ?? ''}` : 'Perform NVD Scan'}
+                    </button>
+                )}
+                {canTriggerScan && (
+                    <button
+                        onClick={handleTriggerOsvScan}
+                        disabled={osvStatus === 'running' || loading}
+                        className={[
+                            "inline-flex items-center gap-2 px-3 py-1 rounded text-sm font-semibold transition-colors",
+                            osvStatus === 'running'
+                                ? "bg-green-800/50 text-green-300 cursor-wait"
+                                : "bg-green-700 hover:bg-green-600 text-white",
+                        ].join(' ')}
+                    >
+                        <FontAwesomeIcon icon={faLeaf} />
+                        {osvStatus === 'running' ? `OSV Scan… ${osvProgress ?? ''}` : 'Perform OSV Scan'}
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+
+    const grypePct = grypeState.total > 0
+        ? Math.round((grypeState.doneCount / grypeState.total) * 100)
+        : 0;
+
+    const grypeLogBoxRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        const el = grypeLogBoxRef.current;
+        if (el) el.scrollTop = el.scrollHeight;
+    }, [grypeState.logs.length]);
+
+    const grypeProgressPanel = (grypeStatus === "running" || grypeStatus === "done" || (grypeStatus === "error" && grypeState.logs.length > 0)) ? (
+        <div className="mb-4 rounded-lg border border-purple-700/60 bg-neutral-900 overflow-hidden">
+            {/* Header + progress bar */}
+            <div className="px-4 py-2 flex items-center gap-3 bg-purple-900/40">
+                <FontAwesomeIcon icon={faBug} className="text-purple-400" />
+                <span className="text-sm font-semibold text-purple-200">
+                    Grype Scan {grypeStatus === "running" ? "in progress" : grypeStatus === "error" ? "failed" : "complete"}
+                </span>
+                <span className="text-xs text-purple-300/80 ml-auto">
+                    {grypeState.progress ?? ""}
+                    {grypeState.total > 0 && ` (${grypePct}%)`}
+                </span>
+                {grypeStatus !== "running" && (
+                    <button onClick={grypeDismiss} title="Close" className="text-neutral-400 hover:text-white transition-colors ml-1">
+                        <FontAwesomeIcon icon={faXmark} className="text-sm" />
+                    </button>
+                )}
+            </div>
+            {/* Progress bar */}
+            <div className="w-full h-2 bg-neutral-800">
+                <div
+                    className={[
+                        "h-full transition-all duration-500 ease-out",
+                        grypeStatus === "done" ? "bg-green-500" : "bg-purple-500",
+                    ].join(" ")}
+                    style={{ width: `${grypePct}%` }}
+                />
+            </div>
+            {/* Log box */}
+            <div ref={grypeLogBoxRef} className="max-h-52 overflow-y-auto px-4 py-2 font-mono text-xs text-neutral-300 space-y-0.5 scrollbar-thin scrollbar-thumb-neutral-700">
+                {grypeState.logs.length === 0 && grypeStatus === "running" && (
+                    <div className="text-neutral-500 italic">Waiting for first results…</div>
+                )}
+                {grypeState.logs.map((line, i) => (
+                    <div key={i} className={line.startsWith("[") && line.includes("ERROR") ? "text-red-400" : line.startsWith("✓") ? "text-green-400 font-semibold" : ""}>
+                        {line}
+                    </div>
+                ))}
+            </div>
+        </div>
+    ) : null;
+
+    const nvdPct = nvdState.total > 0
+        ? Math.round((nvdState.doneCount / nvdState.total) * 100)
+        : 0;
+
+    const nvdLogBoxRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        const el = nvdLogBoxRef.current;
+        if (el) el.scrollTop = el.scrollHeight;
+    }, [nvdState.logs.length]);
+
+    const nvdProgressPanel = (nvdStatus === "running" || nvdStatus === "done" || (nvdStatus === "error" && nvdState.logs.length > 0)) ? (
+        <div className="mb-4 rounded-lg border border-orange-700/60 bg-neutral-900 overflow-hidden">
+            {/* Header + progress bar */}
+            <div className="px-4 py-2 flex items-center gap-3 bg-orange-900/40">
+                <FontAwesomeIcon icon={faShieldHalved} className="text-orange-400" />
+                <span className="text-sm font-semibold text-orange-200">
+                    NVD Scan {nvdStatus === "running" ? "in progress" : nvdStatus === "error" ? "failed" : "complete"}
+                </span>
+                <span className="text-xs text-orange-300/80 ml-auto">
+                    {nvdState.progress ?? ""}
+                    {nvdState.total > 0 && ` (${nvdPct}%)`}
+                </span>
+                {nvdStatus !== "running" && (
+                    <button onClick={nvdDismiss} title="Close" className="text-neutral-400 hover:text-white transition-colors ml-1">
+                        <FontAwesomeIcon icon={faXmark} className="text-sm" />
+                    </button>
+                )}
+            </div>
+            {/* Progress bar */}
+            <div className="w-full h-2 bg-neutral-800">
+                <div
+                    className={[
+                        "h-full transition-all duration-500 ease-out",
+                        nvdStatus === "done" ? "bg-green-500" : "bg-orange-500",
+                    ].join(" ")}
+                    style={{ width: `${nvdPct}%` }}
+                />
+            </div>
+            {/* Log box */}
+            <div ref={nvdLogBoxRef} className="max-h-52 overflow-y-auto px-4 py-2 font-mono text-xs text-neutral-300 space-y-0.5 scrollbar-thin scrollbar-thumb-neutral-700">
+                {nvdState.logs.length === 0 && nvdStatus === "running" && (
+                    <div className="text-neutral-500 italic">Waiting for first results…</div>
+                )}
+                {nvdState.logs.map((line, i) => (
+                    <div key={i} className={line.startsWith("[") && line.includes("ERROR") ? "text-red-400" : line.startsWith("✓") ? "text-green-400 font-semibold" : ""}>
+                        {line}
+                    </div>
+                ))}
+            </div>
+        </div>
+    ) : null;
+
+    const osvPct = osvState.total > 0
+        ? Math.round((osvState.doneCount / osvState.total) * 100)
+        : 0;
+
+    const osvLogBoxRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        const el = osvLogBoxRef.current;
+        if (el) el.scrollTop = el.scrollHeight;
+    }, [osvState.logs.length]);
+
+    const osvProgressPanel = (osvStatus === "running" || osvStatus === "done" || (osvStatus === "error" && osvState.logs.length > 0)) ? (
+        <div className="mb-4 rounded-lg border border-green-700/60 bg-neutral-900 overflow-hidden">
+            {/* Header + progress bar */}
+            <div className="px-4 py-2 flex items-center gap-3 bg-green-900/40">
+                <FontAwesomeIcon icon={faLeaf} className="text-green-400" />
+                <span className="text-sm font-semibold text-green-200">
+                    OSV Scan {osvStatus === "running" ? "in progress" : osvStatus === "error" ? "failed" : "complete"}
+                </span>
+                <span className="text-xs text-green-300/80 ml-auto">
+                    {osvState.progress ?? ""}
+                    {osvState.total > 0 && ` (${osvPct}%)`}
+                </span>
+                {osvStatus !== "running" && (
+                    <button onClick={osvDismiss} title="Close" className="text-neutral-400 hover:text-white transition-colors ml-1">
+                        <FontAwesomeIcon icon={faXmark} className="text-sm" />
+                    </button>
+                )}
+            </div>
+            {/* Progress bar */}
+            <div className="w-full h-2 bg-neutral-800">
+                <div
+                    className={[
+                        "h-full transition-all duration-500 ease-out",
+                        osvStatus === "done" ? "bg-green-500" : "bg-green-500",
+                    ].join(" ")}
+                    style={{ width: `${osvPct}%` }}
+                />
+            </div>
+            {/* Log box */}
+            <div ref={osvLogBoxRef} className="max-h-52 overflow-y-auto px-4 py-2 font-mono text-xs text-neutral-300 space-y-0.5 scrollbar-thin scrollbar-thumb-neutral-700">
+                {osvState.logs.length === 0 && osvStatus === "running" && (
+                    <div className="text-neutral-500 italic">Waiting for first results…</div>
+                )}
+                {osvState.logs.map((line, i) => (
+                    <div key={i} className={line.startsWith("[") && line.includes("ERROR") ? "text-red-400" : line.startsWith("✓") ? "text-green-400 font-semibold" : ""}>
+                        {line}
+                    </div>
+                ))}
+            </div>
         </div>
     ) : null;
 
     if (loading) {
         return (
-            <div className="max-w-7xl mx-auto py-6">
-                <div className="flex items-center justify-between mb-6">
-                    <h1 className="text-2xl font-bold text-gray-800 dark:text-neutral-100">Scan History</h1>
-                    {scanButton}
-                </div>
+            <div className="w-full px-6 py-6">
+                {menuBar}
+                {grypeProgressPanel}
+                {nvdProgressPanel}
+                {osvProgressPanel}
                 <div className="flex items-center justify-center h-32 text-gray-400">
                     Loading scan history…
                 </div>
@@ -662,11 +1262,11 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
     }
     if (error) {
         return (
-            <div className="max-w-7xl mx-auto py-6">
-                <div className="flex items-center justify-between mb-6">
-                    <h1 className="text-2xl font-bold text-gray-800 dark:text-neutral-100">Scan History</h1>
-                    {scanButton}
-                </div>
+            <div className="w-full px-6 py-6">
+                {menuBar}
+                {grypeProgressPanel}
+                {nvdProgressPanel}
+                {osvProgressPanel}
                 <div className="flex items-center justify-center h-32 text-red-400">
                     {error}
                 </div>
@@ -675,11 +1275,11 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
     }
     if (scans.length === 0) {
         return (
-            <div className="max-w-7xl mx-auto py-6">
-                <div className="flex items-center justify-between mb-6">
-                    <h1 className="text-2xl font-bold text-gray-800 dark:text-neutral-100">Scan History</h1>
-                    {scanButton}
-                </div>
+            <div className="w-full px-6 py-6">
+                {menuBar}
+                {grypeProgressPanel}
+                {nvdProgressPanel}
+                {osvProgressPanel}
                 <div className="flex items-center justify-center h-32 text-gray-400 dark:text-neutral-400">
                     No scans found.
                 </div>
@@ -692,111 +1292,341 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
             {openDiffId && (
                 <DiffModal scanId={openDiffId} scanType={openDiffType} onClose={() => setOpenDiffId(null)} />
             )}
+            {openGlobalId && (
+                <GlobalResultModal scanId={openGlobalId} onClose={() => setOpenGlobalId(null)} />
+            )}
+            <ConfirmationModal
+                isOpen={deletingId !== null}
+                title="Delete Scan"
+                message="Are you sure you want to delete this scan? Associated observations and orphaned findings will be removed. This action cannot be undone."
+                confirmText="Yes, delete"
+                cancelText="Cancel"
+                showTitleIcon={true}
+                onConfirm={() => { if (deletingId) handleDeleteScan(deletingId); }}
+                onCancel={() => setDeletingId(null)}
+            />
 
-            <div className="max-w-7xl mx-auto py-6">
-                <div className="flex items-center justify-between mb-6">
-                    <h1 className="text-2xl font-bold text-gray-800 dark:text-neutral-100">
-                        Scan History
-                    </h1>
-                    {scanButton}
-                </div>
+            <div className="w-full px-6 py-6">
+                {menuBar}
+                {grypeProgressPanel}
+                {nvdProgressPanel}
+                {osvProgressPanel}
 
-                <ol className="relative border-l-2 border-cyan-700 dark:border-cyan-600">
-                    {scans.map((scan, index) => (
-                        <li key={scan.id} className="mb-8 ml-6">
-                            {/* Connector dot */}
-                            <span className={[
-                                "absolute -left-3 flex items-center justify-center",
-                                "w-6 h-6 rounded-full ring-4",
-                                "ring-gray-200 dark:ring-neutral-800",
-                                index === 0
-                                    ? "bg-cyan-600"
-                                    : "bg-neutral-400 dark:bg-neutral-600",
-                            ].join(' ')} />
+                {/* Timeline rows */}
+                <div className="relative">
+                    {filteredScans.map((scan, index) => {
+                        const isTool = (scan.scan_type || "sbom") === "tool";
+                        const isFirst = index === 0;
+                        const isLast = index === filteredScans.length - 1;
 
-                            <div className="p-4 bg-white dark:bg-neutral-700 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-600">
+                        return (
+                        <div key={scan.id} className="flex items-stretch mb-0">
+                            {/* Lane indicator — single linear column */}
+                            <div className="flex-shrink-0 relative" style={{ width: LANE_W, minHeight: 80 }}>
+                                {/* Vertical line */}
+                                <div
+                                    className="absolute border-l-2 border-cyan-700 dark:border-cyan-600"
+                                    style={{ left: mainCX, top: isFirst ? "50%" : 0, bottom: isLast ? "50%" : 0 }}
+                                />
+
+                                {/* Dot: circle for SBOM, colored square for tool scans */}
+                                {!isTool ? (
+                                    <span
+                                        className={[
+                                            "absolute flex items-center justify-center",
+                                            "w-5 h-5 rounded-full ring-[3px]",
+                                            "ring-gray-200 dark:ring-neutral-800",
+                                            isFirst ? "bg-cyan-500" : "bg-cyan-700",
+                                        ].join(" ")}
+                                        style={{ left: mainCX, top: "50%", transform: "translate(-50%, -50%)" }}
+                                    />
+                                ) : (
+                                    <span
+                                        className={[
+                                            "absolute flex items-center justify-center",
+                                            "w-3 h-3 rounded-sm ring-2",
+                                            "ring-gray-200 dark:ring-neutral-800",
+                                            sourceSquareColor[scan.scan_source ?? ""] ?? "bg-neutral-400",
+                                        ].join(" ")}
+                                        style={{ left: mainCX, top: "50%", transform: "translate(-50%, -50%)" }}
+                                    />
+                                )}
+                            </div>
+
+                            {/* Scan card */}
+                            <div className="flex-1 min-w-0 py-2 pl-3">
+                            <div className="group/card relative p-4 bg-white dark:bg-neutral-700 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-600">
+                                {/* Delete button — top-right corner */}
+                                <button
+                                    onClick={() => setDeletingId(scan.id)}
+                                    title="Delete scan"
+                                    className="absolute top-2 right-2 z-10 opacity-0 group-hover/card:opacity-100 text-neutral-400 hover:text-red-400 transition-all p-1"
+                                >
+                                    <FontAwesomeIcon icon={faTrash} className="text-sm" />
+                                </button>
                                 {/* Row 1: timestamp + scan type badge */}
                                 <div className="flex items-center gap-2 mb-1">
                                     <time className="text-sm font-semibold text-gray-500 dark:text-neutral-400">
                                         {formatDate(scan.timestamp)}
                                     </time>
-                                    {(scan.scan_type || 'sbom') === 'tool' && (
+                                    {(scan.scan_type || 'sbom') === 'tool' && scan.scan_source === 'osv' ? (
+                                        <>
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+                                            <FontAwesomeIcon icon={faCrosshairs} className="mr-1" />
+                                            Vulnerability Scan
+                                        </span>
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300">
+                                            <FontAwesomeIcon icon={faLeaf} className="mr-1" />
+                                            OSV Scan
+                                        </span>
+                                        </>
+                                    ) : (scan.scan_type || 'sbom') === 'tool' && scan.scan_source === 'nvd' ? (
+                                        <>
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+                                            <FontAwesomeIcon icon={faCrosshairs} className="mr-1" />
+                                            Vulnerability Scan
+                                        </span>
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300">
+                                            <FontAwesomeIcon icon={faShieldHalved} className="mr-1" />
+                                            NVD CPE Scan
+                                        </span>
+                                        </>
+                                    ) : (scan.scan_type || 'sbom') === 'tool' ? (
+                                        <>
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+                                            <FontAwesomeIcon icon={faCrosshairs} className="mr-1" />
+                                            Vulnerability Scan
+                                        </span>
                                         <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
                                             <FontAwesomeIcon icon={faBug} className="mr-1" />
-                                            Tool Scan
+                                            Grype Scan
                                         </span>
+                                        </>
+                                    ) : (
+                                        <>
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
+                                            <FontAwesomeIcon icon={faFile} className="mr-1" />
+                                            Import SBOM
+                                        </span>
+                                        {(scan.formats || []).map((fmt: string) => (
+                                            <span key={fmt} className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-50 text-cyan-600 dark:bg-cyan-900/20 dark:text-cyan-400">
+                                                {fmt}
+                                            </span>
+                                        ))}
+                                        </>
                                     )}
                                 </div>
 
-                                {/* Row 2: badges + details button */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                        {scan.is_first ? (
-                                            /* First scan: total counts */
-                                            <>
-                                                {(scan.scan_type || 'sbom') !== 'tool' && (
-                                                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
-                                                    {(scan.package_count ?? 0).toLocaleString()} packages
-                                                </span>
-                                                )}
-                                                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
-                                                    {(scan.finding_count ?? 0).toLocaleString()} findings
-                                                </span>
-                                                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300">
-                                                    {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities
-                                                </span>
-                                            </>
-                                        ) : (
-                                            /* Subsequent scans: diff badges */
-                                            <>
-                                                {(scan.scan_type || 'sbom') !== 'tool' && (
-                                                <>
-                                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    +{(scan.packages_added ?? 0).toLocaleString()} packages
-                                                </span>
-                                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    −{(scan.packages_removed ?? 0).toLocaleString()} packages
-                                                </span>
-                                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    ↑{(scan.packages_upgraded ?? 0).toLocaleString()} packages upgraded
-                                                </span>
-                                                </>
-                                                )}
-                                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    +{(scan.findings_added ?? 0).toLocaleString()} findings
-                                                </span>
-                                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    −{(scan.findings_removed ?? 0).toLocaleString()} findings
-                                                </span>
-                                                {(scan.scan_type || 'sbom') !== 'tool' && (
-                                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    ↑{(scan.findings_upgraded ?? 0).toLocaleString()} findings upgraded
-                                                </span>
-                                                )}
-                                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    +{(scan.vulns_added ?? 0).toLocaleString()} vulnerabilities
-                                                </span>
-                                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                    −{(scan.vulns_removed ?? 0).toLocaleString()} vulnerabilities
-                                                </span>
-                                            </>
-                                        )}
-
-                                        {/* Details button */}
-                                        <button
-                                            onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
-                                            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
-                                        >
-                                            Details
-                                        </button>
-                                    </div>
-
                                 {/* Project / Variant */}
-                                <p className="text-base font-medium text-gray-800 dark:text-neutral-100">
+                                <p className="text-sm font-medium text-gray-800 dark:text-neutral-100 mb-1">
                                     {scan.project_name
                                         ? <><span className="text-neutral-500 dark:text-neutral-400">{scan.project_name}</span><span className="mx-1 text-neutral-400">/</span><span>{scan.variant_name ?? scan.variant_id}</span></>
                                         : <span>{scan.variant_name ?? scan.variant_id}</span>
                                     }
                                 </p>
+
+                                {/* Row 2: badges + details button */}
+                                {(scan.scan_type || 'sbom') === 'tool' && (
+                                <>
+                                {/* Update Vulnerabilities row */}
+                                <div className="flex items-center gap-2 flex-wrap mb-1">
+                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Update Vulnerabilities:</span>
+                                    {scan.is_first ? (
+                                        <>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
+                                            </span>
+                                            {scan.newly_detected_vulns != null && (
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_vulns > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                {scan.newly_detected_vulns.toLocaleString()} new vulnerabilities discovered
+                                            </span>
+                                            )}
+                                        </>
+                                    ) : (
+                                        <>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                +{(scan.vulns_added ?? 0).toLocaleString()} vulnerabilities detected
+                                            </span>
+                                            {scan.newly_detected_vulns != null && (
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_vulns > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                {scan.newly_detected_vulns.toLocaleString()} new vulnerabilities discovered
+                                            </span>
+                                            )}
+                                        </>
+                                    )}
+                                </div>
+                                {/* Update Findings row */}
+                                <div className="flex items-center gap-2 flex-wrap mb-1">
+                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Update Findings:</span>
+                                    {scan.is_first ? (
+                                        <>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                {(scan.finding_count ?? 0).toLocaleString()} findings detected
+                                            </span>
+                                            {scan.newly_detected_findings != null && (
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_findings > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                {scan.newly_detected_findings.toLocaleString()} new findings discovered
+                                            </span>
+                                            )}
+                                        </>
+                                    ) : (
+                                        <>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                +{(scan.findings_added ?? 0).toLocaleString()} findings detected
+                                            </span>
+                                            {scan.newly_detected_findings != null && (
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_findings > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                {scan.newly_detected_findings.toLocaleString()} new findings discovered
+                                            </span>
+                                            )}
+                                        </>
+                                    )}
+
+                                    {/* Details button */}
+                                    <button
+                                        onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
+                                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
+                                    >
+                                        Details
+                                    </button>
+                                </div>
+                                </>
+                                )}
+                                {(scan.scan_type || 'sbom') !== 'tool' && (
+                                <>
+                                {/* Vulnerabilities row */}
+                                <div className="flex items-center gap-2 flex-wrap mb-1">
+                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Vulnerabilities:</span>
+                                    {scan.is_first ? (
+                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                            {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
+                                        </span>
+                                    ) : (
+                                        <>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                +{(scan.vulns_added ?? 0).toLocaleString()} vulnerabilities detected
+                                            </span>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                −{(scan.vulns_removed ?? 0).toLocaleString()} vulnerabilities detected
+                                            </span>
+                                        </>
+                                    )}
+                                </div>
+                                {/* Findings row */}
+                                <div className="flex items-center gap-2 flex-wrap mb-1">
+                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Findings:</span>
+                                    {scan.is_first ? (
+                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                            {(scan.finding_count ?? 0).toLocaleString()} findings detected
+                                        </span>
+                                    ) : (
+                                        <>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                +{(scan.findings_added ?? 0).toLocaleString()} findings detected
+                                            </span>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                −{(scan.findings_removed ?? 0).toLocaleString()} findings detected
+                                            </span>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                ↑{(scan.findings_upgraded ?? 0).toLocaleString()} findings upgraded
+                                            </span>
+                                        </>
+                                    )}
+                                </div>
+                                {/* Packages row */}
+                                <div className="flex items-center gap-2 flex-wrap mb-1">
+                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Packages:</span>
+                                    {scan.is_first ? (
+                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                            {(scan.package_count ?? 0).toLocaleString()} packages
+                                        </span>
+                                    ) : (
+                                        <>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                +{(scan.packages_added ?? 0).toLocaleString()} packages
+                                            </span>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                −{(scan.packages_removed ?? 0).toLocaleString()} packages
+                                            </span>
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                ↑{(scan.packages_upgraded ?? 0).toLocaleString()} packages upgraded
+                                            </span>
+                                        </>
+                                    )}
+                                    {/* Details button */}
+                                    <button
+                                        onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
+                                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
+                                    >
+                                        Details
+                                    </button>
+                                </div>
+
+                                {/* SBOM Result row */}
+                                <div className="flex items-center gap-2 flex-wrap mb-1 mt-2 pt-2 border-t border-neutral-300 dark:border-neutral-600">
+                                    <span className="text-xs font-bold text-cyan-400 uppercase tracking-wide">SBOM Result:</span>
+                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                        {(scan.package_count ?? 0).toLocaleString()} packages
+                                    </span>
+                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                        {(scan.finding_count ?? 0).toLocaleString()} findings detected
+                                    </span>
+                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                        {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
+                                    </span>
+                                    <button
+                                        onClick={() => setOpenGlobalId(scan.id)}
+                                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
+                                    >
+                                        Details
+                                    </button>
+                                </div>
+
+                                {/* Scan Result (SBOM ∪ all tool scans) — only when tool scans exist */}
+                                {scan.global_finding_count != null && (
+                                    <div className="flex items-center gap-2 flex-wrap mb-1 mt-2 pt-2 border-t border-neutral-300 dark:border-neutral-600">
+                                        <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Scan Result:</span>
+                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                            {(scan.global_package_count ?? 0).toLocaleString()} packages
+                                        </span>
+                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                            {(scan.global_finding_count ?? 0).toLocaleString()} findings detected
+                                        </span>
+                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                            {(scan.global_vuln_count ?? 0).toLocaleString()} vulnerabilities detected
+                                        </span>
+                                        <button
+                                            onClick={() => setOpenGlobalId(scan.id)}
+                                            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
+                                        >
+                                            Details
+                                        </button>
+                                    </div>
+                                )}
+                                </>
+                                )}
+
+                                {/* Scan Result (tool scans only) — SBOM ∪ all sources */}
+                                {(scan.scan_type || 'sbom') === 'tool' && scan.global_finding_count != null && (
+                                    <div className="flex items-center gap-2 flex-wrap mb-1 mt-2 pt-2 border-t border-neutral-300 dark:border-neutral-600">
+                                        <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Scan Result:</span>
+                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                            {(scan.global_package_count ?? 0).toLocaleString()} packages
+                                        </span>
+                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                            {(scan.global_finding_count ?? 0).toLocaleString()} findings detected
+                                        </span>
+                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                            {(scan.global_vuln_count ?? 0).toLocaleString()} vulnerabilities detected
+                                        </span>
+                                        <button
+                                            onClick={() => setOpenGlobalId(scan.id)}
+                                            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
+                                        >
+                                            Details
+                                        </button>
+                                    </div>
+                                )}
 
                                 {/* Description row */}
                                 {editingDescId === scan.id ? (
@@ -843,9 +1673,11 @@ function ScanHistory({ variantId, projectId }: Readonly<Props>) {
                                     </div>
                                 )}
                             </div>
-                        </li>
-                    ))}
-                </ol>
+                            </div>
+                        </div>
+                        );
+                    })}
+                </div>
             </div>
         </>
     );

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -51,11 +51,13 @@ function FindingDiffTable({ entries, label, colorClass }: {
     colorClass: string;
 }) {
     const [filter, setFilter] = useState('');
+    const hasOrigin = entries.some(e => e.origin);
     const filtered = filter
         ? entries.filter(e =>
             e.package_name.toLowerCase().includes(filter.toLowerCase()) ||
             e.package_version.toLowerCase().includes(filter.toLowerCase()) ||
-            e.vulnerability_id.toLowerCase().includes(filter.toLowerCase())
+            e.vulnerability_id.toLowerCase().includes(filter.toLowerCase()) ||
+            (e.origin || '').toLowerCase().includes(filter.toLowerCase())
         )
         : entries;
 
@@ -83,6 +85,7 @@ function FindingDiffTable({ entries, label, colorClass }: {
                                 <th className="px-3 py-2">Package</th>
                                 <th className="px-3 py-2">Version</th>
                                 <th className="px-3 py-2">Vulnerability</th>
+                                {hasOrigin && <th className="px-3 py-2">Origin</th>}
                             </tr>
                         </thead>
                         <tbody>
@@ -91,6 +94,7 @@ function FindingDiffTable({ entries, label, colorClass }: {
                                     <td className="px-3 py-1.5 font-mono">{e.package_name}</td>
                                     <td className="px-3 py-1.5 font-mono text-gray-400">{e.package_version}</td>
                                     <td className="px-3 py-1.5 font-mono">{e.vulnerability_id}</td>
+                                    {hasOrigin && <td className="px-3 py-1.5 text-gray-400">{e.origin ?? ''}</td>}
                                 </tr>
                             ))}
                         </tbody>
@@ -273,14 +277,19 @@ function PackageUpgradeDiffTable({ entries, label, colorClass }: {
     );
 }
 
-function VulnDiffList({ vulns, label, colorClass }: {
+function VulnDiffList({ vulns, label, colorClass, originMap }: {
     vulns: string[];
     label: string;
     colorClass: string;
+    originMap?: Record<string, string[]>;
 }) {
     const [filter, setFilter] = useState('');
+    const hasOrigin = !!originMap && Object.keys(originMap).length > 0;
     const filtered = filter
-        ? vulns.filter(v => v.toLowerCase().includes(filter.toLowerCase()))
+        ? vulns.filter(v =>
+            v.toLowerCase().includes(filter.toLowerCase()) ||
+            (originMap?.[v] || []).some(o => o.toLowerCase().includes(filter.toLowerCase()))
+        )
         : vulns;
 
     return (
@@ -307,12 +316,14 @@ function VulnDiffList({ vulns, label, colorClass }: {
                         <thead className="sticky top-0 bg-gray-800 text-gray-300 uppercase">
                             <tr>
                                 <th className="px-3 py-2">CVE / Vulnerability ID</th>
+                                {hasOrigin && <th className="px-3 py-2">Origin</th>}
                             </tr>
                         </thead>
                         <tbody>
                             {filtered.map((v) => (
                                 <tr key={v} className="border-t border-gray-600 hover:bg-gray-600/40">
                                     <td className="px-3 py-1.5 font-mono">{v}</td>
+                                    {hasOrigin && <td className="px-3 py-1.5 text-gray-400">{(originMap?.[v] || []).join(', ')}</td>}
                                 </tr>
                             ))}
                         </tbody>
@@ -723,13 +734,25 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
                                     label={diff.is_first ? "All vulnerabilities" : "New vulnerabilities"}
                                     colorClass="text-green-400"
                                 />
-                                {!diff.is_first && (
-                                    <VulnDiffList
-                                        vulns={diff.vulns_removed}
-                                        label="Removed vulnerabilities"
-                                        colorClass="text-red-400"
-                                    />
-                                )}
+                                {!diff.is_first && (() => {
+                                    // Build origin map from findings_removed
+                                    const originMap: Record<string, string[]> = {};
+                                    for (const f of diff.findings_removed) {
+                                        if (f.origin) {
+                                            const origins = originMap[f.vulnerability_id] || [];
+                                            if (!origins.includes(f.origin)) origins.push(f.origin);
+                                            originMap[f.vulnerability_id] = origins;
+                                        }
+                                    }
+                                    return (
+                                        <VulnDiffList
+                                            vulns={diff.vulns_removed}
+                                            label="Removed vulnerabilities"
+                                            colorClass="text-red-400"
+                                            originMap={originMap}
+                                        />
+                                    );
+                                })()}
                             </>
                         )}
                         {diff && section === 'newly_detected' && isToolScan && (

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1501,8 +1501,8 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                         </>
                                     ) : (
                                         <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                +{(scan.vulns_added ?? 0).toLocaleString()} vulnerabilities detected
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                {(scan.vulns_added ?? 0).toLocaleString()} vulnerabilities detected
                                             </span>
                                             {scan.newly_detected_vulns != null && (
                                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_vulns > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
@@ -1528,8 +1528,8 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                         </>
                                     ) : (
                                         <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                +{(scan.findings_added ?? 0).toLocaleString()} findings detected
+                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
+                                                {(scan.findings_added ?? 0).toLocaleString()} findings detected
                                             </span>
                                             {scan.newly_detected_findings != null && (
                                             <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_findings > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -253,9 +253,9 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
       const uploadId = result.upload_id;
       const poll = async () => {
         for (let i = 0; i < 600; i++) {
-          if (unmountedRef.current) return;
+          if (unmountedRef.current) { onLoadingMessage?.(null); return; }
           await new Promise((r) => setTimeout(r, 1000));
-          if (unmountedRef.current) return;
+          if (unmountedRef.current) { onLoadingMessage?.(null); return; }
           const status = await Variants.getUploadStatus(uploadId);
           if (status.status === "done") {
             setImportFiles([]);

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -387,6 +387,8 @@ def init_app(app) -> None:
     app.cli.add_command(list_projects_command)
     app.cli.add_command(list_scans_command)
     app.cli.add_command(delete_scan_command)
+    app.cli.add_command(nvd_scan_command)
+    app.cli.add_command(osv_scan_command)
 
 
 @click.command("export")
@@ -1015,6 +1017,413 @@ def list_scans_command(json_format: bool = False):
 def delete_scan_command(scan_id: uuid.UUID):
     ScanController.delete(scan_id)
     click.echo(f"Successfully deleted scan {scan_id}")
+
+
+@click.command("nvd-scan")
+@click.option("--project", "-p", required=True, help="Project name.")
+@click.option("--variant", "-v", default=None,
+              help=f"Variant name (defaults to '{DEFAULT_VARIANT_NAME}').")
+@with_appcontext
+def nvd_scan_command(project: str, variant: str | None) -> None:
+    """Run an NVD CPE-based vulnerability scan for the given project/variant.
+
+    Queries the NVD API for every CPE found in the variant's active packages
+    and creates findings/observations in a new tool scan.
+    """
+    from ..controllers.nvd_db import NVD_DB
+    from ..models.vulnerability import Vulnerability as VulnModel
+    from ..models.metrics import Metrics as MetricsModel
+    from ..models.cvss import CVSS
+    from ..models.assessment import Assessment
+    from ..models.package import Package
+
+    variant_name = variant or DEFAULT_VARIANT_NAME
+    project_obj = ProjectController.get_or_create(project)
+    variant_obj = VariantController.get_or_create(variant_name, project_obj.id)
+    variant_uuid = variant_obj.id
+
+    nvd_api_key = os.getenv("NVD_API_KEY")
+    nvd = NVD_DB(nvd_api_key=nvd_api_key)
+
+    # 1. Get active packages for this variant
+    click.echo("Resolving active packages…")
+    latest_rows = _db.session.execute(
+        _db.select(ScanModel.id, ScanModel.scan_type)
+        .where(ScanModel.variant_id == variant_uuid)
+        .order_by(ScanModel.timestamp.desc())
+    ).all()
+    latest_ids: list = []
+    seen_types: set = set()
+    for sid, stype in latest_rows:
+        st = stype or "sbom"
+        if st not in seen_types:
+            seen_types.add(st)
+            latest_ids.append(sid)
+        if len(seen_types) >= 2:
+            break
+
+    if not latest_ids:
+        raise click.ClickException("No scans found for variant")
+
+    from ..routes.scans import _packages_by_scan_ids
+    pkg_sets = _packages_by_scan_ids(latest_ids)
+    all_pkg_ids: set = set()
+    for s in pkg_sets.values():
+        all_pkg_ids |= s
+
+    if not all_pkg_ids:
+        raise click.ClickException("No packages found for variant")
+
+    packages = _db.session.execute(
+        _db.select(Package).where(Package.id.in_(all_pkg_ids))
+    ).scalars().all()
+
+    # 2. Collect CPE names from packages
+    _valid_cpe_parts = {"a", "o", "h"}
+    cpe_to_pkgs: dict = {}
+    for pkg in packages:
+        for cpe in (pkg.cpe or []):
+            parts = cpe.split(":")
+            if (len(parts) >= 6
+                    and parts[2] in _valid_cpe_parts
+                    and parts[4] != "*"):
+                cpe_to_pkgs.setdefault(cpe, []).append(pkg)
+
+    if not cpe_to_pkgs:
+        raise click.ClickException(
+            "No packages with valid CPE identifiers"
+        )
+
+    click.echo(
+        f"Found {len(packages)} packages with "
+        f"{len(cpe_to_pkgs)} unique CPEs to query"
+    )
+
+    # 3. Create a tool scan
+    scan = ScanModel.create(
+        description="empty description",
+        variant_id=variant_uuid,
+        scan_type="tool",
+        scan_source="nvd",
+    )
+    total_cpes = len(cpe_to_pkgs)
+    cves_found: set = set()
+    observation_pairs: set = set()
+    assessed_findings: set = set()
+
+    for idx, (cpe_name, pkgs) in enumerate(cpe_to_pkgs.items(), 1):
+        click.echo(f"[{idx}/{total_cpes}] Querying {cpe_name}…")
+        try:
+            cpe_parts = cpe_name.split(":")
+            has_wildcards = (
+                len(cpe_parts) >= 6
+                and (cpe_parts[3] == "*" or cpe_parts[5] == "*")
+            )
+            nvd_vulns = nvd.api_get_cves_by_cpe(
+                cpe_name,
+                results_per_page=100,
+                use_virtual_match=has_wildcards,
+            )
+        except Exception as e:
+            click.echo(
+                f"[{idx}/{total_cpes}] ERROR {cpe_name}: {str(e)[:200]}",
+                err=True,
+            )
+            continue
+
+        cpe_cves = [
+            v.get("cve", {}).get("id", "")
+            for v in nvd_vulns if v.get("cve", {}).get("id")
+        ]
+        if cpe_cves:
+            ids_str = ', '.join(cpe_cves[:10])
+            ellip = '…' if len(cpe_cves) > 10 else ''
+            click.echo(
+                f"[{idx}/{total_cpes}] {cpe_name} → "
+                f"{len(cpe_cves)} CVE(s): {ids_str}{ellip}"
+            )
+        else:
+            click.echo(f"[{idx}/{total_cpes}] {cpe_name} → no CVEs")
+
+        for nvd_vuln in nvd_vulns:
+            cve = nvd_vuln.get("cve", {})
+            cve_id = cve.get("id", "")
+            if not cve_id:
+                continue
+
+            cves_found.add(cve_id)
+            details = NVD_DB.extract_cve_details(cve)
+
+            existing_vuln = _db.session.get(VulnModel, cve_id.upper())
+            if existing_vuln is None:
+                existing_vuln = VulnModel.create_record(
+                    id=cve_id,
+                    description=details.get("description"),
+                    status=details.get("status"),
+                    publish_date=details.get("publish_date"),
+                    attack_vector=details.get("attack_vector"),
+                    links=details.get("links"),
+                    weaknesses=details.get("weaknesses"),
+                    nvd_last_modified=details.get("nvd_last_modified"),
+                )
+                existing_vuln.add_found_by("nvd")
+            else:
+                existing_vuln.add_found_by("nvd")
+                _update = {}
+                if not existing_vuln.description and details.get("description"):
+                    _update["description"] = details["description"]
+                if not existing_vuln.status and details.get("status"):
+                    _update["status"] = details["status"]
+                if not existing_vuln.publish_date and details.get("publish_date"):
+                    _update["publish_date"] = details["publish_date"]
+                if not existing_vuln.attack_vector and details.get("attack_vector"):
+                    _update["attack_vector"] = details["attack_vector"]
+                if not existing_vuln.links and details.get("links"):
+                    _update["links"] = details["links"]
+                if not existing_vuln.weaknesses and details.get("weaknesses"):
+                    _update["weaknesses"] = details["weaknesses"]
+                if _update:
+                    existing_vuln.update_record(**_update, commit=False)
+
+            # Persist CVSS metrics
+            if details.get("base_score") is not None:
+                _cvss_v = details.get("cvss_version")
+                _cvss_s = details["base_score"]
+                _cvss_vec = details.get("cvss_vector")
+                _dedup = (cve_id.upper(), _cvss_v, float(_cvss_s))
+                if _dedup not in MetricsModel._seen:
+                    try:
+                        MetricsModel.from_cvss(
+                            CVSS(
+                                version=_cvss_v or "",
+                                vector_string=_cvss_vec or "",
+                                author="nvd",
+                                base_score=float(_cvss_s),
+                                exploitability_score=(
+                                    float(details["cvss_exploitability"])
+                                    if details.get("cvss_exploitability") is not None
+                                    else 0
+                                ),
+                                impact_score=(
+                                    float(details["cvss_impact"])
+                                    if details.get("cvss_impact") is not None
+                                    else 0
+                                ),
+                            ),
+                            existing_vuln.id,
+                        )
+                    except Exception:
+                        pass
+
+            for pkg in pkgs:
+                finding = FindingModel.get_or_create(pkg.id, cve_id)
+                pair = (finding.id, scan.id)
+                if pair not in observation_pairs:
+                    observation_pairs.add(pair)
+                    Observation.create(
+                        finding_id=finding.id, scan_id=scan.id, commit=False,
+                    )
+                fv_key = (finding.id, variant_uuid)
+                if fv_key not in assessed_findings:
+                    assessed_findings.add(fv_key)
+                    has_assess = _db.session.execute(
+                        _db.select(Assessment.id).where(
+                            Assessment.finding_id == finding.id,
+                            Assessment.variant_id == variant_uuid,
+                        ).limit(1)
+                    ).scalar_one_or_none()
+                    if has_assess is None:
+                        Assessment.create(
+                            status="under_investigation",
+                            simplified_status="Pending Assessment",
+                            finding_id=finding.id,
+                            variant_id=variant_uuid,
+                            origin="nvd",
+                            commit=False,
+                        )
+
+    _db.session.commit()
+    click.echo(
+        f"✓ Scan complete — found {len(cves_found)} unique CVEs "
+        f"across {total_cpes} CPEs"
+    )
+
+
+@click.command("osv-scan")
+@click.option("--project", "-p", required=True, help="Project name.")
+@click.option("--variant", "-v", default=None,
+              help=f"Variant name (defaults to '{DEFAULT_VARIANT_NAME}').")
+@with_appcontext
+def osv_scan_command(project: str, variant: str | None) -> None:
+    """Run an OSV PURL-based vulnerability scan for the given project/variant.
+
+    Queries the OSV.dev API for every PURL found in the variant's active
+    packages and creates findings/observations in a new tool scan.
+    """
+    from ..controllers.osv_client import OSVClient
+    from ..models.vulnerability import Vulnerability as VulnModel
+    from ..models.assessment import Assessment
+    from ..models.package import Package
+
+    variant_name = variant or DEFAULT_VARIANT_NAME
+    project_obj = ProjectController.get_or_create(project)
+    variant_obj = VariantController.get_or_create(variant_name, project_obj.id)
+    variant_uuid = variant_obj.id
+
+    osv = OSVClient()
+
+    # 1. Get active packages for this variant
+    click.echo("Resolving active packages…")
+    latest_rows = _db.session.execute(
+        _db.select(ScanModel.id, ScanModel.scan_type)
+        .where(ScanModel.variant_id == variant_uuid)
+        .order_by(ScanModel.timestamp.desc())
+    ).all()
+    latest_ids: list = []
+    seen_types: set = set()
+    for sid, stype in latest_rows:
+        st = stype or "sbom"
+        if st not in seen_types:
+            seen_types.add(st)
+            latest_ids.append(sid)
+        if len(seen_types) >= 2:
+            break
+
+    if not latest_ids:
+        raise click.ClickException("No scans found for variant")
+
+    from ..routes.scans import _packages_by_scan_ids
+    pkg_sets = _packages_by_scan_ids(latest_ids)
+    all_pkg_ids: set = set()
+    for s in pkg_sets.values():
+        all_pkg_ids |= s
+
+    if not all_pkg_ids:
+        raise click.ClickException("No packages found for variant")
+
+    packages = _db.session.execute(
+        _db.select(Package).where(Package.id.in_(all_pkg_ids))
+    ).scalars().all()
+
+    # 2. Collect packages with PURL identifiers
+    pkg_purl_list: list[tuple] = []
+    seen_purls: set = set()
+    for pkg in packages:
+        for purl in (pkg.purl or []):
+            purl_str = str(purl).strip()
+            if purl_str and purl_str.startswith("pkg:") and purl_str not in seen_purls:
+                seen_purls.add(purl_str)
+                pkg_purl_list.append((purl_str, pkg))
+                break
+
+    if not pkg_purl_list:
+        raise click.ClickException(
+            "No packages with valid PURL identifiers"
+        )
+
+    total_pkgs = len(pkg_purl_list)
+    click.echo(
+        f"Found {len(packages)} packages, "
+        f"{total_pkgs} with PURL identifiers to query"
+    )
+
+    # 3. Create a tool scan
+    scan = ScanModel.create(
+        description="empty description",
+        variant_id=variant_uuid,
+        scan_type="tool",
+        scan_source="osv",
+    )
+    vulns_found: set = set()
+    observation_pairs: set = set()
+    assessed_findings: set = set()
+
+    for idx, (purl_str, pkg) in enumerate(pkg_purl_list, 1):
+        pkg_label = f"{pkg.name}@{pkg.version}" if pkg.name else purl_str
+        click.echo(f"[{idx}/{total_pkgs}] Querying {pkg_label}…")
+        try:
+            osv_vulns = osv.query_by_purl(purl_str)
+        except Exception as e:
+            click.echo(
+                f"[{idx}/{total_pkgs}] ERROR {pkg_label}: {str(e)[:200]}",
+                err=True,
+            )
+            continue
+
+        vuln_ids = [v.get("id", "") for v in osv_vulns if v.get("id")]
+        if vuln_ids:
+            ids_str = ', '.join(vuln_ids[:10])
+            ellip = '…' if len(vuln_ids) > 10 else ''
+            click.echo(
+                f"[{idx}/{total_pkgs}] {pkg_label} → "
+                f"{len(vuln_ids)} vuln(s): {ids_str}{ellip}"
+            )
+        else:
+            click.echo(f"[{idx}/{total_pkgs}] {pkg_label} → no vulnerabilities")
+
+        for osv_vuln in osv_vulns:
+            vuln_id = osv_vuln.get("id", "")
+            if not vuln_id:
+                continue
+
+            all_ids = [vuln_id] + [
+                a for a in osv_vuln.get("aliases", [])
+                if a.startswith("CVE-")
+            ]
+            vulns_found.add(vuln_id)
+            osv_desc = osv_vuln.get("summary") or osv_vuln.get("details")
+
+            for vid in all_ids:
+                existing_vuln = _db.session.get(VulnModel, vid.upper())
+                if existing_vuln is None:
+                    existing_vuln = VulnModel.create_record(
+                        id=vid,
+                        description=osv_desc,
+                        links=[
+                            r.get("url")
+                            for r in osv_vuln.get("references", [])
+                            if r.get("url")
+                        ] or None,
+                    )
+                    existing_vuln.add_found_by("osv")
+                else:
+                    existing_vuln.add_found_by("osv")
+                    if not existing_vuln.description and osv_desc:
+                        existing_vuln.update_record(
+                            description=osv_desc, commit=False,
+                        )
+
+                finding = FindingModel.get_or_create(pkg.id, vid)
+                pair = (finding.id, scan.id)
+                if pair not in observation_pairs:
+                    observation_pairs.add(pair)
+                    Observation.create(
+                        finding_id=finding.id, scan_id=scan.id, commit=False,
+                    )
+                fv_key = (finding.id, variant_uuid)
+                if fv_key not in assessed_findings:
+                    assessed_findings.add(fv_key)
+                    has_assess = _db.session.execute(
+                        _db.select(Assessment.id).where(
+                            Assessment.finding_id == finding.id,
+                            Assessment.variant_id == variant_uuid,
+                        ).limit(1)
+                    ).scalar_one_or_none()
+                    if has_assess is None:
+                        Assessment.create(
+                            status="under_investigation",
+                            simplified_status="Pending Assessment",
+                            finding_id=finding.id,
+                            variant_id=variant_uuid,
+                            origin="osv",
+                            commit=False,
+                        )
+
+    _db.session.commit()
+    click.echo(
+        f"✓ Scan complete — found {len(vulns_found)} unique vulnerabilities "
+        f"across {total_pkgs} packages"
+    )
 
 
 def main() -> dict:

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -1079,14 +1079,13 @@ def nvd_scan_command(project: str, variant: str | None) -> None:
     ).scalars().all()
 
     # 2. Collect CPE names from packages
-    _valid_cpe_parts = {"a", "o", "h"}
+    # Accept any CPE with a non-wildcard product (parts[4]).
+    # Wildcard part/vendor/version are handled via virtualMatchString.
     cpe_to_pkgs: dict = {}
     for pkg in packages:
         for cpe in (pkg.cpe or []):
             parts = cpe.split(":")
-            if (len(parts) >= 6
-                    and parts[2] in _valid_cpe_parts
-                    and parts[4] != "*"):
+            if len(parts) >= 6 and parts[4] != "*":
                 cpe_to_pkgs.setdefault(cpe, []).append(pkg)
 
     if not cpe_to_pkgs:
@@ -1117,7 +1116,9 @@ def nvd_scan_command(project: str, variant: str | None) -> None:
             cpe_parts = cpe_name.split(":")
             has_wildcards = (
                 len(cpe_parts) >= 6
-                and (cpe_parts[3] == "*" or cpe_parts[5] == "*")
+                and (cpe_parts[2] == "*"
+                     or cpe_parts[3] == "*"
+                     or cpe_parts[5] == "*")
             )
             nvd_vulns = nvd.api_get_cves_by_cpe(
                 cpe_name,

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -215,8 +215,14 @@ def create_project_context(
 
     project_obj = ProjectController.get_or_create(project)
     variant_obj = VariantController.get_or_create(variant_name, project_obj.id)
-    scan = ScanController.create("empty description", variant_obj.id)
-    click.echo(f"project='{project}' variant='{variant_name}' scan={scan.id}")
+
+    # Determine scan type: if there are any SBOM inputs (spdx, cdx, yocto_cve)
+    # or openvex, it's an "sbom" scan.  Grype-only → "tool" scan.
+    has_sbom_inputs = bool(spdx_inputs or cdx_inputs or openvex_inputs or yocto_cve_inputs)
+    scan_type = "sbom" if has_sbom_inputs else "tool"
+
+    scan = ScanController.create("empty description", variant_obj.id, scan_type=scan_type)
+    click.echo(f"project='{project}' variant='{variant_name}' scan={scan.id} type={scan_type}")
 
     format_groups: list[tuple[tuple, str]] = [
         (spdx_inputs, "spdx"),

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -220,8 +220,11 @@ def create_project_context(
     # or openvex, it's an "sbom" scan.  Grype-only → "tool" scan.
     has_sbom_inputs = bool(spdx_inputs or cdx_inputs or openvex_inputs or yocto_cve_inputs)
     scan_type = "sbom" if has_sbom_inputs else "tool"
+    scan_description = "empty description"
+    scan_source = "grype" if (not has_sbom_inputs and grype_inputs) else None
 
-    scan = ScanController.create("empty description", variant_obj.id, scan_type=scan_type)
+    scan = ScanController.create(scan_description, variant_obj.id, scan_type=scan_type,
+                                 scan_source=scan_source)
     click.echo(f"project='{project}' variant='{variant_name}' scan={scan.id} type={scan_type}")
 
     format_groups: list[tuple[tuple, str]] = [

--- a/src/controllers/nvd_db.py
+++ b/src/controllers/nvd_db.py
@@ -101,6 +101,62 @@ class NVD_DB(BaseAPIClient):
             "If the issue persists after adding the API key, it may have been invalidated."
         )
 
+    def api_get_cves_by_cpe(
+        self,
+        cpe_name: str,
+        results_per_page: int = 100,
+        use_virtual_match: bool = False,
+    ) -> list[dict]:
+        """Query the NVD API for CVEs matching a CPE name.
+
+        When *use_virtual_match* is ``True`` the ``virtualMatchString``
+        parameter is sent instead of ``cpeName``.  This is required when
+        the CPE contains wildcard fields (e.g. vendor ``*``) because the
+        NVD ``cpeName`` parameter expects an entry from its CPE
+        dictionary, whereas ``virtualMatchString`` performs pattern
+        matching against CVE match criteria.
+
+        Returns a (possibly empty) list of CVE items from the NVD response.
+        Handles pagination transparently.
+        """
+        all_vulns: list[dict] = []
+        start_index = 0
+        first_request = True
+        while True:
+            retry = 0
+            status = 0
+            data: dict = {}
+            while retry <= 3:
+                # Rate-limit: skip sleep for the very first request of this CPE,
+                # sleep between retries / pagination pages.
+                if not first_request or retry > 0:
+                    time.sleep(max(6, 10 * retry))
+                first_request = False
+                param_key = (
+                    "virtualMatchString" if use_virtual_match
+                    else "cpeName"
+                )
+                status, data = self._call_nvd_api({
+                    param_key: cpe_name,
+                    "startIndex": start_index,
+                    "resultsPerPage": results_per_page,
+                })
+                if status == 200:
+                    break
+                elif status in self._NON_RETRYABLE_STATUSES:
+                    return all_vulns
+                else:
+                    retry += 1
+            if status != 200:
+                break
+            vulns = data.get("vulnerabilities", [])
+            all_vulns.extend(vulns)
+            total = data.get("totalResults", 0)
+            start_index += results_per_page
+            if start_index >= total:
+                break
+        return all_vulns
+
     def api_weaknesses_to_list_str(self, weaknesses: list) -> list[str]:
         """
         Convert a list of weaknesses obtained from API to a list of strings.
@@ -113,6 +169,106 @@ class NVD_DB(BaseAPIClient):
         Filter a list of references to get only the ones related to git patches.
         """
         return [x["url"] for x in references if "tags" in x and "Patch" in x["tags"]]
+
+    @staticmethod
+    def extract_cve_details(cve: dict) -> dict:
+        """Extract description, severity, links, weaknesses from an NVD CVE dict.
+
+        *cve* is the ``vulnerabilities[n]["cve"]`` object returned by the
+        NVD API v2.0.  Returns a dict with keys usable by
+        ``Vulnerability.update_record`` / ``create_record``.
+        """
+        # Description — prefer English
+        description = None
+        for desc in cve.get("descriptions", []):
+            if desc.get("lang", "").startswith("en"):
+                description = desc.get("value")
+                break
+        if description is None:
+            descs = cve.get("descriptions", [])
+            if descs:
+                description = descs[0].get("value")
+
+        # Severity label + base score — try CVSS v3.1, v3.0, v4.0, v2.0
+        severity = None
+        base_score = None
+        attack_vector = None
+        cvss_version = None
+        cvss_vector = None
+        cvss_exploitability = None
+        cvss_impact = None
+        metrics = cve.get("metrics", {})
+        _metric_version_map = {
+            "cvssMetricV31": "3.1",
+            "cvssMetricV30": "3.0",
+            "cvssMetricV40": "4.0",
+            "cvssMetricV2": "2.0",
+        }
+        for metric_key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV40", "cvssMetricV2"):
+            metric_list = metrics.get(metric_key, [])
+            if metric_list:
+                primary = next(
+                    (m for m in metric_list if m.get("type") == "Primary"),
+                    metric_list[0],
+                )
+                cvss_data = primary.get("cvssData", {})
+                severity = (
+                    primary.get("baseSeverity")
+                    or cvss_data.get("baseSeverity")
+                    or ""
+                ).lower() or None
+                base_score = cvss_data.get("baseScore")
+                attack_vector = cvss_data.get("attackVector")
+                cvss_version = _metric_version_map.get(metric_key)
+                cvss_vector = cvss_data.get("vectorString")
+                cvss_exploitability = primary.get("exploitabilityScore")
+                cvss_impact = primary.get("impactScore")
+                break
+
+        # References / links
+        links = [
+            ref.get("url")
+            for ref in cve.get("references", [])
+            if ref.get("url")
+        ]
+        # Always include the NVD detail page
+        cve_id = cve.get("id", "")
+        nvd_url = f"https://nvd.nist.gov/vuln/detail/{cve_id}"
+        if nvd_url not in links:
+            links.insert(0, nvd_url)
+
+        # Published date
+        published = cve.get("published")
+        publish_date = None
+        if published:
+            try:
+                import datetime
+                publish_date = datetime.date.fromisoformat(str(published)[:10])
+            except ValueError:
+                pass
+
+        # Weaknesses
+        weaknesses = []
+        for w in cve.get("weaknesses", []):
+            for d in w.get("description", []):
+                val = d.get("value", "")
+                if val and val not in weaknesses:
+                    weaknesses.append(val)
+
+        return {
+            "description": description,
+            "status": severity,
+            "base_score": base_score,
+            "attack_vector": attack_vector,
+            "cvss_version": cvss_version,
+            "cvss_vector": cvss_vector,
+            "cvss_exploitability": cvss_exploitability,
+            "cvss_impact": cvss_impact,
+            "links": links,
+            "publish_date": publish_date,
+            "weaknesses": weaknesses or None,
+            "nvd_last_modified": cve.get("lastModified"),
+        }
 
     def fetch_cve_data(self, cve_id: str) -> Optional[dict]:
         """

--- a/src/controllers/osv_client.py
+++ b/src/controllers/osv_client.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""
+Lightweight client for the OSV.dev API (https://api.osv.dev).
+
+No API key is required.  The main endpoint used is:
+  POST https://api.osv.dev/v1/query   — query by PURL
+"""
+
+import json
+import urllib.request
+import urllib.error
+import time
+
+
+OSV_API_BASE = "https://api.osv.dev/v1"
+
+
+class OSVClient:
+    """Query the OSV.dev API for vulnerabilities by PURL."""
+
+    def __init__(self, timeout: int = 30):
+        self._timeout = timeout
+
+    def query_by_purl(self, purl: str, retries: int = 3) -> list[dict]:
+        """Query OSV for vulnerabilities affecting *purl*.
+
+        Returns a (possibly empty) list of vulnerability objects.
+        Each object follows the OSV schema:
+          https://ossf.github.io/osv-schema/
+        """
+        body = json.dumps({"package": {"purl": purl}}).encode("utf-8")
+        url = f"{OSV_API_BASE}/query"
+
+        for attempt in range(retries):
+            if attempt > 0:
+                time.sleep(min(2 ** attempt, 10))
+            try:
+                req = urllib.request.Request(
+                    url,
+                    data=body,
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    return data.get("vulns", [])
+            except urllib.error.HTTPError as e:
+                if e.code in (400, 404):
+                    # Bad PURL or not found — don't retry
+                    return []
+                if attempt == retries - 1:
+                    raise
+            except (urllib.error.URLError, TimeoutError, OSError):
+                if attempt == retries - 1:
+                    raise
+        return []

--- a/src/controllers/osv_client.py
+++ b/src/controllers/osv_client.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
 """

--- a/src/controllers/scans.py
+++ b/src/controllers/scans.py
@@ -28,6 +28,7 @@ class ScanController:
         return {
             "id": str(scan.id),
             "description": scan.description,
+            "scan_type": scan.scan_type or "sbom",
             "timestamp": ensure_utc_iso(scan.timestamp),
             "variant_id": str(scan.variant_id),
         }
@@ -72,7 +73,7 @@ class ScanController:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def create(description: str, variant_id: uuid.UUID | str) -> Scan:
+    def create(description: str, variant_id: uuid.UUID | str, scan_type: str = "sbom") -> Scan:
         """
         Create a new scan under *variant_id*.
 
@@ -80,7 +81,7 @@ class ScanController:
         """
         if isinstance(variant_id, str):
             variant_id = uuid.UUID(variant_id)
-        return Scan.create(description, variant_id)
+        return Scan.create(description, variant_id, scan_type=scan_type)
 
     @staticmethod
     def update(scan: Scan | uuid.UUID | str, description: str) -> Scan:

--- a/src/controllers/scans.py
+++ b/src/controllers/scans.py
@@ -29,6 +29,7 @@ class ScanController:
             "id": str(scan.id),
             "description": scan.description,
             "scan_type": scan.scan_type or "sbom",
+            "scan_source": scan.scan_source,
             "timestamp": ensure_utc_iso(scan.timestamp),
             "variant_id": str(scan.variant_id),
         }
@@ -73,7 +74,8 @@ class ScanController:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def create(description: str, variant_id: uuid.UUID | str, scan_type: str = "sbom") -> Scan:
+    def create(description: str, variant_id: uuid.UUID | str,
+               scan_type: str = "sbom", scan_source: str | None = None) -> Scan:
         """
         Create a new scan under *variant_id*.
 
@@ -81,7 +83,8 @@ class ScanController:
         """
         if isinstance(variant_id, str):
             variant_id = uuid.UUID(variant_id)
-        return Scan.create(description, variant_id, scan_type=scan_type)
+        return Scan.create(description, variant_id, scan_type=scan_type,
+                           scan_source=scan_source)
 
     @staticmethod
     def update(scan: Scan | uuid.UUID | str, description: str) -> Scan:

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -238,8 +238,18 @@ class VulnerabilitiesController:
             db_record_cache=self._db_record_cache,
         )
 
-        def _persist_if_needed(stored: Vulnerability, new_packages: set[str]) -> None:
-            """Only persist if this vuln has new packages or hasn't been persisted yet."""
+        def _persist_if_needed(stored: Vulnerability, new_packages: set[str],
+                               merged: bool = False) -> None:
+            """Persist if this vuln has new packages, hasn't been persisted yet,
+            or was just merged with new metadata (texts/CVSS/links).
+
+            The ``persist_from_transient`` method already performs its own
+            change detection (comparing in-memory values against the cached DB
+            record), so calling it when there are no actual changes is cheap —
+            just a dict lookup + a few comparisons — and avoids silently
+            dropping metadata updates when only texts/CVSS/links changed
+            without new packages.
+            """
             canonical_id = stored.id
             known_pkgs = stored._persisted_packages
             if known_pkgs is None:
@@ -247,8 +257,8 @@ class VulnerabilitiesController:
                 _persist_vuln_to_db(stored, use_savepoint=self.use_savepoints, **_caches)
                 stored._persisted_packages = set(stored.packages)
                 self._persisted_ids.add(canonical_id)
-            elif new_packages - known_pkgs:
-                # New packages were added — need to create new Findings
+            elif (new_packages - known_pkgs) or merged:
+                # New packages or metadata may have changed — re-persist.
                 _persist_vuln_to_db(stored, use_savepoint=self.use_savepoints, **_caches)
                 stored._persisted_packages = set(stored.packages)
             # else: already persisted, nothing new — skip DB entirely
@@ -258,7 +268,7 @@ class VulnerabilitiesController:
             old_pkgs = set(stored.packages)
             stored.merge(vulnerability)
             new_pkgs = set(vulnerability.packages)
-            _persist_if_needed(stored, new_pkgs - old_pkgs)
+            _persist_if_needed(stored, new_pkgs - old_pkgs, merged=True)
             self._encountered_this_run.add(stored.id)
             return stored
 
@@ -268,7 +278,7 @@ class VulnerabilitiesController:
             old_pkgs = set(stored.packages)
             stored.merge(vulnerability)
             new_pkgs = set(vulnerability.packages)
-            _persist_if_needed(stored, new_pkgs - old_pkgs)
+            _persist_if_needed(stored, new_pkgs - old_pkgs, merged=True)
             self._encountered_this_run.add(stored.id)
             return stored
 
@@ -280,7 +290,7 @@ class VulnerabilitiesController:
                 old_pkgs = set(stored.packages)
                 stored.merge(vulnerability)
                 new_pkgs = set(vulnerability.packages)
-                _persist_if_needed(stored, new_pkgs - old_pkgs)
+                _persist_if_needed(stored, new_pkgs - old_pkgs, merged=True)
                 self._encountered_this_run.add(stored.id)
                 return stored
             if alias in self.alias_registered:
@@ -291,7 +301,7 @@ class VulnerabilitiesController:
                 old_pkgs = set(stored.packages)
                 stored.merge(vulnerability)
                 new_pkgs = set(vulnerability.packages)
-                _persist_if_needed(stored, new_pkgs - old_pkgs)
+                _persist_if_needed(stored, new_pkgs - old_pkgs, merged=True)
                 self._encountered_this_run.add(stored.id)
                 return stored
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -37,6 +37,8 @@ Input commands:
   --add-cdx <path>          Add a CycloneDX file
   --add-grype <path>        Add a Grype results file
   --perform-grype-scan      Perform a Grype scan on the added inputs
+  --perform-nvd-scan        Run an NVD CPE-based vulnerability scan
+  --perform-osv-scan        Run an OSV PURL-based vulnerability scan
 
 Scan & output commands:
   --serve                   Run scan then start interactive web UI (port 7275)
@@ -292,7 +294,7 @@ cmd_scan() {
     [[ ${#INIT_APP_ARGS[@]} -gt 4 ]]     && has_inputs=true
     [[ -n "${MATCH_CONDITION:-}" ]]       && has_condition=true
 
-    if [[ "$has_inputs" == "true" ]] || [[ "$has_condition" == "true" ]] || [[ "${GRYPE_SCAN_REQUESTED:-false}" == "true" ]]; then
+    if [[ "$has_inputs" == "true" ]] || [[ "$has_condition" == "true" ]] || [[ "${GRYPE_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${NVD_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${OSV_SCAN_REQUESTED:-false}" == "true" ]]; then
         if [[ "$has_inputs" == "true" ]]; then
             if [[ "${INTERACTIVE_MODE}" == "true" ]]; then
                 set_status "1" "Merging inputs and processing vulnerabilities"
@@ -322,6 +324,20 @@ cmd_scan() {
                 echo "Warning: CycloneDX export produced no file, skipping Grype scan."
             fi
             rm -rf "$grype_tmp"
+        fi
+
+        # If an NVD scan was requested, run it synchronously via the flask CLI.
+        if [[ "${NVD_SCAN_REQUESTED:-false}" == "true" ]]; then
+            echo "Running NVD scan for project '$PROJECT_NAME' variant '$VARIANT_NAME'..."
+            (cd "$BASE_DIR" && flask --app src.bin.webapp nvd-scan \
+                --project "$PROJECT_NAME" --variant "$VARIANT_NAME")
+        fi
+
+        # If an OSV scan was requested, run it synchronously via the flask CLI.
+        if [[ "${OSV_SCAN_REQUESTED:-false}" == "true" ]]; then
+            echo "Running OSV scan for project '$PROJECT_NAME' variant '$VARIANT_NAME'..."
+            (cd "$BASE_DIR" && flask --app src.bin.webapp osv-scan \
+                --project "$PROJECT_NAME" --variant "$VARIANT_NAME")
         fi
 
         # merger_ci.py emits lines of the form  ::STATUS::<step>::<message>
@@ -500,6 +516,8 @@ function set_status() {
 MATCH_CONDITION=""
 SERVE_REQUESTED=false
 GRYPE_SCAN_REQUESTED=false
+NVD_SCAN_REQUESTED=false
+OSV_SCAN_REQUESTED=false
 REPORT_TEMPLATES=()
 EXPORT_FORMATS=()
 SCAN_REQUIRED=false
@@ -594,6 +612,10 @@ while [[ $# -gt 0 ]]; do
             cmd_add_file grype "$2"; SCAN_REQUIRED=true; shift 2 ;;
         --perform-grype-scan)
             GRYPE_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
+        --perform-nvd-scan)
+            NVD_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
+        --perform-osv-scan)
+            OSV_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --clear-inputs)
             cmd_clear_inputs; shift ;;
         --delete-scan)

--- a/src/migrations/versions/e2a4b6c8d0f2_add_scan_type_to_scans.py
+++ b/src/migrations/versions/e2a4b6c8d0f2_add_scan_type_to_scans.py
@@ -1,0 +1,26 @@
+"""add scan_type column to scans
+
+Revision ID: e2a4b6c8d0f2
+Revises: b4e9f2a7c3d1
+Create Date: 2026-06-18 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e2a4b6c8d0f2'
+down_revision = 'b4e9f2a7c3d1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('scans', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('scan_type', sa.String(), nullable=True, server_default='sbom'))
+
+
+def downgrade():
+    with op.batch_alter_table('scans', schema=None) as batch_op:
+        batch_op.drop_column('scan_type')

--- a/src/migrations/versions/g3b4c5d6e7f8_add_scan_source_to_scans.py
+++ b/src/migrations/versions/g3b4c5d6e7f8_add_scan_source_to_scans.py
@@ -1,0 +1,26 @@
+"""add scan_source column to scans
+
+Revision ID: g3b4c5d6e7f8
+Revises: e2a4b6c8d0f2
+Create Date: 2026-04-13 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'g3b4c5d6e7f8'
+down_revision = 'e2a4b6c8d0f2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('scans', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('scan_source', sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('scans', schema=None) as batch_op:
+        batch_op.drop_column('scan_source')

--- a/src/migrations/versions/h4c5d6e7f8a9_add_scan_diff_cache_table.py
+++ b/src/migrations/versions/h4c5d6e7f8a9_add_scan_diff_cache_table.py
@@ -1,0 +1,51 @@
+"""add scan_diff_cache table
+
+Revision ID: h4c5d6e7f8a9
+Revises: g3b4c5d6e7f8
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'h4c5d6e7f8a9'
+down_revision = 'g3b4c5d6e7f8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'scan_diff_cache',
+        sa.Column('scan_id', sa.Uuid(), sa.ForeignKey('scans.id', ondelete='CASCADE'), primary_key=True),
+        sa.Column('finding_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('package_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('vuln_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('is_first', sa.Boolean(), nullable=False, server_default='1'),
+        sa.Column('findings_added', sa.Integer(), nullable=True),
+        sa.Column('findings_removed', sa.Integer(), nullable=True),
+        sa.Column('findings_upgraded', sa.Integer(), nullable=True),
+        sa.Column('findings_unchanged', sa.Integer(), nullable=True),
+        sa.Column('packages_added', sa.Integer(), nullable=True),
+        sa.Column('packages_removed', sa.Integer(), nullable=True),
+        sa.Column('packages_upgraded', sa.Integer(), nullable=True),
+        sa.Column('packages_unchanged', sa.Integer(), nullable=True),
+        sa.Column('vulns_added', sa.Integer(), nullable=True),
+        sa.Column('vulns_removed', sa.Integer(), nullable=True),
+        sa.Column('vulns_unchanged', sa.Integer(), nullable=True),
+        sa.Column('newly_detected_findings', sa.Integer(), nullable=True),
+        sa.Column('newly_detected_vulns', sa.Integer(), nullable=True),
+        sa.Column('branch_finding_count', sa.Integer(), nullable=True),
+        sa.Column('branch_vuln_count', sa.Integer(), nullable=True),
+        sa.Column('branch_package_count', sa.Integer(), nullable=True),
+        sa.Column('global_finding_count', sa.Integer(), nullable=True),
+        sa.Column('global_vuln_count', sa.Integer(), nullable=True),
+        sa.Column('global_package_count', sa.Integer(), nullable=True),
+        sa.Column('formats_json', sa.Text(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('scan_diff_cache')

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -13,3 +13,4 @@ from .observation import Observation  # noqa: F401
 from .assessment import Assessment  # noqa: F401
 from .time_estimate import TimeEstimate  # noqa: F401
 from .metrics import Metrics  # noqa: F401
+from .scan_diff_cache import ScanDiffCache  # noqa: F401

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -119,15 +119,21 @@ class Metrics(Base):
         # _seen is pre-populated from the DB at startup for all existing metrics.
         # Reaching here means this is genuinely new — skip the existence SELECT
         # and attempt the insert directly. On the rare race/duplicate, fall back.
+        #
+        # Use flush() instead of create() (which calls commit()) so the
+        # caller's SAVEPOINT context stays open for subsequent metric inserts.
         try:
             with db.session.begin_nested():
-                return cls.create(
+                record = cls(
                     vulnerability_id=vid,
                     version=cvss.version,
                     score=cvss.base_score,
                     vector=cvss.vector_string,
                     author=cvss.author,
                 )
+                db.session.add(record)
+                db.session.flush()
+                return record
         except Exception:
             return db.session.execute(
                 db.select(Metrics).where(

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -4,101 +4,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import uuid
-import re
 import semver
 from typing import Optional
 from ..extensions import db, Base
-
-
-# ---------------------------------------------------------------------------
-# Well-known CPE mappings: package name patterns → (part, vendor, product)
-# The NVD CPE dictionary uses specific vendor:product pairs that often
-# differ from distro package names.  This table lets VulnScout translate
-# common package names into their canonical CPE representation so that
-# NVD queries return meaningful results.
-# Keys are compiled regexes matched against the *lowercased* package name.
-# ---------------------------------------------------------------------------
-_KNOWN_CPE_MAPPINGS: list[tuple[re.Pattern, str, str, str]] = [
-    # Linux kernel
-    (re.compile(r"^(linux|kernel|kernel-image|linux-image|linux-kernel)"),
-     "o", "linux", "linux_kernel"),
-    # GNU core utilities
-    (re.compile(r"^(glibc|libc6|eglibc)$"), "a", "gnu", "glibc"),
-    (re.compile(r"^(openssl|libssl)"), "a", "openssl", "openssl"),
-    (re.compile(r"^(busybox)$"), "a", "busybox", "busybox"),
-    (re.compile(r"^(bash)$"), "a", "gnu", "bash"),
-    (re.compile(r"^(tar)$"), "a", "gnu", "tar"),
-    (re.compile(r"^(gzip)$"), "a", "gnu", "gzip"),
-    (re.compile(r"^(wget)$"), "a", "gnu", "wget"),
-    (re.compile(r"^(curl|libcurl)"), "a", "haxx", "curl"),
-    (re.compile(r"^(zlib)$"), "a", "zlib", "zlib"),
-    (re.compile(r"^(sqlite|libsqlite)"), "a", "sqlite", "sqlite"),
-    (re.compile(r"^(openssh|libssh)"), "a", "openbsd", "openssh"),
-    (re.compile(r"^(dbus|libdbus)"), "a", "freedesktop", "dbus"),
-    (re.compile(r"^(systemd|libsystemd|udev)"), "a", "systemd_project", "systemd"),
-    (re.compile(r"^(sudo)$"), "a", "sudo_project", "sudo"),
-    (re.compile(r"^(binutils|ld|as|objdump)$"), "a", "gnu", "binutils"),
-    (re.compile(r"^(gcc|libgcc|libstdc\+\+)"), "a", "gnu", "gcc"),
-    (re.compile(r"^(python|python3|libpython)"), "a", "python", "python"),
-    (re.compile(r"^(perl)$"), "a", "perl", "perl"),
-    (re.compile(r"^(nginx)$"), "a", "f5", "nginx"),
-    (re.compile(r"^(apache2|httpd)$"), "a", "apache", "http_server"),
-    (re.compile(r"^(u-boot)"), "a", "denx", "u-boot"),
-    (re.compile(r"^(grub|grub2)"), "a", "gnu", "grub2"),
-    (re.compile(r"^(expat|libexpat)"), "a", "libexpat_project", "libexpat"),
-    (re.compile(r"^(libxml2)$"), "a", "xmlsoft", "libxml2"),
-    (re.compile(r"^(libpng)"), "a", "libpng", "libpng"),
-    (re.compile(r"^(libtiff)"), "a", "libtiff", "libtiff"),
-    (re.compile(r"^(libjpeg|jpeg)"), "a", "ijg", "libjpeg"),
-    (re.compile(r"^(freetype)"), "a", "freetype", "freetype"),
-    (re.compile(r"^(cups)$"), "a", "openprinting", "cups"),
-    (re.compile(r"^(samba)$"), "a", "samba", "samba"),
-    (re.compile(r"^(ntp)$"), "a", "ntp", "ntp"),
-    (re.compile(r"^(dhcp|isc-dhcp)"), "a", "isc", "dhcp"),
-    (re.compile(r"^(bind|named)$"), "a", "isc", "bind"),
-    (re.compile(r"^(dnsmasq)$"), "a", "thekelleys", "dnsmasq"),
-    (re.compile(r"^(avahi)"), "a", "avahi", "avahi"),
-    (re.compile(r"^(bluez)$"), "a", "bluez", "bluez"),
-    (re.compile(r"^(wpa_supplicant|wpa-supplicant)$"), "a", "w1.fi", "wpa_supplicant"),
-    (re.compile(r"^(gnutls|libgnutls)"), "a", "gnu", "gnutls"),
-    (re.compile(r"^(gstreamer)"), "a", "gstreamer_project", "gstreamer"),
-    (re.compile(r"^(libarchive)$"), "a", "libarchive", "libarchive"),
-    (re.compile(r"^(util-linux)$"), "a", "kernel", "util-linux"),
-    (re.compile(r"^(coreutils)$"), "a", "gnu", "coreutils"),
-    (re.compile(r"^(shadow|shadow-utils)$"), "a", "shadow_project", "shadow"),
-    (re.compile(r"^(xz|liblzma|xz-utils)"), "a", "tukaani", "xz"),
-]
-
-
-def normalize_cpe(cpe: str, pkg_name: str = "") -> str:
-    """Normalize a CPE 2.3 string for NVD compatibility.
-
-    Fixes:
-    - Replace ``*`` in the *part* field with ``a`` (application).
-    - Look up known package-to-CPE mappings to set the correct
-      vendor and product when they are currently wildcards.
-    """
-    parts = cpe.split(":")
-    if len(parts) < 6:
-        return cpe
-
-    # Fix part field: NVD rejects * — default to 'a'
-    if parts[2] == "*":
-        parts[2] = "a"
-
-    # Try well-known mappings when vendor or product is still a wildcard
-    if parts[3] == "*" or parts[4] == "*":
-        lookup_name = (pkg_name or parts[4]).lower().strip()
-        for pattern, part, vendor, product in _KNOWN_CPE_MAPPINGS:
-            if pattern.search(lookup_name):
-                parts[2] = part
-                if parts[3] == "*":
-                    parts[3] = vendor
-                if parts[4] == "*" or parts[4] == lookup_name:
-                    parts[4] = product
-                break
-
-    return ":".join(parts)
 
 
 class Package(Base):
@@ -177,7 +85,6 @@ class Package(Base):
         """Add a single cpe (str) identifier to the package if not already present."""
         if not cpe:
             return
-        cpe = normalize_cpe(cpe, self.name or "")
         current = list(self.cpe or [])
         if cpe not in current:
             current.append(cpe)

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -4,9 +4,101 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import uuid
+import re
 import semver
 from typing import Optional
 from ..extensions import db, Base
+
+
+# ---------------------------------------------------------------------------
+# Well-known CPE mappings: package name patterns → (part, vendor, product)
+# The NVD CPE dictionary uses specific vendor:product pairs that often
+# differ from distro package names.  This table lets VulnScout translate
+# common package names into their canonical CPE representation so that
+# NVD queries return meaningful results.
+# Keys are compiled regexes matched against the *lowercased* package name.
+# ---------------------------------------------------------------------------
+_KNOWN_CPE_MAPPINGS: list[tuple[re.Pattern, str, str, str]] = [
+    # Linux kernel
+    (re.compile(r"^(linux|kernel|kernel-image|linux-image|linux-kernel)"),
+     "o", "linux", "linux_kernel"),
+    # GNU core utilities
+    (re.compile(r"^(glibc|libc6|eglibc)$"), "a", "gnu", "glibc"),
+    (re.compile(r"^(openssl|libssl)"), "a", "openssl", "openssl"),
+    (re.compile(r"^(busybox)$"), "a", "busybox", "busybox"),
+    (re.compile(r"^(bash)$"), "a", "gnu", "bash"),
+    (re.compile(r"^(tar)$"), "a", "gnu", "tar"),
+    (re.compile(r"^(gzip)$"), "a", "gnu", "gzip"),
+    (re.compile(r"^(wget)$"), "a", "gnu", "wget"),
+    (re.compile(r"^(curl|libcurl)"), "a", "haxx", "curl"),
+    (re.compile(r"^(zlib)$"), "a", "zlib", "zlib"),
+    (re.compile(r"^(sqlite|libsqlite)"), "a", "sqlite", "sqlite"),
+    (re.compile(r"^(openssh|libssh)"), "a", "openbsd", "openssh"),
+    (re.compile(r"^(dbus|libdbus)"), "a", "freedesktop", "dbus"),
+    (re.compile(r"^(systemd|libsystemd|udev)"), "a", "systemd_project", "systemd"),
+    (re.compile(r"^(sudo)$"), "a", "sudo_project", "sudo"),
+    (re.compile(r"^(binutils|ld|as|objdump)$"), "a", "gnu", "binutils"),
+    (re.compile(r"^(gcc|libgcc|libstdc\+\+)"), "a", "gnu", "gcc"),
+    (re.compile(r"^(python|python3|libpython)"), "a", "python", "python"),
+    (re.compile(r"^(perl)$"), "a", "perl", "perl"),
+    (re.compile(r"^(nginx)$"), "a", "f5", "nginx"),
+    (re.compile(r"^(apache2|httpd)$"), "a", "apache", "http_server"),
+    (re.compile(r"^(u-boot)"), "a", "denx", "u-boot"),
+    (re.compile(r"^(grub|grub2)"), "a", "gnu", "grub2"),
+    (re.compile(r"^(expat|libexpat)"), "a", "libexpat_project", "libexpat"),
+    (re.compile(r"^(libxml2)$"), "a", "xmlsoft", "libxml2"),
+    (re.compile(r"^(libpng)"), "a", "libpng", "libpng"),
+    (re.compile(r"^(libtiff)"), "a", "libtiff", "libtiff"),
+    (re.compile(r"^(libjpeg|jpeg)"), "a", "ijg", "libjpeg"),
+    (re.compile(r"^(freetype)"), "a", "freetype", "freetype"),
+    (re.compile(r"^(cups)$"), "a", "openprinting", "cups"),
+    (re.compile(r"^(samba)$"), "a", "samba", "samba"),
+    (re.compile(r"^(ntp)$"), "a", "ntp", "ntp"),
+    (re.compile(r"^(dhcp|isc-dhcp)"), "a", "isc", "dhcp"),
+    (re.compile(r"^(bind|named)$"), "a", "isc", "bind"),
+    (re.compile(r"^(dnsmasq)$"), "a", "thekelleys", "dnsmasq"),
+    (re.compile(r"^(avahi)"), "a", "avahi", "avahi"),
+    (re.compile(r"^(bluez)$"), "a", "bluez", "bluez"),
+    (re.compile(r"^(wpa_supplicant|wpa-supplicant)$"), "a", "w1.fi", "wpa_supplicant"),
+    (re.compile(r"^(gnutls|libgnutls)"), "a", "gnu", "gnutls"),
+    (re.compile(r"^(gstreamer)"), "a", "gstreamer_project", "gstreamer"),
+    (re.compile(r"^(libarchive)$"), "a", "libarchive", "libarchive"),
+    (re.compile(r"^(util-linux)$"), "a", "kernel", "util-linux"),
+    (re.compile(r"^(coreutils)$"), "a", "gnu", "coreutils"),
+    (re.compile(r"^(shadow|shadow-utils)$"), "a", "shadow_project", "shadow"),
+    (re.compile(r"^(xz|liblzma|xz-utils)"), "a", "tukaani", "xz"),
+]
+
+
+def normalize_cpe(cpe: str, pkg_name: str = "") -> str:
+    """Normalize a CPE 2.3 string for NVD compatibility.
+
+    Fixes:
+    - Replace ``*`` in the *part* field with ``a`` (application).
+    - Look up known package-to-CPE mappings to set the correct
+      vendor and product when they are currently wildcards.
+    """
+    parts = cpe.split(":")
+    if len(parts) < 6:
+        return cpe
+
+    # Fix part field: NVD rejects * — default to 'a'
+    if parts[2] == "*":
+        parts[2] = "a"
+
+    # Try well-known mappings when vendor or product is still a wildcard
+    if parts[3] == "*" or parts[4] == "*":
+        lookup_name = (pkg_name or parts[4]).lower().strip()
+        for pattern, part, vendor, product in _KNOWN_CPE_MAPPINGS:
+            if pattern.search(lookup_name):
+                parts[2] = part
+                if parts[3] == "*":
+                    parts[3] = vendor
+                if parts[4] == "*" or parts[4] == lookup_name:
+                    parts[4] = product
+                break
+
+    return ":".join(parts)
 
 
 class Package(Base):
@@ -85,6 +177,7 @@ class Package(Base):
         """Add a single cpe (str) identifier to the package if not already present."""
         if not cpe:
             return
+        cpe = normalize_cpe(cpe, self.name or "")
         current = list(self.cpe or [])
         if cpe not in current:
             current.append(cpe)
@@ -101,7 +194,7 @@ class Package(Base):
 
     def generate_generic_cpe(self) -> str:
         """Build a generic cpe string for the package, add it to the cpe list and return it."""
-        item = f"cpe:2.3:*:*:{self.name or '*'}:{self.version or '*'}:*:*:*:*:*:*:*"
+        item = f"cpe:2.3:a:*:{self.name or '*'}:{self.version or '*'}:*:*:*:*:*:*:*"
         self.add_cpe(item)
         return item
 

--- a/src/models/scan.py
+++ b/src/models/scan.py
@@ -27,6 +27,7 @@ class Scan(Base):
     id: Mapped[uuid.UUID] = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
     description: Mapped[str | None] = db.Column(db.Text, nullable=True)
     scan_type: Mapped[str | None] = db.Column(db.String, nullable=True, default="sbom")  # 'sbom' or 'tool'
+    scan_source: Mapped[str | None] = db.Column(db.String, nullable=True)  # 'grype', 'nvd', 'osv', or None
     timestamp: Mapped[datetime] = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
@@ -73,9 +74,11 @@ class Scan(Base):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def create(description: str, variant_id: uuid.UUID, scan_type: str = "sbom") -> "Scan":
+    def create(description: str, variant_id: uuid.UUID, scan_type: str = "sbom",
+               scan_source: str | None = None) -> "Scan":
         """Create a new scan with the given *description* under *variant_id*, persist it and return it."""
-        scan = Scan(description=description, variant_id=variant_id, scan_type=scan_type)
+        scan = Scan(description=description, variant_id=variant_id,
+                    scan_type=scan_type, scan_source=scan_source)
         db.session.add(scan)
         db.session.commit()
         return scan

--- a/src/models/scan.py
+++ b/src/models/scan.py
@@ -26,6 +26,7 @@ class Scan(Base):
 
     id: Mapped[uuid.UUID] = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
     description: Mapped[str | None] = db.Column(db.Text, nullable=True)
+    scan_type: Mapped[str | None] = db.Column(db.String, nullable=True, default="sbom")  # 'sbom' or 'tool'
     timestamp: Mapped[datetime] = db.Column(
         db.DateTime(timezone=True),
         nullable=False,
@@ -72,9 +73,9 @@ class Scan(Base):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def create(description: str, variant_id: uuid.UUID) -> "Scan":
+    def create(description: str, variant_id: uuid.UUID, scan_type: str = "sbom") -> "Scan":
         """Create a new scan with the given *description* under *variant_id*, persist it and return it."""
-        scan = Scan(description=description, variant_id=variant_id)
+        scan = Scan(description=description, variant_id=variant_id, scan_type=scan_type)
         db.session.add(scan)
         db.session.commit()
         return scan

--- a/src/models/scan_diff_cache.py
+++ b/src/models/scan_diff_cache.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
 import uuid

--- a/src/models/scan_diff_cache.py
+++ b/src/models/scan_diff_cache.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import uuid
+
+from ..extensions import db, Base
+
+from sqlalchemy.orm import Mapped
+
+
+class ScanDiffCache(Base):
+    """Pre-computed scan history diff data.
+
+    This is a **derived / cache** table — every row can be regenerated
+    from the source data (scans, observations, findings, packages).
+    It should *not* be exported when shipping the database for
+    portability; instead it is rebuilt on import via
+    ``recompute_variant_cache()``.
+    """
+
+    __tablename__ = "scan_diff_cache"
+
+    scan_id: Mapped[uuid.UUID] = db.Column(
+        db.Uuid, db.ForeignKey("scans.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    # --- absolute counts (always present) ---
+    finding_count: Mapped[int] = db.Column(db.Integer, nullable=False, default=0)
+    package_count: Mapped[int] = db.Column(db.Integer, nullable=False, default=0)
+    vuln_count: Mapped[int] = db.Column(db.Integer, nullable=False, default=0)
+
+    is_first: Mapped[bool] = db.Column(db.Boolean, nullable=False, default=True)
+
+    # --- diff counts (nullable — None for first-SBOM scans) ---
+    findings_added: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    findings_removed: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    findings_upgraded: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    findings_unchanged: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+
+    packages_added: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    packages_removed: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    packages_upgraded: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    packages_unchanged: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+
+    vulns_added: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    vulns_removed: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    vulns_unchanged: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+
+    # --- tool-scan specific (nullable — None for SBOM scans) ---
+    newly_detected_findings: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    newly_detected_vulns: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    branch_finding_count: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    branch_vuln_count: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    branch_package_count: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+
+    # --- global result (nullable — None when no tool scans exist) ---
+    global_finding_count: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    global_vuln_count: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+    global_package_count: Mapped[int | None] = db.Column(db.Integer, nullable=True)
+
+    # --- SBOM formats (JSON list as text, e.g. '["spdx2","spdx3"]') ---
+    formats_json: Mapped[str | None] = db.Column(db.Text, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<ScanDiffCache scan_id={self.scan_id}>"

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -674,7 +674,8 @@ class Vulnerability(Base):
         if vuln.severity_cvss:
             av = getattr(vuln.severity_cvss[0], "attack_vector", None)
 
-        desc = vuln.texts.get("description")
+        desc = (vuln.texts.get("description")
+                or vuln.texts.get("vulnerability description"))
         yocto_desc = vuln.texts.get("yocto description")
         status = (vuln.severity_label
                   if vuln.severity_label != "unknown" else None)
@@ -686,7 +687,10 @@ class Vulnerability(Base):
         nvd_last_modified = getattr(vuln, "nvd_last_modified", None)
 
         if record is None:
-            record = cls.create_record(
+            # Create the record inline with flush() (not commit()) so
+            # the caller's SAVEPOINT stays open for subsequent Metrics
+            # and Finding persists within the same transaction context.
+            record = cls(
                 id=vuln.id,
                 description=desc,
                 yocto_description=yocto_desc,
@@ -700,6 +704,8 @@ class Vulnerability(Base):
                 patch_url=nvd_patch_url,
                 nvd_last_modified=nvd_last_modified,
             )
+            db.session.add(record)
+            db.session.flush()
             db_record_cache[vuln_key] = record  # cache for subsequent persists
         else:
             # Only call update_record if something actually changed

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -4,7 +4,6 @@
 
 import uuid
 
-from sqlalchemy import func
 from ..models.package import Package
 from ..models.scan import Scan
 from ..models.variant import Variant
@@ -14,32 +13,45 @@ from ..extensions import db
 
 
 def _latest_scan_id_for_variant(variant_uuid):
-    """Return the ID of the most recent Scan for the given variant, or None."""
-    return db.session.execute(
-        db.select(Scan.id)
+    """Return the active Scan IDs for the given variant.
+
+    The current view is the union of the latest SBOM scan and the latest tool
+    scan (if any).  Returns a list of 0–2 scan IDs.
+    """
+    rows = db.session.execute(
+        db.select(Scan.id, Scan.scan_type)
         .where(Scan.variant_id == variant_uuid)
         .order_by(Scan.timestamp.desc())
-        .limit(1)
-    ).scalar_one_or_none()
+    ).all()
+    ids: list = []
+    seen_types: set = set()
+    for scan_id, scan_type in rows:
+        st = scan_type or "sbom"
+        if st not in seen_types:
+            seen_types.add(st)
+            ids.append(scan_id)
+        if len(seen_types) >= 2:
+            break
+    return ids
 
 
 def _latest_scan_ids_for_project(project_uuid):
-    """Return a list of Scan IDs – the latest scan for each variant in the project."""
-    latest_ts_sub = (
-        db.select(Scan.variant_id, func.max(Scan.timestamp).label("max_ts"))
+    """Return the active Scan IDs for each variant in the project."""
+    rows = db.session.execute(
+        db.select(Scan.id, Scan.variant_id, Scan.scan_type, Scan.timestamp)
         .join(Variant, Scan.variant_id == Variant.id)
         .where(Variant.project_id == project_uuid)
-        .group_by(Scan.variant_id)
-        .subquery()
-    )
-    return list(db.session.execute(
-        db.select(Scan.id)
-        .join(
-            latest_ts_sub,
-            (Scan.variant_id == latest_ts_sub.c.variant_id)
-            & (Scan.timestamp == latest_ts_sub.c.max_ts),
-        )
-    ).scalars().all())
+        .order_by(Scan.variant_id, Scan.timestamp.desc())
+    ).all()
+    ids: list = []
+    seen: dict = {}
+    for scan_id, vid, scan_type, _ts in rows:
+        st = scan_type or "sbom"
+        variant_seen = seen.setdefault(vid, set())
+        if st not in variant_seen:
+            variant_seen.add(st)
+            ids.append(scan_id)
+    return ids
 
 
 def init_app(app):
@@ -99,15 +111,15 @@ def init_app(app):
                 variant_uuid = uuid.UUID(variant_id)
             except ValueError:
                 return {"error": "Invalid variant_id"}, 400
-            latest_id = _latest_scan_id_for_variant(variant_uuid)
-            if latest_id is None:
+            latest_ids = _latest_scan_id_for_variant(variant_uuid)
+            if not latest_ids:
                 pkgs = []
             else:
                 pkg_ids_sub = (
                     db.select(Package.id)
                     .join(SBOMPackage, Package.id == SBOMPackage.package_id)
                     .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
-                    .where(SBOMDocument.scan_id == latest_id)
+                    .where(SBOMDocument.scan_id.in_(latest_ids))
                     .distinct()
                 )
                 pkgs = list(db.session.execute(

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -163,14 +163,19 @@ def _variant_info(variant_ids: list) -> dict:
 # ---------------------------------------------------------------------------
 
 def _prev_scan_map(scans: list[Scan]) -> dict:
-    """Return {scan.id: previous_scan_or_None} grouped by variant, ordered by timestamp."""
-    by_variant: dict = {}
+    """Return {scan.id: previous_scan_or_None} grouped by (variant, scan_type), ordered by timestamp.
+
+    Tool scans (e.g. Grype) are only compared against previous tool scans,
+    and SBOM scans are only compared against previous SBOM scans.
+    """
+    by_key: dict = {}
     for s in scans:
-        by_variant.setdefault(s.variant_id, []).append(s)
+        key = (s.variant_id, s.scan_type or "sbom")
+        by_key.setdefault(key, []).append(s)
     mapping: dict = {}
-    for variant_scans in by_variant.values():
-        for i, s in enumerate(variant_scans):
-            mapping[s.id] = variant_scans[i - 1] if i > 0 else None
+    for group_scans in by_key.values():
+        for i, s in enumerate(group_scans):
+            mapping[s.id] = group_scans[i - 1] if i > 0 else None
     return mapping
 
 
@@ -199,6 +204,7 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
         curr_p = packages_map.get(scan.id, set())
         curr_v = vulns_map.get(scan.id, set())
         prev = prev_map.get(scan.id)
+        is_tool_scan = (scan.scan_type or "sbom") == "tool"
 
         entry = {
             "scan": scan,
@@ -208,7 +214,9 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             "raw_added_f": set(), "raw_removed_f": set(),
         }
 
-        if prev is not None:
+        # Skip package-level diff for tool scans (e.g. Grype) since they only
+        # report the subset of packages that have vulnerabilities.
+        if prev is not None and not is_tool_scan:
             prev_p = packages_map.get(prev.id, set())
             raw_added_p = curr_p - prev_p
             raw_removed_p = prev_p - curr_p
@@ -256,6 +264,8 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
         base["package_count"] = len(entry["curr_p"])
         base["vuln_count"] = len(curr_v)
 
+        is_tool_scan = (scan.scan_type or "sbom") == "tool"
+
         if prev is None:
             base["is_first"] = True
             base["findings_added"] = None
@@ -271,38 +281,47 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             prev_v = vulns_map.get(prev.id, set())
             base["is_first"] = False
 
-            upgraded_pairs = entry["upgraded_pairs"]
-            prev_pkgs = packages_map.get(prev.id, set())
-            base["packages_added"] = entry.get("truly_added_p", len(entry["curr_p"] - prev_pkgs))
-            base["packages_removed"] = entry.get("truly_removed_p", len(prev_pkgs - entry["curr_p"]))
-            base["packages_upgraded"] = len(upgraded_pairs)
-
-            raw_added_f = curr_f - prev_f
-            raw_removed_f = prev_f - curr_f
-
-            if upgraded_pairs and entry["raw_added_f"]:
-                # Classify findings on upgraded packages
-                upgraded_old_ids = {str(old_pkg.id) for old_pkg, _ in upgraded_pairs}
-                upgraded_new_ids = {str(new_pkg.id) for _, new_pkg in upgraded_pairs}
-                # Vulns on removed side that belong to upgraded old packages
-                removed_vulns_on_upgraded = {
-                    fid_to_info[fid][1]
-                    for fid in raw_removed_f
-                    if fid in fid_to_info and str(fid_to_info[fid][0]) in upgraded_old_ids
-                }
-                upgraded_count = sum(
-                    1 for fid in raw_added_f
-                    if fid in fid_to_info
-                    and str(fid_to_info[fid][0]) in upgraded_new_ids
-                    and fid_to_info[fid][1] in removed_vulns_on_upgraded
-                )
-                base["findings_upgraded"] = upgraded_count
-                base["findings_added"] = len(raw_added_f) - upgraded_count
-                base["findings_removed"] = len(raw_removed_f) - upgraded_count
-            else:
+            if is_tool_scan:
+                # Tool scans: no package diffs, only findings/vulns
+                base["packages_added"] = 0
+                base["packages_removed"] = 0
+                base["packages_upgraded"] = 0
                 base["findings_upgraded"] = 0
-                base["findings_added"] = len(raw_added_f)
-                base["findings_removed"] = len(raw_removed_f)
+                base["findings_added"] = len(curr_f - prev_f)
+                base["findings_removed"] = len(prev_f - curr_f)
+            else:
+                upgraded_pairs = entry["upgraded_pairs"]
+                prev_pkgs = packages_map.get(prev.id, set())
+                base["packages_added"] = entry.get("truly_added_p", len(entry["curr_p"] - prev_pkgs))
+                base["packages_removed"] = entry.get("truly_removed_p", len(prev_pkgs - entry["curr_p"]))
+                base["packages_upgraded"] = len(upgraded_pairs)
+
+                raw_added_f = curr_f - prev_f
+                raw_removed_f = prev_f - curr_f
+
+                if upgraded_pairs and entry["raw_added_f"]:
+                    # Classify findings on upgraded packages
+                    upgraded_old_ids = {str(old_pkg.id) for old_pkg, _ in upgraded_pairs}
+                    upgraded_new_ids = {str(new_pkg.id) for _, new_pkg in upgraded_pairs}
+                    # Vulns on removed side that belong to upgraded old packages
+                    removed_vulns_on_upgraded = {
+                        fid_to_info[fid][1]
+                        for fid in raw_removed_f
+                        if fid in fid_to_info and str(fid_to_info[fid][0]) in upgraded_old_ids
+                    }
+                    upgraded_count = sum(
+                        1 for fid in raw_added_f
+                        if fid in fid_to_info
+                        and str(fid_to_info[fid][0]) in upgraded_new_ids
+                        and fid_to_info[fid][1] in removed_vulns_on_upgraded
+                    )
+                    base["findings_upgraded"] = upgraded_count
+                    base["findings_added"] = len(raw_added_f) - upgraded_count
+                    base["findings_removed"] = len(raw_removed_f) - upgraded_count
+                else:
+                    base["findings_upgraded"] = 0
+                    base["findings_added"] = len(raw_added_f)
+                    base["findings_removed"] = len(raw_removed_f)
 
             base["vulns_added"] = len(curr_v - prev_v)
             base["vulns_removed"] = len(prev_v - curr_v)
@@ -406,6 +425,9 @@ def _classify_finding_changes(findings_added, findings_removed, upgraded_pairs):
 
 def init_app(app):
 
+    # Track running Grype scans so we can report status / prevent duplicates
+    _grype_scans_in_progress: dict = {}  # variant_id -> {"status": str, "error": str|None}
+
     @app.route('/api/scans')
     def list_all_scans():
         scans = ScanController.get_all()
@@ -457,13 +479,17 @@ def init_app(app):
         if scan is None:
             return jsonify({"error": "Scan not found"}), 404
 
-        # Locate the previous scan for the same variant
+        # Locate the previous scan of the same type for the same variant
         all_variant_scans = ScanController.get_by_variant(scan.variant_id)
+        scan_type = scan.scan_type or "sbom"
         prev_scan_id = None
-        for i, s in enumerate(all_variant_scans):
+        same_type_scans = [s for s in all_variant_scans if (s.scan_type or "sbom") == scan_type]
+        for i, s in enumerate(same_type_scans):
             if s.id == scan.id and i > 0:
-                prev_scan_id = all_variant_scans[i - 1].id
+                prev_scan_id = same_type_scans[i - 1].id
                 break
+
+        is_tool_scan = scan_type == "tool"
 
         # --- Findings diff ---
         current_finding_ids = {obs.finding_id for obs in scan.observations}
@@ -488,34 +514,41 @@ def init_app(app):
             vulns_added = sorted(curr_vulns - prev_vulns)
             vulns_removed = sorted(prev_vulns - curr_vulns)
 
-        # --- Packages diff ---
-        scans_to_query = [scan.id] if prev_scan_id is None else [scan.id, prev_scan_id]
-        pkg_sets = _packages_by_scan_ids(scans_to_query)
-        curr_pkg_ids = pkg_sets.get(scan.id, set())
-        prev_pkg_ids = pkg_sets.get(prev_scan_id, set()) if prev_scan_id else set()
+        # --- Packages diff (skipped for tool scans) ---
+        if is_tool_scan:
+            curr_pkg_ids: set = set()
+            packages_added: list = []
+            packages_removed: list = []
+            packages_upgraded: list = []
+            upgraded_pairs: list = []
+        else:
+            scans_to_query = [scan.id] if prev_scan_id is None else [scan.id, prev_scan_id]
+            pkg_sets = _packages_by_scan_ids(scans_to_query)
+            curr_pkg_ids = pkg_sets.get(scan.id, set())
+            prev_pkg_ids = pkg_sets.get(prev_scan_id, set()) if prev_scan_id else set()
 
-        raw_added_pkg_ids = curr_pkg_ids - prev_pkg_ids
-        raw_removed_pkg_ids = prev_pkg_ids - curr_pkg_ids
+            raw_added_pkg_ids = curr_pkg_ids - prev_pkg_ids
+            raw_removed_pkg_ids = prev_pkg_ids - curr_pkg_ids
 
-        all_relevant_pkg_ids = raw_added_pkg_ids | raw_removed_pkg_ids
-        pkg_lookup = _package_rows(all_relevant_pkg_ids)
+            all_relevant_pkg_ids = raw_added_pkg_ids | raw_removed_pkg_ids
+            pkg_lookup = _package_rows(all_relevant_pkg_ids)
 
-        truly_added_ids, truly_removed_ids, upgraded_pairs = _classify_package_changes(
-            raw_added_pkg_ids, raw_removed_pkg_ids, pkg_lookup
-        )
+            truly_added_ids, truly_removed_ids, upgraded_pairs = _classify_package_changes(
+                raw_added_pkg_ids, raw_removed_pkg_ids, pkg_lookup
+            )
 
-        packages_added = [_pkg_to_dict(pkg_lookup[pid]) for pid in truly_added_ids if pid in pkg_lookup]
-        packages_removed = [_pkg_to_dict(pkg_lookup[pid]) for pid in truly_removed_ids if pid in pkg_lookup]
-        packages_upgraded = [
-            {
-                "package_name": (old_pkg.name or "unknown"),
-                "old_version": (old_pkg.version or ""),
-                "new_version": (new_pkg.version or ""),
-                "old_package_id": str(old_pkg.id),
-                "new_package_id": str(new_pkg.id),
-            }
-            for old_pkg, new_pkg in upgraded_pairs
-        ]
+            packages_added = [_pkg_to_dict(pkg_lookup[pid]) for pid in truly_added_ids if pid in pkg_lookup]
+            packages_removed = [_pkg_to_dict(pkg_lookup[pid]) for pid in truly_removed_ids if pid in pkg_lookup]
+            packages_upgraded = [
+                {
+                    "package_name": (old_pkg.name or "unknown"),
+                    "old_version": (old_pkg.version or ""),
+                    "new_version": (new_pkg.version or ""),
+                    "old_package_id": str(old_pkg.id),
+                    "new_package_id": str(new_pkg.id),
+                }
+                for old_pkg, new_pkg in upgraded_pairs
+            ]
 
         # --- Classify findings on upgraded packages ---
         if prev_scan_id is not None and upgraded_pairs:
@@ -533,6 +566,7 @@ def init_app(app):
 
         return jsonify({
             "scan_id": str(scan.id),
+            "scan_type": scan_type,
             "previous_scan_id": str(prev_scan_id) if prev_scan_id else None,
             "is_first": prev_scan_id is None,
             "finding_count": len(current_finding_ids),
@@ -547,3 +581,139 @@ def init_app(app):
             "vulns_added": vulns_added,
             "vulns_removed": vulns_removed,
         })
+
+    @app.route('/api/variants/<variant_id>/grype-scan', methods=['POST'])
+    def trigger_grype_scan(variant_id):
+        """Trigger a Grype vulnerability scan for the given variant.
+
+        Exports the variant's packages as CycloneDX, runs ``grype`` on the
+        export, and merges the results back into the DB as a tool scan.
+        """
+        import threading
+        import subprocess
+        import tempfile
+        import os
+        import shutil
+
+        try:
+            variant_uuid = uuid_module.UUID(variant_id)
+        except ValueError:
+            return jsonify({"error": "Invalid variant id"}), 400
+
+        variant = VariantController.get(variant_uuid)
+        if variant is None:
+            return jsonify({"error": "Variant not found"}), 404
+
+        vid_str = str(variant_uuid)
+        if vid_str in _grype_scans_in_progress and _grype_scans_in_progress[vid_str]["status"] == "running":
+            return jsonify({"error": "A Grype scan is already in progress for this variant"}), 409
+
+        # Check that grype is available
+        if shutil.which("grype") is None:
+            return jsonify({"error": "grype binary not found on this system"}), 503
+
+        project = db.session.get(Project, variant.project_id)
+        project_name = project.name if project else "unknown"
+        variant_name = variant.name
+
+        _grype_scans_in_progress[vid_str] = {"status": "running", "error": None}
+
+        def _run_grype_scan():
+            try:
+                base_dir = os.environ.get(
+                    "BASE_DIR",
+                    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                )
+                grype_tmp = tempfile.mkdtemp(prefix="vulnscout_grype_")
+                try:
+                    # 1. Export current DB as CycloneDX
+                    subprocess.run(
+                        ["flask", "--app", "src.bin.webapp", "export",
+                         "--format", "cdx16", "--output-dir", grype_tmp],
+                        cwd=base_dir, check=True, capture_output=True, text=True,
+                        timeout=120,
+                    )
+
+                    exported_cdx = os.path.join(grype_tmp, "sbom_cyclonedx_v1_6.cdx.json")
+                    if not os.path.isfile(exported_cdx):
+                        _grype_scans_in_progress[vid_str] = {
+                            "status": "error",
+                            "error": "CycloneDX export produced no file",
+                        }
+                        return
+
+                    # 2. Run grype on the exported SBOM
+                    grype_out = os.path.join(grype_tmp, "grype_results.grype.json")
+                    with open(grype_out, "w") as gf:
+                        subprocess.run(
+                            ["grype", "--add-cpes-if-none",
+                             f"sbom:{exported_cdx}", "-o", "json"],
+                            cwd=base_dir, check=True, text=True,
+                            stdout=gf, stderr=subprocess.PIPE,
+                            timeout=600,
+                        )
+
+                    if not os.path.isfile(grype_out) or os.path.getsize(grype_out) == 0:
+                        _grype_scans_in_progress[vid_str] = {
+                            "status": "error",
+                            "error": "Grype produced no output",
+                        }
+                        return
+
+                    # 3. Merge Grype results as a tool scan
+                    subprocess.run(
+                        ["flask", "--app", "src.bin.webapp", "merge",
+                         "--project", project_name, "--variant", variant_name,
+                         "--grype", grype_out],
+                        cwd=base_dir, check=True, capture_output=True, text=True,
+                        timeout=120,
+                    )
+
+                    # 4. Process
+                    subprocess.run(
+                        ["flask", "--app", "src.bin.webapp", "process"],
+                        cwd=base_dir, check=True, capture_output=True, text=True,
+                        timeout=300,
+                    )
+
+                    _grype_scans_in_progress[vid_str] = {"status": "done", "error": None}
+                finally:
+                    shutil.rmtree(grype_tmp, ignore_errors=True)
+            except subprocess.TimeoutExpired:
+                _grype_scans_in_progress[vid_str] = {
+                    "status": "error",
+                    "error": "Grype scan timed out",
+                }
+            except subprocess.CalledProcessError as e:
+                _grype_scans_in_progress[vid_str] = {
+                    "status": "error",
+                    "error": f"Command failed: {e.stderr[:500] if e.stderr else str(e)}",
+                }
+            except Exception as e:
+                _grype_scans_in_progress[vid_str] = {
+                    "status": "error",
+                    "error": str(e)[:500],
+                }
+
+        thread = threading.Thread(
+            target=_run_grype_scan,
+            name=f"grype-scan-{vid_str}",
+            daemon=True,
+        )
+        thread.start()
+
+        return jsonify({"status": "started", "variant_id": vid_str}), 202
+
+    @app.route('/api/variants/<variant_id>/grype-scan/status')
+    def grype_scan_status(variant_id):
+        """Check the status of a running Grype scan for the given variant."""
+        try:
+            variant_uuid = uuid_module.UUID(variant_id)
+        except ValueError:
+            return jsonify({"error": "Invalid variant id"}), 400
+
+        vid_str = str(variant_uuid)
+        info = _grype_scans_in_progress.get(vid_str)
+        if info is None:
+            return jsonify({"status": "idle"})
+        return jsonify(info)

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -188,21 +188,6 @@ def _prev_scan_map(scans: list[Scan]) -> dict:
 # Helpers — serialisation for list view
 # ---------------------------------------------------------------------------
 
-def _latest_sbom_scan_per_variant(scans: list[Scan]) -> dict:
-    """Return {variant_id: latest_sbom_Scan} from the given scan list.
-
-    Only considers scans with scan_type == 'sbom' (or NULL which defaults to
-    'sbom').  For each variant, keeps the scan with the latest timestamp.
-    """
-    latest: dict = {}
-    for s in scans:
-        if (s.scan_type or "sbom") != "sbom":
-            continue
-        prev = latest.get(s.variant_id)
-        if prev is None or s.timestamp > prev.timestamp:
-            latest[s.variant_id] = s
-    return latest
-
 
 def _sbom_scans_by_variant(scans: list[Scan]) -> dict:
     """Return {variant_id: [sbom_scan, …]} ordered by timestamp ascending.
@@ -978,7 +963,10 @@ def init_app(app):
             prev_vulns = {obs.finding.vulnerability_id for obs in prev_scan.observations} if prev_scan else set()
             added_fids = current_finding_ids - prev_finding_ids
             removed_fids = prev_finding_ids - current_finding_ids
-            findings_added = [_obs_to_dict(obs, scan_origin) for obs in scan.observations if obs.finding_id in added_fids]
+            findings_added = [
+                _obs_to_dict(obs, scan_origin)
+                for obs in scan.observations if obs.finding_id in added_fids
+            ]
             findings_removed = (
                 [_obs_to_dict(obs, scan_origin) for obs in prev_scan.observations if obs.finding_id in removed_fids]
                 if prev_scan else []

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
+import json
 import uuid as uuid_module
 
 from flask import jsonify
@@ -11,6 +12,7 @@ from ..controllers.scans import ScanController
 from ..controllers.projects import ProjectController
 from ..controllers.variants import VariantController
 from ..models.scan import Scan
+from ..models.scan_diff_cache import ScanDiffCache
 from ..models.observation import Observation
 from ..models.finding import Finding
 from ..models.sbom_document import SBOMDocument
@@ -602,6 +604,114 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Cache — computed diff fields
+# ---------------------------------------------------------------------------
+
+# Fields stored in ScanDiffCache (must match the model columns).
+_CACHE_FIELDS = (
+    "finding_count", "package_count", "vuln_count", "is_first",
+    "findings_added", "findings_removed", "findings_upgraded", "findings_unchanged",
+    "packages_added", "packages_removed", "packages_upgraded", "packages_unchanged",
+    "vulns_added", "vulns_removed", "vulns_unchanged",
+    "newly_detected_findings", "newly_detected_vulns",
+    "branch_finding_count", "branch_vuln_count", "branch_package_count",
+    "global_finding_count", "global_vuln_count", "global_package_count",
+)
+
+
+def _store_cache(results: list[dict]) -> None:
+    """Upsert computed diff data into scan_diff_cache for each result dict."""
+    if not results:
+        return
+    scan_ids = [uuid_module.UUID(r["id"]) for r in results]
+    # Delete existing cache rows for these scans
+    db.session.execute(
+        db.delete(ScanDiffCache).where(ScanDiffCache.scan_id.in_(scan_ids))
+    )
+    for r in results:
+        row = ScanDiffCache(scan_id=uuid_module.UUID(r["id"]))
+        for field in _CACHE_FIELDS:
+            setattr(row, field, r.get(field))
+        formats = r.get("formats")
+        row.formats_json = json.dumps(formats) if formats is not None else None
+        db.session.add(row)
+    db.session.commit()
+
+
+def _read_cache(scans: list[Scan]) -> list[dict] | None:
+    """Try to build the list-view response entirely from cache.
+
+    Returns the list of result dicts (same shape as _serialize_list_with_diff)
+    if every scan has a cache entry.  Returns ``None`` on any cache miss so
+    the caller can fall back to full computation.
+    """
+    if not scans:
+        return []
+    scan_ids = [s.id for s in scans]
+    rows = db.session.execute(
+        db.select(ScanDiffCache).where(ScanDiffCache.scan_id.in_(scan_ids))
+    ).scalars().all()
+    cache_map = {r.scan_id: r for r in rows}
+    if len(cache_map) != len(scan_ids):
+        return None  # cache miss
+    # Build variant info for display names
+    variant_map = _variant_info(list({s.variant_id for s in scans}))
+    result = []
+    for scan in scans:
+        c = cache_map[scan.id]
+        base = ScanController.serialize(scan)
+        variant_name, project_name = variant_map.get(scan.variant_id, (None, None))
+        base["variant_name"] = variant_name
+        base["project_name"] = project_name
+        for field in _CACHE_FIELDS:
+            base[field] = getattr(c, field)
+        base["formats"] = json.loads(c.formats_json) if c.formats_json else []
+        result.append(base)
+    return result
+
+
+def recompute_variant_cache(variant_id) -> None:
+    """Re-compute and store the scan-history diff cache for *variant_id*.
+
+    Call this after any mutation that affects scan history (SBOM upload,
+    tool scan completion, scan deletion).
+    """
+    scans = Scan.get_by_variant_id(variant_id)
+    if not scans:
+        # No scans left — clear any stale cache rows
+        db.session.execute(
+            db.delete(ScanDiffCache).where(
+                ScanDiffCache.scan_id.in_(
+                    db.select(Scan.id).where(Scan.variant_id == variant_id)
+                )
+            )
+        )
+        db.session.commit()
+        return
+    results = _serialize_list_with_diff(scans)
+    _store_cache(results)
+
+
+def invalidate_variant_cache(variant_id) -> None:
+    """Delete cached scan-history data for *variant_id*.
+
+    The cache will be lazily rebuilt the next time a list endpoint is hit.
+    Use this when the calling context cannot easily recompute (e.g. a
+    background thread that spawns sub-processes without direct DB access).
+    """
+    scan_ids = [
+        row[0] for row in db.session.execute(
+            db.select(Scan.id).where(Scan.variant_id == variant_id)
+        ).all()
+    ]
+    if scan_ids:
+        db.session.execute(
+            db.delete(ScanDiffCache).where(ScanDiffCache.scan_id.in_(scan_ids))
+        )
+        db.session.commit()
+
+
+# ---------------------------------------------------------------------------
 # Helpers — detailed diff (for the diff endpoint)
 # ---------------------------------------------------------------------------
 
@@ -720,7 +830,12 @@ def init_app(app):
     @app.route('/api/scans')
     def list_all_scans():
         scans = ScanController.get_all()
-        return jsonify(_serialize_list_with_diff(scans))
+        cached = _read_cache(scans)
+        if cached is not None:
+            return jsonify(cached)
+        result = _serialize_list_with_diff(scans)
+        _store_cache(result)
+        return jsonify(result)
 
     @app.route('/api/projects/<project_id>/scans')
     def list_scans_by_project(project_id):
@@ -728,7 +843,12 @@ def init_app(app):
         if project is None:
             return jsonify({"error": "Project not found"}), 404
         scans = ScanController.get_by_project(project_id)
-        return jsonify(_serialize_list_with_diff(scans))
+        cached = _read_cache(scans)
+        if cached is not None:
+            return jsonify(cached)
+        result = _serialize_list_with_diff(scans)
+        _store_cache(result)
+        return jsonify(result)
 
     @app.route('/api/variants/<variant_id>/scans')
     def list_scans_by_variant(variant_id):
@@ -736,7 +856,12 @@ def init_app(app):
         if variant is None:
             return jsonify({"error": "Variant not found"}), 404
         scans = ScanController.get_by_variant(variant_id)
-        return jsonify(_serialize_list_with_diff(scans))
+        cached = _read_cache(scans)
+        if cached is not None:
+            return jsonify(cached)
+        result = _serialize_list_with_diff(scans)
+        _store_cache(result)
+        return jsonify(result)
 
     @app.route('/api/scans/<scan_id>', methods=['PATCH'])
     def update_scan(scan_id):
@@ -773,6 +898,9 @@ def init_app(app):
         if scan is None:
             return jsonify({"error": "Scan not found"}), 404
 
+        # Remember variant so we can recompute cache after deletion.
+        variant_id = scan.variant_id
+
         # Collect finding IDs referenced by this scan's observations
         # *before* the cascade delete removes them.
         finding_ids = {obs.finding_id for obs in (scan.observations or [])}
@@ -796,6 +924,9 @@ def init_app(app):
                         orphaned_count += 1
             if orphaned_count:
                 db.session.commit()
+
+        # Recompute scan-history cache for the affected variant.
+        recompute_variant_cache(variant_id)
 
         return jsonify({
             "deleted": True,
@@ -1415,6 +1546,13 @@ def init_app(app):
                     )
                     _grype_scans_in_progress[vid_str]["done_count"] = 4
 
+                    # Invalidate scan-history cache so next list request recomputes.
+                    try:
+                        with app.app_context():
+                            invalidate_variant_cache(variant_uuid)
+                    except Exception:
+                        pass  # non-critical; cache rebuilt lazily on next request
+
                     done_logs = _grype_scans_in_progress[vid_str].get("logs", [])
                     done_logs.append("✓ Grype scan complete")
                     _grype_scans_in_progress[vid_str] = {
@@ -1832,6 +1970,12 @@ def init_app(app):
 
                 db.session.commit()
 
+                # Recompute scan-history cache for the affected variant.
+                try:
+                    recompute_variant_cache(variant_uuid)
+                except Exception:
+                    pass  # non-critical; cache rebuilt lazily
+
                 done_logs = _nvd_scans_in_progress[vid_str].get(
                     "logs", []
                 )
@@ -2159,6 +2303,12 @@ def init_app(app):
                                     )
 
                 db.session.commit()
+
+                # Recompute scan-history cache for the affected variant.
+                try:
+                    recompute_variant_cache(variant_uuid)
+                except Exception:
+                    pass  # non-critical; cache rebuilt lazily
 
                 done_logs = _osv_scans_in_progress[vid_str].get(
                     "logs", []

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -163,14 +163,17 @@ def _variant_info(variant_ids: list) -> dict:
 # ---------------------------------------------------------------------------
 
 def _prev_scan_map(scans: list[Scan]) -> dict:
-    """Return {scan.id: previous_scan_or_None} grouped by (variant, scan_type), ordered by timestamp.
+    """Return {scan.id: previous_scan_or_None} grouped by (variant, scan_type, scan_source), ordered by timestamp.
 
-    Tool scans (e.g. Grype) are only compared against previous tool scans,
-    and SBOM scans are only compared against previous SBOM scans.
+    Tool scans are further grouped by scan_source so that Grype scans only
+    compare against previous Grype scans, NVD against NVD, etc.
+    SBOM scans are only compared against previous SBOM scans.
     """
     by_key: dict = {}
     for s in scans:
-        key = (s.variant_id, s.scan_type or "sbom")
+        stype = s.scan_type or "sbom"
+        source = s.scan_source if stype == "tool" else None
+        key = (s.variant_id, stype, source)
         by_key.setdefault(key, []).append(s)
     mapping: dict = {}
     for group_scans in by_key.values():
@@ -183,6 +186,22 @@ def _prev_scan_map(scans: list[Scan]) -> dict:
 # Helpers — serialisation for list view
 # ---------------------------------------------------------------------------
 
+def _latest_sbom_scan_per_variant(scans: list[Scan]) -> dict:
+    """Return {variant_id: latest_sbom_Scan} from the given scan list.
+
+    Only considers scans with scan_type == 'sbom' (or NULL which defaults to
+    'sbom').  For each variant, keeps the scan with the latest timestamp.
+    """
+    latest: dict = {}
+    for s in scans:
+        if (s.scan_type or "sbom") != "sbom":
+            continue
+        prev = latest.get(s.variant_id)
+        if prev is None or s.timestamp > prev.timestamp:
+            latest[s.variant_id] = s
+    return latest
+
+
 def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
     if not scans:
         return []
@@ -193,6 +212,18 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
     vulns_map = _vulns_by_scan_ids(scan_ids)
     prev_map = _prev_scan_map(scans)
     variant_map = _variant_info(list({s.variant_id for s in scans}))
+
+    # For tool scans: find the latest SBOM scan per variant so we can compute
+    # "newly detected" counts (findings/vulns found by the tool but absent
+    # from the SBOM baseline).
+    latest_sbom = _latest_sbom_scan_per_variant(scans)
+    # We may need findings/vulns for SBOM scans that aren't already in our maps
+    # (they already are because all scans in the list are fetched).
+    sbom_findings: dict = {}  # variant_id -> set(finding_id)
+    sbom_vulns: dict = {}     # variant_id -> set(vulnerability_id)
+    for vid, sbom_scan in latest_sbom.items():
+        sbom_findings[vid] = findings_map.get(sbom_scan.id, set())
+        sbom_vulns[vid] = vulns_map.get(sbom_scan.id, set())
 
     # First pass: compute package diffs and collect all finding IDs that need
     # package-level info for upgrade classification.
@@ -249,6 +280,11 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
         fid_to_info = {r[0]: (r[1], r[2]) for r in rows}
 
     # Second pass: build result dicts
+    # Track latest tool-scan findings/vulns per (variant, source) as we
+    # iterate in chronological order so we can compute the "global" result
+    # (SBOM ∪ all latest sources) at each point in time.
+    running_src_findings: dict = {}  # (variant_id, source) -> set
+    running_src_vulns: dict = {}     # (variant_id, source) -> set
     result = []
     for entry in scan_data:
         scan = entry["scan"]
@@ -266,7 +302,72 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
 
         is_tool_scan = (scan.scan_type or "sbom") == "tool"
 
-        if prev is None:
+        if is_tool_scan:
+            # ---- Tool scan: diff against the GLOBAL state ----
+            # Compare the global result (SBOM ∪ all tool sources) before and
+            # after this scan so that added/removed counts reflect the real
+            # impact on the combined result, not the delta vs. the previous
+            # scan of the same tool type.
+            baseline_f = sbom_findings.get(scan.variant_id, set())
+            baseline_v = sbom_vulns.get(scan.variant_id, set())
+            src_key = (scan.variant_id, scan.scan_source)
+
+            # Global state BEFORE this scan
+            global_before_f = set(baseline_f)
+            global_before_v = set(baseline_v)
+            for (vid, _src), f_ids in running_src_findings.items():
+                if vid == scan.variant_id:
+                    global_before_f |= f_ids
+            for (vid, _src), v_ids in running_src_vulns.items():
+                if vid == scan.variant_id:
+                    global_before_v |= v_ids
+
+            # Update running tracker for this source
+            running_src_findings[src_key] = curr_f
+            running_src_vulns[src_key] = curr_v
+
+            # Global state AFTER this scan
+            global_f = set(baseline_f)
+            global_v = set(baseline_v)
+            for (vid, _src), f_ids in running_src_findings.items():
+                if vid == scan.variant_id:
+                    global_f |= f_ids
+            for (vid, _src), v_ids in running_src_vulns.items():
+                if vid == scan.variant_id:
+                    global_v |= v_ids
+
+            base["is_first"] = (prev is None)
+            base["packages_added"] = 0
+            base["packages_removed"] = 0
+            base["packages_upgraded"] = 0
+            base["findings_upgraded"] = 0
+            base["findings_added"] = len(global_f - global_before_f)
+            base["findings_removed"] = len(global_before_f - global_f)
+            base["vulns_added"] = len(global_v - global_before_v)
+            base["vulns_removed"] = len(global_before_v - global_v)
+
+            # "Newly detected" = findings/vulns added to the global result.
+            # By definition these are NOT in the SBOM baseline since SBOM is
+            # part of both global_before and global_after.
+            base["newly_detected_findings"] = base["findings_added"]
+            base["newly_detected_vulns"] = base["vulns_added"]
+
+            # Branch result = SBOM baseline ∪ this tool scan only
+            sbom_scan_obj = latest_sbom.get(scan.variant_id)
+            sbom_pkg = packages_map.get(
+                sbom_scan_obj.id, set()
+            ) if sbom_scan_obj else set()
+            base["branch_finding_count"] = len(baseline_f | curr_f)
+            base["branch_vuln_count"] = len(baseline_v | curr_v)
+            base["branch_package_count"] = len(sbom_pkg)
+
+            # Global result = SBOM baseline ∪ all latest tool-scan sources
+            base["global_finding_count"] = len(global_f)
+            base["global_vuln_count"] = len(global_v)
+            base["global_package_count"] = len(sbom_pkg)
+
+            base["formats"] = []
+        elif prev is None:
             base["is_first"] = True
             base["findings_added"] = None
             base["findings_removed"] = None
@@ -281,50 +382,76 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             prev_v = vulns_map.get(prev.id, set())
             base["is_first"] = False
 
-            if is_tool_scan:
-                # Tool scans: no package diffs, only findings/vulns
-                base["packages_added"] = 0
-                base["packages_removed"] = 0
-                base["packages_upgraded"] = 0
-                base["findings_upgraded"] = 0
-                base["findings_added"] = len(curr_f - prev_f)
-                base["findings_removed"] = len(prev_f - curr_f)
+            upgraded_pairs = entry["upgraded_pairs"]
+            prev_pkgs = packages_map.get(prev.id, set())
+            base["packages_added"] = entry.get("truly_added_p", len(entry["curr_p"] - prev_pkgs))
+            base["packages_removed"] = entry.get("truly_removed_p", len(prev_pkgs - entry["curr_p"]))
+            base["packages_upgraded"] = len(upgraded_pairs)
+
+            raw_added_f = curr_f - prev_f
+            raw_removed_f = prev_f - curr_f
+
+            if upgraded_pairs and entry["raw_added_f"]:
+                # Classify findings on upgraded packages
+                upgraded_old_ids = {str(old_pkg.id) for old_pkg, _ in upgraded_pairs}
+                upgraded_new_ids = {str(new_pkg.id) for _, new_pkg in upgraded_pairs}
+                # Vulns on removed side that belong to upgraded old packages
+                removed_vulns_on_upgraded = {
+                    fid_to_info[fid][1]
+                    for fid in raw_removed_f
+                    if fid in fid_to_info and str(fid_to_info[fid][0]) in upgraded_old_ids
+                }
+                upgraded_count = sum(
+                    1 for fid in raw_added_f
+                    if fid in fid_to_info
+                    and str(fid_to_info[fid][0]) in upgraded_new_ids
+                    and fid_to_info[fid][1] in removed_vulns_on_upgraded
+                )
+                base["findings_upgraded"] = upgraded_count
+                base["findings_added"] = len(raw_added_f) - upgraded_count
+                base["findings_removed"] = len(raw_removed_f) - upgraded_count
             else:
-                upgraded_pairs = entry["upgraded_pairs"]
-                prev_pkgs = packages_map.get(prev.id, set())
-                base["packages_added"] = entry.get("truly_added_p", len(entry["curr_p"] - prev_pkgs))
-                base["packages_removed"] = entry.get("truly_removed_p", len(prev_pkgs - entry["curr_p"]))
-                base["packages_upgraded"] = len(upgraded_pairs)
-
-                raw_added_f = curr_f - prev_f
-                raw_removed_f = prev_f - curr_f
-
-                if upgraded_pairs and entry["raw_added_f"]:
-                    # Classify findings on upgraded packages
-                    upgraded_old_ids = {str(old_pkg.id) for old_pkg, _ in upgraded_pairs}
-                    upgraded_new_ids = {str(new_pkg.id) for _, new_pkg in upgraded_pairs}
-                    # Vulns on removed side that belong to upgraded old packages
-                    removed_vulns_on_upgraded = {
-                        fid_to_info[fid][1]
-                        for fid in raw_removed_f
-                        if fid in fid_to_info and str(fid_to_info[fid][0]) in upgraded_old_ids
-                    }
-                    upgraded_count = sum(
-                        1 for fid in raw_added_f
-                        if fid in fid_to_info
-                        and str(fid_to_info[fid][0]) in upgraded_new_ids
-                        and fid_to_info[fid][1] in removed_vulns_on_upgraded
-                    )
-                    base["findings_upgraded"] = upgraded_count
-                    base["findings_added"] = len(raw_added_f) - upgraded_count
-                    base["findings_removed"] = len(raw_removed_f) - upgraded_count
-                else:
-                    base["findings_upgraded"] = 0
-                    base["findings_added"] = len(raw_added_f)
-                    base["findings_removed"] = len(raw_removed_f)
+                base["findings_upgraded"] = 0
+                base["findings_added"] = len(raw_added_f)
+                base["findings_removed"] = len(raw_removed_f)
 
             base["vulns_added"] = len(curr_v - prev_v)
             base["vulns_removed"] = len(prev_v - curr_v)
+
+        # ---- Non-tool (SBOM) scans: set tool-only fields to None ----
+        if not is_tool_scan:
+            base["newly_detected_findings"] = None
+            base["newly_detected_vulns"] = None
+            base["branch_finding_count"] = None
+            base["branch_vuln_count"] = None
+            base["branch_package_count"] = None
+
+            # Scan Result for SBOM scans = SBOM ∪ all latest tool-scan sources
+            has_tool_scans = any(
+                vid == scan.variant_id for (vid, _src) in running_src_findings
+            )
+            if has_tool_scans:
+                merge_f = set(curr_f)
+                merge_v = set(curr_v)
+                for (vid, _src), f_ids in running_src_findings.items():
+                    if vid == scan.variant_id:
+                        merge_f |= f_ids
+                for (vid, _src), v_ids in running_src_vulns.items():
+                    if vid == scan.variant_id:
+                        merge_v |= v_ids
+                base["global_finding_count"] = len(merge_f)
+                base["global_vuln_count"] = len(merge_v)
+                base["global_package_count"] = len(entry["curr_p"])
+            else:
+                base["global_finding_count"] = None
+                base["global_vuln_count"] = None
+                base["global_package_count"] = None
+
+            doc_formats = set()
+            for doc in (scan.sbom_documents or []):
+                if doc.format:
+                    doc_formats.add(doc.format)
+            base["formats"] = sorted(doc_formats)
 
         result.append(base)
     return result
@@ -426,7 +553,7 @@ def _classify_finding_changes(findings_added, findings_removed, upgraded_pairs):
 def init_app(app):
 
     # Track running Grype scans so we can report status / prevent duplicates
-    _grype_scans_in_progress: dict = {}  # variant_id -> {"status": str, "error": str|None}
+    _grype_scans_in_progress: dict = {}  # variant_id -> {status, error, progress, logs, total, done_count}
 
     @app.route('/api/scans')
     def list_all_scans():
@@ -468,6 +595,52 @@ def init_app(app):
         updated = ScanController.update(scan, description)
         return jsonify(ScanController.serialize(updated))
 
+    @app.route('/api/scans/<scan_id>', methods=['DELETE'])
+    def delete_scan(scan_id):
+        """Delete a scan and its observations.
+
+        Findings that are no longer referenced by any observation are
+        also removed (cascade cleaned).  The response includes the
+        number of orphaned findings that were deleted.
+        """
+        try:
+            scan_uuid = uuid_module.UUID(scan_id)
+        except ValueError:
+            return jsonify({"error": "Invalid scan id"}), 400
+        scan = ScanController.get(scan_uuid)
+        if scan is None:
+            return jsonify({"error": "Scan not found"}), 404
+
+        # Collect finding IDs referenced by this scan's observations
+        # *before* the cascade delete removes them.
+        finding_ids = {obs.finding_id for obs in (scan.observations or [])}
+
+        # Delete the scan (cascades to observations + sbom_documents)
+        ScanController.delete(scan)
+
+        # Clean up orphaned findings — those that no longer have any
+        # observation linking them to a remaining scan.
+        orphaned_count = 0
+        if finding_ids:
+            from sqlalchemy import exists as sa_exists
+            for fid in finding_ids:
+                has_obs = db.session.query(
+                    sa_exists().where(Observation.finding_id == fid)
+                ).scalar()
+                if not has_obs:
+                    finding = db.session.get(Finding, fid)
+                    if finding:
+                        db.session.delete(finding)
+                        orphaned_count += 1
+            if orphaned_count:
+                db.session.commit()
+
+        return jsonify({
+            "deleted": True,
+            "scan_id": scan_id,
+            "orphaned_findings_removed": orphaned_count,
+        })
+
     @app.route('/api/scans/<scan_id>/diff')
     def get_scan_diff(scan_id):
         try:
@@ -479,11 +652,16 @@ def init_app(app):
         if scan is None:
             return jsonify({"error": "Scan not found"}), 404
 
-        # Locate the previous scan of the same type for the same variant
+        # Locate the previous scan of the same type (and source) for the same variant
         all_variant_scans = ScanController.get_by_variant(scan.variant_id)
         scan_type = scan.scan_type or "sbom"
+        scan_source = scan.scan_source
         prev_scan_id = None
-        same_type_scans = [s for s in all_variant_scans if (s.scan_type or "sbom") == scan_type]
+        same_type_scans = [
+            s for s in all_variant_scans
+            if (s.scan_type or "sbom") == scan_type
+            and (s.scan_source == scan_source if scan_type == "tool" else True)
+        ]
         for i, s in enumerate(same_type_scans):
             if s.id == scan.id and i > 0:
                 prev_scan_id = same_type_scans[i - 1].id
@@ -564,6 +742,45 @@ def init_app(app):
         packages_upgraded.sort(key=lambda p: (p["package_name"], p["old_version"]))
         findings_upgraded.sort(key=lambda f: (f["package_name"], f["vulnerability_id"]))
 
+        # --- Newly detected (tool scans only): findings/vulns that are in
+        # this tool scan but NOT in the latest SBOM scan AND NOT already
+        # present in the previous tool scan.
+        newly_detected_findings_count = None
+        newly_detected_vulns_count = None
+        newly_detected_findings_list = None
+        newly_detected_vulns_list = None
+        if is_tool_scan:
+            sbom_scans = [s for s in all_variant_scans if (s.scan_type or "sbom") == "sbom"]
+            sbom_fids: set = set()
+            sbom_vids: set = set()
+            if sbom_scans:
+                latest_sbom = sbom_scans[-1]  # ordered by timestamp
+                sbom_scan_loaded = _load_scan_with_findings(latest_sbom.id)
+                if sbom_scan_loaded:
+                    sbom_fids = {obs.finding_id for obs in sbom_scan_loaded.observations}
+                    sbom_vids = {obs.finding.vulnerability_id for obs in sbom_scan_loaded.observations}
+
+            # Start from findings/vulns not in SBOM
+            new_fids = current_finding_ids - sbom_fids
+            new_vids = curr_vulns - sbom_vids
+
+            # Subtract what was already present in the previous tool scan
+            if prev_scan_id is not None:
+                prev_scan_loaded = _load_scan_with_findings(prev_scan_id)
+                if prev_scan_loaded:
+                    prev_tool_fids = {obs.finding_id for obs in prev_scan_loaded.observations}
+                    new_fids = new_fids - prev_tool_fids
+                    prev_tool_vids = {obs.finding.vulnerability_id for obs in prev_scan_loaded.observations}
+                    new_vids = new_vids - prev_tool_vids
+
+            newly_detected_findings_count = len(new_fids)
+            newly_detected_vulns_count = len(new_vids)
+            newly_detected_findings_list = [
+                _obs_to_dict(obs) for obs in scan.observations
+                if obs.finding_id in new_fids
+            ]
+            newly_detected_vulns_list = sorted(new_vids)
+
         return jsonify({
             "scan_id": str(scan.id),
             "scan_type": scan_type,
@@ -580,6 +797,138 @@ def init_app(app):
             "packages_upgraded": packages_upgraded,
             "vulns_added": vulns_added,
             "vulns_removed": vulns_removed,
+            "newly_detected_findings": newly_detected_findings_count,
+            "newly_detected_vulns": newly_detected_vulns_count,
+            "newly_detected_findings_list": newly_detected_findings_list,
+            "newly_detected_vulns_list": newly_detected_vulns_list,
+        })
+
+    # ------------------------------------------------------------------
+    # Merge result — all active items (SBOM ∪ tool scan) with source info
+    # ------------------------------------------------------------------
+
+    @app.route('/api/scans/<scan_id>/global-result')
+    def get_scan_global_result(scan_id):
+        """Return every active finding, vulnerability, and package at the
+        time of *scan_id* together with their source (SBOM document name /
+        format or scan source label).
+
+        For an SBOM scan the merge result is just that scan's own data.
+        For a tool scan the merge result is the union of the latest SBOM
+        scan for the same variant **plus** this tool scan.
+        """
+        try:
+            scan_uuid = uuid_module.UUID(scan_id)
+        except ValueError:
+            return jsonify({"error": "Invalid scan id"}), 400
+
+        scan = _load_scan_with_findings(scan_uuid)
+        if scan is None:
+            return jsonify({"error": "Scan not found"}), 404
+
+        scan_type = scan.scan_type or "sbom"
+        is_tool_scan = scan_type == "tool"
+
+        # Determine which scans contribute to the global view
+        contributing_scan_ids: list = [scan.id]
+        sbom_scan = None
+        if is_tool_scan:
+            all_variant_scans = ScanController.get_by_variant(scan.variant_id)
+            sbom_scans = [s for s in all_variant_scans if (s.scan_type or "sbom") == "sbom"]
+            if sbom_scans:
+                sbom_scan = sbom_scans[-1]
+                contributing_scan_ids.append(sbom_scan.id)
+
+        # --- Packages with source ---
+        # Packages come from SBOM documents only (tool scans don't add packages)
+        pkg_rows = db.session.execute(
+            db.select(
+                Package.id, Package.name, Package.version,
+                SBOMDocument.source_name, SBOMDocument.format, SBOMDocument.scan_id,
+            )
+            .join(SBOMPackage, SBOMPackage.package_id == Package.id)
+            .join(SBOMDocument, SBOMDocument.id == SBOMPackage.sbom_document_id)
+            .where(SBOMDocument.scan_id.in_(contributing_scan_ids))
+        ).all()
+        # Deduplicate by package id, keep all sources
+        pkg_map: dict = {}  # package_id -> dict
+        for pid, pname, pversion, src_name, src_fmt, src_scan_id in pkg_rows:
+            source_label = f"{src_name} ({src_fmt})" if src_fmt else src_name
+            if pid not in pkg_map:
+                pkg_map[pid] = {
+                    "package_id": str(pid),
+                    "package_name": pname or "unknown",
+                    "package_version": pversion or "",
+                    "sources": [source_label],
+                }
+            else:
+                if source_label not in pkg_map[pid]["sources"]:
+                    pkg_map[pid]["sources"].append(source_label)
+        packages = sorted(pkg_map.values(), key=lambda p: (p["package_name"], p["package_version"]))
+
+        # --- Findings & vulnerabilities with source ---
+        # Load observations from all contributing scans
+        loaded_scans: dict = {scan.id: scan}  # already loaded
+        for sid in contributing_scan_ids:
+            if sid not in loaded_scans:
+                loaded = _load_scan_with_findings(sid)
+                if loaded:
+                    loaded_scans[sid] = loaded
+
+        finding_map: dict = {}   # finding_id -> dict
+        vuln_set: dict = {}      # vulnerability_id -> set of sources
+        for sid, loaded in loaded_scans.items():
+            s_type = loaded.scan_type or "sbom"
+            if s_type == "tool":
+                source_labels = {
+                    "grype": "Grype",
+                    "nvd": "NVD CPE",
+                    "osv": "OSV",
+                }
+                source_label = source_labels.get(
+                    loaded.scan_source or "", "Vulnerability Scan"
+                )
+            else:
+                # Use SBOM document names as source
+                doc_names = []
+                for doc in (loaded.sbom_documents if hasattr(loaded, 'sbom_documents') else []):
+                    label = f"{doc.source_name} ({doc.format})" if doc.format else doc.source_name
+                    doc_names.append(label)
+                source_label = ", ".join(doc_names) if doc_names else "SBOM Scan"
+            for obs in loaded.observations:
+                fid = obs.finding_id
+                f = obs.finding
+                pkg = f.package
+                if fid not in finding_map:
+                    finding_map[fid] = {
+                        "finding_id": str(fid),
+                        "package_name": pkg.name if pkg else "unknown",
+                        "package_version": pkg.version if pkg else "",
+                        "package_id": str(f.package_id),
+                        "vulnerability_id": f.vulnerability_id,
+                        "sources": [source_label],
+                    }
+                else:
+                    if source_label not in finding_map[fid]["sources"]:
+                        finding_map[fid]["sources"].append(source_label)
+                vid = f.vulnerability_id
+                vuln_set.setdefault(vid, set()).add(source_label)
+
+        findings = sorted(finding_map.values(), key=lambda f: (f["vulnerability_id"], f["package_name"]))
+        vulnerabilities = [
+            {"vulnerability_id": vid, "sources": sorted(srcs)}
+            for vid, srcs in sorted(vuln_set.items())
+        ]
+
+        return jsonify({
+            "scan_id": str(scan.id),
+            "scan_type": scan_type,
+            "packages": packages,
+            "findings": findings,
+            "vulnerabilities": vulnerabilities,
+            "package_count": len(packages),
+            "finding_count": len(findings),
+            "vuln_count": len(vulnerabilities),
         })
 
     @app.route('/api/variants/<variant_id>/grype-scan', methods=['POST'])
@@ -616,7 +965,10 @@ def init_app(app):
         project_name = project.name if project else "unknown"
         variant_name = variant.name
 
-        _grype_scans_in_progress[vid_str] = {"status": "running", "error": None}
+        _grype_scans_in_progress[vid_str] = {
+            "status": "running", "error": None, "progress": "starting",
+            "logs": [], "total": 4, "done_count": 0,
+        }
 
         def _run_grype_scan():
             try:
@@ -627,22 +979,38 @@ def init_app(app):
                 grype_tmp = tempfile.mkdtemp(prefix="vulnscout_grype_")
                 try:
                     # 1. Export current DB as CycloneDX
+                    _grype_scans_in_progress[vid_str]["progress"] = "1/4 Exporting CycloneDX"
+                    _grype_scans_in_progress[vid_str]["logs"].append(
+                        "[1/4] Exporting current DB as CycloneDX…"
+                    )
                     subprocess.run(
                         ["flask", "--app", "src.bin.webapp", "export",
                          "--format", "cdx16", "--output-dir", grype_tmp],
                         cwd=base_dir, check=True, capture_output=True, text=True,
                         timeout=120,
                     )
+                    _grype_scans_in_progress[vid_str]["done_count"] = 1
 
                     exported_cdx = os.path.join(grype_tmp, "sbom_cyclonedx_v1_6.cdx.json")
                     if not os.path.isfile(exported_cdx):
+                        old_logs = _grype_scans_in_progress[vid_str].get("logs", [])
+                        old_logs.append("ERROR: CycloneDX export produced no file")
                         _grype_scans_in_progress[vid_str] = {
                             "status": "error",
                             "error": "CycloneDX export produced no file",
+                            "progress": None,
+                            "logs": old_logs, "total": 4, "done_count": 1,
                         }
                         return
+                    _grype_scans_in_progress[vid_str]["logs"].append(
+                        "[1/4] CycloneDX export complete"
+                    )
 
                     # 2. Run grype on the exported SBOM
+                    _grype_scans_in_progress[vid_str]["progress"] = "2/4 Running Grype"
+                    _grype_scans_in_progress[vid_str]["logs"].append(
+                        "[2/4] Running Grype vulnerability scanner…"
+                    )
                     grype_out = os.path.join(grype_tmp, "grype_results.grype.json")
                     with open(grype_out, "w") as gf:
                         subprocess.run(
@@ -652,15 +1020,27 @@ def init_app(app):
                             stdout=gf, stderr=subprocess.PIPE,
                             timeout=600,
                         )
+                    _grype_scans_in_progress[vid_str]["done_count"] = 2
 
                     if not os.path.isfile(grype_out) or os.path.getsize(grype_out) == 0:
+                        old_logs = _grype_scans_in_progress[vid_str].get("logs", [])
+                        old_logs.append("ERROR: Grype produced no output")
                         _grype_scans_in_progress[vid_str] = {
                             "status": "error",
                             "error": "Grype produced no output",
+                            "progress": None,
+                            "logs": old_logs, "total": 4, "done_count": 2,
                         }
                         return
+                    _grype_scans_in_progress[vid_str]["logs"].append(
+                        "[2/4] Grype scan complete"
+                    )
 
                     # 3. Merge Grype results as a tool scan
+                    _grype_scans_in_progress[vid_str]["progress"] = "3/4 Merging results"
+                    _grype_scans_in_progress[vid_str]["logs"].append(
+                        "[3/4] Merging Grype results into database…"
+                    )
                     subprocess.run(
                         ["flask", "--app", "src.bin.webapp", "merge",
                          "--project", project_name, "--variant", variant_name,
@@ -668,31 +1048,62 @@ def init_app(app):
                         cwd=base_dir, check=True, capture_output=True, text=True,
                         timeout=120,
                     )
+                    _grype_scans_in_progress[vid_str]["done_count"] = 3
+                    _grype_scans_in_progress[vid_str]["logs"].append(
+                        "[3/4] Merge complete"
+                    )
 
                     # 4. Process
+                    _grype_scans_in_progress[vid_str]["progress"] = "4/4 Processing"
+                    _grype_scans_in_progress[vid_str]["logs"].append(
+                        "[4/4] Processing scan results…"
+                    )
                     subprocess.run(
                         ["flask", "--app", "src.bin.webapp", "process"],
                         cwd=base_dir, check=True, capture_output=True, text=True,
                         timeout=300,
                     )
+                    _grype_scans_in_progress[vid_str]["done_count"] = 4
 
-                    _grype_scans_in_progress[vid_str] = {"status": "done", "error": None}
+                    done_logs = _grype_scans_in_progress[vid_str].get("logs", [])
+                    done_logs.append("✓ Grype scan complete")
+                    _grype_scans_in_progress[vid_str] = {
+                        "status": "done", "error": None,
+                        "progress": "Scan complete",
+                        "logs": done_logs, "total": 4, "done_count": 4,
+                    }
                 finally:
                     shutil.rmtree(grype_tmp, ignore_errors=True)
             except subprocess.TimeoutExpired:
+                old_logs = _grype_scans_in_progress[vid_str].get("logs", [])
+                old_logs.append("ERROR: Grype scan timed out")
                 _grype_scans_in_progress[vid_str] = {
                     "status": "error",
                     "error": "Grype scan timed out",
+                    "progress": None,
+                    "logs": old_logs, "total": 4,
+                    "done_count": _grype_scans_in_progress[vid_str].get("done_count", 0),
                 }
             except subprocess.CalledProcessError as e:
+                old_logs = _grype_scans_in_progress[vid_str].get("logs", [])
+                err_msg = f"Command failed: {e.stderr[:500] if e.stderr else str(e)}"
+                old_logs.append(f"ERROR: {err_msg}")
                 _grype_scans_in_progress[vid_str] = {
                     "status": "error",
-                    "error": f"Command failed: {e.stderr[:500] if e.stderr else str(e)}",
+                    "error": err_msg,
+                    "progress": None,
+                    "logs": old_logs, "total": 4,
+                    "done_count": _grype_scans_in_progress[vid_str].get("done_count", 0),
                 }
             except Exception as e:
+                old_logs = _grype_scans_in_progress[vid_str].get("logs", [])
+                old_logs.append(f"ERROR: {str(e)[:500]}")
                 _grype_scans_in_progress[vid_str] = {
                     "status": "error",
                     "error": str(e)[:500],
+                    "progress": None,
+                    "logs": old_logs, "total": 4,
+                    "done_count": _grype_scans_in_progress[vid_str].get("done_count", 0),
                 }
 
         thread = threading.Thread(
@@ -714,6 +1125,748 @@ def init_app(app):
 
         vid_str = str(variant_uuid)
         info = _grype_scans_in_progress.get(vid_str)
+        if info is None:
+            return jsonify({"status": "idle"})
+        return jsonify(info)
+
+    # ------------------------------------------------------------------
+    # NVD CPE Scan — query NVD by CPE for each active package
+    # ------------------------------------------------------------------
+
+    _nvd_scans_in_progress: dict = {}  # variant_id -> {"status": str, "error": str|None, "progress": str|None}
+
+    @app.route('/api/variants/<variant_id>/nvd-scan', methods=['POST'])
+    def trigger_nvd_scan(variant_id):
+        """Trigger an NVD CPE-based vulnerability scan for the given variant.
+
+        For every active package that has CPE identifiers, query the NVD CVE
+        API (``cpeName=…``) and create findings/observations for any CVEs
+        returned.  The result is stored as a tool scan.
+        """
+        import threading
+        import os
+
+        try:
+            variant_uuid = uuid_module.UUID(variant_id)
+        except ValueError:
+            return jsonify({"error": "Invalid variant id"}), 400
+
+        variant = VariantController.get(variant_uuid)
+        if variant is None:
+            return jsonify({"error": "Variant not found"}), 404
+
+        vid_str = str(variant_uuid)
+        if vid_str in _nvd_scans_in_progress and _nvd_scans_in_progress[vid_str]["status"] == "running":
+            return jsonify({"error": "An NVD scan is already in progress for this variant"}), 409
+
+        _nvd_scans_in_progress[vid_str] = {
+            "status": "running", "error": None, "progress": "starting",
+            "logs": [], "total": 0, "done_count": 0,
+        }
+
+        def _run_nvd_scan():
+            with app.app_context():
+                _do_nvd_scan(vid_str, variant_uuid)
+
+        def _do_nvd_scan(vid_str, variant_uuid):
+            try:
+                from ..controllers.nvd_db import NVD_DB
+                from ..models.vulnerability import Vulnerability as VulnModel
+                from ..models.metrics import Metrics as MetricsModel
+                from ..models.cvss import CVSS
+                from ..models.assessment import Assessment
+
+                nvd_api_key = os.getenv("NVD_API_KEY")
+                nvd = NVD_DB(nvd_api_key=nvd_api_key)
+
+                # 1. Get active packages for this variant (latest scans)
+                _nvd_scans_in_progress[vid_str]["logs"].append(
+                    "Resolving active packages…"
+                )
+                latest_rows = db.session.execute(
+                    db.select(Scan.id, Scan.scan_type)
+                    .where(Scan.variant_id == variant_uuid)
+                    .order_by(Scan.timestamp.desc())
+                ).all()
+                latest_ids: list = []
+                seen_types: set = set()
+                for sid, stype in latest_rows:
+                    st = stype or "sbom"
+                    if st not in seen_types:
+                        seen_types.add(st)
+                        latest_ids.append(sid)
+                    if len(seen_types) >= 2:
+                        break
+
+                if not latest_ids:
+                    _nvd_scans_in_progress[vid_str] = {
+                        "status": "error",
+                        "error": "No scans found for variant",
+                        "progress": None,
+                    }
+                    return
+
+                pkg_sets = _packages_by_scan_ids(latest_ids)
+                all_pkg_ids: set = set()
+                for s in pkg_sets.values():
+                    all_pkg_ids |= s
+
+                if not all_pkg_ids:
+                    _nvd_scans_in_progress[vid_str] = {
+                        "status": "error",
+                        "error": "No packages found for variant",
+                        "progress": None,
+                    }
+                    return
+
+                packages = db.session.execute(
+                    db.select(Package).where(Package.id.in_(all_pkg_ids))
+                ).scalars().all()
+
+                # 2. Collect CPE names from packages
+                # A CPE is queryable when it has a valid part (a/o/h) and
+                # at least a non-wildcard product.  Wildcard vendor is
+                # acceptable — the NVD virtualMatchString API handles it.
+                _valid_cpe_parts = {"a", "o", "h"}
+                cpe_to_pkgs: dict = {}  # cpeName -> list[Package]
+                for pkg in packages:
+                    for cpe in (pkg.cpe or []):
+                        parts = cpe.split(":")
+                        if (len(parts) >= 6
+                                and parts[2] in _valid_cpe_parts
+                                and parts[4] != "*"):
+                            cpe_to_pkgs.setdefault(cpe, []).append(pkg)
+
+                if not cpe_to_pkgs:
+                    old_logs = _nvd_scans_in_progress[vid_str].get(
+                        "logs", []
+                    )
+                    old_logs.append(
+                        "ERROR: No packages with valid CPE identifiers"
+                    )
+                    _nvd_scans_in_progress[vid_str] = {
+                        "status": "error",
+                        "error": "No packages with valid CPE identifiers",
+                        "progress": None,
+                        "logs": old_logs,
+                        "total": 0, "done_count": 0,
+                    }
+                    return
+
+                _nvd_scans_in_progress[vid_str]["logs"].append(
+                    f"Found {len(packages)} packages with "
+                    f"{len(cpe_to_pkgs)} unique CPEs to query"
+                )
+
+                # 3. Create a tool scan
+                scan = Scan.create(
+                    description="empty description",
+                    variant_id=variant_uuid,
+                    scan_type="tool",
+                    scan_source="nvd",
+                )
+                total_cpes = len(cpe_to_pkgs)
+                _nvd_scans_in_progress[vid_str]["total"] = total_cpes
+                cves_found: set = set()
+                observation_pairs: set = set()
+                assessed_findings: set = set()
+                observation_pairs: set = set()
+
+                for idx, (cpe_name, pkgs) in enumerate(
+                    cpe_to_pkgs.items(), 1
+                ):
+                    _nvd_scans_in_progress[vid_str]["progress"] = (
+                        f"{idx}/{total_cpes} CPEs"
+                    )
+                    _nvd_scans_in_progress[vid_str]["logs"].append(
+                        f"[{idx}/{total_cpes}] Querying {cpe_name}…"
+                    )
+                    try:
+                        # Use virtualMatchString when the CPE contains
+                        # wildcard fields (vendor/version) so the NVD
+                        # applies pattern matching instead of a
+                        # dictionary lookup.
+                        cpe_parts = cpe_name.split(":")
+                        has_wildcards = (
+                            len(cpe_parts) >= 6
+                            and (cpe_parts[3] == "*"
+                                 or cpe_parts[5] == "*")
+                        )
+                        nvd_vulns = nvd.api_get_cves_by_cpe(
+                            cpe_name,
+                            results_per_page=100,
+                            use_virtual_match=has_wildcards,
+                        )
+                    except Exception as e:
+                        log_entry = (
+                            f"[{idx}/{total_cpes}] ERROR "
+                            f"{cpe_name}: {str(e)[:200]}"
+                        )
+                        _nvd_scans_in_progress[vid_str]["logs"].append(
+                            log_entry
+                        )
+                        _nvd_scans_in_progress[vid_str]["done_count"] = idx
+                        print(
+                            f"[NVD Scan] Error querying CPE "
+                            f"{cpe_name}: {e}",
+                            flush=True,
+                        )
+                        continue
+
+                    cpe_cves = [
+                        v.get("cve", {}).get("id", "")
+                        for v in nvd_vulns
+                        if v.get("cve", {}).get("id")
+                    ]
+                    if cpe_cves:
+                        ids_str = ', '.join(cpe_cves[:10])
+                        ellip = '…' if len(cpe_cves) > 10 else ''
+                        log_entry = (
+                            f"[{idx}/{total_cpes}] {cpe_name} → "
+                            f"{len(cpe_cves)} CVE(s): {ids_str}{ellip}"
+                        )
+                    else:
+                        log_entry = (
+                            f"[{idx}/{total_cpes}] {cpe_name} → no CVEs"
+                        )
+                    _nvd_scans_in_progress[vid_str]["logs"].append(
+                        log_entry
+                    )
+                    _nvd_scans_in_progress[vid_str]["done_count"] = idx
+
+                    for nvd_vuln in nvd_vulns:
+                        cve = nvd_vuln.get("cve", {})
+                        cve_id = cve.get("id", "")
+                        if not cve_id:
+                            continue
+
+                        cves_found.add(cve_id)
+
+                        # Extract full CVE details from the response
+                        details = NVD_DB.extract_cve_details(cve)
+
+                        existing_vuln = db.session.get(
+                            VulnModel, cve_id.upper()
+                        )
+                        if existing_vuln is None:
+                            existing_vuln = VulnModel.create_record(
+                                id=cve_id,
+                                description=details.get("description"),
+                                status=details.get("status"),
+                                publish_date=details.get("publish_date"),
+                                attack_vector=details.get("attack_vector"),
+                                links=details.get("links"),
+                                weaknesses=details.get("weaknesses"),
+                                nvd_last_modified=details.get(
+                                    "nvd_last_modified"
+                                ),
+                            )
+                            existing_vuln.add_found_by("nvd")
+                        else:
+                            existing_vuln.add_found_by("nvd")
+                            # Enrich existing CVEs that lack data
+                            _update = {}
+                            if (not existing_vuln.description
+                                    and details.get("description")):
+                                _update["description"] = details[
+                                    "description"
+                                ]
+                            if (not existing_vuln.status
+                                    and details.get("status")):
+                                _update["status"] = details["status"]
+                            if (not existing_vuln.publish_date
+                                    and details.get("publish_date")):
+                                _update["publish_date"] = details[
+                                    "publish_date"
+                                ]
+                            if (not existing_vuln.attack_vector
+                                    and details.get("attack_vector")):
+                                _update["attack_vector"] = details[
+                                    "attack_vector"
+                                ]
+                            if (not existing_vuln.links
+                                    and details.get("links")):
+                                _update["links"] = details["links"]
+                            if (not existing_vuln.weaknesses
+                                    and details.get("weaknesses")):
+                                _update["weaknesses"] = details[
+                                    "weaknesses"
+                                ]
+                            if _update:
+                                existing_vuln.update_record(
+                                    **_update, commit=False
+                                )
+
+                        # Persist CVSS metrics
+                        if details.get("base_score") is not None:
+                            _cvss_v = details.get("cvss_version")
+                            _cvss_s = details["base_score"]
+                            _cvss_vec = details.get("cvss_vector")
+                            _dedup = (
+                                cve_id.upper(),
+                                _cvss_v,
+                                float(_cvss_s),
+                            )
+                            if _dedup not in MetricsModel._seen:
+                                try:
+                                    MetricsModel.from_cvss(
+                                        CVSS(
+                                            version=_cvss_v or "",
+                                            vector_string=(
+                                                _cvss_vec or ""
+                                            ),
+                                            author="nvd",
+                                            base_score=float(
+                                                _cvss_s
+                                            ),
+                                            exploitability_score=(
+                                                float(
+                                                    details[
+                                                        "cvss_exploitability"
+                                                    ]
+                                                )
+                                                if details.get(
+                                                    "cvss_exploitability"
+                                                )
+                                                is not None
+                                                else 0
+                                            ),
+                                            impact_score=(
+                                                float(
+                                                    details[
+                                                        "cvss_impact"
+                                                    ]
+                                                )
+                                                if details.get(
+                                                    "cvss_impact"
+                                                )
+                                                is not None
+                                                else 0
+                                            ),
+                                        ),
+                                        existing_vuln.id,
+                                    )
+                                except Exception:
+                                    pass
+
+                        for pkg in pkgs:
+                            finding = Finding.get_or_create(
+                                pkg.id, cve_id
+                            )
+                            pair = (finding.id, scan.id)
+                            if pair not in observation_pairs:
+                                observation_pairs.add(pair)
+                                Observation.create(
+                                    finding_id=finding.id,
+                                    scan_id=scan.id,
+                                    commit=False,
+                                )
+                            # Create initial assessment if none exists
+                            fv_key = (finding.id, variant_uuid)
+                            if fv_key not in assessed_findings:
+                                assessed_findings.add(fv_key)
+                                has_assess = db.session.execute(
+                                    db.select(Assessment.id).where(
+                                        Assessment.finding_id == finding.id,
+                                        Assessment.variant_id == variant_uuid,
+                                    ).limit(1)
+                                ).scalar_one_or_none()
+                                if has_assess is None:
+                                    Assessment.create(
+                                        status="under_investigation",
+                                        simplified_status="Pending Assessment",
+                                        finding_id=finding.id,
+                                        variant_id=variant_uuid,
+                                        origin="nvd",
+                                        commit=False,
+                                    )
+
+                db.session.commit()
+
+                done_logs = _nvd_scans_in_progress[vid_str].get(
+                    "logs", []
+                )
+                done_logs.append(
+                    f"✓ Scan complete — found {len(cves_found)} "
+                    f"unique CVEs across {total_cpes} CPEs"
+                )
+                _nvd_scans_in_progress[vid_str] = {
+                    "status": "done",
+                    "error": None,
+                    "progress": (
+                        f"Found {len(cves_found)} CVEs "
+                        f"across {total_cpes} CPEs"
+                    ),
+                    "logs": done_logs,
+                    "total": total_cpes,
+                    "done_count": total_cpes,
+                }
+
+            except Exception as e:
+                db.session.rollback()
+                _nvd_scans_in_progress[vid_str] = {
+                    "status": "error",
+                    "error": str(e)[:500],
+                    "progress": None,
+                }
+
+        thread = threading.Thread(
+            target=_run_nvd_scan,
+            name=f"nvd-scan-{vid_str}",
+            daemon=True,
+        )
+        thread.start()
+
+        return jsonify({"status": "started", "variant_id": vid_str}), 202
+
+    @app.route('/api/variants/<variant_id>/nvd-scan/status')
+    def nvd_scan_status(variant_id):
+        """Check the status of a running NVD scan for the given variant."""
+        try:
+            variant_uuid = uuid_module.UUID(variant_id)
+        except ValueError:
+            return jsonify({"error": "Invalid variant id"}), 400
+
+        vid_str = str(variant_uuid)
+        info = _nvd_scans_in_progress.get(vid_str)
+        if info is None:
+            return jsonify({"status": "idle"})
+        return jsonify(info)
+
+    # ------------------------------------------------------------------
+    # OSV Scan — query OSV.dev by PURL for each active package
+    # ------------------------------------------------------------------
+
+    _osv_scans_in_progress: dict = {}  # variant_id -> {status, error, progress, logs, total, done_count}
+
+    @app.route('/api/variants/<variant_id>/osv-scan', methods=['POST'])
+    def trigger_osv_scan(variant_id):
+        """Trigger an OSV PURL-based vulnerability scan for the given variant.
+
+        For every active package that has PURL identifiers, query the OSV API
+        and create findings/observations for any vulnerabilities returned.
+        The result is stored as a tool scan.
+        """
+        import threading
+
+        try:
+            variant_uuid = uuid_module.UUID(variant_id)
+        except ValueError:
+            return jsonify({"error": "Invalid variant id"}), 400
+
+        variant = VariantController.get(variant_uuid)
+        if variant is None:
+            return jsonify({"error": "Variant not found"}), 404
+
+        vid_str = str(variant_uuid)
+        if vid_str in _osv_scans_in_progress and _osv_scans_in_progress[vid_str]["status"] == "running":
+            return jsonify({"error": "An OSV scan is already in progress for this variant"}), 409
+
+        _osv_scans_in_progress[vid_str] = {
+            "status": "running", "error": None, "progress": "starting",
+            "logs": [], "total": 0, "done_count": 0,
+        }
+
+        def _run_osv_scan():
+            with app.app_context():
+                _do_osv_scan(vid_str, variant_uuid)
+
+        def _do_osv_scan(vid_str, variant_uuid):
+            try:
+                from ..controllers.osv_client import OSVClient
+                from ..models.vulnerability import Vulnerability as VulnModel
+                from ..models.assessment import Assessment
+
+                osv = OSVClient()
+
+                # 1. Get active packages for this variant
+                _osv_scans_in_progress[vid_str]["logs"].append(
+                    "Resolving active packages…"
+                )
+                latest_rows = db.session.execute(
+                    db.select(Scan.id, Scan.scan_type)
+                    .where(Scan.variant_id == variant_uuid)
+                    .order_by(Scan.timestamp.desc())
+                ).all()
+                latest_ids: list = []
+                seen_types: set = set()
+                for sid, stype in latest_rows:
+                    st = stype or "sbom"
+                    if st not in seen_types:
+                        seen_types.add(st)
+                        latest_ids.append(sid)
+                    if len(seen_types) >= 2:
+                        break
+
+                if not latest_ids:
+                    _osv_scans_in_progress[vid_str] = {
+                        "status": "error",
+                        "error": "No scans found for variant",
+                        "progress": None,
+                        "logs": _osv_scans_in_progress[vid_str].get(
+                            "logs", []
+                        ),
+                        "total": 0, "done_count": 0,
+                    }
+                    return
+
+                pkg_sets = _packages_by_scan_ids(latest_ids)
+                all_pkg_ids: set = set()
+                for s in pkg_sets.values():
+                    all_pkg_ids |= s
+
+                if not all_pkg_ids:
+                    _osv_scans_in_progress[vid_str] = {
+                        "status": "error",
+                        "error": "No packages found for variant",
+                        "progress": None,
+                        "logs": _osv_scans_in_progress[vid_str].get(
+                            "logs", []
+                        ),
+                        "total": 0, "done_count": 0,
+                    }
+                    return
+
+                packages = db.session.execute(
+                    db.select(Package).where(
+                        Package.id.in_(all_pkg_ids)
+                    )
+                ).scalars().all()
+
+                # 2. Collect packages with PURL identifiers
+                pkg_purl_list: list[tuple] = []
+                seen_purls: set = set()
+                for pkg in packages:
+                    for purl in (pkg.purl or []):
+                        purl_str = str(purl).strip()
+                        if (purl_str
+                                and purl_str.startswith("pkg:")
+                                and purl_str not in seen_purls):
+                            seen_purls.add(purl_str)
+                            pkg_purl_list.append((purl_str, pkg))
+                            break  # one PURL per package
+
+                if not pkg_purl_list:
+                    old_logs = _osv_scans_in_progress[vid_str].get(
+                        "logs", []
+                    )
+                    old_logs.append(
+                        "ERROR: No packages with valid PURL identifiers"
+                    )
+                    _osv_scans_in_progress[vid_str] = {
+                        "status": "error",
+                        "error": "No packages with valid PURL identifiers",
+                        "progress": None,
+                        "logs": old_logs,
+                        "total": 0, "done_count": 0,
+                    }
+                    return
+
+                total_pkgs = len(pkg_purl_list)
+                _osv_scans_in_progress[vid_str]["total"] = total_pkgs
+                _osv_scans_in_progress[vid_str]["logs"].append(
+                    f"Found {len(packages)} packages, "
+                    f"{total_pkgs} with PURL identifiers to query"
+                )
+
+                # 3. Create a tool scan
+                scan = Scan.create(
+                    description="empty description",
+                    variant_id=variant_uuid,
+                    scan_type="tool",
+                    scan_source="osv",
+                )
+                vulns_found: set = set()
+                observation_pairs: set = set()
+                assessed_findings: set = set()
+
+                for idx, (purl_str, pkg) in enumerate(
+                    pkg_purl_list, 1
+                ):
+                    _osv_scans_in_progress[vid_str]["progress"] = (
+                        f"{idx}/{total_pkgs} packages"
+                    )
+                    pkg_label = (
+                        f"{pkg.name}@{pkg.version}"
+                        if pkg.name else purl_str
+                    )
+                    _osv_scans_in_progress[vid_str]["logs"].append(
+                        f"[{idx}/{total_pkgs}] Querying {pkg_label}…"
+                    )
+                    try:
+                        osv_vulns = osv.query_by_purl(purl_str)
+                    except Exception as e:
+                        log_entry = (
+                            f"[{idx}/{total_pkgs}] ERROR "
+                            f"{pkg_label}: {str(e)[:200]}"
+                        )
+                        _osv_scans_in_progress[vid_str]["logs"].append(
+                            log_entry
+                        )
+                        _osv_scans_in_progress[vid_str][
+                            "done_count"
+                        ] = idx
+                        print(
+                            f"[OSV Scan] Error querying PURL "
+                            f"{purl_str}: {e}",
+                            flush=True,
+                        )
+                        continue
+
+                    vuln_ids = [
+                        v.get("id", "")
+                        for v in osv_vulns if v.get("id")
+                    ]
+                    if vuln_ids:
+                        ids_str = ', '.join(vuln_ids[:10])
+                        ellip = '…' if len(vuln_ids) > 10 else ''
+                        log_entry = (
+                            f"[{idx}/{total_pkgs}] {pkg_label} → "
+                            f"{len(vuln_ids)} vuln(s): {ids_str}{ellip}"
+                        )
+                    else:
+                        log_entry = (
+                            f"[{idx}/{total_pkgs}] {pkg_label}"
+                            f" → no vulnerabilities"
+                        )
+                    _osv_scans_in_progress[vid_str]["logs"].append(
+                        log_entry
+                    )
+                    _osv_scans_in_progress[vid_str]["done_count"] = idx
+
+                    for osv_vuln in osv_vulns:
+                        vuln_id = osv_vuln.get("id", "")
+                        if not vuln_id:
+                            continue
+
+                        all_ids = [vuln_id] + [
+                            a for a in osv_vuln.get("aliases", [])
+                            if a.startswith("CVE-")
+                        ]
+                        vulns_found.add(vuln_id)
+
+                        # Extract summary/details from OSV response
+                        osv_desc = (
+                            osv_vuln.get("summary")
+                            or osv_vuln.get("details")
+                        )
+
+                        for vid in all_ids:
+                            existing_vuln = db.session.get(
+                                VulnModel, vid.upper()
+                            )
+                            if existing_vuln is None:
+                                existing_vuln = VulnModel.create_record(
+                                    id=vid,
+                                    description=osv_desc,
+                                    links=[
+                                        r.get("url")
+                                        for r in osv_vuln.get(
+                                            "references", []
+                                        )
+                                        if r.get("url")
+                                    ] or None,
+                                )
+                                existing_vuln.add_found_by("osv")
+                            else:
+                                existing_vuln.add_found_by("osv")
+                                # Enrich if description is missing
+                                if (not existing_vuln.description
+                                        and osv_desc):
+                                    existing_vuln.update_record(
+                                        description=osv_desc,
+                                        commit=False,
+                                    )
+
+                            finding = Finding.get_or_create(
+                                pkg.id, vid
+                            )
+                            pair = (finding.id, scan.id)
+                            if pair not in observation_pairs:
+                                observation_pairs.add(pair)
+                                Observation.create(
+                                    finding_id=finding.id,
+                                    scan_id=scan.id,
+                                    commit=False,
+                                )
+                            # Create initial assessment if none exists
+                            fv_key = (finding.id, variant_uuid)
+                            if fv_key not in assessed_findings:
+                                assessed_findings.add(fv_key)
+                                has_assess = db.session.execute(
+                                    db.select(Assessment.id).where(
+                                        Assessment.finding_id == finding.id,
+                                        Assessment.variant_id == variant_uuid,
+                                    ).limit(1)
+                                ).scalar_one_or_none()
+                                if has_assess is None:
+                                    Assessment.create(
+                                        status="under_investigation",
+                                        simplified_status="Pending Assessment",
+                                        finding_id=finding.id,
+                                        variant_id=variant_uuid,
+                                        origin="osv",
+                                        commit=False,
+                                    )
+
+                db.session.commit()
+
+                done_logs = _osv_scans_in_progress[vid_str].get(
+                    "logs", []
+                )
+                done_logs.append(
+                    f"✓ Scan complete — found {len(vulns_found)} "
+                    f"unique vulnerabilities across {total_pkgs} "
+                    f"packages"
+                )
+                _osv_scans_in_progress[vid_str] = {
+                    "status": "done",
+                    "error": None,
+                    "progress": (
+                        f"Found {len(vulns_found)} vulnerabilities "
+                        f"across {total_pkgs} packages"
+                    ),
+                    "logs": done_logs,
+                    "total": total_pkgs,
+                    "done_count": total_pkgs,
+                }
+
+            except Exception as e:
+                db.session.rollback()
+                _osv_scans_in_progress[vid_str] = {
+                    "status": "error",
+                    "error": str(e)[:500],
+                    "progress": None,
+                    "logs": _osv_scans_in_progress[vid_str].get(
+                        "logs", []
+                    ),
+                    "total": _osv_scans_in_progress[vid_str].get(
+                        "total", 0
+                    ),
+                    "done_count": _osv_scans_in_progress[vid_str].get(
+                        "done_count", 0
+                    ),
+                }
+
+        thread = threading.Thread(
+            target=_run_osv_scan,
+            name=f"osv-scan-{vid_str}",
+            daemon=True,
+        )
+        thread.start()
+
+        return jsonify({"status": "started", "variant_id": vid_str}), 202
+
+    @app.route('/api/variants/<variant_id>/osv-scan/status')
+    def osv_scan_status(variant_id):
+        """Check the status of a running OSV scan for the given variant."""
+        try:
+            variant_uuid = uuid_module.UUID(variant_id)
+        except ValueError:
+            return jsonify({"error": "Invalid variant id"}), 400
+
+        vid_str = str(variant_uuid)
+        info = _osv_scans_in_progress.get(vid_str)
         if info is None:
             return jsonify({"status": "idle"})
         return jsonify(info)

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -781,8 +781,10 @@ def init_app(app):
         findings_upgraded.sort(key=lambda f: (f["package_name"], f["vulnerability_id"]))
 
         # --- Newly detected (tool scans only): findings/vulns that are in
-        # this tool scan but NOT in the latest SBOM scan AND NOT already
-        # present in the previous tool scan.
+        # this tool scan but NOT in the SBOM baseline that was active at
+        # scan time AND NOT already present in the previous tool scan.
+        # Using the SBOM active at scan time (not the globally latest)
+        # ensures counts stay stable when a newer SBOM is imported later.
         newly_detected_findings_count = None
         newly_detected_vulns_count = None
         newly_detected_findings_list = None
@@ -792,8 +794,11 @@ def init_app(app):
             sbom_fids: set = set()
             sbom_vids: set = set()
             if sbom_scans:
-                latest_sbom = sbom_scans[-1]  # ordered by timestamp
-                sbom_scan_loaded = _load_scan_with_findings(latest_sbom.id)
+                sbom_at_time = _sbom_active_at(sbom_scans, scan.timestamp)
+                if sbom_at_time:
+                    sbom_scan_loaded = _load_scan_with_findings(sbom_at_time.id)
+                else:
+                    sbom_scan_loaded = None
                 if sbom_scan_loaded:
                     sbom_fids = {obs.finding_id for obs in sbom_scan_loaded.observations}
                     sbom_vids = {obs.finding.vulnerability_id for obs in sbom_scan_loaded.observations}

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -1224,17 +1224,15 @@ def init_app(app):
                 ).scalars().all()
 
                 # 2. Collect CPE names from packages
-                # A CPE is queryable when it has a valid part (a/o/h) and
-                # at least a non-wildcard product.  Wildcard vendor is
-                # acceptable — the NVD virtualMatchString API handles it.
-                _valid_cpe_parts = {"a", "o", "h"}
+                # A CPE is queryable when it has at least a non-wildcard
+                # product (parts[4]).  Wildcard part/vendor/version are
+                # acceptable — the NVD virtualMatchString API handles
+                # pattern matching for those.
                 cpe_to_pkgs: dict = {}  # cpeName -> list[Package]
                 for pkg in packages:
                     for cpe in (pkg.cpe or []):
                         parts = cpe.split(":")
-                        if (len(parts) >= 6
-                                and parts[2] in _valid_cpe_parts
-                                and parts[4] != "*"):
+                        if len(parts) >= 6 and parts[4] != "*":
                             cpe_to_pkgs.setdefault(cpe, []).append(pkg)
 
                 if not cpe_to_pkgs:
@@ -1283,13 +1281,14 @@ def init_app(app):
                     )
                     try:
                         # Use virtualMatchString when the CPE contains
-                        # wildcard fields (vendor/version) so the NVD
-                        # applies pattern matching instead of a
+                        # wildcard fields (part/vendor/version) so the
+                        # NVD applies pattern matching instead of a
                         # dictionary lookup.
                         cpe_parts = cpe_name.split(":")
                         has_wildcards = (
                             len(cpe_parts) >= 6
-                            and (cpe_parts[3] == "*"
+                            and (cpe_parts[2] == "*"
+                                 or cpe_parts[3] == "*"
                                  or cpe_parts[5] == "*")
                         )
                         nvd_vulns = nvd.api_get_cves_by_cpe(

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -255,6 +255,7 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
     # package-level info for upgrade classification.
     scan_data = []
     all_fids_needing_lookup: set = set()
+    all_pkg_ids_needing_lookup: set = set()
 
     for scan in scans:
         curr_f = findings_map.get(scan.id, set())
@@ -278,24 +279,39 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             raw_added_p = curr_p - prev_p
             raw_removed_p = prev_p - curr_p
             if raw_added_p or raw_removed_p:
-                pkg_lk = _package_rows(raw_added_p | raw_removed_p)
-                truly_added, truly_removed, upgraded = _classify_package_changes(
-                    raw_added_p, raw_removed_p, pkg_lk
-                )
-                entry["truly_added_p"] = len(truly_added)
-                entry["truly_removed_p"] = len(truly_removed)
-                entry["truly_removed_ids"] = truly_removed
-                entry["upgraded_pairs"] = upgraded
-
-                if upgraded:
-                    prev_f = findings_map.get(prev.id, set())
-                    raw_added_f = curr_f - prev_f
-                    raw_removed_f = prev_f - curr_f
-                    entry["raw_added_f"] = raw_added_f
-                    entry["raw_removed_f"] = raw_removed_f
-                    all_fids_needing_lookup |= raw_added_f | raw_removed_f
+                entry["_raw_added_p"] = raw_added_p
+                entry["_raw_removed_p"] = raw_removed_p
+                all_pkg_ids_needing_lookup |= raw_added_p | raw_removed_p
 
         scan_data.append(entry)
+
+    # Single batch query: package_id -> Package for all changed packages
+    all_pkg_lookup = _package_rows(all_pkg_ids_needing_lookup)
+
+    # Second mini-pass: classify packages and collect finding IDs
+    for entry in scan_data:
+        raw_added_p = entry.pop("_raw_added_p", None)
+        if raw_added_p is None:
+            continue
+        raw_removed_p = entry.pop("_raw_removed_p", set())
+        truly_added, truly_removed, upgraded = _classify_package_changes(
+            raw_added_p, raw_removed_p, all_pkg_lookup
+        )
+        entry["truly_added_p"] = len(truly_added)
+        entry["truly_removed_p"] = len(truly_removed)
+        entry["truly_removed_ids"] = truly_removed
+        entry["upgraded_pairs"] = upgraded
+
+        if upgraded:
+            scan = entry["scan"]
+            prev = entry["prev"]
+            curr_f = entry["curr_f"]
+            prev_f = findings_map.get(prev.id, set())
+            raw_added_f = curr_f - prev_f
+            raw_removed_f = prev_f - curr_f
+            entry["raw_added_f"] = raw_added_f
+            entry["raw_removed_f"] = raw_removed_f
+            all_fids_needing_lookup |= raw_added_f | raw_removed_f
 
     # Single batch query: finding_id -> (package_id, vulnerability_id)
     # Include all tool-scan finding IDs so we can check which ones belong
@@ -314,6 +330,13 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
         ).all()
         fid_to_info = {r[0]: (r[1], r[2]) for r in rows}
 
+    # Pre-build reverse index: tool-scan finding → package_id
+    # so scan-result computation can filter by package set in O(1).
+    tool_fid_to_pkg: dict = {}  # finding_id → package_id (tool scans only)
+    for fid in tool_scan_fids:
+        info = fid_to_info.get(fid)
+        if info:
+            tool_fid_to_pkg[fid] = info[0]
     # Second pass: build result dicts
     # Track latest tool-scan findings/vulns per (variant, source) as we
     # iterate in chronological order so we can compute the "global" result
@@ -362,53 +385,71 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
 
             src_key = (scan.variant_id, scan.scan_source)
 
-            # Global state BEFORE this scan
+            # SBOM active package set — used to filter tool findings.
+            sbom_pkg = packages_map.get(
+                sbom_at_time.id, set()
+            ) if sbom_at_time else set()
+
+            def _filtered_tool_f(f_ids: set) -> set:
+                """Return only findings whose package is in the active SBOM."""
+                return {fid for fid in f_ids
+                        if tool_fid_to_pkg.get(fid) in sbom_pkg}
+
+            # Global state BEFORE this scan (filtered to SBOM packages)
             global_before_f = set(baseline_f)
             global_before_v = set(baseline_v)
             for (vid, _src), f_ids in running_src_findings.items():
                 if vid == scan.variant_id:
-                    global_before_f |= f_ids
-            for (vid, _src), v_ids in running_src_vulns.items():
-                if vid == scan.variant_id:
-                    global_before_v |= v_ids
+                    global_before_f |= _filtered_tool_f(f_ids)
+            for fid in global_before_f - baseline_f:
+                info = fid_to_info.get(fid)
+                if info:
+                    global_before_v.add(info[1])
 
             # Update running tracker for this source
             running_src_findings[src_key] = curr_f
             running_src_vulns[src_key] = curr_v
 
-            # Global state AFTER this scan
+            # Global state AFTER this scan (filtered to SBOM packages)
             global_f = set(baseline_f)
             global_v = set(baseline_v)
             for (vid, _src), f_ids in running_src_findings.items():
                 if vid == scan.variant_id:
-                    global_f |= f_ids
-            for (vid, _src), v_ids in running_src_vulns.items():
-                if vid == scan.variant_id:
-                    global_v |= v_ids
+                    global_f |= _filtered_tool_f(f_ids)
+            for fid in global_f - baseline_f:
+                info = fid_to_info.get(fid)
+                if info:
+                    global_v.add(info[1])
 
             base["is_first"] = (prev is None)
             base["packages_added"] = 0
             base["packages_removed"] = 0
             base["packages_upgraded"] = 0
+            base["packages_unchanged"] = 0
             base["findings_upgraded"] = 0
+            base["findings_unchanged"] = 0
             base["findings_added"] = len(global_f - global_before_f)
             base["findings_removed"] = len(global_before_f - global_f)
             base["vulns_added"] = len(global_v - global_before_v)
             base["vulns_removed"] = len(global_before_v - global_v)
+            base["vulns_unchanged"] = 0
 
             # "Newly detected" = findings/vulns added to the global result.
             base["newly_detected_findings"] = base["findings_added"]
             base["newly_detected_vulns"] = base["vulns_added"]
 
-            # Branch result = SBOM baseline (at scan time) ∪ this tool scan
-            sbom_pkg = packages_map.get(
-                sbom_at_time.id, set()
-            ) if sbom_at_time else set()
-            base["branch_finding_count"] = len(baseline_f | curr_f)
-            base["branch_vuln_count"] = len(baseline_v | curr_v)
+            # Branch result = SBOM baseline ∪ this tool scan (already filtered)
+            branch_f = baseline_f | _filtered_tool_f(curr_f)
+            branch_v = set(baseline_v)
+            for fid in branch_f - baseline_f:
+                info = fid_to_info.get(fid)
+                if info:
+                    branch_v.add(info[1])
+            base["branch_finding_count"] = len(branch_f)
+            base["branch_vuln_count"] = len(branch_v)
             base["branch_package_count"] = len(sbom_pkg)
 
-            # Global result = SBOM baseline (at scan time) ∪ all tool sources
+            # Global result = already-filtered global_f / global_v
             base["global_finding_count"] = len(global_f)
             base["global_vuln_count"] = len(global_v)
             base["global_package_count"] = len(sbom_pkg)
@@ -419,11 +460,14 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             base["findings_added"] = None
             base["findings_removed"] = None
             base["findings_upgraded"] = None
+            base["findings_unchanged"] = None
             base["packages_added"] = None
             base["packages_removed"] = None
             base["packages_upgraded"] = None
+            base["packages_unchanged"] = None
             base["vulns_added"] = None
             base["vulns_removed"] = None
+            base["vulns_unchanged"] = None
         else:
             prev_f = findings_map.get(prev.id, set())
             prev_v = vulns_map.get(prev.id, set())
@@ -435,78 +479,79 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             base["packages_removed"] = entry.get("truly_removed_p", len(prev_pkgs - entry["curr_p"]))
             base["packages_upgraded"] = len(upgraded_pairs)
 
-            raw_added_f = curr_f - prev_f
-            raw_removed_f = prev_f - curr_f
-
-            upgraded_removed_fids: set = set()
-            if upgraded_pairs and entry["raw_added_f"]:
-                # Classify findings on upgraded packages with 1:1 matching
-                # (mirrors _classify_finding_changes in the detail view).
-                upgraded_old_ids = {str(old_pkg.id) for old_pkg, _ in upgraded_pairs}
-                upgraded_new_ids = {str(new_pkg.id) for _, new_pkg in upgraded_pairs}
-                # Group removed findings on upgraded-old packages by vuln
-                _rem_by_vuln: dict = {}
-                for fid in raw_removed_f:
-                    info = fid_to_info.get(fid)
-                    if info and str(info[0]) in upgraded_old_ids:
-                        _rem_by_vuln.setdefault(info[1], []).append(fid)
-                # Match added findings on upgraded-new packages 1:1
-                upgraded_count = 0
-                for fid in raw_added_f:
-                    info = fid_to_info.get(fid)
-                    if info and str(info[0]) in upgraded_new_ids:
-                        candidates = _rem_by_vuln.get(info[1], [])
-                        if candidates:
-                            upgraded_removed_fids.add(candidates.pop(0))
-                            upgraded_count += 1
-                base["findings_upgraded"] = upgraded_count
-                base["findings_added"] = len(raw_added_f) - upgraded_count
-                base["findings_removed"] = len(raw_removed_f) - upgraded_count
-            else:
-                base["findings_upgraded"] = 0
-                base["findings_added"] = len(raw_added_f)
-                base["findings_removed"] = len(raw_removed_f)
-
-            base["vulns_added"] = len(curr_v - prev_v)
-            base["vulns_removed"] = len(prev_v - curr_v)
-
-            # Include tool-scan findings on removed/upgraded-old packages
-            # in the removed counts so the history matches the detail view.
-            gone_pkg_ids: set = set()
-            gone_pkg_ids |= entry.get("truly_removed_ids", set())
-            for old_pkg, _new_pkg in upgraded_pairs:
-                gone_pkg_ids.add(old_pkg.id)
-            if gone_pkg_ids:
-                extra_removed_f = 0
-                extra_removed_v: set = set()
-                # Dedup must mirror the detail view's already_removed sets:
-                # - findings: only the SBOM truly-removed (not upgraded)
-                # - vulns: only the SBOM-removed vuln IDs
-                # Upgraded SBOM findings had their count subtracted, so
-                # re-adding them via tool scans is correct.
-                sbom_truly_removed = raw_removed_f - upgraded_removed_fids
-                _seen_fids: set = set(sbom_truly_removed)
-                _seen_vids: set = set(prev_v - curr_v)
-                for (vid, _src), f_ids in running_src_findings.items():
-                    if vid != scan.variant_id:
-                        continue
+            # --- Compute current scan result (SBOM ∪ tool-scan on active pkgs) ---
+            curr_pkg_id_set = entry["curr_p"]
+            curr_scan_result_f = set(curr_f)
+            for (vid, _src), f_ids in running_src_findings.items():
+                if vid == scan.variant_id:
                     for fid in f_ids:
-                        if fid in _seen_fids:
-                            continue
-                        info = fid_to_info.get(fid)
-                        if info is None:
-                            continue
-                        pkg_id, vuln_id = info
-                        if pkg_id in gone_pkg_ids:
-                            extra_removed_f += 1
-                            _seen_fids.add(fid)
-                            if vuln_id not in _seen_vids:
-                                _seen_vids.add(vuln_id)
-                                extra_removed_v.add(vuln_id)
-                if extra_removed_f:
-                    base["findings_removed"] += extra_removed_f
-                if extra_removed_v:
-                    base["vulns_removed"] += len(extra_removed_v)
+                        if tool_fid_to_pkg.get(fid) in curr_pkg_id_set:
+                            curr_scan_result_f.add(fid)
+            curr_scan_result_v: set = set(curr_v)  # start with complete SBOM vulns
+            for fid in curr_scan_result_f - curr_f:  # add vulns from tool findings only
+                info = fid_to_info.get(fid)
+                if info:
+                    curr_scan_result_v.add(info[1])
+
+            # --- Compute previous scan result (prev SBOM ∪ tool-scan on prev pkgs) ---
+            # This uses the CURRENT running_src_findings (which includes all
+            # tool scans that ran between the two SBOMs), reflecting what the
+            # user would have seen on the previous card right before this SBOM.
+            prev_v = vulns_map.get(prev.id, set())
+            prev_sr_f = set(prev_f)
+            for (vid, _src), f_ids in running_src_findings.items():
+                if vid == scan.variant_id:
+                    for fid in f_ids:
+                        if tool_fid_to_pkg.get(fid) in prev_pkgs:
+                            prev_sr_f.add(fid)
+            prev_sr_v: set = set(prev_v)  # start with complete prev SBOM vulns
+            for fid in prev_sr_f - prev_f:  # add vulns from tool findings only
+                info = fid_to_info.get(fid)
+                if info:
+                    prev_sr_v.add(info[1])
+
+            # --- Classify findings using scan result diffs ---
+            # new + upgraded + unchanged = current scan result
+            # removed + upgraded + unchanged = previous scan result
+            sr_new_f = curr_scan_result_f - prev_sr_f
+            sr_gone_f = prev_sr_f - curr_scan_result_f
+            sr_unchanged_f = prev_sr_f & curr_scan_result_f
+
+            upgraded_old_ids_set: set = {old_pkg.id for old_pkg, _ in upgraded_pairs}
+            upgraded_new_ids_set: set = {new_pkg.id for _, new_pkg in upgraded_pairs}
+
+            # Group gone findings on upgraded-old packages by vuln
+            _rem_by_vuln: dict = {}
+            for fid in sr_gone_f:
+                info = fid_to_info.get(fid)
+                if info and info[0] in upgraded_old_ids_set:
+                    _rem_by_vuln.setdefault(info[1], []).append(fid)
+            # Match new findings on upgraded-new packages 1:1
+            sr_upgraded_count = 0
+            for fid in sr_new_f:
+                info = fid_to_info.get(fid)
+                if info and info[0] in upgraded_new_ids_set:
+                    candidates = _rem_by_vuln.get(info[1], [])
+                    if candidates:
+                        candidates.pop(0)
+                        sr_upgraded_count += 1
+
+            base["findings_added"] = len(sr_new_f) - sr_upgraded_count
+            base["findings_removed"] = len(sr_gone_f) - sr_upgraded_count
+            base["findings_upgraded"] = sr_upgraded_count
+            base["findings_unchanged"] = len(sr_unchanged_f)
+
+            # --- vulns: all from scan result ---
+            base["vulns_added"] = len(curr_scan_result_v - prev_sr_v)
+            base["vulns_removed"] = len(prev_sr_v - curr_scan_result_v)
+            base["vulns_unchanged"] = len(prev_sr_v & curr_scan_result_v)
+
+            # Unchanged packages = intersection minus upgraded (old+new) IDs
+            unchanged_pkg_ids = entry["curr_p"] & prev_pkgs
+            for old_pkg, new_pkg in upgraded_pairs:
+                unchanged_pkg_ids.discard(old_pkg.id)
+                unchanged_pkg_ids.discard(new_pkg.id)
+            base["packages_unchanged"] = len(unchanged_pkg_ids)
 
         # ---- Non-tool (SBOM) scans: set tool-only fields to None ----
         if not is_tool_scan:
@@ -516,21 +561,30 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             base["branch_vuln_count"] = None
             base["branch_package_count"] = None
 
-            # Scan Result for SBOM scans = SBOM ∪ all latest tool-scan sources
+            # Scan Result for SBOM scans = SBOM ∪ tool-scan findings
+            # BUT only tool-scan findings whose package is still in the
+            # current SBOM (removed/upgraded-away packages are dropped).
             has_tool_scans = any(
                 vid == scan.variant_id for (vid, _src) in running_src_findings
             )
             if has_tool_scans:
-                merge_f = set(curr_f)
-                merge_v = set(curr_v)
-                for (vid, _src), f_ids in running_src_findings.items():
-                    if vid == scan.variant_id:
-                        merge_f |= f_ids
-                for (vid, _src), v_ids in running_src_vulns.items():
-                    if vid == scan.variant_id:
-                        merge_v |= v_ids
-                base["global_finding_count"] = len(merge_f)
-                base["global_vuln_count"] = len(merge_v)
+                # Reuse curr_scan_result_f/v if already computed in the diff
+                # section above (i.e. prev is not None); otherwise compute now.
+                if prev is None:
+                    curr_pkg_id_set = entry["curr_p"]
+                    curr_scan_result_f = set(curr_f)
+                    for (vid, _src), f_ids in running_src_findings.items():
+                        if vid == scan.variant_id:
+                            for fid in f_ids:
+                                if tool_fid_to_pkg.get(fid) in curr_pkg_id_set:
+                                    curr_scan_result_f.add(fid)
+                    curr_scan_result_v = set(curr_v)  # complete SBOM vulns
+                    for fid in curr_scan_result_f - curr_f:  # add tool vulns
+                        info = fid_to_info.get(fid)
+                        if info:
+                            curr_scan_result_v.add(info[1])
+                base["global_finding_count"] = len(curr_scan_result_f)
+                base["global_vuln_count"] = len(curr_scan_result_v)
                 base["global_package_count"] = len(entry["curr_p"])
             else:
                 base["global_finding_count"] = None
@@ -603,8 +657,9 @@ def _classify_finding_changes(findings_added, findings_removed, upgraded_pairs):
         findings_removed: list of obs dicts that were removed
         upgraded_pairs: list of (old_pkg, new_pkg) Package objects
 
-    Returns (truly_added, truly_removed, upgraded_findings) where
-    upgraded_findings is a list of dicts with vuln_id, pkg_name, old_version, new_version.
+    Returns (truly_added, truly_removed, upgraded_findings, upgraded_keys) where
+    upgraded_findings is a list of dicts with vuln_id, pkg_name, old_version, new_version,
+    and upgraded_keys is a set of (vuln_id, old_pkg_id_str) pairs that were matched.
     """
     # Build set of (old_pkg_id, new_pkg_id) from upgraded pairs
     upgraded_pkg_map = {}  # old_pkg_id -> new_pkg Package
@@ -622,6 +677,7 @@ def _classify_finding_changes(findings_added, findings_removed, upgraded_pairs):
     upgraded_findings = []
     matched_added_ids = set()
     matched_removed_ids = set()
+    matched_upgraded_keys: set = set()  # (vuln_id, old_pkg_id_str)
 
     for f_added in findings_added:
         pkg_id = f_added["package_id"]
@@ -644,11 +700,12 @@ def _classify_finding_changes(findings_added, findings_removed, upgraded_pairs):
             })
             matched_added_ids.add(f_added["finding_id"])
             matched_removed_ids.add(f_removed["finding_id"])
+            matched_upgraded_keys.add(key)
             break
 
     truly_added = [f for f in findings_added if f["finding_id"] not in matched_added_ids]
     truly_removed = [f for f in findings_removed if f["finding_id"] not in matched_removed_ids]
-    return truly_added, truly_removed, upgraded_findings
+    return truly_added, truly_removed, upgraded_findings, matched_upgraded_keys
 
 
 # ---------------------------------------------------------------------------
@@ -834,59 +891,172 @@ def init_app(app):
                 for old_pkg, new_pkg in upgraded_pairs
             ]
 
-        # --- Classify findings on upgraded packages ---
-        if prev_scan_id is not None and upgraded_pairs:
-            findings_added, findings_removed, findings_upgraded = _classify_finding_changes(
-                findings_added, findings_removed, upgraded_pairs
-            )
+        # --- Classify findings using scan-result diffs ---
+        # For SBOM scans: scan result = SBOM ∪ tool-scan findings on
+        # that SBOM's active packages.  The diff is between the current
+        # and previous scan results so all categories are consistent:
+        #   new + upgraded + unchanged  = current scan result
+        #   removed + upgraded + unchanged = previous scan result
+        if not is_tool_scan and prev_scan_id is not None:
+            # Collect latest tool scans for this variant that were active
+            # at this SBOM's timestamp (mirrors the list view's chronological
+            # running_src_findings snapshot).
+            tool_scans = [
+                s for s in all_variant_scans
+                if (s.scan_type or "sbom") == "tool"
+                and s.timestamp <= scan.timestamp
+            ]
+            latest_tool_by_source: dict = {}
+            for ts in tool_scans:
+                src = ts.scan_source or ""
+                prev_ts = latest_tool_by_source.get(src)
+                if prev_ts is None or ts.timestamp > prev_ts.timestamp:
+                    latest_tool_by_source[src] = ts
+
+            # Build finding_id → (obs_dict, origin) lookup for all sources
+            fid_obs_map: dict = {}  # finding_id → obs dict
+            fid_info: dict = {}     # finding_id → (pkg_id, vuln_id)
+            # Current SBOM observations
+            for obs in scan.observations:
+                fid = obs.finding_id
+                fid_obs_map[fid] = _obs_to_dict(obs, scan_origin)
+                fid_info[fid] = (obs.finding.package_id, obs.finding.vulnerability_id)
+            # Previous SBOM observations
+            for obs in prev_scan.observations:  # type: ignore[possibly-undefined]
+                fid = obs.finding_id
+                if fid not in fid_obs_map:
+                    fid_obs_map[fid] = _obs_to_dict(obs, scan_origin)
+                if fid not in fid_info:
+                    fid_info[fid] = (obs.finding.package_id, obs.finding.vulnerability_id)
+            # Tool-scan observations
+            for tool_scan_obj in latest_tool_by_source.values():
+                tool_loaded = _load_scan_with_findings(tool_scan_obj.id)
+                if not tool_loaded:
+                    continue
+                tool_origin = _origin_for_scan(tool_loaded)
+                for obs in tool_loaded.observations:
+                    fid = obs.finding_id
+                    if fid not in fid_obs_map:
+                        fid_obs_map[fid] = _obs_to_dict(obs, tool_origin)
+                    if fid not in fid_info:
+                        fid_info[fid] = (obs.finding.package_id, obs.finding.vulnerability_id)
+
+            # Build current scan result = curr SBOM ∪ tool findings on curr pkgs
+            curr_sr_fids: set = set(current_finding_ids)
+            for tool_scan_obj in latest_tool_by_source.values():
+                tool_loaded = _load_scan_with_findings(tool_scan_obj.id)
+                if not tool_loaded:
+                    continue
+                for obs in tool_loaded.observations:
+                    if obs.finding.package_id in curr_pkg_ids:
+                        curr_sr_fids.add(obs.finding_id)
+
+            # Build previous scan result = prev SBOM ∪ tool findings on prev pkgs
+            prev_sr_fids: set = set(prev_finding_ids)  # type: ignore[possibly-undefined]
+            for tool_scan_obj in latest_tool_by_source.values():
+                tool_loaded = _load_scan_with_findings(tool_scan_obj.id)
+                if not tool_loaded:
+                    continue
+                for obs in tool_loaded.observations:
+                    if obs.finding.package_id in prev_pkg_ids:  # type: ignore[possibly-undefined]
+                        prev_sr_fids.add(obs.finding_id)
+
+            # Derive vuln sets from scan results — start from complete SBOM
+            # vuln sets and add only tool-scan vulns on top.
+            curr_sr_vids: set = set(curr_vulns)
+            for fid in curr_sr_fids - current_finding_ids:
+                info = fid_info.get(fid)
+                if info:
+                    curr_sr_vids.add(info[1])
+            prev_sr_vids: set = set(prev_vulns)  # type: ignore[possibly-undefined]
+            for fid in prev_sr_fids - prev_finding_ids:  # type: ignore[possibly-undefined]
+                info = fid_info.get(fid)
+                if info:
+                    prev_sr_vids.add(info[1])
+
+            # Diff scan results
+            sr_new_fids = curr_sr_fids - prev_sr_fids
+            sr_gone_fids = prev_sr_fids - curr_sr_fids
+            sr_unchanged_fids = prev_sr_fids & curr_sr_fids
+
+            # 1:1 upgrade matching
+            upgraded_old_ids_set: set = {old_pkg.id for old_pkg, _ in upgraded_pairs}
+            upgraded_new_ids_set: set = {new_pkg.id for _, new_pkg in upgraded_pairs}
+            upgraded_old_to_new: dict = {}
+            for old_pkg, new_pkg in upgraded_pairs:
+                upgraded_old_to_new[old_pkg.id] = (old_pkg, new_pkg)
+
+            # Group gone findings on upgraded-old packages by vuln
+            _rem_by_vuln: dict = {}  # vuln_id → [(fid, pkg_id)]
+            for fid in sr_gone_fids:
+                info = fid_info.get(fid)
+                if info and info[0] in upgraded_old_ids_set:
+                    _rem_by_vuln.setdefault(info[1], []).append((fid, info[0]))
+
+            # Match new findings on upgraded-new packages 1:1
+            sr_upgraded_fids_new: set = set()   # fids from new (on new pkg)
+            sr_upgraded_fids_gone: set = set()   # fids from gone (on old pkg)
+            findings_upgraded_list: list = []
+            for fid in sr_new_fids:
+                info = fid_info.get(fid)
+                if info and info[0] in upgraded_new_ids_set:
+                    candidates = _rem_by_vuln.get(info[1], [])
+                    if candidates:
+                        old_fid, old_pkg_id = candidates.pop(0)
+                        sr_upgraded_fids_new.add(fid)
+                        sr_upgraded_fids_gone.add(old_fid)
+                        old_pkg, new_pkg = upgraded_old_to_new[old_pkg_id]
+                        obs_dict = fid_obs_map.get(fid, {})
+                        findings_upgraded_list.append({
+                            "vulnerability_id": info[1],
+                            "package_name": old_pkg.name or "unknown",
+                            "old_version": old_pkg.version or "",
+                            "new_version": new_pkg.version or "",
+                            "origin": obs_dict.get("origin", scan_origin),
+                        })
+
+            findings_added = [
+                fid_obs_map[fid] for fid in sr_new_fids - sr_upgraded_fids_new
+                if fid in fid_obs_map
+            ]
+            findings_removed = [
+                fid_obs_map[fid] for fid in sr_gone_fids - sr_upgraded_fids_gone
+                if fid in fid_obs_map
+            ]
+            findings_upgraded = findings_upgraded_list
+            findings_unchanged = [
+                fid_obs_map[fid] for fid in sr_unchanged_fids
+                if fid in fid_obs_map
+            ]
+
+            vulns_added = sorted(curr_sr_vids - prev_sr_vids)
+            vulns_removed = sorted(prev_sr_vids - curr_sr_vids)
+            vulns_unchanged = sorted(prev_sr_vids & curr_sr_vids)
+
+            # Unchanged packages
+            unchanged_pkg_ids = curr_pkg_ids & prev_pkg_ids  # type: ignore[possibly-undefined]
+            for old_pkg, new_pkg in upgraded_pairs:
+                unchanged_pkg_ids.discard(old_pkg.id)
+                unchanged_pkg_ids.discard(new_pkg.id)
+            if unchanged_pkg_ids:
+                unchanged_pkg_lookup = _package_rows(unchanged_pkg_ids)
+                packages_unchanged = [
+                    _pkg_to_dict(unchanged_pkg_lookup[pid])
+                    for pid in unchanged_pkg_ids if pid in unchanged_pkg_lookup
+                ]
+            else:
+                packages_unchanged = []
+        elif not is_tool_scan:
+            # First SBOM scan — no previous scan result
+            findings_upgraded = []
+            findings_unchanged = []
+            vulns_unchanged = []
+            packages_unchanged = []
         else:
             findings_upgraded = []
-
-        # --- For SBOM scans: include tool-scan findings on removed/upgraded
-        # old packages so the user sees all CVEs that disappear from the
-        # global view when packages are dropped. ---
-        if not is_tool_scan and prev_scan_id is not None:
-            # Collect package IDs that are no longer in the new SBOM
-            gone_pkg_ids: set = set()
-            if truly_removed_ids:  # type: ignore[possibly-undefined]
-                gone_pkg_ids |= truly_removed_ids
-            for old_pkg, _new_pkg in upgraded_pairs:
-                gone_pkg_ids.add(old_pkg.id)
-
-            if gone_pkg_ids:
-                # Find active tool scans for this variant (latest per source)
-                tool_scans = [
-                    s for s in all_variant_scans
-                    if (s.scan_type or "sbom") == "tool"
-                ]
-                # Group by source, keep latest (scans are ordered by timestamp)
-                latest_tool_by_source: dict = {}
-                for ts in tool_scans:
-                    src = ts.scan_source or ""
-                    prev_ts = latest_tool_by_source.get(src)
-                    if prev_ts is None or ts.timestamp > prev_ts.timestamp:
-                        latest_tool_by_source[src] = ts
-
-                already_removed_fids = {f["finding_id"] for f in findings_removed}
-                already_removed_vids = set(vulns_removed)
-                for tool_scan_obj in latest_tool_by_source.values():
-                    tool_loaded = _load_scan_with_findings(tool_scan_obj.id)
-                    if not tool_loaded:
-                        continue
-                    tool_origin = _origin_for_scan(tool_loaded)
-                    for obs in tool_loaded.observations:
-                        f = obs.finding
-                        if f.package_id in gone_pkg_ids:
-                            fid_str = str(f.id)
-                            if fid_str not in already_removed_fids:
-                                already_removed_fids.add(fid_str)
-                                findings_removed.append(
-                                    _obs_to_dict(obs, tool_origin)
-                                )
-                            vid = f.vulnerability_id
-                            if vid not in already_removed_vids:
-                                already_removed_vids.add(vid)
-                                vulns_removed.append(vid)
+            findings_unchanged = []
+            vulns_unchanged = []
+            packages_unchanged = []
 
         # Sort for stable output
         packages_added.sort(key=lambda p: (p["package_name"], p["package_version"]))
@@ -894,15 +1064,12 @@ def init_app(app):
         packages_upgraded.sort(key=lambda p: (p["package_name"], p["old_version"]))
         findings_upgraded.sort(key=lambda f: (f["package_name"], f["vulnerability_id"]))
 
-        # --- Newly detected (tool scans only): findings/vulns that are in
-        # this tool scan but NOT in the SBOM baseline that was active at
-        # scan time AND NOT already present in the previous tool scan.
-        # Using the SBOM active at scan time (not the globally latest)
-        # ensures counts stay stable when a newer SBOM is imported later.
+        # --- Newly detected (tool scans only) ---
         newly_detected_findings_count = None
         newly_detected_vulns_count = None
         newly_detected_findings_list = None
         newly_detected_vulns_list = None
+
         if is_tool_scan:
             sbom_scans = [s for s in all_variant_scans if (s.scan_type or "sbom") == "sbom"]
             sbom_fids: set = set()
@@ -949,11 +1116,14 @@ def init_app(app):
             "findings_added": findings_added,
             "findings_removed": findings_removed,
             "findings_upgraded": findings_upgraded,
+            "findings_unchanged": findings_unchanged,
             "packages_added": packages_added,
             "packages_removed": packages_removed,
             "packages_upgraded": packages_upgraded,
+            "packages_unchanged": packages_unchanged,
             "vulns_added": vulns_added,
             "vulns_removed": vulns_removed,
+            "vulns_unchanged": vulns_unchanged,
             "newly_detected_findings": newly_detected_findings_count,
             "newly_detected_vulns": newly_detected_vulns_count,
             "newly_detected_findings_list": newly_detected_findings_list,
@@ -995,6 +1165,20 @@ def init_app(app):
             if sbom_scans:
                 sbom_scan = sbom_scans[-1]
                 contributing_scan_ids.append(sbom_scan.id)
+        else:
+            # SBOM scan: include latest tool scan per source so the global
+            # view shows SBOM ∪ all tool-scan sources (matching list view).
+            all_variant_scans = ScanController.get_by_variant(scan.variant_id)
+            latest_tool_by_source: dict = {}
+            for s in all_variant_scans:
+                if (s.scan_type or "sbom") == "tool":
+                    src = s.scan_source or ""
+                    prev = latest_tool_by_source.get(src)
+                    if prev is None or s.timestamp > prev.timestamp:
+                        latest_tool_by_source[src] = s
+            for tool_s in latest_tool_by_source.values():
+                if tool_s.id not in contributing_scan_ids:
+                    contributing_scan_ids.append(tool_s.id)
 
         # --- Packages with source ---
         # Packages come from SBOM documents only (tool scans don't add packages)
@@ -1032,11 +1216,15 @@ def init_app(app):
                 if loaded:
                     loaded_scans[sid] = loaded
 
+        # Active package IDs = packages from the SBOM scan (not tool scans)
+        active_pkg_ids: set = set(pkg_map.keys())
+
         finding_map: dict = {}   # finding_id -> dict
         vuln_set: dict = {}      # vulnerability_id -> set of sources
         for sid, loaded in loaded_scans.items():
             s_type = loaded.scan_type or "sbom"
-            if s_type == "tool":
+            is_tool = s_type == "tool"
+            if is_tool:
                 source_labels = {
                     "grype": "Grype",
                     "nvd": "NVD CPE",
@@ -1056,6 +1244,11 @@ def init_app(app):
                 fid = obs.finding_id
                 f = obs.finding
                 pkg = f.package
+                # For tool-scan findings on an SBOM scan's global view,
+                # only include findings whose package is still active
+                # (present in the current SBOM).
+                if is_tool and not is_tool_scan and f.package_id not in active_pkg_ids:
+                    continue
                 if fid not in finding_map:
                     finding_map[fid] = {
                         "finding_id": str(fid),

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -284,6 +284,7 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
                 )
                 entry["truly_added_p"] = len(truly_added)
                 entry["truly_removed_p"] = len(truly_removed)
+                entry["truly_removed_ids"] = truly_removed
                 entry["upgraded_pairs"] = upgraded
 
                 if upgraded:
@@ -297,6 +298,14 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
         scan_data.append(entry)
 
     # Single batch query: finding_id -> (package_id, vulnerability_id)
+    # Include all tool-scan finding IDs so we can check which ones belong
+    # to removed packages when computing SBOM diff counts.
+    tool_scan_fids: set = set()
+    for scan in scans:
+        if (scan.scan_type or "sbom") == "tool":
+            tool_scan_fids |= findings_map.get(scan.id, set())
+    all_fids_needing_lookup |= tool_scan_fids
+
     fid_to_info: dict = {}
     if all_fids_needing_lookup:
         rows = db.session.execute(
@@ -429,22 +438,27 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             raw_added_f = curr_f - prev_f
             raw_removed_f = prev_f - curr_f
 
+            upgraded_removed_fids: set = set()
             if upgraded_pairs and entry["raw_added_f"]:
-                # Classify findings on upgraded packages
+                # Classify findings on upgraded packages with 1:1 matching
+                # (mirrors _classify_finding_changes in the detail view).
                 upgraded_old_ids = {str(old_pkg.id) for old_pkg, _ in upgraded_pairs}
                 upgraded_new_ids = {str(new_pkg.id) for _, new_pkg in upgraded_pairs}
-                # Vulns on removed side that belong to upgraded old packages
-                removed_vulns_on_upgraded = {
-                    fid_to_info[fid][1]
-                    for fid in raw_removed_f
-                    if fid in fid_to_info and str(fid_to_info[fid][0]) in upgraded_old_ids
-                }
-                upgraded_count = sum(
-                    1 for fid in raw_added_f
-                    if fid in fid_to_info
-                    and str(fid_to_info[fid][0]) in upgraded_new_ids
-                    and fid_to_info[fid][1] in removed_vulns_on_upgraded
-                )
+                # Group removed findings on upgraded-old packages by vuln
+                _rem_by_vuln: dict = {}
+                for fid in raw_removed_f:
+                    info = fid_to_info.get(fid)
+                    if info and str(info[0]) in upgraded_old_ids:
+                        _rem_by_vuln.setdefault(info[1], []).append(fid)
+                # Match added findings on upgraded-new packages 1:1
+                upgraded_count = 0
+                for fid in raw_added_f:
+                    info = fid_to_info.get(fid)
+                    if info and str(info[0]) in upgraded_new_ids:
+                        candidates = _rem_by_vuln.get(info[1], [])
+                        if candidates:
+                            upgraded_removed_fids.add(candidates.pop(0))
+                            upgraded_count += 1
                 base["findings_upgraded"] = upgraded_count
                 base["findings_added"] = len(raw_added_f) - upgraded_count
                 base["findings_removed"] = len(raw_removed_f) - upgraded_count
@@ -455,6 +469,44 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
 
             base["vulns_added"] = len(curr_v - prev_v)
             base["vulns_removed"] = len(prev_v - curr_v)
+
+            # Include tool-scan findings on removed/upgraded-old packages
+            # in the removed counts so the history matches the detail view.
+            gone_pkg_ids: set = set()
+            gone_pkg_ids |= entry.get("truly_removed_ids", set())
+            for old_pkg, _new_pkg in upgraded_pairs:
+                gone_pkg_ids.add(old_pkg.id)
+            if gone_pkg_ids:
+                extra_removed_f = 0
+                extra_removed_v: set = set()
+                # Dedup must mirror the detail view's already_removed sets:
+                # - findings: only the SBOM truly-removed (not upgraded)
+                # - vulns: only the SBOM-removed vuln IDs
+                # Upgraded SBOM findings had their count subtracted, so
+                # re-adding them via tool scans is correct.
+                sbom_truly_removed = raw_removed_f - upgraded_removed_fids
+                _seen_fids: set = set(sbom_truly_removed)
+                _seen_vids: set = set(prev_v - curr_v)
+                for (vid, _src), f_ids in running_src_findings.items():
+                    if vid != scan.variant_id:
+                        continue
+                    for fid in f_ids:
+                        if fid in _seen_fids:
+                            continue
+                        info = fid_to_info.get(fid)
+                        if info is None:
+                            continue
+                        pkg_id, vuln_id = info
+                        if pkg_id in gone_pkg_ids:
+                            extra_removed_f += 1
+                            _seen_fids.add(fid)
+                            if vuln_id not in _seen_vids:
+                                _seen_vids.add(vuln_id)
+                                extra_removed_v.add(vuln_id)
+                if extra_removed_f:
+                    base["findings_removed"] += extra_removed_f
+                if extra_removed_v:
+                    base["vulns_removed"] += len(extra_removed_v)
 
         # ---- Non-tool (SBOM) scans: set tool-only fields to None ----
         if not is_tool_scan:
@@ -512,7 +564,7 @@ def _load_scan_with_findings(scan_id: uuid_module.UUID) -> Scan | None:
     ).scalar_one_or_none()
 
 
-def _obs_to_dict(obs: Observation) -> dict:
+def _obs_to_dict(obs: Observation, origin: str = "Imported SBOM") -> dict:
     f = obs.finding
     pkg = f.package
     return {
@@ -521,7 +573,22 @@ def _obs_to_dict(obs: Observation) -> dict:
         "package_version": pkg.version if pkg else "",
         "package_id": str(f.package_id),
         "vulnerability_id": f.vulnerability_id,
+        "origin": origin,
     }
+
+
+_TOOL_SOURCE_LABELS: dict = {
+    "grype": "Grype Scan",
+    "nvd": "NVD CPE Scan",
+    "osv": "OSV Scan",
+}
+
+
+def _origin_for_scan(scan) -> str:
+    """Return a human-readable origin label for a scan."""
+    if (scan.scan_type or "sbom") == "tool":
+        return _TOOL_SOURCE_LABELS.get(scan.scan_source or "", "Vulnerability Scan")
+    return "Imported SBOM"
 
 
 def _classify_finding_changes(findings_added, findings_removed, upgraded_pairs):
@@ -706,13 +773,14 @@ def init_app(app):
                 break
 
         is_tool_scan = scan_type == "tool"
+        scan_origin = _origin_for_scan(scan)
 
         # --- Findings diff ---
         current_finding_ids = {obs.finding_id for obs in scan.observations}
         curr_vulns = {obs.finding.vulnerability_id for obs in scan.observations}
 
         if prev_scan_id is None:
-            findings_added = [_obs_to_dict(obs) for obs in scan.observations]
+            findings_added = [_obs_to_dict(obs, scan_origin) for obs in scan.observations]
             findings_removed: list = []
             vulns_added = sorted(curr_vulns)
             vulns_removed: list = []
@@ -722,9 +790,9 @@ def init_app(app):
             prev_vulns = {obs.finding.vulnerability_id for obs in prev_scan.observations} if prev_scan else set()
             added_fids = current_finding_ids - prev_finding_ids
             removed_fids = prev_finding_ids - current_finding_ids
-            findings_added = [_obs_to_dict(obs) for obs in scan.observations if obs.finding_id in added_fids]
+            findings_added = [_obs_to_dict(obs, scan_origin) for obs in scan.observations if obs.finding_id in added_fids]
             findings_removed = (
-                [_obs_to_dict(obs) for obs in prev_scan.observations if obs.finding_id in removed_fids]
+                [_obs_to_dict(obs, scan_origin) for obs in prev_scan.observations if obs.finding_id in removed_fids]
                 if prev_scan else []
             )
             vulns_added = sorted(curr_vulns - prev_vulns)
@@ -774,6 +842,52 @@ def init_app(app):
         else:
             findings_upgraded = []
 
+        # --- For SBOM scans: include tool-scan findings on removed/upgraded
+        # old packages so the user sees all CVEs that disappear from the
+        # global view when packages are dropped. ---
+        if not is_tool_scan and prev_scan_id is not None:
+            # Collect package IDs that are no longer in the new SBOM
+            gone_pkg_ids: set = set()
+            if truly_removed_ids:  # type: ignore[possibly-undefined]
+                gone_pkg_ids |= truly_removed_ids
+            for old_pkg, _new_pkg in upgraded_pairs:
+                gone_pkg_ids.add(old_pkg.id)
+
+            if gone_pkg_ids:
+                # Find active tool scans for this variant (latest per source)
+                tool_scans = [
+                    s for s in all_variant_scans
+                    if (s.scan_type or "sbom") == "tool"
+                ]
+                # Group by source, keep latest (scans are ordered by timestamp)
+                latest_tool_by_source: dict = {}
+                for ts in tool_scans:
+                    src = ts.scan_source or ""
+                    prev_ts = latest_tool_by_source.get(src)
+                    if prev_ts is None or ts.timestamp > prev_ts.timestamp:
+                        latest_tool_by_source[src] = ts
+
+                already_removed_fids = {f["finding_id"] for f in findings_removed}
+                already_removed_vids = set(vulns_removed)
+                for tool_scan_obj in latest_tool_by_source.values():
+                    tool_loaded = _load_scan_with_findings(tool_scan_obj.id)
+                    if not tool_loaded:
+                        continue
+                    tool_origin = _origin_for_scan(tool_loaded)
+                    for obs in tool_loaded.observations:
+                        f = obs.finding
+                        if f.package_id in gone_pkg_ids:
+                            fid_str = str(f.id)
+                            if fid_str not in already_removed_fids:
+                                already_removed_fids.add(fid_str)
+                                findings_removed.append(
+                                    _obs_to_dict(obs, tool_origin)
+                                )
+                            vid = f.vulnerability_id
+                            if vid not in already_removed_vids:
+                                already_removed_vids.add(vid)
+                                vulns_removed.append(vid)
+
         # Sort for stable output
         packages_added.sort(key=lambda p: (p["package_name"], p["package_version"]))
         packages_removed.sort(key=lambda p: (p["package_name"], p["package_version"]))
@@ -819,7 +933,7 @@ def init_app(app):
             newly_detected_findings_count = len(new_fids)
             newly_detected_vulns_count = len(new_vids)
             newly_detected_findings_list = [
-                _obs_to_dict(obs) for obs in scan.observations
+                _obs_to_dict(obs, scan_origin) for obs in scan.observations
                 if obs.finding_id in new_fids
             ]
             newly_detected_vulns_list = sorted(new_vids)

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -202,6 +202,36 @@ def _latest_sbom_scan_per_variant(scans: list[Scan]) -> dict:
     return latest
 
 
+def _sbom_scans_by_variant(scans: list[Scan]) -> dict:
+    """Return {variant_id: [sbom_scan, …]} ordered by timestamp ascending.
+
+    Used to look up which SBOM scan was active at any point in time.
+    """
+    by_variant: dict = {}
+    for s in scans:
+        if (s.scan_type or "sbom") != "sbom":
+            continue
+        by_variant.setdefault(s.variant_id, []).append(s)
+    # scans are already chronological but be safe
+    for v in by_variant.values():
+        v.sort(key=lambda s: s.timestamp)
+    return by_variant
+
+
+def _sbom_active_at(sbom_list: list, timestamp) -> "Scan | None":
+    """Return the most recent SBOM scan whose timestamp <= *timestamp*.
+
+    *sbom_list* must be sorted ascending by timestamp.
+    """
+    result = None
+    for s in sbom_list:
+        if s.timestamp <= timestamp:
+            result = s
+        else:
+            break
+    return result
+
+
 def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
     if not scans:
         return []
@@ -213,17 +243,13 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
     prev_map = _prev_scan_map(scans)
     variant_map = _variant_info(list({s.variant_id for s in scans}))
 
-    # For tool scans: find the latest SBOM scan per variant so we can compute
-    # "newly detected" counts (findings/vulns found by the tool but absent
-    # from the SBOM baseline).
-    latest_sbom = _latest_sbom_scan_per_variant(scans)
+    # For tool scans: determine the SBOM baseline that was active at the
+    # time of each tool scan.  This ensures that historical tool scan
+    # entries show the "newly detected" counts as they were at scan time,
+    # not re-calculated against a later SBOM import.
+    sbom_lists = _sbom_scans_by_variant(scans)
     # We may need findings/vulns for SBOM scans that aren't already in our maps
     # (they already are because all scans in the list are fetched).
-    sbom_findings: dict = {}  # variant_id -> set(finding_id)
-    sbom_vulns: dict = {}     # variant_id -> set(vulnerability_id)
-    for vid, sbom_scan in latest_sbom.items():
-        sbom_findings[vid] = findings_map.get(sbom_scan.id, set())
-        sbom_vulns[vid] = vulns_map.get(sbom_scan.id, set())
 
     # First pass: compute package diffs and collect all finding IDs that need
     # package-level info for upgrade classification.
@@ -283,8 +309,12 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
     # Track latest tool-scan findings/vulns per (variant, source) as we
     # iterate in chronological order so we can compute the "global" result
     # (SBOM ∪ all latest sources) at each point in time.
+    # Also track the SBOM baseline that was active at each tool scan's
+    # timestamp so historical counts stay stable.
     running_src_findings: dict = {}  # (variant_id, source) -> set
     running_src_vulns: dict = {}     # (variant_id, source) -> set
+    # Cache: sbom_scan.id -> (findings_set, vulns_set)
+    _sbom_cache: dict = {}
     result = []
     for entry in scan_data:
         scan = entry["scan"]
@@ -304,12 +334,23 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
 
         if is_tool_scan:
             # ---- Tool scan: diff against the GLOBAL state ----
-            # Compare the global result (SBOM ∪ all tool sources) before and
-            # after this scan so that added/removed counts reflect the real
-            # impact on the combined result, not the delta vs. the previous
-            # scan of the same tool type.
-            baseline_f = sbom_findings.get(scan.variant_id, set())
-            baseline_v = sbom_vulns.get(scan.variant_id, set())
+            # Use the SBOM baseline that was active at THIS scan's timestamp
+            # so that a later SBOM import doesn't retroactively change the
+            # "newly detected" counts of earlier tool scans.
+            sbom_at_time = _sbom_active_at(
+                sbom_lists.get(scan.variant_id, []),
+                scan.timestamp,
+            )
+            if sbom_at_time and sbom_at_time.id not in _sbom_cache:
+                _sbom_cache[sbom_at_time.id] = (
+                    findings_map.get(sbom_at_time.id, set()),
+                    vulns_map.get(sbom_at_time.id, set()),
+                )
+            if sbom_at_time:
+                baseline_f, baseline_v = _sbom_cache[sbom_at_time.id]
+            else:
+                baseline_f, baseline_v = set(), set()
+
             src_key = (scan.variant_id, scan.scan_source)
 
             # Global state BEFORE this scan
@@ -347,21 +388,18 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             base["vulns_removed"] = len(global_before_v - global_v)
 
             # "Newly detected" = findings/vulns added to the global result.
-            # By definition these are NOT in the SBOM baseline since SBOM is
-            # part of both global_before and global_after.
             base["newly_detected_findings"] = base["findings_added"]
             base["newly_detected_vulns"] = base["vulns_added"]
 
-            # Branch result = SBOM baseline ∪ this tool scan only
-            sbom_scan_obj = latest_sbom.get(scan.variant_id)
+            # Branch result = SBOM baseline (at scan time) ∪ this tool scan
             sbom_pkg = packages_map.get(
-                sbom_scan_obj.id, set()
-            ) if sbom_scan_obj else set()
+                sbom_at_time.id, set()
+            ) if sbom_at_time else set()
             base["branch_finding_count"] = len(baseline_f | curr_f)
             base["branch_vuln_count"] = len(baseline_v | curr_v)
             base["branch_package_count"] = len(sbom_pkg)
 
-            # Global result = SBOM baseline ∪ all latest tool-scan sources
+            # Global result = SBOM baseline (at scan time) ∪ all tool sources
             base["global_finding_count"] = len(global_f)
             base["global_vuln_count"] = len(global_v)
             base["global_package_count"] = len(sbom_pkg)

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -162,6 +162,13 @@ def _process_sbom_background(app, upload_id: str, file_paths: list[str], scan_id
             except Exception as e:
                 verbose(f"settings/upload: EPSS enrichment failed: {e}")
 
+            # Recompute scan-history cache for the affected variant.
+            try:
+                from ..routes.scans import recompute_variant_cache
+                recompute_variant_cache(variant_id)
+            except Exception as e:
+                verbose(f"settings/upload: Cache recompute failed: {e}")
+
             _upload_status[upload_id] = {
                 "status": "done",
                 "message": "SBOM imported successfully.",

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -447,7 +447,7 @@ def init_app(app):
             return jsonify({"error": "No valid SBOM files provided."}), 400
 
         # All files validated — now create the scan and register documents
-        scan = ScanController.create("", variant.id)
+        scan = ScanController.create("empty description", variant.id)
         tmp_paths: list[str] = []
 
         for tmp_path, filename, fmt in validated_files:

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -28,45 +28,48 @@ TIME_ESTIMATES_PATH = "/scan/outputs/time_estimates.json"
 def _latest_scan_id_for_variant(variant_uuid):
     """Return the active Scan IDs for the given variant.
 
-    The current view is the union of the latest SBOM scan and the latest tool
-    scan (if any).  Returns a list of 0–2 scan IDs.
+    The current view is the union of the latest SBOM scan and the latest
+    tool scan **per source** (nvd, osv, grype, …).  This ensures that
+    running an OSV scan does not hide CVEs discovered by a previous NVD
+    scan.
     """
     rows = db.session.execute(
-        db.select(Scan.id, Scan.scan_type)
+        db.select(Scan.id, Scan.scan_type, Scan.scan_source)
         .where(Scan.variant_id == variant_uuid)
         .order_by(Scan.timestamp.desc())
     ).all()
     ids: list = []
-    seen_types: set = set()
-    for scan_id, scan_type in rows:
+    seen_keys: set = set()  # "sbom" or "tool:<source>"
+    for scan_id, scan_type, scan_source in rows:
         st = scan_type or "sbom"
-        if st not in seen_types:
-            seen_types.add(st)
+        key = f"tool:{scan_source}" if st == "tool" else "sbom"
+        if key not in seen_keys:
+            seen_keys.add(key)
             ids.append(scan_id)
-        if len(seen_types) >= 2:          # sbom + tool
-            break
     return ids
 
 
 def _latest_scan_ids_for_project(project_uuid):
     """Return the active Scan IDs for each variant in the project.
 
-    For every variant the latest SBOM scan and the latest tool scan (if any)
-    are included so the view = latest SBOM ∪ latest tool scan.
+    For every variant the latest SBOM scan and the latest tool scan **per
+    source** (nvd, osv, grype, …) are included so the view =
+    latest SBOM ∪ latest tool scans from all sources.
     """
     rows = db.session.execute(
-        db.select(Scan.id, Scan.variant_id, Scan.scan_type, Scan.timestamp)
+        db.select(Scan.id, Scan.variant_id, Scan.scan_type, Scan.scan_source, Scan.timestamp)
         .join(Variant, Scan.variant_id == Variant.id)
         .where(Variant.project_id == project_uuid)
         .order_by(Scan.variant_id, Scan.timestamp.desc())
     ).all()
     ids: list = []
-    seen: dict = {}  # variant_id -> set of scan_types already picked
-    for scan_id, vid, scan_type, _ts in rows:
+    seen: dict = {}  # variant_id -> set of keys already picked
+    for scan_id, vid, scan_type, scan_source, _ts in rows:
         st = scan_type or "sbom"
+        key = f"tool:{scan_source}" if st == "tool" else "sbom"
         variant_seen = seen.setdefault(vid, set())
-        if st not in variant_seen:
-            variant_seen.add(st)
+        if key not in variant_seen:
+            variant_seen.add(key)
             ids.append(scan_id)
     return ids
 

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -26,32 +26,49 @@ TIME_ESTIMATES_PATH = "/scan/outputs/time_estimates.json"
 
 
 def _latest_scan_id_for_variant(variant_uuid):
-    """Return the ID of the most recent Scan for the given variant, or None."""
-    return db.session.execute(
-        db.select(Scan.id)
+    """Return the active Scan IDs for the given variant.
+
+    The current view is the union of the latest SBOM scan and the latest tool
+    scan (if any).  Returns a list of 0–2 scan IDs.
+    """
+    rows = db.session.execute(
+        db.select(Scan.id, Scan.scan_type)
         .where(Scan.variant_id == variant_uuid)
         .order_by(Scan.timestamp.desc())
-        .limit(1)
-    ).scalar_one_or_none()
+    ).all()
+    ids: list = []
+    seen_types: set = set()
+    for scan_id, scan_type in rows:
+        st = scan_type or "sbom"
+        if st not in seen_types:
+            seen_types.add(st)
+            ids.append(scan_id)
+        if len(seen_types) >= 2:          # sbom + tool
+            break
+    return ids
 
 
 def _latest_scan_ids_for_project(project_uuid):
-    """Return a list of Scan IDs – the latest scan for each variant in the project."""
-    latest_ts_sub = (
-        db.select(Scan.variant_id, func.max(Scan.timestamp).label("max_ts"))
+    """Return the active Scan IDs for each variant in the project.
+
+    For every variant the latest SBOM scan and the latest tool scan (if any)
+    are included so the view = latest SBOM ∪ latest tool scan.
+    """
+    rows = db.session.execute(
+        db.select(Scan.id, Scan.variant_id, Scan.scan_type, Scan.timestamp)
         .join(Variant, Scan.variant_id == Variant.id)
         .where(Variant.project_id == project_uuid)
-        .group_by(Scan.variant_id)
-        .subquery()
-    )
-    return list(db.session.execute(
-        db.select(Scan.id)
-        .join(
-            latest_ts_sub,
-            (Scan.variant_id == latest_ts_sub.c.variant_id)
-            & (Scan.timestamp == latest_ts_sub.c.max_ts),
-        )
-    ).scalars().all())
+        .order_by(Scan.variant_id, Scan.timestamp.desc())
+    ).all()
+    ids: list = []
+    seen: dict = {}  # variant_id -> set of scan_types already picked
+    for scan_id, vid, scan_type, _ts in rows:
+        st = scan_type or "sbom"
+        variant_seen = seen.setdefault(vid, set())
+        if st not in variant_seen:
+            variant_seen.add(st)
+            ids.append(scan_id)
+    return ids
 
 
 def _parse_effort_hours(value) -> int:
@@ -174,9 +191,9 @@ def init_app(app):
                 compare_uuid = uuid.UUID(compare_variant_id)
             except ValueError:
                 return {"error": "Invalid variant_id or compare_variant_id"}, 400
-            base_latest_id = _latest_scan_id_for_variant(base_uuid)
-            compare_latest_id = _latest_scan_id_for_variant(compare_uuid)
-            current_scan_ids = [compare_latest_id] if compare_latest_id else []
+            base_latest_ids = _latest_scan_id_for_variant(base_uuid)
+            compare_latest_ids = _latest_scan_id_for_variant(compare_uuid)
+            current_scan_ids = compare_latest_ids
             _scope_variant = compare_uuid
             _scope_project = None
             opts = (
@@ -184,26 +201,26 @@ def init_app(app):
                 selectinload(Vulnerability.findings).selectinload(Finding.time_estimate),
                 selectinload(Vulnerability.metrics),
             )
-            if base_latest_id is None:
+            if not base_latest_ids:
                 base_ids = set()
             else:
                 base_ids = set(db.session.execute(
                     db.select(Vulnerability.id)
                     .join(Finding, Vulnerability.id == Finding.vulnerability_id)
                     .join(Observation, Finding.id == Observation.finding_id)
-                    .where(Observation.scan_id == base_latest_id)
+                    .where(Observation.scan_id.in_(base_latest_ids))
                     .distinct()
                 ).scalars().all())
             operation = request.args.get('operation', 'difference')
             if operation == 'intersection':
-                if compare_latest_id is None:
+                if not compare_latest_ids:
                     records = []
                 else:
                     compare_ids = set(db.session.execute(
                         db.select(Vulnerability.id)
                         .join(Finding, Vulnerability.id == Finding.vulnerability_id)
                         .join(Observation, Finding.id == Observation.finding_id)
-                        .where(Observation.scan_id == compare_latest_id)
+                        .where(Observation.scan_id.in_(compare_latest_ids))
                         .distinct()
                     ).scalars().all())
                     intersection_ids = list(base_ids & compare_ids)
@@ -214,7 +231,7 @@ def init_app(app):
                         .order_by(Vulnerability.id)
                     ).scalars().all()) if intersection_ids else []
             else:  # difference (default): vulns in compare but NOT in base
-                if compare_latest_id is None:
+                if not compare_latest_ids:
                     records = []
                 else:
                     query = (
@@ -222,7 +239,7 @@ def init_app(app):
                         .options(*opts)
                         .join(Finding, Vulnerability.id == Finding.vulnerability_id)
                         .join(Observation, Finding.id == Observation.finding_id)
-                        .where(Observation.scan_id == compare_latest_id)
+                        .where(Observation.scan_id.in_(compare_latest_ids))
                         .distinct()
                         .order_by(Vulnerability.id)
                     )
@@ -236,9 +253,9 @@ def init_app(app):
                 return {"error": "Invalid variant_id"}, 400
             _scope_variant = variant_uuid
             _scope_project = None
-            latest_id = _latest_scan_id_for_variant(variant_uuid)
-            current_scan_ids = [latest_id] if latest_id else []
-            if latest_id is None:
+            latest_ids = _latest_scan_id_for_variant(variant_uuid)
+            current_scan_ids = latest_ids
+            if not latest_ids:
                 records = []
             else:
                 records = list(db.session.execute(
@@ -250,7 +267,7 @@ def init_app(app):
                     )
                     .join(Finding, Vulnerability.id == Finding.vulnerability_id)
                     .join(Observation, Finding.id == Observation.finding_id)
-                    .where(Observation.scan_id == latest_id)
+                    .where(Observation.scan_id.in_(latest_ids))
                     .distinct()
                     .order_by(Vulnerability.id)
                 ).scalars().all())

--- a/src/views/fast_spdx3.py
+++ b/src/views/fast_spdx3.py
@@ -197,7 +197,11 @@ class FastSPDX3:
         if not graph:
             return
 
-        self._extract_explicit_vulnerabilities(graph)
+        # Pre-build CVSS lookup so scores are available when vulnerabilities
+        # are first persisted via add(), avoiding a costly re-persist pass.
+        cvss_by_vuln = self._collect_cvss_from_graph(graph)
+
+        self._extract_explicit_vulnerabilities(graph, cvss_by_vuln)
 
         self._extract_vulnerabilities_cvss(graph)
 
@@ -218,7 +222,54 @@ class FastSPDX3:
         for vuln_id in vulnerabilities_to_remove:
             self.vulnerabilitiesCtrl.remove(vuln_id)
 
-    def _extract_explicit_vulnerabilities(self, graph: List[Dict]):
+    def _collect_cvss_from_graph(self, graph: List[Dict]) -> Dict[str, List["CVSS"]]:
+        """Pre-scan the graph for CVSS assessment relationships.
+
+        Returns a dict mapping CVE ID → list of CVSS objects so they can be
+        registered on the Vulnerability *before* the initial ``add()`` call,
+        ensuring the first DB persist already includes all CVSS data.
+        """
+        from collections import defaultdict
+        result: Dict[str, list] = defaultdict(list)
+
+        for element in graph:
+            if not isinstance(element, dict):
+                continue
+            if element.get('type') not in self.CVSS_ASSESSMENT_TYPES:
+                continue
+            if element.get('relationshipType') != 'hasAssessmentFor':
+                continue
+
+            from_value = element.get('from')
+            if not from_value:
+                continue
+            vuln_id = self._extract_cve_id(from_value)
+            if not vuln_id:
+                continue
+
+            vector_string = element.get('security_vectorString', '')
+
+            if element["type"] == "security_CvssV2VulnAssessmentRelationship":
+                cvss_version = "2.0"
+            else:
+                match = self.CVSS_PATTERN.search(vector_string)
+                if not match:
+                    continue
+                cvss_version = match.group(1)
+
+            result[vuln_id].append(CVSS(
+                cvss_version,
+                vector_string,
+                element.get('comment', 'unknown'),
+                float(element.get('security_score', '0')),
+                0.0,
+                0.0,
+            ))
+
+        return dict(result)
+
+    def _extract_explicit_vulnerabilities(self, graph: List[Dict],
+                                          cvss_by_vuln: Optional[Dict[str, List["CVSS"]]] = None):
         """
         Extract vulnerabilities explicitly defined as security_Vulnerability elements.
 
@@ -268,7 +319,13 @@ class FastSPDX3:
                         vulnerability.add_url(locator)
 
                 if description:
-                    vulnerability.add_text(description, "vulnerability description")
+                    vulnerability.add_text(description, "description")
+
+                # Register pre-collected CVSS scores so the initial add()
+                # persist includes them, avoiding a separate re-persist pass.
+                if cvss_by_vuln:
+                    for cvss_obj in cvss_by_vuln.get(cve_id, []):
+                        vulnerability.register_cvss(cvss_obj)
 
                 self.vulnerabilitiesCtrl.add(vulnerability)
 
@@ -294,6 +351,7 @@ class FastSPDX3:
             "security_vectorString": "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:H/I:L/A:N"
         }
         """
+        modified_vulns: set[str] = set()
         for element in graph:
             if not isinstance(element, dict):
                 continue
@@ -332,6 +390,7 @@ class FastSPDX3:
                 0.0,
                 0.0,
             ))
+            modified_vulns.add(vuln_id)
 
     def _process_package_vulnerability_relationships(self, graph: List[Dict]):
         """
@@ -476,7 +535,10 @@ class FastSPDX3:
         if relationship_type == 'doesNotAffect':
             assessment.set_status('not_affected')
         elif relationship_type == 'affects':
-            assessment.set_status('affected')
+            # Yocto cve-check uses "affects" for Unpatched CVEs which are
+            # not yet triaged — map to under_investigation ("Pending
+            # Assessment") rather than "affected" ("Exploitable").
+            assessment.set_status('under_investigation')
         elif relationship_type == "fixedIn":
             assessment.set_status('fixed')
 

--- a/src/views/grype_vulns.py
+++ b/src/views/grype_vulns.py
@@ -21,13 +21,65 @@ class GrypeVulns:
         self.vulnerabilitiesCtrl = controllers["vulnerabilities"]
         self.assessmentsCtrl = controllers["assessments"]
 
+    @staticmethod
+    def _normalize_artifact_name(name: str, purl: Optional[str] = None) -> str:
+        """Extract the canonical package name, avoiding namespace duplication.
+
+        When Grype reads a CycloneDX SBOM that has a ``group`` field, it
+        concatenates ``group/name`` in the artifact name.  If that combined
+        name is later re-exported as CycloneDX (with a ``group`` derived from
+        the CPE vendor), a second Grype scan ends up with
+        ``group/group/name``, growing indefinitely.
+
+        To break this cycle we prefer the package name from the PURL (which
+        never carries the group prefix) and fall-back to stripping repeated
+        namespace prefixes from *name*.
+        """
+        # 1. Try to extract the name from the PURL — it's always canonical.
+        if purl and "/" in purl:
+            try:
+                # PURLs look like  pkg:<type>/<namespace>/<name>@<version>
+                #              or  pkg:<type>/<name>@<version>
+                path_part = purl.split("://", 1)[-1] if "://" in purl else purl
+                # Remove 'pkg:' prefix
+                if path_part.startswith("pkg:"):
+                    path_part = path_part[4:]
+                # Remove type/  (e.g. "apk/", "generic/")
+                if "/" in path_part:
+                    path_part = path_part.split("/", 1)[1]
+                # Strip version (@...)
+                if "@" in path_part:
+                    path_part = path_part.rsplit("@", 1)[0]
+                # path_part may now be "namespace/name" or just "name"
+                # Take the last component as the package name
+                purl_name = path_part.rsplit("/", 1)[-1] if "/" in path_part else path_part
+                if purl_name:
+                    return purl_name
+            except Exception:
+                pass
+
+        # 2. Fallback: strip repeated leading namespace segments.
+        #    e.g. "openssl/openssl/openssl-foo" → "openssl-foo"
+        #         "openssl/openssl-foo" → "openssl-foo"
+        if "/" in name:
+            parts = name.split("/")
+            # Remove leading segments that are a prefix of the last segment
+            base = parts[-1]
+            return base
+
+        return name
+
     def parse_artifact_section(self, artifact: dict) -> Optional[str]:
         """Parse the `artifact` part of grype JSON output."""
         if "name" in artifact and "version" in artifact:
-            package = Package(artifact["name"], artifact["version"], [], [])
+            raw_name = artifact["name"]
+            purl_str = artifact.get("purl")
+            name = self._normalize_artifact_name(raw_name, purl_str)
 
-            if "purl" in artifact:
-                package.add_purl(artifact["purl"])
+            package = Package(name, artifact["version"], [], [])
+
+            if purl_str:
+                package.add_purl(purl_str)
             if "cpes" in artifact:
                 for cpe in artifact["cpes"]:
                     package.add_cpe(cpe)

--- a/src/views/yocto_vulns.py
+++ b/src/views/yocto_vulns.py
@@ -79,10 +79,24 @@ class YoctoVulns:
                     if "description" in issue:
                         vuln.add_text(issue.get("description"), "yocto description")
 
+                    vector_string = issue.get("vectorString", "")
+
+                    if "scorev4" in issue and issue["scorev4"] != "0.0":
+                        v4_vector = vector_string if vector_string.startswith("CVSS:4") else ""
+                        cvss_item = CVSS(
+                            "4.0",
+                            v4_vector,
+                            "unknown",
+                            float(issue.get("scorev4")),
+                            0.0,
+                            0.0
+                        )
+                        vuln.register_cvss(cvss_item)
                     if "scorev3" in issue and issue["scorev3"] != "0.0":
+                        v3_vector = vector_string if vector_string.startswith("CVSS:3") else ""
                         cvss_item = CVSS(
                             "3.1",
-                            f"CVSS:3.1/AV:{issue['vector']}" if "vector" in issue else "",
+                            v3_vector,
                             "unknown",
                             float(issue.get("scorev3")),
                             0.0,
@@ -90,9 +104,12 @@ class YoctoVulns:
                         )
                         vuln.register_cvss(cvss_item)
                     if "scorev2" in issue and issue["scorev2"] != "0.0":
+                        v2_vector = vector_string if (
+                            vector_string and not vector_string.startswith("CVSS:")
+                        ) else ""
                         cvss_item = CVSS(
                             "2.0",
-                            f"AV:{issue['vector']}" if "vector" in issue else "",
+                            v2_vector,
                             "unknown",
                             float(issue.get("scorev2")),
                             0.0,

--- a/tests/integration_tests/test_cyclonedx_export.py
+++ b/tests/integration_tests/test_cyclonedx_export.py
@@ -98,7 +98,7 @@ def test_export_components_json(cdx_exporter):
             "bom-ref": "pkg:generic/cairo@1.16.0",
             "name": "cairo",
             "version": "1.16.0",
-            "cpe": "cpe:2.3:*:*:cairo:1.16.0:*:*:*:*:*:*:*",
+            "cpe": "cpe:2.3:a:*:cairo:1.16.0:*:*:*:*:*:*:*",
             "purl": "pkg:generic/cairo@1.16.0"
         }.items() <= output["components"][1].items()
 

--- a/tests/integration_tests/test_fastsdpx_parsing.py
+++ b/tests/integration_tests/test_fastsdpx_parsing.py
@@ -107,8 +107,8 @@ def test_parse_components_json(spdx_parser):
     assert "xyz@rev2.3" in spdx_parser.packagesCtrl
     assert "linux@6.8.0-40-generic" in spdx_parser.packagesCtrl
     binutils = spdx_parser.packagesCtrl.get("binutils@2.38")
-    assert "cpe:2.3:a:gnu:binutils:2.38:*:*:*:*:*:*:*" in binutils
+    assert "cpe:2.3:a:*:binutils:2.38:*:*:*:*:*:*:*" in binutils
     board = spdx_parser.packagesCtrl.get("xyz@rev2.3")
-    assert "cpe:2.3:h:*:xyz:rev2.3:*:*:*:*:*:*:*" in board
+    assert "cpe:2.3:a:*:xyz:rev2.3:*:*:*:*:*:*:*" in board
     linux = spdx_parser.packagesCtrl.get("linux@6.8.0-40-generic")
-    assert "cpe:2.3:o:linux:linux_kernel:6.8.0-40-generic:*:*:*:*:*:*:*" in linux
+    assert "cpe:2.3:a:*:linux:6.8.0-40-generic:*:*:*:*:*:*:*" in linux

--- a/tests/integration_tests/test_fastsdpx_parsing.py
+++ b/tests/integration_tests/test_fastsdpx_parsing.py
@@ -107,8 +107,8 @@ def test_parse_components_json(spdx_parser):
     assert "xyz@rev2.3" in spdx_parser.packagesCtrl
     assert "linux@6.8.0-40-generic" in spdx_parser.packagesCtrl
     binutils = spdx_parser.packagesCtrl.get("binutils@2.38")
-    assert "cpe:2.3:a:*:binutils:2.38:*:*:*:*:*:*:*" in binutils
+    assert "cpe:2.3:a:gnu:binutils:2.38:*:*:*:*:*:*:*" in binutils
     board = spdx_parser.packagesCtrl.get("xyz@rev2.3")
     assert "cpe:2.3:h:*:xyz:rev2.3:*:*:*:*:*:*:*" in board
     linux = spdx_parser.packagesCtrl.get("linux@6.8.0-40-generic")
-    assert "cpe:2.3:o:*:linux:6.8.0-40-generic:*:*:*:*:*:*:*" in linux
+    assert "cpe:2.3:o:linux:linux_kernel:6.8.0-40-generic:*:*:*:*:*:*:*" in linux

--- a/tests/integration_tests/test_spdx3_parsing.py
+++ b/tests/integration_tests/test_spdx3_parsing.py
@@ -193,7 +193,7 @@ def test_parse_assessments(spdx3_parser):
     assert "The vulnerable code is not present in this package" in not_affected.impact_statement
 
     affected = spdx3_parser.assessmentsCtrl.gets_by_vuln("CVE-2023-5678")[0]
-    assert affected.status == "affected"
+    assert affected.status == "under_investigation"
     assert len(affected.packages) == 1
     # exploitabilityConfirmed is not in the JUSTIFICATION_MAP, so it should not be set
     assert affected.justification == ""
@@ -288,6 +288,8 @@ def test_extract_vulnerabilities(spdx3_parser):
     assert vuln.namespace == "unknown"
     assert "https://www.cve.org/CVERecord?id=CVE-2023-1234" in vuln.urls
     assert "Inappropriate implementation in Intents in Google Chrome..." in vuln.texts.values()
+    # Description must be under "description" key to be persisted to the DB
+    assert vuln.texts.get("description") == "Inappropriate implementation in Intents in Google Chrome..."
 
 
 def test_package_vulnerability_relationships(spdx3_parser):
@@ -1366,3 +1368,152 @@ def test_parse_vex_relationship_no_cve_in_from(spdx3_parser):
     }
     result = spdx3_parser._parse_vex_relationship(element)
     assert result is None
+
+
+def test_spdx3_cvss_persisted_to_db(spdx3_parser):
+    """CVSS scores from security_CvssV*VulnAssessmentRelationship elements
+    must be persisted as Metrics rows in the DB, not just kept in-memory."""
+    from src.models.metrics import Metrics
+    from src.extensions import db
+
+    spdx3_parser.parse_from_dict({
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "@graph": [
+            {
+                "type": "CreationInfo",
+                "@id": "_:CreationInfo1",
+                "created": "2025-04-08T13:09:06Z",
+                "createdBy": ["http://spdx.org/agents/test"],
+                "specVersion": "3.0.1"
+            },
+            {
+                "type": "software_Package",
+                "spdxId": "http://spdx.org/spdxdocs/test/package/foo",
+                "creationInfo": "_:CreationInfo1",
+                "name": "foo",
+                "software_packageVersion": "1.0",
+                "externalIdentifier": [{
+                    "type": "ExternalIdentifier",
+                    "externalIdentifierType": "cpe23Type",
+                    "identifier": "cpe:2.3:a:foo:foo:1.0:*:*:*:*:*:*:*"
+                }]
+            },
+            {
+                "type": "security_Vulnerability",
+                "spdxId": "http://spdx.org/spdxdocs/test/vulnerability/CVE-2025-90001",
+                "creationInfo": "_:CreationInfo1",
+                "externalIdentifier": [{
+                    "type": "ExternalIdentifier",
+                    "externalIdentifierType": "cve",
+                    "identifier": "CVE-2025-90001",
+                    "identifierLocator": ["https://www.cve.org/CVERecord?id=CVE-2025-90001"]
+                }]
+            },
+            {
+                "type": "Relationship",
+                "spdxId": "http://spdx.org/spdxdocs/test/relationship/1",
+                "creationInfo": "_:CreationInfo1",
+                "from": "http://spdx.org/spdxdocs/test/package/foo",
+                "relationshipType": "hasAssociatedVulnerability",
+                "to": ["http://spdx.org/spdxdocs/test/vulnerability/CVE-2025-90001"]
+            },
+            {
+                "type": "security_VexNotAffectedVulnAssessmentRelationship",
+                "spdxId": "http://spdx.org/spdxdocs/test/vex/1",
+                "creationInfo": "_:CreationInfo1",
+                "from": "http://spdx.org/spdxdocs/test/vulnerability/CVE-2025-90001",
+                "to": ["http://spdx.org/spdxdocs/test/package/foo"],
+                "relationshipType": "doesNotAffect"
+            },
+            {
+                "type": "security_CvssV3VulnAssessmentRelationship",
+                "spdxId": "http://spdx.org/spdxdocs/test/cvss-v3/1",
+                "comment": "nvd@nist.gov",
+                "creationInfo": "_:CreationInfo1",
+                "from": "http://spdx.org/spdxdocs/test/vulnerability/CVE-2025-90001",
+                "relationshipType": "hasAssessmentFor",
+                "to": ["http://spdx.org/spdxdocs/test/package/foo"],
+                "security_score": "9.8",
+                "security_severity": "critical",
+                "security_vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+            },
+            {
+                "type": "security_CvssV2VulnAssessmentRelationship",
+                "spdxId": "http://spdx.org/spdxdocs/test/cvss-v2/1",
+                "creationInfo": "_:CreationInfo1",
+                "from": "http://spdx.org/spdxdocs/test/vulnerability/CVE-2025-90001",
+                "relationshipType": "hasAssessmentFor",
+                "to": ["http://spdx.org/spdxdocs/test/package/foo"],
+                "security_score": "7.5",
+                "security_vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+            }
+        ]
+    })
+    db.session.commit()
+
+    # In-memory: severity_cvss should have both entries
+    vuln = spdx3_parser.vulnerabilitiesCtrl.get("CVE-2025-90001")
+    assert vuln is not None
+    assert len(vuln.severity_cvss) == 2
+
+    # DB: Metrics rows must exist
+    db.session.expire_all()
+    metrics = db.session.execute(
+        db.select(Metrics).where(Metrics.vulnerability_id == "CVE-2025-90001")
+    ).scalars().all()
+    assert len(metrics) == 2
+
+    versions = {m.version: m for m in metrics}
+    assert "3.1" in versions
+    assert float(versions["3.1"].score) == 9.8
+    assert versions["3.1"].vector == "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+
+    assert "2.0" in versions
+    assert float(versions["2.0"].score) == 7.5
+    assert versions["2.0"].vector == "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+
+
+def test_spdx3_description_persisted_to_db(spdx3_parser):
+    """SPDX3 vulnerability description must be stored under the 'description' key
+    and persisted to the DB description column."""
+    from src.models.vulnerability import Vulnerability as VulnModel
+    from src.extensions import db
+
+    spdx3_parser.parse_from_dict({
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "@graph": [
+            {
+                "type": "CreationInfo",
+                "@id": "_:CreationInfo1",
+                "created": "2025-04-08T13:09:06Z",
+                "createdBy": ["http://spdx.org/agents/test"],
+                "specVersion": "3.0.1"
+            },
+            {
+                "type": "security_Vulnerability",
+                "spdxId": "http://spdx.org/spdxdocs/test/vulnerability/CVE-2025-SPDX3DESC",
+                "creationInfo": "_:CreationInfo1",
+                "description": "Test description from SPDX3 vulnerability element.",
+                "externalIdentifier": [{
+                    "type": "ExternalIdentifier",
+                    "externalIdentifierType": "cve",
+                    "identifier": "CVE-2025-SPDX3DESC",
+                    "identifierLocator": ["https://www.cve.org/CVERecord?id=CVE-2025-SPDX3DESC"]
+                }]
+            }
+        ]
+    })
+    db.session.commit()
+
+    # Verify description is under the 'description' key in the in-memory DTO
+    vuln = spdx3_parser.vulnerabilitiesCtrl.get("CVE-2025-SPDX3DESC")
+    assert vuln is not None
+    assert vuln.texts.get("description") == "Test description from SPDX3 vulnerability element."
+
+    # Verify it persists to the DB
+    db.session.expire_all()
+    record = VulnModel.get_by_id("CVE-2025-SPDX3DESC")
+    assert record is not None
+    assert record.description == "Test description from SPDX3 vulnerability element."
+    # Verify to_dict returns it under "texts" → "description"
+    assert record.to_dict()["texts"]["description"] == "Test description from SPDX3 vulnerability element."

--- a/tests/integration_tests/test_spdx_parsing.py
+++ b/tests/integration_tests/test_spdx_parsing.py
@@ -128,11 +128,11 @@ def test_parse_components_json(spdx_parser):
     assert "xyz@rev2.3" in spdx_parser.packagesCtrl
     assert "linux@6.8.0-40-generic" in spdx_parser.packagesCtrl
     binutils = spdx_parser.packagesCtrl.get("binutils@2.38")
-    assert "cpe:2.3:a:*:binutils:2.38:*:*:*:*:*:*:*" in binutils
+    assert "cpe:2.3:a:gnu:binutils:2.38:*:*:*:*:*:*:*" in binutils
     board = spdx_parser.packagesCtrl.get("xyz@rev2.3")
     assert "cpe:2.3:h:*:xyz:rev2.3:*:*:*:*:*:*:*" in board
     linux = spdx_parser.packagesCtrl.get("linux@6.8.0-40-generic")
-    assert "cpe:2.3:o:*:linux:6.8.0-40-generic:*:*:*:*:*:*:*" in linux
+    assert "cpe:2.3:o:linux:linux_kernel:6.8.0-40-generic:*:*:*:*:*:*:*" in linux
 
 
 def test_parse_components_tagvalue(spdx_parser, spdx_tagvalue_file):

--- a/tests/integration_tests/test_spdx_parsing.py
+++ b/tests/integration_tests/test_spdx_parsing.py
@@ -128,11 +128,11 @@ def test_parse_components_json(spdx_parser):
     assert "xyz@rev2.3" in spdx_parser.packagesCtrl
     assert "linux@6.8.0-40-generic" in spdx_parser.packagesCtrl
     binutils = spdx_parser.packagesCtrl.get("binutils@2.38")
-    assert "cpe:2.3:a:gnu:binutils:2.38:*:*:*:*:*:*:*" in binutils
+    assert "cpe:2.3:a:*:binutils:2.38:*:*:*:*:*:*:*" in binutils
     board = spdx_parser.packagesCtrl.get("xyz@rev2.3")
-    assert "cpe:2.3:h:*:xyz:rev2.3:*:*:*:*:*:*:*" in board
+    assert "cpe:2.3:a:*:xyz:rev2.3:*:*:*:*:*:*:*" in board
     linux = spdx_parser.packagesCtrl.get("linux@6.8.0-40-generic")
-    assert "cpe:2.3:o:linux:linux_kernel:6.8.0-40-generic:*:*:*:*:*:*:*" in linux
+    assert "cpe:2.3:a:*:linux:6.8.0-40-generic:*:*:*:*:*:*:*" in linux
 
 
 def test_parse_components_tagvalue(spdx_parser, spdx_tagvalue_file):

--- a/tests/integration_tests/test_yocto_parsing.py
+++ b/tests/integration_tests/test_yocto_parsing.py
@@ -451,3 +451,303 @@ def test_yocto_summary_stored_as_description(yocto_parser):
     assert "description" in vuln.texts
     assert vuln.texts["description"] == "This is the vulnerability summary text."
     assert "summary" not in vuln.texts
+
+
+# ---------------------------------------------------------------------------
+# CVSS vector string parsing tests
+# ---------------------------------------------------------------------------
+
+def test_cvss_v3_vector_string_from_yocto(yocto_parser):
+    """The CVSSv3 vector should use the full 'vectorString' field, not 'vector'."""
+    data = {
+        "version": "1",
+        "package": [{
+            "name": "base-files",
+            "version": "3.0.14",
+            "issue": [{
+                "id": "CVE-2018-6557",
+                "status": "Unpatched",
+                "summary": "The MOTD update script vulnerability.",
+                "scorev2": "4.4",
+                "scorev3": "7.0",
+                "scorev4": "0.0",
+                "vector": "LOCAL",
+                "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-6557"
+            }]
+        }]
+    }
+    yocto_parser.load_from_dict(data)
+    vuln = yocto_parser.vulnerabilitiesCtrl.get("CVE-2018-6557")
+    assert vuln is not None
+
+    # Should have both v2 and v3 CVSS entries
+    assert len(vuln.severity_cvss) == 2
+
+    v3 = [c for c in vuln.severity_cvss if c.version == "3.1"]
+    assert len(v3) == 1
+    assert v3[0].vector_string == "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
+    assert v3[0].base_score == 7.0
+
+    # v2 should NOT use the v3 vectorString
+    v2 = [c for c in vuln.severity_cvss if c.version == "2.0"]
+    assert len(v2) == 1
+    assert v2[0].vector_string == ""  # vectorString starts with CVSS: → not used for v2
+    assert v2[0].base_score == 4.4
+
+
+def test_cvss_v2_only_vector_string_from_yocto(yocto_parser):
+    """When only scorev2 is non-zero, the CVSSv2 vector should use vectorString (no CVSS: prefix)."""
+    data = {
+        "version": "1",
+        "package": [{
+            "name": "acl",
+            "version": "2.3.2",
+            "issue": [{
+                "id": "CVE-2009-4411",
+                "status": "Patched",
+                "summary": "The setfacl and getfacl commands vulnerability.",
+                "scorev2": "3.7",
+                "scorev3": "0.0",
+                "scorev4": "0.0",
+                "vector": "LOCAL",
+                "vectorString": "AV:L/AC:H/Au:N/C:P/I:P/A:P",
+                "link": "https://nvd.nist.gov/vuln/detail/CVE-2009-4411"
+            }]
+        }]
+    }
+    yocto_parser.load_from_dict(data)
+    vuln = yocto_parser.vulnerabilitiesCtrl.get("CVE-2009-4411")
+    assert vuln is not None
+
+    # Only v2 since scorev3 = 0.0
+    assert len(vuln.severity_cvss) == 1
+    assert vuln.severity_cvss[0].version == "2.0"
+    assert vuln.severity_cvss[0].vector_string == "AV:L/AC:H/Au:N/C:P/I:P/A:P"
+    assert vuln.severity_cvss[0].base_score == 3.7
+
+
+def test_cvss_v4_support(yocto_parser):
+    """CVSSv4 scores should be parsed when scorev4 is non-zero."""
+    data = {
+        "version": "1",
+        "package": [{
+            "name": "libfoo",
+            "version": "2.0",
+            "issue": [{
+                "id": "CVE-2025-V4TEST",
+                "status": "Unpatched",
+                "summary": "A CVSSv4-scored vulnerability.",
+                "scorev2": "0.0",
+                "scorev3": "0.0",
+                "scorev4": "8.7",
+                "vector": "NETWORK",
+                "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+                "link": "https://nvd.nist.gov/vuln/detail/CVE-2025-V4TEST"
+            }]
+        }]
+    }
+    yocto_parser.load_from_dict(data)
+    vuln = yocto_parser.vulnerabilitiesCtrl.get("CVE-2025-V4TEST")
+    assert vuln is not None
+    assert len(vuln.severity_cvss) == 1
+    assert vuln.severity_cvss[0].version == "4.0"
+    assert vuln.severity_cvss[0].vector_string == "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+    assert vuln.severity_cvss[0].base_score == 8.7
+    assert vuln.severity_label == "high"
+
+
+def test_cvss_all_versions_present(yocto_parser):
+    """When all three CVSS versions have non-zero scores, all three should be registered."""
+    data = {
+        "version": "1",
+        "package": [{
+            "name": "libbar",
+            "version": "3.0",
+            "issue": [{
+                "id": "CVE-2025-ALLV",
+                "status": "Unpatched",
+                "summary": "All CVSS versions present.",
+                "scorev2": "5.0",
+                "scorev3": "7.5",
+                "scorev4": "8.0",
+                "vector": "NETWORK",
+                "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+                "link": "https://nvd.nist.gov/vuln/detail/CVE-2025-ALLV"
+            }]
+        }]
+    }
+    yocto_parser.load_from_dict(data)
+    vuln = yocto_parser.vulnerabilitiesCtrl.get("CVE-2025-ALLV")
+    assert vuln is not None
+    assert len(vuln.severity_cvss) == 3
+    versions = {c.version for c in vuln.severity_cvss}
+    assert versions == {"2.0", "3.1", "4.0"}
+
+    # v4 gets the vectorString (starts with CVSS:4)
+    v4 = [c for c in vuln.severity_cvss if c.version == "4.0"][0]
+    assert v4.vector_string.startswith("CVSS:4.0/")
+    assert v4.base_score == 8.0
+
+    # v3 does NOT get the vectorString (it starts with CVSS:4, not CVSS:3)
+    v3 = [c for c in vuln.severity_cvss if c.version == "3.1"][0]
+    assert v3.vector_string == ""
+    assert v3.base_score == 7.5
+
+    # v2 does NOT get the vectorString either (starts with CVSS:)
+    v2 = [c for c in vuln.severity_cvss if c.version == "2.0"][0]
+    assert v2.vector_string == ""
+    assert v2.base_score == 5.0
+
+
+def test_cvss_no_vector_string_field(yocto_parser):
+    """When there's no vectorString field at all, CVSS scores still get created with empty vectors."""
+    data = {
+        "version": "1",
+        "package": [{
+            "name": "libnovc",
+            "version": "1.0",
+            "issue": [{
+                "id": "CVE-2025-NOVEC",
+                "status": "Unpatched",
+                "summary": "No vector string.",
+                "scorev2": "5.0",
+                "scorev3": "7.5"
+            }]
+        }]
+    }
+    yocto_parser.load_from_dict(data)
+    vuln = yocto_parser.vulnerabilitiesCtrl.get("CVE-2025-NOVEC")
+    assert vuln is not None
+    assert len(vuln.severity_cvss) == 2
+    for c in vuln.severity_cvss:
+        assert c.vector_string == ""
+    assert vuln.severity_label == "high"  # 7.5 → high
+
+
+# ---------------------------------------------------------------------------
+# DB persistence tests — verify data survives the DB round-trip
+# ---------------------------------------------------------------------------
+
+def test_yocto_description_persisted_to_db(yocto_parser):
+    """Description from the Yocto CVE check JSON must be persisted to the DB."""
+    from src.models.vulnerability import Vulnerability as VulnModel
+    from src.extensions import db
+
+    data = {
+        "version": "1",
+        "package": [{
+            "name": "test-pkg",
+            "version": "1.0",
+            "issue": [{
+                "id": "CVE-2025-DBDESC",
+                "status": "Unpatched",
+                "summary": "DB persistence test description.",
+                "scorev3": "6.5",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+                "link": "https://nvd.nist.gov/vuln/detail/CVE-2025-DBDESC"
+            }]
+        }]
+    }
+    yocto_parser.load_from_dict(data)
+    db.session.commit()
+
+    # Load fresh from DB (bypassing all caches)
+    db.session.expire_all()
+    record = VulnModel.get_by_id("CVE-2025-DBDESC")
+    assert record is not None
+    assert record.description == "DB persistence test description."
+    assert record.status == "medium"
+    assert "https://nvd.nist.gov/vuln/detail/CVE-2025-DBDESC" in (record.links or [])
+
+
+def test_yocto_cvss_metrics_persisted_to_db(yocto_parser):
+    """CVSS metrics from the Yocto CVE check JSON must be persisted as Metrics rows."""
+    from src.models.vulnerability import Vulnerability as VulnModel
+    from src.models.metrics import Metrics
+    from src.extensions import db
+
+    data = {
+        "version": "1",
+        "package": [{
+            "name": "test-pkg",
+            "version": "1.0",
+            "issue": [{
+                "id": "CVE-2025-DBCVSS",
+                "status": "Unpatched",
+                "summary": "CVSS DB persistence test.",
+                "scorev2": "5.0",
+                "scorev3": "9.8",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "link": "https://nvd.nist.gov/vuln/detail/CVE-2025-DBCVSS"
+            }]
+        }]
+    }
+    yocto_parser.load_from_dict(data)
+    db.session.commit()
+
+    # Load metrics fresh from DB
+    db.session.expire_all()
+    metrics = db.session.execute(
+        db.select(Metrics).where(Metrics.vulnerability_id == "CVE-2025-DBCVSS")
+    ).scalars().all()
+    assert len(metrics) == 2
+
+    versions = {m.version: m for m in metrics}
+    assert "3.1" in versions
+    assert float(versions["3.1"].score) == 9.8
+    assert versions["3.1"].vector == "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+
+    assert "2.0" in versions
+    assert float(versions["2.0"].score) == 5.0
+
+
+def test_yocto_reimport_updates_metadata(yocto_parser):
+    """Re-importing with enriched metadata should update DB even when packages don't change."""
+    from src.models.vulnerability import Vulnerability as VulnModel
+    from src.extensions import db
+
+    # First import: minimal data (no summary, no CVSS)
+    data_minimal = {
+        "version": "1",
+        "package": [{
+            "name": "test-pkg",
+            "version": "1.0",
+            "issue": [{
+                "id": "CVE-2025-REIMPORT",
+                "status": "Unpatched",
+                "link": "https://nvd.nist.gov/vuln/detail/CVE-2025-REIMPORT"
+            }]
+        }]
+    }
+    yocto_parser.load_from_dict(data_minimal)
+    db.session.commit()
+
+    record = VulnModel.get_by_id("CVE-2025-REIMPORT")
+    assert record is not None
+    assert record.description is None
+
+    # Second import: same CVE + package, but now with description and CVSS
+    data_enriched = {
+        "version": "1",
+        "package": [{
+            "name": "test-pkg",
+            "version": "1.0",
+            "issue": [{
+                "id": "CVE-2025-REIMPORT",
+                "status": "Unpatched",
+                "summary": "Now with a description.",
+                "scorev3": "7.5",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "link": "https://nvd.nist.gov/vuln/detail/CVE-2025-REIMPORT"
+            }]
+        }]
+    }
+    yocto_parser.load_from_dict(data_enriched)
+    db.session.commit()
+
+    db.session.expire_all()
+    record = VulnModel.get_by_id("CVE-2025-REIMPORT")
+    assert record is not None
+    assert record.description == "Now with a description."
+    assert record.status == "high"

--- a/tests/unit_tests/test_new_db_models.py
+++ b/tests/unit_tests/test_new_db_models.py
@@ -736,7 +736,7 @@ class TestMetricsModelExtra:
         assert metrics.version == "2.0"
 
     def test_from_cvss_duplicate_fallback(self, app, vuln, metrics):
-        """from_cvss() falls back to SELECT when INSERT raises (lines 131-132)."""
+        """from_cvss() falls back to SELECT when INSERT raises IntegrityError."""
         from src.models.cvss import CVSS
         from sqlalchemy.exc import IntegrityError
         from unittest.mock import patch as mock_patch
@@ -751,8 +751,8 @@ class TestMetricsModelExtra:
         )
         # Clear _seen so from_cvss attempts the INSERT path
         Metrics._seen.discard((vuln.id, cvss.version, float(cvss.base_score)))
-        # Mock create() to raise IntegrityError, forcing the SELECT fallback (lines 131-132)
-        with mock_patch.object(Metrics, "create", side_effect=IntegrityError("stmt", {}, None)):
+        # Mock session.flush() to raise IntegrityError, forcing the SELECT fallback
+        with mock_patch.object(_db.session, "flush", side_effect=IntegrityError("stmt", {}, None)):
             result = Metrics.from_cvss(cvss, vuln.id)
         assert result is not None
         assert result.id == metrics.id

--- a/tests/unit_tests/test_osv_client.py
+++ b/tests/unit_tests/test_osv_client.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
 """Unit tests for src/controllers/osv_client.py — OSVClient."""

--- a/tests/unit_tests/test_osv_client.py
+++ b/tests/unit_tests/test_osv_client.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for src/controllers/osv_client.py — OSVClient."""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+import urllib.error
+
+from src.controllers.osv_client import OSVClient
+
+
+class TestOSVClientQueryByPurl:
+    """Tests for OSVClient.query_by_purl()."""
+
+    def _mock_urlopen_response(self, data_dict, status=200):
+        """Create a mock context-manager for urlopen that returns JSON."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(data_dict).encode("utf-8")
+        mock_resp.status = status
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    @patch("src.controllers.osv_client.urllib.request.urlopen")
+    def test_returns_vulns_on_success(self, mock_urlopen):
+        vulns = [{"id": "GHSA-1234", "summary": "test"}]
+        mock_urlopen.return_value = self._mock_urlopen_response({"vulns": vulns})
+        client = OSVClient(timeout=5)
+        result = client.query_by_purl("pkg:pypi/requests@2.28.0")
+        assert result == vulns
+        mock_urlopen.assert_called_once()
+
+    @patch("src.controllers.osv_client.urllib.request.urlopen")
+    def test_returns_empty_when_no_vulns(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen_response({})
+        client = OSVClient(timeout=5)
+        result = client.query_by_purl("pkg:pypi/safe-lib@1.0.0")
+        assert result == []
+
+    @patch("src.controllers.osv_client.urllib.request.urlopen")
+    def test_returns_empty_on_http_400(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="https://api.osv.dev/v1/query",
+            code=400, msg="Bad Request", hdrs={}, fp=None,
+        )
+        client = OSVClient(timeout=5)
+        result = client.query_by_purl("invalid-purl")
+        assert result == []
+
+    @patch("src.controllers.osv_client.urllib.request.urlopen")
+    def test_returns_empty_on_http_404(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="https://api.osv.dev/v1/query",
+            code=404, msg="Not Found", hdrs={}, fp=None,
+        )
+        client = OSVClient(timeout=5)
+        result = client.query_by_purl("pkg:pypi/nonexistent@0.0.0")
+        assert result == []
+
+    @patch("src.controllers.osv_client.time.sleep")
+    @patch("src.controllers.osv_client.urllib.request.urlopen")
+    def test_retries_on_http_500(self, mock_urlopen, mock_sleep):
+        vulns = [{"id": "CVE-2023-1234"}]
+        mock_urlopen.side_effect = [
+            urllib.error.HTTPError(
+                url="https://api.osv.dev/v1/query",
+                code=500, msg="Server Error", hdrs={}, fp=None,
+            ),
+            self._mock_urlopen_response({"vulns": vulns}),
+        ]
+        client = OSVClient(timeout=5)
+        result = client.query_by_purl("pkg:pypi/lib@1.0")
+        assert result == vulns
+        assert mock_urlopen.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("src.controllers.osv_client.time.sleep")
+    @patch("src.controllers.osv_client.urllib.request.urlopen")
+    def test_raises_after_all_retries_exhausted(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="https://api.osv.dev/v1/query",
+            code=500, msg="Server Error", hdrs={}, fp=None,
+        )
+        client = OSVClient(timeout=5)
+        with pytest.raises(urllib.error.HTTPError):
+            client.query_by_purl("pkg:pypi/lib@1.0", retries=3)
+        assert mock_urlopen.call_count == 3
+
+    @patch("src.controllers.osv_client.time.sleep")
+    @patch("src.controllers.osv_client.urllib.request.urlopen")
+    def test_retries_on_url_error(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+        client = OSVClient(timeout=5)
+        with pytest.raises(urllib.error.URLError):
+            client.query_by_purl("pkg:pypi/lib@1.0", retries=2)
+        assert mock_urlopen.call_count == 2
+
+    @patch("src.controllers.osv_client.time.sleep")
+    @patch("src.controllers.osv_client.urllib.request.urlopen")
+    def test_retries_on_timeout(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = TimeoutError("timed out")
+        client = OSVClient(timeout=1)
+        with pytest.raises(TimeoutError):
+            client.query_by_purl("pkg:pypi/lib@1.0", retries=2)
+        assert mock_urlopen.call_count == 2

--- a/tests/unit_tests/test_package.py
+++ b/tests/unit_tests/test_package.py
@@ -45,7 +45,7 @@ def test_create_package(generic_pkg):
     THEN check the Package id, cpe and purl is correct
     """
     assert generic_pkg.string_id == "mypackage@1.0.0"
-    assert generic_pkg.cpe[0] == "cpe:2.3:*:*:mypackage:1.0.0:*:*:*:*:*:*:*"
+    assert generic_pkg.cpe[0] == "cpe:2.3:a:*:mypackage:1.0.0:*:*:*:*:*:*:*"
     assert generic_pkg.purl[0] == "pkg:generic/mypackage@1.0.0"
 
 

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -68,7 +68,7 @@ def test_get_packages_list(client):
     assert len(data) == 1
     assert data[0]["name"] == "cairo"
     assert data[0]["version"] == "1.16.0"
-    assert len(data[0]["cpe"]) == 4
+    assert len(data[0]["cpe"]) == 3
 
 
 def test_get_packages_dict(client):
@@ -79,7 +79,7 @@ def test_get_packages_dict(client):
     assert "cairo@1.16.0" in data
     assert data["cairo@1.16.0"]["name"] == "cairo"
     assert data["cairo@1.16.0"]["version"] == "1.16.0"
-    assert len(data["cairo@1.16.0"]["cpe"]) == 4
+    assert len(data["cairo@1.16.0"]["cpe"]) == 3
 
 
 def test_get_vulnerabilities_list(client):

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -68,7 +68,7 @@ def test_get_packages_list(client):
     assert len(data) == 1
     assert data[0]["name"] == "cairo"
     assert data[0]["version"] == "1.16.0"
-    assert len(data[0]["cpe"]) == 3
+    assert len(data[0]["cpe"]) == 4
 
 
 def test_get_packages_dict(client):
@@ -79,7 +79,7 @@ def test_get_packages_dict(client):
     assert "cairo@1.16.0" in data
     assert data["cairo@1.16.0"]["name"] == "cairo"
     assert data["cairo@1.16.0"]["version"] == "1.16.0"
-    assert len(data["cairo@1.16.0"]["cpe"]) == 3
+    assert len(data["cairo@1.16.0"]["cpe"]) == 4
 
 
 def test_get_vulnerabilities_list(client):

--- a/tests/webapp_tests/test_scan.py
+++ b/tests/webapp_tests/test_scan.py
@@ -774,7 +774,7 @@ class TestClassifyFindingChangesUnit:
                 "package_version": "1.16.0",
                 "vulnerability_id": "CVE-2020-35492",
             }]
-            truly_add, truly_rem, upgraded = _classify_finding_changes(
+            truly_add, truly_rem, upgraded, upgraded_keys = _classify_finding_changes(
                 added, removed, [(pkg_old, pkg_new)]
             )
             assert len(upgraded) == 1
@@ -783,6 +783,7 @@ class TestClassifyFindingChangesUnit:
             assert upgraded[0]["new_version"] == "1.17.0"
             assert len(truly_add) == 0
             assert len(truly_rem) == 0
+            assert len(upgraded_keys) == 1
 
     def test_no_upgrade_different_vuln(self, upgrade_app):
         """Findings on different vulns don't match as upgrades."""
@@ -814,9 +815,10 @@ class TestClassifyFindingChangesUnit:
                 "package_version": "1.16.0",
                 "vulnerability_id": "CVE-2020-35492",
             }]
-            truly_add, truly_rem, upgraded = _classify_finding_changes(
+            truly_add, truly_rem, upgraded, upgraded_keys = _classify_finding_changes(
                 added, removed, [(pkg_old, pkg_new)]
             )
             assert len(upgraded) == 0
             assert len(truly_add) == 1
             assert len(truly_rem) == 1
+            assert len(upgraded_keys) == 0

--- a/tests/webapp_tests/test_scan.py
+++ b/tests/webapp_tests/test_scan.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
 """Tests for src/routes/scans.py — covering all routes and helpers."""

--- a/tests/webapp_tests/test_scan.py
+++ b/tests/webapp_tests/test_scan.py
@@ -224,6 +224,99 @@ class TestListScansByVariant:
 
 
 # ---------------------------------------------------------------------------
+# Scan diff cache
+# ---------------------------------------------------------------------------
+
+class TestScanDiffCache:
+    def test_second_request_uses_cache(self, client, ids):
+        """Second GET /api/scans should be served from cache."""
+        # First request populates cache
+        r1 = client.get("/api/scans")
+        assert r1.status_code == 200
+        data1 = json.loads(r1.data)
+        # Second request should hit cache and return identical data
+        r2 = client.get("/api/scans")
+        assert r2.status_code == 200
+        data2 = json.loads(r2.data)
+        assert len(data1) == len(data2)
+        for d1, d2 in zip(data1, data2):
+            assert d1["id"] == d2["id"]
+            assert d1["finding_count"] == d2["finding_count"]
+            assert d1["is_first"] == d2["is_first"]
+            assert d1["findings_added"] == d2["findings_added"]
+
+    def test_cache_hit_variant_endpoint(self, client, ids):
+        """Cache also works for variant-scoped endpoint."""
+        url = f"/api/variants/{ids['variant_id']}/scans"
+        r1 = client.get(url)
+        data1 = json.loads(r1.data)
+        r2 = client.get(url)
+        data2 = json.loads(r2.data)
+        assert len(data1) == len(data2)
+        for d1, d2 in zip(data1, data2):
+            assert d1["id"] == d2["id"]
+            assert d1["finding_count"] == d2["finding_count"]
+
+    def test_cache_hit_project_endpoint(self, client, ids):
+        """Cache also works for project-scoped endpoint."""
+        url = f"/api/projects/{ids['project_id']}/scans"
+        r1 = client.get(url)
+        data1 = json.loads(r1.data)
+        r2 = client.get(url)
+        data2 = json.loads(r2.data)
+        assert len(data1) == len(data2)
+        for d1, d2 in zip(data1, data2):
+            assert d1["id"] == d2["id"]
+            assert d1["finding_count"] == d2["finding_count"]
+
+    def test_recompute_variant_cache(self, app, client, ids):
+        """recompute_variant_cache rebuilds cache and subsequent GET uses it."""
+        from src.routes.scans import recompute_variant_cache
+        with app.app_context():
+            recompute_variant_cache(uuid.UUID(ids["variant_id"]))
+        # Should now be served from cache
+        r = client.get(f"/api/variants/{ids['variant_id']}/scans")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert len(data) == 2
+
+    def test_invalidate_variant_cache(self, app, client, ids):
+        """invalidate_variant_cache clears cache; next GET recomputes."""
+        from src.routes.scans import invalidate_variant_cache, recompute_variant_cache
+        with app.app_context():
+            recompute_variant_cache(uuid.UUID(ids["variant_id"]))
+            invalidate_variant_cache(uuid.UUID(ids["variant_id"]))
+        # Next request should recompute (cold cache)
+        r = client.get(f"/api/variants/{ids['variant_id']}/scans")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert len(data) == 2
+        assert data[0]["is_first"] is True
+
+    def test_delete_scan_recomputes_cache(self, app, client, ids):
+        """Deleting a scan recomputes the cache for the variant."""
+        # Populate cache via a first request
+        client.get("/api/scans")
+        # Delete scan_b
+        r = client.delete(f"/api/scans/{ids['scan_b_id']}")
+        assert r.status_code == 200
+        # The remaining scan should be served (cache was recomputed)
+        r2 = client.get(f"/api/variants/{ids['variant_id']}/scans")
+        data = json.loads(r2.data)
+        assert len(data) == 1
+        assert data[0]["id"] == ids["scan_a_id"]
+        assert data[0]["is_first"] is True
+
+    def test_recompute_empty_variant(self, app, ids):
+        """recompute_variant_cache on a variant with no scans doesn't crash."""
+        from src.routes.scans import recompute_variant_cache
+        fake_variant = uuid.uuid4()
+        with app.app_context():
+            # Should complete without error
+            recompute_variant_cache(fake_variant)
+
+
+# ---------------------------------------------------------------------------
 # PATCH /api/scans/<scan_id>
 # ---------------------------------------------------------------------------
 
@@ -822,3 +915,178 @@ class TestClassifyFindingChangesUnit:
             assert len(truly_add) == 1
             assert len(truly_rem) == 1
             assert len(upgraded_keys) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tool-scan integration (SBOM + tool scan, diff + global-result + list)
+# ---------------------------------------------------------------------------
+
+def _build_tool_scan_db(app):
+    """Set up: SBOM scan A → tool scan → SBOM scan B (different pkg version).
+
+    Layout
+    ------
+    ProjectT / VariantT
+        ScanA  (SBOM, pkg cairo@1.16.0, CVE-2020-35492)
+        ScanT  (tool/nvd, pkg cairo@1.16.0, CVE-TOOL-001)
+        ScanB  (SBOM, pkg cairo@1.17.0, CVE-2020-35492)
+    """
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.observation import Observation
+    from datetime import datetime, timezone, timedelta
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("ToolTestProject")
+        variant = Variant.create("ToolTestVariant", project.id)
+
+        t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        # SBOM scan A — cairo@1.16.0 with CVE-2020-35492
+        scan_a = Scan(
+            description="sbom scan a", variant_id=variant.id,
+            scan_type="sbom", timestamp=t0,
+        )
+        _db.session.add(scan_a)
+        _db.session.flush()
+
+        pkg_old = Package.find_or_create("cairo", "1.16.0")
+        vuln1 = Vulnerability.create_record(id="CVE-2020-35492", description="cairo vuln")
+        finding1 = Finding.get_or_create(pkg_old.id, vuln1.id)
+        _db.session.commit()
+
+        sbom_a = SBOMDocument.create("/a/sbom.json", "spdx2", scan_a.id)
+        SBOMPackage.create(sbom_a.id, pkg_old.id)
+        Observation.create(finding_id=finding1.id, scan_id=scan_a.id)
+        _db.session.commit()
+
+        # Tool scan — same package, different CVE
+        scan_t = Scan(
+            description="nvd tool scan", variant_id=variant.id,
+            scan_type="tool", scan_source="nvd",
+            timestamp=t0 + timedelta(hours=1),
+        )
+        _db.session.add(scan_t)
+        _db.session.flush()
+
+        vuln_tool = Vulnerability.create_record(id="CVE-TOOL-001", description="tool vuln")
+        finding_tool = Finding.get_or_create(pkg_old.id, vuln_tool.id)
+        _db.session.commit()
+
+        Observation.create(finding_id=finding_tool.id, scan_id=scan_t.id)
+        _db.session.commit()
+
+        # SBOM scan B — cairo@1.17.0 (upgraded), same CVE-2020-35492
+        scan_b = Scan(
+            description="sbom scan b", variant_id=variant.id,
+            scan_type="sbom", timestamp=t0 + timedelta(hours=2),
+        )
+        _db.session.add(scan_b)
+        _db.session.flush()
+
+        pkg_new = Package.find_or_create("cairo", "1.17.0")
+        finding2 = Finding.get_or_create(pkg_new.id, vuln1.id)
+        _db.session.commit()
+
+        sbom_b = SBOMDocument.create("/b/sbom.json", "spdx2", scan_b.id)
+        SBOMPackage.create(sbom_b.id, pkg_new.id)
+        Observation.create(finding_id=finding2.id, scan_id=scan_b.id)
+        _db.session.commit()
+
+        return {
+            "project_id": str(project.id),
+            "variant_id": str(variant.id),
+            "scan_a_id": str(scan_a.id),
+            "scan_t_id": str(scan_t.id),
+            "scan_b_id": str(scan_b.id),
+        }
+
+
+@pytest.fixture()
+def tool_app(tmp_path):
+    import os
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        ids = _build_tool_scan_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def tool_client(tool_app):
+    return tool_app.test_client()
+
+
+@pytest.fixture()
+def tool_ids(tool_app):
+    return tool_app._test_ids
+
+
+class TestToolScanIntegration:
+    """Tests for scan history with tool scans present."""
+
+    def test_list_includes_tool_scan(self, tool_client, tool_ids):
+        """GET /api/scans includes tool scan with correct fields."""
+        r = tool_client.get("/api/scans")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert len(data) == 3
+        tool_scan = next(d for d in data if d["id"] == tool_ids["scan_t_id"])
+        assert tool_scan["scan_type"] == "tool"
+        assert tool_scan["scan_source"] == "nvd"
+        assert isinstance(tool_scan["newly_detected_findings"], int)
+        assert isinstance(tool_scan["newly_detected_vulns"], int)
+        assert isinstance(tool_scan["branch_finding_count"], int)
+        assert isinstance(tool_scan["global_finding_count"], int)
+
+    def test_sbom_scan_b_has_global_result(self, tool_client, tool_ids):
+        """Second SBOM scan has global result incorporating tool scan."""
+        r = tool_client.get("/api/scans")
+        data = json.loads(r.data)
+        scan_b = next(d for d in data if d["id"] == tool_ids["scan_b_id"])
+        assert scan_b["global_finding_count"] is not None
+        assert scan_b["global_finding_count"] >= scan_b["finding_count"]
+
+    def test_diff_with_tool_scans(self, tool_client, tool_ids):
+        """Diff for the second SBOM scan includes tool-scan contributions."""
+        r = tool_client.get(f"/api/scans/{tool_ids['scan_b_id']}/diff")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert data["is_first"] is False
+        assert data["previous_scan_id"] == tool_ids["scan_a_id"]
+        # Should have scan result counts
+        assert "finding_count" in data
+        assert "vuln_count" in data
+
+    def test_tool_scan_diff_is_first(self, tool_client, tool_ids):
+        """Tool scan diff has is_first=True (only shows added)."""
+        r = tool_client.get(f"/api/scans/{tool_ids['scan_t_id']}/diff")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert data["is_first"] is True
+        assert isinstance(data["findings_added"], list)
+
+    def test_global_result_endpoint(self, tool_client, tool_ids):
+        """GET /api/scans/<sbom_scan_b>/global-result returns packages."""
+        r = tool_client.get(f"/api/scans/{tool_ids['scan_b_id']}/global-result")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert "packages" in data
+        assert "findings" in data
+        assert "vulnerabilities" in data
+        assert len(data["packages"]) >= 1

--- a/tests/webapp_tests/test_scan_advanced.py
+++ b/tests/webapp_tests/test_scan_advanced.py
@@ -1,0 +1,820 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for _run_grype_scan inner logic, tool-scan diffs, and
+newly-detected computation in scan list serialisation."""
+
+import json
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a DB with both SBOM and tool scans for diff testing
+# ---------------------------------------------------------------------------
+
+def _build_tool_scan_db(app):
+    """Populate DB with SBOM scan + two sequential tool scans.
+
+    - Tool scan A detects CVE-TOOL-1
+    - Tool scan B detects CVE-TOOL-1 + CVE-TOOL-2  (newly detected = 1)
+    """
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.observation import Observation
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("DiffProject")
+        variant = Variant.create("DiffVariant", project.id)
+
+        # --- SBOM scan ---
+        sbom_scan = Scan.create("sbom scan", variant.id, scan_type="sbom")
+        pkg = Package.find_or_create(
+            "openssl", "1.1.1",
+            cpe=["cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"],
+            purl=["pkg:pypi/openssl@1.1.1"],
+        )
+        vuln_sbom = Vulnerability.create_record(
+            id="CVE-SBOM-1", description="sbom vuln"
+        )
+        finding_sbom = Finding.get_or_create(pkg.id, vuln_sbom.id)
+        _db.session.commit()
+
+        sbom_doc = SBOMDocument.create(
+            "/sbom/doc.json", "doc.json", sbom_scan.id, format="spdx"
+        )
+        SBOMPackage.create(sbom_doc.id, pkg.id)
+        Observation.create(
+            finding_id=finding_sbom.id, scan_id=sbom_scan.id
+        )
+        _db.session.commit()
+
+        # --- Tool scan A ---
+        tool_scan_a = Scan.create(
+            "empty description", variant.id, scan_type="tool"
+        )
+        vuln_tool_1 = Vulnerability.create_record(
+            id="CVE-TOOL-1", description="tool vuln 1"
+        )
+        finding_t1 = Finding.get_or_create(pkg.id, vuln_tool_1.id)
+        _db.session.commit()
+        Observation.create(
+            finding_id=finding_t1.id, scan_id=tool_scan_a.id
+        )
+        _db.session.commit()
+
+        # --- Tool scan B (adds CVE-TOOL-2, keeps CVE-TOOL-1) ---
+        tool_scan_b = Scan.create(
+            "empty description", variant.id, scan_type="tool"
+        )
+        vuln_tool_2 = Vulnerability.create_record(
+            id="CVE-TOOL-2", description="tool vuln 2"
+        )
+        finding_t2 = Finding.get_or_create(pkg.id, vuln_tool_2.id)
+        _db.session.commit()
+        Observation.create(
+            finding_id=finding_t1.id, scan_id=tool_scan_b.id
+        )
+        Observation.create(
+            finding_id=finding_t2.id, scan_id=tool_scan_b.id
+        )
+        _db.session.commit()
+
+        return {
+            "project_id": str(project.id),
+            "variant_id": str(variant.id),
+            "sbom_scan_id": str(sbom_scan.id),
+            "tool_scan_a_id": str(tool_scan_a.id),
+            "tool_scan_b_id": str(tool_scan_b.id),
+            "pkg_id": str(pkg.id),
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True, "SCAN_FILE": str(scan_file),
+        })
+        ids = _build_tool_scan_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+# ---------------------------------------------------------------------------
+# Tool scan list serialisation (covers lines 314-319, 195, tool-scan diffs)
+# ---------------------------------------------------------------------------
+
+class TestToolScanListSerialisation:
+    """GET /api/scans returns correct diffs for sequential tool scans."""
+
+    def test_list_includes_tool_scans_with_diffs(self, client, ids):
+        """Second tool scan shows findings_added/removed vs first tool scan."""
+        resp = client.get("/api/scans")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        # Find tool scan B in the list
+        tool_b = [
+            s for s in data
+            if s["id"] == ids["tool_scan_b_id"]
+        ]
+        assert len(tool_b) == 1
+        tb = tool_b[0]
+
+        # Tool scan B added 1 finding (CVE-TOOL-2) vs tool scan A
+        assert tb["findings_added"] == 1
+        assert tb["findings_removed"] == 0
+        assert tb["vulns_added"] == 1
+        assert tb["vulns_removed"] == 0
+
+        # newly_detected should be present for tool scans
+        assert tb["newly_detected_findings"] is not None
+        assert tb["newly_detected_vulns"] is not None
+
+        # Tool scans have empty formats list
+        assert tb["formats"] == []
+
+    def test_list_sbom_scan_has_null_newly_detected(self, client, ids):
+        """SBOM scan should have null for newly_detected fields."""
+        resp = client.get("/api/scans")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        sbom = [
+            s for s in data
+            if s["id"] == ids["sbom_scan_id"]
+        ]
+        assert len(sbom) == 1
+        s = sbom[0]
+        assert s["newly_detected_findings"] is None
+        assert s["newly_detected_vulns"] is None
+
+        # SBOM scan has formats from its SBOM documents
+        assert "spdx" in s["formats"]
+
+    def test_scan_source_field(self, client, ids):
+        """scan_source is present in the serialised response."""
+        resp = client.get("/api/scans")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        # All scans in this fixture have scan_source=None
+        for s in data:
+            assert "scan_source" in s
+
+    def test_tool_scan_a_newly_detected(self, client, ids):
+        """Tool scan A — first tool scan — has newly_detected counts."""
+        resp = client.get("/api/scans")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        tool_a = [
+            s for s in data
+            if s["id"] == ids["tool_scan_a_id"]
+        ]
+        assert len(tool_a) == 1
+        ta = tool_a[0]
+        # CVE-TOOL-1 is not in SBOM scan → it IS newly detected
+        assert ta["newly_detected_findings"] >= 1
+        assert ta["newly_detected_vulns"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tool scan detail diff (covers lines 578-582, 634-663)
+# ---------------------------------------------------------------------------
+
+class TestToolScanDetailDiff:
+    """GET /api/scans/<id>/diff for tool scans."""
+
+    def test_tool_scan_b_diff(self, client, ids):
+        """Detail-diff for tool scan B shows findings added vs tool scan A."""
+        resp = client.get(
+            f"/api/scans/{ids['tool_scan_b_id']}/diff"
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        # Tool scan packages are empty (no package diff for tool scans)
+        assert data["packages_added"] == []
+        assert data["packages_removed"] == []
+        assert data["packages_upgraded"] == []
+
+        # Findings: CVE-TOOL-2 added
+        finding_vuln_ids = [
+            f["vulnerability_id"] for f in data["findings_added"]
+        ]
+        assert "CVE-TOOL-2" in finding_vuln_ids
+
+        # Newly detected: tool scan B has CVE-TOOL-2 not in SBOM and not
+        # in tool scan A → newly_detected_findings should be 1.
+        assert data["newly_detected_findings"] == 1
+        assert data["newly_detected_vulns"] == 1
+
+    def test_tool_scan_a_diff_first(self, client, ids):
+        """First tool scan — all findings are new."""
+        resp = client.get(
+            f"/api/scans/{ids['tool_scan_a_id']}/diff"
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        # Tool scan A has 1 finding (CVE-TOOL-1) — all newly detected
+        assert data["newly_detected_findings"] >= 1
+        assert data["newly_detected_vulns"] >= 1
+
+    def test_sbom_scan_diff_no_newly_detected(self, client, ids):
+        """SBOM scan diff has no newly_detected fields."""
+        resp = client.get(
+            f"/api/scans/{ids['sbom_scan_id']}/diff"
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["newly_detected_findings"] is None
+        assert data["newly_detected_vulns"] is None
+
+
+# ---------------------------------------------------------------------------
+# Merge result for tool scan merging SBOM (covers lines 746-747, 786-787)
+# ---------------------------------------------------------------------------
+
+class TestGlobalResultToolScanSources:
+    """Merge result endpoint resolves source labels for SBOM + tool."""
+
+    def test_tool_scan_global_result_has_sources(self, client, ids):
+        resp = client.get(
+            f"/api/scans/{ids['tool_scan_b_id']}/global-result"
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["scan_type"] == "tool"
+
+        # Vulnerabilities should include CVEs from both tool and SBOM scans
+        vuln_ids = [v["vulnerability_id"] for v in data["vulnerabilities"]]
+        assert "CVE-SBOM-1" in vuln_ids
+        assert "CVE-TOOL-1" in vuln_ids
+
+        # Check that sources include both "Grype" and the SBOM name
+        all_sources = set()
+        for v in data["vulnerabilities"]:
+            for s in v.get("sources", []):
+                all_sources.add(s)
+        # "Grype" should be among sources for tool findings
+        assert any("Grype" in s or "SBOM" in s or "spdx" in s for s in all_sources)
+
+
+# ---------------------------------------------------------------------------
+# _run_grype_scan logic (covers lines 845-916 via subprocess mocking)
+# ---------------------------------------------------------------------------
+
+def _make_sync_thread_patch():
+    """Return a context-manager patch that makes Thread.start() synchronous."""
+    return patch(
+        "threading.Thread",
+        side_effect=lambda **kwargs: type(
+            "SyncThread", (), {
+                "_target": kwargs.get("target"),
+                "start": lambda self: kwargs.get("target")(),
+                "daemon": True,
+            }
+        )(),
+    )
+
+
+class TestRunGrypeScan:
+    """Test the _run_grype_scan inner function with mocked subprocesses."""
+
+    @pytest.fixture()
+    def grype_app(self, tmp_path):
+        """Separate app fixture for Grype tests (avoids scan-state leaks)."""
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.package import Package
+
+        scan_file = tmp_path / "scan_status.txt"
+        scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+        os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        try:
+            application = create_app()
+            application.config.update({
+                "TESTING": True, "SCAN_FILE": str(scan_file),
+            })
+            with application.app_context():
+                _db.drop_all()
+                _db.create_all()
+                project = Project.create("GrypeProject")
+                variant = Variant.create("GrypeVariant", project.id)
+                scan = Scan.create("base scan", variant.id)
+                pkg = Package.find_or_create("pkg", "1.0")
+                _db.session.commit()
+                sbom = SBOMDocument.create(
+                    "/test/s.json", "spdx", scan.id
+                )
+                SBOMPackage.create(sbom.id, pkg.id)
+                _db.session.commit()
+                application._test_ids = {
+                    "project_id": str(project.id),
+                    "variant_id": str(variant.id),
+                }
+            yield application
+        finally:
+            os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_grype_scan_success(
+        self, mock_which, mock_sp_run, grype_app, tmp_path
+    ):
+        """Grype scan completes when subprocess calls succeed."""
+        # Make subprocess.run create the expected files
+        def subprocess_side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if isinstance(cmd, list) and "export" in cmd:
+                # Simulate export creating the CDX file
+                out_dir = cmd[cmd.index("--output-dir") + 1]
+                cdx_path = os.path.join(
+                    out_dir, "sbom_cyclonedx_v1_6.cdx.json"
+                )
+                with open(cdx_path, "w") as f:
+                    f.write("{}")
+            elif isinstance(cmd, list) and "grype" in cmd:
+                # grype writes to stdout which is redirected to a file
+                stdout_file = kwargs.get("stdout")
+                if stdout_file and hasattr(stdout_file, "write"):
+                    stdout_file.write('{"matches": []}')
+            return MagicMock(returncode=0)
+
+        mock_sp_run.side_effect = subprocess_side_effect
+        client = grype_app.test_client()
+        vid = grype_app._test_ids["variant_id"]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/grype-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "done"
+        assert data["error"] is None
+        assert data["progress"] == "Scan complete"
+        assert data["total"] == 4
+        assert data["done_count"] == 4
+        assert any("\u2713" in line for line in data["logs"])
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_grype_scan_export_no_file(
+        self, mock_which, mock_sp_run, grype_app
+    ):
+        """Grype scan errors when export produces no CDX file."""
+        mock_sp_run.return_value = MagicMock(returncode=0)
+        client = grype_app.test_client()
+        vid = grype_app._test_ids["variant_id"]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/grype-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "CycloneDX export produced no file" in data["error"]
+        assert any("ERROR" in line for line in data.get("logs", []))
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_grype_scan_timeout(
+        self, mock_which, mock_sp_run, grype_app
+    ):
+        """Grype scan handles timeout."""
+        import subprocess
+        mock_sp_run.side_effect = subprocess.TimeoutExpired(
+            cmd="flask export", timeout=120
+        )
+        client = grype_app.test_client()
+        vid = grype_app._test_ids["variant_id"]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/grype-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "timed out" in data["error"]
+        assert any("ERROR" in line for line in data.get("logs", []))
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_grype_scan_command_failure(
+        self, mock_which, mock_sp_run, grype_app
+    ):
+        """Grype scan handles CalledProcessError."""
+        import subprocess
+        mock_sp_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd="flask export", stderr="something failed"
+        )
+        client = grype_app.test_client()
+        vid = grype_app._test_ids["variant_id"]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/grype-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "Command failed" in data["error"]
+        assert any("ERROR" in line for line in data.get("logs", []))
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_grype_scan_generic_exception(
+        self, mock_which, mock_sp_run, grype_app
+    ):
+        """Grype scan handles unexpected exceptions."""
+        mock_sp_run.side_effect = RuntimeError("unexpected")
+        client = grype_app.test_client()
+        vid = grype_app._test_ids["variant_id"]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/grype-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "unexpected" in data["error"]
+        assert any("ERROR" in line for line in data.get("logs", []))
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_grype_scan_grype_no_output(
+        self, mock_which, mock_sp_run, grype_app, tmp_path
+    ):
+        """Grype scan errors when grype produces an empty output file."""
+        def subprocess_side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if isinstance(cmd, list) and "export" in cmd:
+                out_dir = cmd[cmd.index("--output-dir") + 1]
+                cdx_path = os.path.join(
+                    out_dir, "sbom_cyclonedx_v1_6.cdx.json"
+                )
+                with open(cdx_path, "w") as f:
+                    f.write("{}")
+            # grype call — don't write anything to stdout
+            return MagicMock(returncode=0)
+
+        mock_sp_run.side_effect = subprocess_side_effect
+        client = grype_app.test_client()
+        vid = grype_app._test_ids["variant_id"]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/grype-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "Grype produced no output" in data["error"]
+        assert any("ERROR" in line for line in data.get("logs", []))
+
+
+# ---------------------------------------------------------------------------
+# NVD / OSV scans with two scan types → break at line 1008/1280
+# ---------------------------------------------------------------------------
+
+class TestNvdScanWithToolAndSbom:
+    """NVD scan on a variant that has both sbom and tool scans
+    (triggers the ``break`` at line 1008)."""
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scans_variant_two_types(self, MockNvdDb, app, client, ids):
+        mock_nvd = MagicMock()
+        MockNvdDb.return_value = mock_nvd
+        mock_nvd.api_get_cves_by_cpe.return_value = []
+
+        with _make_sync_thread_patch():
+            resp = client.post(
+                f"/api/variants/{ids['variant_id']}/nvd-scan"
+            )
+        assert resp.status_code == 202
+
+        resp_s = client.get(
+            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
+        )
+        data = json.loads(resp_s.data)
+        assert data["status"] == "done"
+
+
+class TestOsvScanWithToolAndSbom:
+    """OSV scan on a variant that has both sbom and tool scans
+    (triggers the ``break`` at line 1280)."""
+
+    @patch("src.controllers.osv_client.OSVClient.query_by_purl")
+    def test_osv_scans_variant_two_types(self, mock_query, app, client, ids):
+        mock_query.return_value = []
+
+        with _make_sync_thread_patch():
+            resp = client.post(
+                f"/api/variants/{ids['variant_id']}/osv-scan"
+            )
+        assert resp.status_code == 202
+
+        resp_s = client.get(
+            f"/api/variants/{ids['variant_id']}/osv-scan/status"
+        )
+        data = json.loads(resp_s.data)
+        assert data["status"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# NVD / OSV scans outer exception handler (lines 1187-1189 / 1479-1481)
+# ---------------------------------------------------------------------------
+
+class TestNvdScanOuterException:
+    """NVD scan outer except catches unexpected crashes."""
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scan_outer_crash(self, MockNvdDb, app, client, ids):
+        """An exception in the NVD scan body is caught and reported."""
+        MockNvdDb.side_effect = RuntimeError("crashed at construction")
+
+        with _make_sync_thread_patch():
+            resp = client.post(
+                f"/api/variants/{ids['variant_id']}/nvd-scan"
+            )
+        assert resp.status_code == 202
+
+        resp_s = client.get(
+            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
+        )
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "crashed at construction" in data["error"]
+
+
+class TestOsvScanOuterException:
+    """OSV scan outer except catches unexpected crashes."""
+
+    @patch("src.controllers.osv_client.OSVClient")
+    def test_osv_scan_outer_crash(self, MockOsv, app, client, ids):
+        MockOsv.side_effect = RuntimeError("osv crash")
+
+        with _make_sync_thread_patch():
+            resp = client.post(
+                f"/api/variants/{ids['variant_id']}/osv-scan"
+            )
+        assert resp.status_code == 202
+
+        resp_s = client.get(
+            f"/api/variants/{ids['variant_id']}/osv-scan/status"
+        )
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "osv crash" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/scans/<scan_id> tests
+# ---------------------------------------------------------------------------
+
+class TestDeleteScanEndpoint:
+    """DELETE /api/scans/<scan_id> removes a scan and orphaned findings."""
+
+    def test_delete_scan_invalid_id(self, client):
+        resp = client.delete("/api/scans/not-a-uuid")
+        assert resp.status_code == 400
+
+    def test_delete_scan_not_found(self, client):
+        import uuid
+        resp = client.delete(f"/api/scans/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+    def test_delete_tool_scan_success(self, client, ids):
+        """Deleting a tool scan removes it and cleans up orphaned findings."""
+        resp = client.delete(f"/api/scans/{ids['tool_scan_b_id']}")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["deleted"] is True
+        assert data["scan_id"] == ids["tool_scan_b_id"]
+        # CVE-TOOL-2 was only in tool_scan_b so it should be orphaned
+        assert data["orphaned_findings_removed"] >= 1
+
+        # Verify the scan no longer appears in the list
+        resp2 = client.get("/api/scans")
+        scan_ids = [s["id"] for s in json.loads(resp2.data)]
+        assert ids["tool_scan_b_id"] not in scan_ids
+
+
+# ---------------------------------------------------------------------------
+# Tool-scan diff compares against GLOBAL state, not previous same-type scan
+# ---------------------------------------------------------------------------
+
+def _build_multi_source_db(app):
+    """Populate DB with SBOM + NVD tool scan + Grype tool scan.
+
+    SBOM: findings S1, S2 (CVE-S1, CVE-S2)
+    NVD:  findings S1, N1, N2 (CVE-S1, CVE-N1, CVE-N2)  → adds 2 to global
+    Grype: findings S2, N1, G1 (CVE-S2, CVE-N1, CVE-G1) → adds 1 to global
+    Second SBOM re-import (same findings as first): expected global includes
+    tool-scan findings.
+    """
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.observation import Observation
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("MultiSrcProject")
+        variant = Variant.create("MultiSrcVariant", project.id)
+        pkg = Package.find_or_create("libfoo", "2.0.0")
+
+        vuln_s1 = Vulnerability.create_record(id="CVE-S1", description="s1")
+        vuln_s2 = Vulnerability.create_record(id="CVE-S2", description="s2")
+        vuln_n1 = Vulnerability.create_record(id="CVE-N1", description="n1")
+        vuln_n2 = Vulnerability.create_record(id="CVE-N2", description="n2")
+        vuln_g1 = Vulnerability.create_record(id="CVE-G1", description="g1")
+        f_s1 = Finding.get_or_create(pkg.id, vuln_s1.id)
+        f_s2 = Finding.get_or_create(pkg.id, vuln_s2.id)
+        f_n1 = Finding.get_or_create(pkg.id, vuln_n1.id)
+        f_n2 = Finding.get_or_create(pkg.id, vuln_n2.id)
+        f_g1 = Finding.get_or_create(pkg.id, vuln_g1.id)
+        _db.session.commit()
+
+        # 1) SBOM scan: S1, S2
+        sbom1 = Scan.create("sbom1", variant.id, scan_type="sbom")
+        doc = SBOMDocument.create("/doc.json", "doc", sbom1.id, format="spdx")
+        SBOMPackage.create(doc.id, pkg.id)
+        Observation.create(finding_id=f_s1.id, scan_id=sbom1.id)
+        Observation.create(finding_id=f_s2.id, scan_id=sbom1.id)
+        _db.session.commit()
+
+        # 2) NVD tool scan: S1, N1, N2  (source="NVD")
+        nvd_scan = Scan.create(
+            "empty description", variant.id, scan_type="tool",
+            scan_source="NVD",
+        )
+        Observation.create(finding_id=f_s1.id, scan_id=nvd_scan.id)
+        Observation.create(finding_id=f_n1.id, scan_id=nvd_scan.id)
+        Observation.create(finding_id=f_n2.id, scan_id=nvd_scan.id)
+        _db.session.commit()
+
+        # 3) Grype tool scan: S2, N1, G1  (source="Grype")
+        grype_scan = Scan.create(
+            "empty description", variant.id, scan_type="tool",
+            scan_source="Grype",
+        )
+        Observation.create(finding_id=f_s2.id, scan_id=grype_scan.id)
+        Observation.create(finding_id=f_n1.id, scan_id=grype_scan.id)
+        Observation.create(finding_id=f_g1.id, scan_id=grype_scan.id)
+        _db.session.commit()
+
+        # 4) Second SBOM re-import (same content): S1, S2
+        sbom2 = Scan.create("sbom2", variant.id, scan_type="sbom")
+        doc2 = SBOMDocument.create("/doc2.json", "doc2", sbom2.id, format="spdx")
+        SBOMPackage.create(doc2.id, pkg.id)
+        Observation.create(finding_id=f_s1.id, scan_id=sbom2.id)
+        Observation.create(finding_id=f_s2.id, scan_id=sbom2.id)
+        _db.session.commit()
+
+        return {
+            "variant_id": str(variant.id),
+            "sbom1_id": str(sbom1.id),
+            "nvd_scan_id": str(nvd_scan.id),
+            "grype_scan_id": str(grype_scan.id),
+            "sbom2_id": str(sbom2.id),
+        }
+
+
+@pytest.fixture()
+def multi_app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True, "SCAN_FILE": str(scan_file),
+        })
+        ids = _build_multi_source_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def multi_client(multi_app):
+    return multi_app.test_client()
+
+
+@pytest.fixture()
+def multi_ids(multi_app):
+    return multi_app._test_ids
+
+
+class TestToolScanGlobalStateDiff:
+    """Tool scan diffs compare against the global state (SBOM ∪ all tools),
+    NOT the previous scan of the same tool type."""
+
+    def test_nvd_scan_diff_vs_sbom_baseline(self, multi_client, multi_ids):
+        """NVD scan adds 2 findings (N1, N2) to the global state."""
+        resp = multi_client.get("/api/scans")
+        data = json.loads(resp.data)
+        nvd = next(s for s in data if s["id"] == multi_ids["nvd_scan_id"])
+
+        # S1 is already in SBOM → not counted as added.
+        # N1, N2 are new to global → findings_added = 2
+        assert nvd["findings_added"] == 2
+        assert nvd["findings_removed"] == 0
+        assert nvd["vulns_added"] == 2
+        assert nvd["vulns_removed"] == 0
+
+    def test_grype_scan_diff_vs_global_state(self, multi_client, multi_ids):
+        """Grype scan adds 1 finding (G1) to the global state.
+
+        S2 is in SBOM, N1 is already contributed by NVD → only G1 is new.
+        """
+        resp = multi_client.get("/api/scans")
+        data = json.loads(resp.data)
+        grype = next(s for s in data if s["id"] == multi_ids["grype_scan_id"])
+
+        assert grype["findings_added"] == 1
+        assert grype["findings_removed"] == 0
+        assert grype["vulns_added"] == 1
+        assert grype["vulns_removed"] == 0
+
+    def test_grype_global_result_includes_all_sources(self, multi_client, multi_ids):
+        """Global result for Grype scan = SBOM ∪ NVD ∪ Grype = 5 findings."""
+        resp = multi_client.get("/api/scans")
+        data = json.loads(resp.data)
+        grype = next(s for s in data if s["id"] == multi_ids["grype_scan_id"])
+
+        # SBOM: S1, S2  NVD: S1, N1, N2  Grype: S2, N1, G1
+        # Union = S1, S2, N1, N2, G1 → 5
+        assert grype["global_finding_count"] == 5
+        assert grype["global_vuln_count"] == 5
+
+    def test_sbom_reimport_global_includes_tool_scans(self, multi_client, multi_ids):
+        """Second SBOM import has global_finding_count = SBOM ∪ tools."""
+        resp = multi_client.get("/api/scans")
+        data = json.loads(resp.data)
+        sbom2 = next(s for s in data if s["id"] == multi_ids["sbom2_id"])
+
+        # The re-imported SBOM scan should show the global result
+        # including tool-scan findings.
+        assert sbom2["global_finding_count"] == 5
+        assert sbom2["global_vuln_count"] == 5
+
+    def test_first_tool_scan_has_diff_fields(self, multi_client, multi_ids):
+        """First tool scan (NVD) should have numeric diff fields, not null."""
+        resp = multi_client.get("/api/scans")
+        data = json.loads(resp.data)
+        nvd = next(s for s in data if s["id"] == multi_ids["nvd_scan_id"])
+
+        # Even though it's the first NVD scan, is_first may be True but
+        # findings_added should still be a number (not None).
+        assert nvd["findings_added"] is not None
+        assert nvd["vulns_added"] is not None

--- a/tests/webapp_tests/test_scan_advanced.py
+++ b/tests/webapp_tests/test_scan_advanced.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
 """Tests for _run_grype_scan inner logic, tool-scan diffs, and

--- a/tests/webapp_tests/test_scan_cli.py
+++ b/tests/webapp_tests/test_scan_cli.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
 """Tests for the ``flask nvd-scan`` and ``flask osv-scan`` CLI commands."""

--- a/tests/webapp_tests/test_scan_cli.py
+++ b/tests/webapp_tests/test_scan_cli.py
@@ -1,0 +1,386 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the ``flask nvd-scan`` and ``flask osv-scan`` CLI commands."""
+
+import json
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.bin.webapp import create_app
+from src.controllers.nvd_db import NVD_DB as _RealNvdDb
+from src.extensions import db as _db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _build_db(app):
+    """DB with packages carrying CPE and PURL identifiers."""
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.package import Package
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("CLIProject")
+        variant = Variant.create("CLIVariant", project.id)
+        scan = Scan.create("base scan", variant.id, scan_type="sbom")
+
+        pkg_cpe = Package.find_or_create(
+            "openssl", "1.1.1",
+            cpe=["cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"],
+            purl=["pkg:pypi/openssl@1.1.1"],
+        )
+        pkg_purl = Package.find_or_create(
+            "requests", "2.28.0",
+            cpe=[],
+            purl=["pkg:pypi/requests@2.28.0"],
+        )
+        _db.session.commit()
+
+        doc = SBOMDocument.create("/sbom.json", "sbom.json", scan.id, format="spdx")
+        SBOMPackage.create(doc.id, pkg_cpe.id)
+        SBOMPackage.create(doc.id, pkg_purl.id)
+
+        from src.models.observation import Observation
+        from src.models.vulnerability import Vulnerability
+        from src.models.finding import Finding
+
+        vuln = Vulnerability.create_record(id="CVE-EXISTING-1", description="existing")
+        finding = Finding.get_or_create(pkg_cpe.id, vuln.id)
+        _db.session.commit()
+        Observation.create(finding_id=finding.id, scan_id=scan.id)
+        _db.session.commit()
+
+        return {
+            "project_name": "CLIProject",
+            "variant_name": "CLIVariant",
+            "variant_id": str(variant.id),
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True, "SCAN_FILE": str(scan_file),
+        })
+        ids = _build_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+# ---------------------------------------------------------------------------
+# NVD scan CLI tests
+# ---------------------------------------------------------------------------
+
+class TestNvdScanCLI:
+    """flask nvd-scan CLI command."""
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scan_creates_findings(self, MockNvdDb, app, ids):
+        """NVD scan via CLI creates findings and a tool scan."""
+        mock_instance = MockNvdDb.return_value
+        mock_instance.api_get_cves_by_cpe.return_value = [
+            {
+                "cve": {
+                    "id": "CVE-2023-0001",
+                    "descriptions": [
+                        {"lang": "en", "value": "test vuln"}
+                    ],
+                    "metrics": {
+                        "cvssMetricV31": [{
+                            "cvssData": {
+                                "version": "3.1",
+                                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                                "baseScore": 9.8,
+                            },
+                            "exploitabilityScore": 3.9,
+                            "impactScore": 5.9,
+                        }],
+                    },
+                    "references": [{"url": "https://example.com"}],
+                    "weaknesses": [{"description": [{"value": "CWE-79"}]}],
+                    "published": "2023-01-01T00:00:00.000",
+                    "lastModified": "2023-06-01T00:00:00.000",
+                    "vulnStatus": "Analyzed",
+                }
+            }
+        ]
+        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "nvd-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "Scan complete" in result.output
+        assert "CVE-2023-0001" in result.output
+
+        # Verify scan was created in DB
+        with app.app_context():
+            from src.models.scan import Scan
+            scans = _db.session.execute(
+                _db.select(Scan).where(Scan.scan_source == "nvd")
+            ).scalars().all()
+            assert len(scans) >= 1
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scan_enriches_existing_vuln(self, MockNvdDb, app, ids):
+        """NVD scan enriches an existing bare CVE with description/links."""
+        mock_instance = MockNvdDb.return_value
+        mock_instance.api_get_cves_by_cpe.return_value = [
+            {
+                "cve": {
+                    "id": "CVE-EXISTING-1",
+                    "descriptions": [
+                        {"lang": "en", "value": "enriched description"}
+                    ],
+                    "metrics": {},
+                    "references": [{"url": "https://nvd.nist.gov"}],
+                    "weaknesses": [],
+                }
+            }
+        ]
+        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "nvd-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "CVE-EXISTING-1" in result.output
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scan_handles_api_error(self, MockNvdDb, app, ids):
+        """NVD scan continues when API call raises an exception."""
+        mock_instance = MockNvdDb.return_value
+        mock_instance.api_get_cves_by_cpe.side_effect = RuntimeError("API timeout")
+        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "nvd-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "Scan complete" in result.output
+        assert "0 unique CVEs" in result.output
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scan_no_cpe_packages(self, MockNvdDb, app):
+        """NVD scan on a project with no CPE packages fails gracefully."""
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.package import Package
+
+        with app.app_context():
+            project = Project.create("NoCPE")
+            variant = Variant.create("NoCPEVar", project.id)
+            scan = Scan.create("scan", variant.id, scan_type="sbom")
+            pkg = Package.find_or_create("nocpe-pkg", "1.0", cpe=[], purl=[])
+            _db.session.commit()
+            doc = SBOMDocument.create("/no.json", "no.json", scan.id)
+            SBOMPackage.create(doc.id, pkg.id)
+            _db.session.commit()
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "nvd-scan", "--project", "NoCPE", "--variant", "NoCPEVar",
+        ])
+        assert result.exit_code != 0
+        assert "CPE" in result.output
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scan_default_variant(self, MockNvdDb, app, ids):
+        """NVD scan uses default variant when --variant is omitted."""
+        mock_instance = MockNvdDb.return_value
+        mock_instance.api_get_cves_by_cpe.return_value = []
+        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "nvd-scan", "--project", ids["project_name"],
+        ])
+        assert result.exit_code != 0
+        assert "No scans found" in result.output
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scan_no_cves_returned(self, MockNvdDb, app, ids):
+        """NVD scan with zero results still completes successfully."""
+        mock_instance = MockNvdDb.return_value
+        mock_instance.api_get_cves_by_cpe.return_value = []
+        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "nvd-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "no CVEs" in result.output
+        assert "Scan complete" in result.output
+
+
+# ---------------------------------------------------------------------------
+# OSV scan CLI tests
+# ---------------------------------------------------------------------------
+
+class TestOsvScanCLI:
+    """flask osv-scan CLI command."""
+
+    @patch("src.controllers.osv_client.OSVClient")
+    def test_osv_scan_creates_findings(self, MockOsvClient, app, ids):
+        """OSV scan via CLI creates findings and a tool scan."""
+        mock_instance = MockOsvClient.return_value
+        mock_instance.query_by_purl.return_value = [
+            {
+                "id": "GHSA-test-0001",
+                "summary": "test osv vuln",
+                "aliases": ["CVE-2023-9999"],
+                "references": [{"url": "https://example.com"}],
+            }
+        ]
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "osv-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "Scan complete" in result.output
+
+        # Verify scan was created in DB
+        with app.app_context():
+            from src.models.scan import Scan
+            scans = _db.session.execute(
+                _db.select(Scan).where(Scan.scan_source == "osv")
+            ).scalars().all()
+            assert len(scans) >= 1
+
+    @patch("src.controllers.osv_client.OSVClient")
+    def test_osv_scan_enriches_existing_vuln(self, MockOsvClient, app, ids):
+        """OSV scan enriches an existing bare CVE with description."""
+        mock_instance = MockOsvClient.return_value
+        # Return a vuln whose alias matches CVE-EXISTING-1 (already in DB)
+        mock_instance.query_by_purl.return_value = [
+            {
+                "id": "GHSA-enrich-001",
+                "summary": "enriched from osv",
+                "aliases": ["CVE-EXISTING-1"],
+                "references": [{"url": "https://osv.dev"}],
+            }
+        ]
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "osv-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "Scan complete" in result.output
+
+    @patch("src.controllers.osv_client.OSVClient")
+    def test_osv_scan_handles_api_error(self, MockOsvClient, app, ids):
+        """OSV scan continues when API call raises an exception."""
+        mock_instance = MockOsvClient.return_value
+        mock_instance.query_by_purl.side_effect = RuntimeError("network error")
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "osv-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "Scan complete" in result.output
+        assert "0 unique vulnerabilities" in result.output
+
+    @patch("src.controllers.osv_client.OSVClient")
+    def test_osv_scan_no_purl_packages(self, MockOsvClient, app):
+        """OSV scan on a project with no PURL packages fails gracefully."""
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.package import Package
+
+        with app.app_context():
+            project = Project.create("NoPURL")
+            variant = Variant.create("NoPURLVar", project.id)
+            scan = Scan.create("scan", variant.id, scan_type="sbom")
+            pkg = Package.find_or_create("nopurl-pkg", "1.0", cpe=[], purl=[])
+            _db.session.commit()
+            doc = SBOMDocument.create("/no.json", "no2.json", scan.id)
+            SBOMPackage.create(doc.id, pkg.id)
+            _db.session.commit()
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "osv-scan", "--project", "NoPURL", "--variant", "NoPURLVar",
+        ])
+        assert result.exit_code != 0
+        assert "PURL" in result.output
+
+    @patch("src.controllers.osv_client.OSVClient")
+    def test_osv_scan_default_variant(self, MockOsvClient, app, ids):
+        """OSV scan uses default variant when --variant is omitted."""
+        mock_instance = MockOsvClient.return_value
+        mock_instance.query_by_purl.return_value = []
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "osv-scan", "--project", ids["project_name"],
+        ])
+        # Default variant won't have scans → error
+        assert result.exit_code != 0
+        assert "No scans found" in result.output
+
+    @patch("src.controllers.osv_client.OSVClient")
+    def test_osv_scan_no_vulns_returned(self, MockOsvClient, app, ids):
+        """OSV scan with zero results still completes successfully."""
+        mock_instance = MockOsvClient.return_value
+        mock_instance.query_by_purl.return_value = []
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "osv-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "no vulnerabilities" in result.output
+        assert "Scan complete" in result.output

--- a/tests/webapp_tests/test_scan_global_result.py
+++ b/tests/webapp_tests/test_scan_global_result.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for GET /api/scans/<scan_id>/global-result endpoint."""
+
+import json
+import uuid
+import pytest
+
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _build_global_result_db(app):
+    """Populate DB with SBOM + tool scan for global-result testing."""
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.observation import Observation
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("GlobalProject")
+        variant = Variant.create("GlobalVariant", project.id)
+
+        # SBOM scan with a package and a finding
+        sbom_scan = Scan.create("SBOM scan", variant.id, scan_type="sbom")
+        pkg = Package.find_or_create("openssl", "1.1.1")
+        vuln_sbom = Vulnerability.create_record(
+            id="CVE-2020-1111", description="sbom vuln"
+        )
+        finding_sbom = Finding.get_or_create(pkg.id, vuln_sbom.id)
+        _db.session.commit()
+
+        sbom_doc = SBOMDocument.create("/sbom/file.json", "spdx", sbom_scan.id)
+        SBOMPackage.create(sbom_doc.id, pkg.id)
+        Observation.create(finding_id=finding_sbom.id, scan_id=sbom_scan.id)
+        _db.session.commit()
+
+        # Tool scan with a different finding + reuses the same pkg
+        tool_scan = Scan.create("empty description", variant.id, scan_type="tool")
+        vuln_tool = Vulnerability.create_record(
+            id="CVE-2021-2222", description="tool vuln"
+        )
+        finding_tool = Finding.get_or_create(pkg.id, vuln_tool.id)
+        _db.session.commit()
+
+        Observation.create(
+            finding_id=finding_tool.id, scan_id=tool_scan.id
+        )
+        _db.session.commit()
+
+        return {
+            "project_id": str(project.id),
+            "variant_id": str(variant.id),
+            "sbom_scan_id": str(sbom_scan.id),
+            "tool_scan_id": str(tool_scan.id),
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    import os
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True, "SCAN_FILE": str(scan_file),
+        })
+        ids = _build_global_result_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetScanGlobalResult:
+    def test_invalid_scan_id(self, client):
+        resp = client.get("/api/scans/not-a-uuid/global-result")
+        assert resp.status_code == 400
+        assert b"Invalid scan id" in resp.data
+
+    def test_scan_not_found(self, client):
+        fake_id = str(uuid.uuid4())
+        resp = client.get(f"/api/scans/{fake_id}/global-result")
+        assert resp.status_code == 404
+        assert b"Scan not found" in resp.data
+
+    def test_sbom_scan_global_result(self, client, ids):
+        """For SBOM scan, merge result is just that scan's own data."""
+        resp = client.get(
+            f"/api/scans/{ids['sbom_scan_id']}/global-result"
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["scan_type"] == "sbom"
+        assert data["package_count"] >= 1
+        assert data["finding_count"] >= 1
+        assert data["vuln_count"] >= 1
+        # Should contain the SBOM finding
+        vuln_ids = [v["vulnerability_id"] for v in data["vulnerabilities"]]
+        assert "CVE-2020-1111" in vuln_ids
+
+    def test_tool_scan_global_result(self, client, ids):
+        """For tool scan, merge result = SBOM + tool scan union."""
+        resp = client.get(
+            f"/api/scans/{ids['tool_scan_id']}/global-result"
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["scan_type"] == "tool"
+        # Should have union of both SBOM and tool findings
+        vuln_ids = [v["vulnerability_id"] for v in data["vulnerabilities"]]
+        assert "CVE-2020-1111" in vuln_ids
+        assert "CVE-2021-2222" in vuln_ids
+        # Packages should come from SBOM
+        assert data["package_count"] >= 1

--- a/tests/webapp_tests/test_scan_global_result.py
+++ b/tests/webapp_tests/test_scan_global_result.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
 """Tests for GET /api/scans/<scan_id>/global-result endpoint."""

--- a/tests/webapp_tests/test_scan_logic.py
+++ b/tests/webapp_tests/test_scan_logic.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
 """Tests exercising the NVD and OSV scan *logic* (``_do_nvd_scan`` / ``_do_osv_scan``).

--- a/tests/webapp_tests/test_scan_logic.py
+++ b/tests/webapp_tests/test_scan_logic.py
@@ -1,0 +1,639 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests exercising the NVD and OSV scan *logic* (``_do_nvd_scan`` / ``_do_osv_scan``).
+
+The inner helper functions are closures inside ``init_app``, so the cleanest
+way to test them is to let the trigger endpoint run the thread target
+synchronously (by making ``Thread.start()`` call ``target()`` immediately).
+"""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.bin.webapp import create_app
+from src.controllers.nvd_db import NVD_DB as _RealNvdDb
+from src.extensions import db as _db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _build_nvd_osv_db(app):
+    """DB with packages carrying CPE and PURL identifiers."""
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.package import Package
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("NvdOsvProject")
+        variant = Variant.create("NvdOsvVariant", project.id)
+        scan = Scan.create("base scan", variant.id, scan_type="sbom")
+
+        pkg_cpe = Package.find_or_create(
+            "openssl", "1.1.1",
+            cpe=["cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"],
+            purl=["pkg:pypi/openssl@1.1.1"],
+        )
+        pkg_purl = Package.find_or_create(
+            "requests", "2.28.0",
+            cpe=[],
+            purl=["pkg:pypi/requests@2.28.0"],
+        )
+        pkg_neither = Package.find_or_create("bare", "0.1.0")
+        _db.session.commit()
+
+        sbom = SBOMDocument.create("/test/base.json", "spdx", scan.id)
+        SBOMPackage.create(sbom.id, pkg_cpe.id)
+        SBOMPackage.create(sbom.id, pkg_purl.id)
+        SBOMPackage.create(sbom.id, pkg_neither.id)
+        _db.session.commit()
+
+        # Also create an empty variant (no scans) for error-path tests
+        variant_empty = Variant.create("EmptyVariant", project.id)
+        _db.session.commit()
+
+        return {
+            "project_id": str(project.id),
+            "variant_id": str(variant.id),
+            "variant_empty_id": str(variant_empty.id),
+            "scan_id": str(scan.id),
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    import os
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        ids = _build_nvd_osv_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+def _make_sync_thread_patch():
+    """Return a patch that makes Thread.start() run target synchronously."""
+    return patch(
+        "threading.Thread",
+        side_effect=lambda **kwargs: type(
+            "SyncThread", (), {
+                "_target": kwargs.get("target"),
+                "start": lambda self: kwargs.get("target")(),
+                "daemon": True,
+            }
+        )(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _do_nvd_scan — full logic
+# ---------------------------------------------------------------------------
+
+class TestDoNvdScan:
+    """Test the NVD scan logic end-to-end via synchronous thread execution."""
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scan_finds_cves(self, MockNvdDb, app, client, ids):
+        """Scan completes and creates findings for discovered CVEs."""
+        mock_nvd = MagicMock()
+        MockNvdDb.return_value = mock_nvd
+        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
+        mock_nvd.api_get_cves_by_cpe.return_value = [
+            {"cve": {"id": "CVE-2023-0001"}},
+            {"cve": {"id": "CVE-2023-0002"}},
+        ]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+        assert resp.status_code == 202
+
+        # Check the scan status was set to done
+        resp_status = client.get(
+            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
+        )
+        data = json.loads(resp_status.data)
+        assert data["status"] == "done"
+        assert data["error"] is None
+        assert data["total"] >= 1
+        assert data["done_count"] >= 1
+
+        # Verify CVEs were actually created in DB
+        with app.app_context():
+            from src.models.vulnerability import Vulnerability
+            v1 = _db.session.get(Vulnerability, "CVE-2023-0001")
+            v2 = _db.session.get(Vulnerability, "CVE-2023-0002")
+            assert v1 is not None
+            assert v2 is not None
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scan_no_cves(self, MockNvdDb, app, client, ids):
+        """No CVEs found — scan completes successfully with 0 CVEs."""
+        mock_nvd = MagicMock()
+        MockNvdDb.return_value = mock_nvd
+        mock_nvd.api_get_cves_by_cpe.return_value = []
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+        assert resp.status_code == 202
+
+        resp_status = client.get(
+            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
+        )
+        data = json.loads(resp_status.data)
+        assert data["status"] == "done"
+        assert "0 CVEs" in data["progress"]
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_nvd_scan_api_error_continues(self, MockNvdDb, app, client, ids):
+        """API error on one CPE doesn't crash the whole scan."""
+        mock_nvd = MagicMock()
+        MockNvdDb.return_value = mock_nvd
+        mock_nvd.api_get_cves_by_cpe.side_effect = Exception("NVD timeout")
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+        assert resp.status_code == 202
+
+        resp_status = client.get(
+            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
+        )
+        data = json.loads(resp_status.data)
+        # Should complete (done) — errors per CPE are logged but don't fail
+        assert data["status"] == "done"
+        any_error_log = any("ERROR" in log for log in data.get("logs", []))
+        assert any_error_log
+
+    def test_nvd_scan_empty_variant(self, app, client, ids):
+        """Variant with no scans produces an error."""
+        with _make_sync_thread_patch():
+            resp = client.post(
+                f"/api/variants/{ids['variant_empty_id']}/nvd-scan"
+            )
+        assert resp.status_code == 202
+
+        resp_status = client.get(
+            f"/api/variants/{ids['variant_empty_id']}/nvd-scan/status"
+        )
+        data = json.loads(resp_status.data)
+        assert data["status"] == "error"
+        assert "No scans found" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# _do_osv_scan — full logic
+# ---------------------------------------------------------------------------
+
+class TestDoOsvScan:
+    """Test the OSV scan logic end-to-end via synchronous thread execution."""
+
+    @patch("src.controllers.osv_client.OSVClient.query_by_purl")
+    def test_osv_scan_finds_vulns(self, mock_query, app, client, ids):
+        """Scan completes and creates findings for discovered vulns."""
+        mock_query.return_value = [
+            {"id": "GHSA-1234-5678", "aliases": ["CVE-2023-9999"]},
+        ]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
+        assert resp.status_code == 202
+
+        resp_status = client.get(
+            f"/api/variants/{ids['variant_id']}/osv-scan/status"
+        )
+        data = json.loads(resp_status.data)
+        assert data["status"] == "done"
+        assert data["error"] is None
+        assert data["total"] >= 1
+
+        # Verify vulns were created in DB
+        with app.app_context():
+            from src.models.vulnerability import Vulnerability
+            v1 = _db.session.get(Vulnerability, "GHSA-1234-5678")
+            assert v1 is not None
+            # CVE alias should also be created
+            v2 = _db.session.get(Vulnerability, "CVE-2023-9999")
+            assert v2 is not None
+
+    @patch("src.controllers.osv_client.OSVClient.query_by_purl")
+    def test_osv_scan_no_vulns(self, mock_query, app, client, ids):
+        """No vulns found — scan completes with 0."""
+        mock_query.return_value = []
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
+        assert resp.status_code == 202
+
+        resp_status = client.get(
+            f"/api/variants/{ids['variant_id']}/osv-scan/status"
+        )
+        data = json.loads(resp_status.data)
+        assert data["status"] == "done"
+        assert "0 vulnerabilities" in data["progress"]
+
+    @patch("src.controllers.osv_client.OSVClient.query_by_purl")
+    def test_osv_scan_api_error_continues(self, mock_query, app, client, ids):
+        """API error on one PURL doesn't crash the whole scan."""
+        mock_query.side_effect = Exception("OSV timeout")
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
+        assert resp.status_code == 202
+
+        resp_status = client.get(
+            f"/api/variants/{ids['variant_id']}/osv-scan/status"
+        )
+        data = json.loads(resp_status.data)
+        assert data["status"] == "done"
+        any_error_log = any("ERROR" in log for log in data.get("logs", []))
+        assert any_error_log
+
+    def test_osv_scan_empty_variant(self, app, client, ids):
+        """Variant with no scans produces an error."""
+        with _make_sync_thread_patch():
+            resp = client.post(
+                f"/api/variants/{ids['variant_empty_id']}/osv-scan"
+            )
+        assert resp.status_code == 202
+
+        resp_status = client.get(
+            f"/api/variants/{ids['variant_empty_id']}/osv-scan/status"
+        )
+        data = json.loads(resp_status.data)
+        assert data["status"] == "error"
+        assert "No scans found" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# NVD scan — no valid CPEs edge case
+# ---------------------------------------------------------------------------
+
+class TestNvdScanNoCpes:
+    """Test NVD scan when packages have no CPEs."""
+
+    @pytest.fixture()
+    def app_no_cpe(self, tmp_path):
+        import os
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.package import Package
+
+        scan_file = tmp_path / "scan_status.txt"
+        scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+        os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        try:
+            application = create_app()
+            application.config.update({
+                "TESTING": True, "SCAN_FILE": str(scan_file),
+            })
+            with application.app_context():
+                _db.drop_all()
+                _db.create_all()
+                project = Project.create("NoCpeProject")
+                variant = Variant.create("NoCpeVariant", project.id)
+                scan = Scan.create("no-cpe scan", variant.id)
+                # Package with only wildcard CPE (invalid for NVD)
+                pkg = Package.find_or_create(
+                    "plain", "1.0.0",
+                    cpe=["cpe:2.3:a:*:*:*:*:*:*:*:*:*:*"],
+                )
+                _db.session.commit()
+                sbom = SBOMDocument.create("/t/sbom.json", "spdx", scan.id)
+                SBOMPackage.create(sbom.id, pkg.id)
+                _db.session.commit()
+                application._test_ids = {
+                    "variant_id": str(variant.id),
+                }
+            yield application
+        finally:
+            os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_no_valid_cpes(self, MockNvdDb, app_no_cpe):
+        client = app_no_cpe.test_client()
+        vid = app_no_cpe._test_ids["variant_id"]
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/nvd-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{vid}/nvd-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "No packages with valid CPE" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# OSV scan — no valid PURLs edge case
+# ---------------------------------------------------------------------------
+
+class TestOsvScanNoPurls:
+    """Test OSV scan when packages have no PURLs."""
+
+    @pytest.fixture()
+    def app_no_purl(self, tmp_path):
+        import os
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.package import Package
+
+        scan_file = tmp_path / "scan_status.txt"
+        scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+        os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        try:
+            application = create_app()
+            application.config.update({
+                "TESTING": True, "SCAN_FILE": str(scan_file),
+            })
+            with application.app_context():
+                _db.drop_all()
+                _db.create_all()
+                project = Project.create("NoPurlProject")
+                variant = Variant.create("NoPurlVariant", project.id)
+                scan = Scan.create("no-purl scan", variant.id)
+                pkg = Package.find_or_create("bare-pkg", "0.0.1", purl=[])
+                _db.session.commit()
+                sbom = SBOMDocument.create("/t/sbom.json", "spdx", scan.id)
+                SBOMPackage.create(sbom.id, pkg.id)
+                _db.session.commit()
+                application._test_ids = {
+                    "variant_id": str(variant.id),
+                }
+            yield application
+        finally:
+            os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+    def test_no_valid_purls(self, app_no_purl):
+        client = app_no_purl.test_client()
+        vid = app_no_purl._test_ids["variant_id"]
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/osv-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{vid}/osv-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "No packages with valid PURL" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# NVD scan — variant with no packages
+# ---------------------------------------------------------------------------
+
+class TestNvdScanNoPackages:
+    """Test NVD scan when variant has scans but no packages."""
+
+    @pytest.fixture()
+    def app_no_pkgs(self, tmp_path):
+        import os
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+
+        scan_file = tmp_path / "scan_status.txt"
+        scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+        os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        try:
+            application = create_app()
+            application.config.update({
+                "TESTING": True, "SCAN_FILE": str(scan_file),
+            })
+            with application.app_context():
+                _db.drop_all()
+                _db.create_all()
+                project = Project.create("NoPkgProject")
+                variant = Variant.create("NoPkgVariant", project.id)
+                # Scan exists but has no SBOM documents → no packages
+                Scan.create("empty scan", variant.id)
+                _db.session.commit()
+                application._test_ids = {
+                    "variant_id": str(variant.id),
+                }
+            yield application
+        finally:
+            os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_no_packages(self, MockNvdDb, app_no_pkgs):
+        client = app_no_pkgs.test_client()
+        vid = app_no_pkgs._test_ids["variant_id"]
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/nvd-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{vid}/nvd-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "No packages found" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# OSV scan — variant with no packages
+# ---------------------------------------------------------------------------
+
+class TestOsvScanNoPackages:
+    """Test OSV scan when variant has scans but no packages."""
+
+    @pytest.fixture()
+    def app_no_pkgs(self, tmp_path):
+        import os
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+
+        scan_file = tmp_path / "scan_status.txt"
+        scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+        os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        try:
+            application = create_app()
+            application.config.update({
+                "TESTING": True, "SCAN_FILE": str(scan_file),
+            })
+            with application.app_context():
+                _db.drop_all()
+                _db.create_all()
+                project = Project.create("NoPkgProject2")
+                variant = Variant.create("NoPkgVariant2", project.id)
+                Scan.create("empty scan", variant.id)
+                _db.session.commit()
+                application._test_ids = {
+                    "variant_id": str(variant.id),
+                }
+            yield application
+        finally:
+            os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+    def test_no_packages(self, app_no_pkgs):
+        client = app_no_pkgs.test_client()
+        vid = app_no_pkgs._test_ids["variant_id"]
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/osv-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{vid}/osv-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "error"
+        assert "No packages found" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# NVD scan — existing vulnerability gets add_found_by("nvd")
+# ---------------------------------------------------------------------------
+
+class TestNvdScanExistingVuln:
+    """NVD scan with a pre-existing vulnerability still completes."""
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_existing_vuln_no_duplicate(self, MockNvdDb, app, client, ids):
+        from src.models.vulnerability import Vulnerability
+
+        # Pre-create the vulnerability
+        with app.app_context():
+            Vulnerability.create_record(
+                id="CVE-2023-9876", description="pre-existing"
+            )
+            _db.session.commit()
+
+        mock_nvd = MagicMock()
+        MockNvdDb.return_value = mock_nvd
+        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
+        mock_nvd.api_get_cves_by_cpe.return_value = [
+            {"cve": {"id": "CVE-2023-9876"}},
+        ]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(
+            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
+        )
+        data = json.loads(resp_s.data)
+        assert data["status"] == "done"
+
+        # Vulnerability still exists and was not duplicated
+        with app.app_context():
+            v = _db.session.get(Vulnerability, "CVE-2023-9876")
+            assert v is not None
+
+
+# ---------------------------------------------------------------------------
+# OSV scan — existing vulnerability gets add_found_by("osv")
+# ---------------------------------------------------------------------------
+
+class TestOsvScanExistingVuln:
+    """OSV scan with a pre-existing vulnerability still completes."""
+
+    @patch("src.controllers.osv_client.OSVClient.query_by_purl")
+    def test_existing_vuln_no_duplicate(self, mock_query, app, client, ids):
+        from src.models.vulnerability import Vulnerability
+
+        with app.app_context():
+            Vulnerability.create_record(
+                id="GHSA-0000-1111", description="pre"
+            )
+            _db.session.commit()
+
+        mock_query.return_value = [
+            {"id": "GHSA-0000-1111", "aliases": []},
+        ]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(
+            f"/api/variants/{ids['variant_id']}/osv-scan/status"
+        )
+        data = json.loads(resp_s.data)
+        assert data["status"] == "done"
+
+        # Vulnerability still exists and was not duplicated
+        with app.app_context():
+            v = _db.session.get(Vulnerability, "GHSA-0000-1111")
+            assert v is not None
+
+
+# ---------------------------------------------------------------------------
+# NVD scan — multiple CVEs returned (> 10 triggers ellipsis in log)
+# ---------------------------------------------------------------------------
+
+class TestNvdScanManyCves:
+    """NVD scan with >10 CVEs per CPE shows ellipsis in log."""
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_many_cves_ellipsis(self, MockNvdDb, app, client, ids):
+        mock_nvd = MagicMock()
+        MockNvdDb.return_value = mock_nvd
+        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
+        mock_nvd.api_get_cves_by_cpe.return_value = [
+            {"cve": {"id": f"CVE-2023-{i:04d}"}} for i in range(15)
+        ]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(
+            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
+        )
+        data = json.loads(resp_s.data)
+        assert data["status"] == "done"
+        log_text = "\n".join(data.get("logs", []))
+        assert "…" in log_text  # ellipsis for >10 CVEs
+
+
+# ---------------------------------------------------------------------------
+# OSV scan — multiple vulns returned (> 10 triggers ellipsis in log)
+# ---------------------------------------------------------------------------
+
+class TestOsvScanManyVulns:
+    """OSV scan with >10 vulns per PURL shows ellipsis in log."""
+
+    @patch("src.controllers.osv_client.OSVClient.query_by_purl")
+    def test_many_vulns_ellipsis(self, mock_query, app, client, ids):
+        mock_query.return_value = [
+            {"id": f"GHSA-{i:04d}", "aliases": []} for i in range(12)
+        ]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
+        assert resp.status_code == 202
+
+        resp_s = client.get(
+            f"/api/variants/{ids['variant_id']}/osv-scan/status"
+        )
+        data = json.loads(resp_s.data)
+        assert data["status"] == "done"
+        log_text = "\n".join(data.get("logs", []))
+        assert "…" in log_text

--- a/tests/webapp_tests/test_scan_triggers.py
+++ b/tests/webapp_tests/test_scan_triggers.py
@@ -1,0 +1,307 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for Grype / NVD / OSV scan trigger & status endpoints in scans.py."""
+
+import pytest
+import json
+import uuid
+from unittest.mock import patch, MagicMock
+
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _build_scan_trigger_db(app):
+    """Populate DB with packages that have CPE and PURL identifiers."""
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.package import Package
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("TriggerProject")
+        variant = Variant.create("TriggerVariant", project.id)
+
+        scan = Scan.create("initial scan", variant.id, scan_type="sbom")
+
+        # Package with valid CPE (vendor:product:version all non-*)
+        pkg_with_cpe = Package.find_or_create(
+            "openssl", "1.1.1",
+            cpe=["cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"],
+            purl=["pkg:generic/openssl/openssl@1.1.1"],
+        )
+        # Package with valid PURL (ecosystem-specific)
+        pkg_with_purl = Package.find_or_create(
+            "requests", "2.28.0",
+            cpe=[],
+            purl=["pkg:pypi/requests@2.28.0"],
+        )
+        # Package with no CPE or PURL
+        pkg_plain = Package.find_or_create("mylib", "0.1.0")
+        _db.session.commit()
+
+        sbom = SBOMDocument.create("/test/sbom.json", "spdx", scan.id)
+        SBOMPackage.create(sbom.id, pkg_with_cpe.id)
+        SBOMPackage.create(sbom.id, pkg_with_purl.id)
+        SBOMPackage.create(sbom.id, pkg_plain.id)
+        _db.session.commit()
+
+        return {
+            "project_id": str(project.id),
+            "variant_id": str(variant.id),
+            "scan_id": str(scan.id),
+            "pkg_cpe_id": str(pkg_with_cpe.id),
+            "pkg_purl_id": str(pkg_with_purl.id),
+            "pkg_plain_id": str(pkg_plain.id),
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    import os
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        ids = _build_scan_trigger_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+# ---------------------------------------------------------------------------
+# Grype scan — trigger
+# ---------------------------------------------------------------------------
+
+class TestTriggerGrypeScan:
+    def test_invalid_variant_id(self, client):
+        resp = client.post("/api/variants/not-a-uuid/grype-scan")
+        assert resp.status_code == 400
+        assert b"Invalid variant id" in resp.data
+
+    def test_variant_not_found(self, client):
+        fake_id = str(uuid.uuid4())
+        resp = client.post(f"/api/variants/{fake_id}/grype-scan")
+        assert resp.status_code == 404
+        assert b"Variant not found" in resp.data
+
+    @patch("shutil.which", return_value=None)
+    def test_grype_not_installed(self, mock_which, client, ids):
+        resp = client.post(f"/api/variants/{ids['variant_id']}/grype-scan")
+        assert resp.status_code == 503
+        assert b"grype binary not found" in resp.data
+
+    @patch("threading.Thread")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_scan_starts_successfully(self, mock_which, mock_thread, client, ids):
+        mock_t = MagicMock()
+        mock_thread.return_value = mock_t
+        resp = client.post(f"/api/variants/{ids['variant_id']}/grype-scan")
+        assert resp.status_code == 202
+        data = json.loads(resp.data)
+        assert data["status"] == "started"
+        assert data["variant_id"] == ids["variant_id"]
+        mock_t.start.assert_called_once()
+
+    @patch("threading.Thread")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_scan_already_running(self, mock_which, mock_thread, client, ids):
+        mock_t = MagicMock()
+        mock_thread.return_value = mock_t
+        # First scan starts
+        resp1 = client.post(f"/api/variants/{ids['variant_id']}/grype-scan")
+        assert resp1.status_code == 202
+        # Second scan blocked
+        resp2 = client.post(f"/api/variants/{ids['variant_id']}/grype-scan")
+        assert resp2.status_code == 409
+        assert b"already in progress" in resp2.data
+
+
+# ---------------------------------------------------------------------------
+# Grype scan — status
+# ---------------------------------------------------------------------------
+
+class TestGrypeScanStatus:
+    def test_invalid_variant_id(self, client):
+        resp = client.get("/api/variants/not-a-uuid/grype-scan/status")
+        assert resp.status_code == 400
+        assert b"Invalid variant id" in resp.data
+
+    def test_idle_when_never_started(self, client):
+        fake_id = str(uuid.uuid4())
+        resp = client.get(f"/api/variants/{fake_id}/grype-scan/status")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "idle"
+
+    @patch("threading.Thread")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_running_after_trigger(self, mock_which, mock_thread, client, ids):
+        mock_t = MagicMock()
+        mock_thread.return_value = mock_t
+        client.post(f"/api/variants/{ids['variant_id']}/grype-scan")
+        resp = client.get(f"/api/variants/{ids['variant_id']}/grype-scan/status")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "running"
+        assert data["progress"] == "starting"
+        assert data["logs"] == []
+        assert data["total"] == 4
+        assert data["done_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# NVD scan — trigger
+# ---------------------------------------------------------------------------
+
+class TestTriggerNvdScan:
+    def test_invalid_variant_id(self, client):
+        resp = client.post("/api/variants/not-a-uuid/nvd-scan")
+        assert resp.status_code == 400
+        assert b"Invalid variant id" in resp.data
+
+    def test_variant_not_found(self, client):
+        fake_id = str(uuid.uuid4())
+        resp = client.post(f"/api/variants/{fake_id}/nvd-scan")
+        assert resp.status_code == 404
+        assert b"Variant not found" in resp.data
+
+    @patch("threading.Thread")
+    def test_scan_starts_successfully(self, mock_thread, client, ids):
+        mock_t = MagicMock()
+        mock_thread.return_value = mock_t
+        resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+        assert resp.status_code == 202
+        data = json.loads(resp.data)
+        assert data["status"] == "started"
+        assert data["variant_id"] == ids["variant_id"]
+        mock_t.start.assert_called_once()
+
+    @patch("threading.Thread")
+    def test_scan_already_running(self, mock_thread, client, ids):
+        mock_t = MagicMock()
+        mock_thread.return_value = mock_t
+        resp1 = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+        assert resp1.status_code == 202
+        resp2 = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+        assert resp2.status_code == 409
+        assert b"already in progress" in resp2.data
+
+
+# ---------------------------------------------------------------------------
+# NVD scan — status
+# ---------------------------------------------------------------------------
+
+class TestNvdScanStatus:
+    def test_invalid_variant_id(self, client):
+        resp = client.get("/api/variants/not-a-uuid/nvd-scan/status")
+        assert resp.status_code == 400
+        assert b"Invalid variant id" in resp.data
+
+    def test_idle_when_never_started(self, client):
+        fake_id = str(uuid.uuid4())
+        resp = client.get(f"/api/variants/{fake_id}/nvd-scan/status")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "idle"
+
+    @patch("threading.Thread")
+    def test_running_after_trigger(self, mock_thread, client, ids):
+        mock_t = MagicMock()
+        mock_thread.return_value = mock_t
+        client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+        resp = client.get(f"/api/variants/{ids['variant_id']}/nvd-scan/status")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# OSV scan — trigger
+# ---------------------------------------------------------------------------
+
+class TestTriggerOsvScan:
+    def test_invalid_variant_id(self, client):
+        resp = client.post("/api/variants/not-a-uuid/osv-scan")
+        assert resp.status_code == 400
+        assert b"Invalid variant id" in resp.data
+
+    def test_variant_not_found(self, client):
+        fake_id = str(uuid.uuid4())
+        resp = client.post(f"/api/variants/{fake_id}/osv-scan")
+        assert resp.status_code == 404
+        assert b"Variant not found" in resp.data
+
+    @patch("threading.Thread")
+    def test_scan_starts_successfully(self, mock_thread, client, ids):
+        mock_t = MagicMock()
+        mock_thread.return_value = mock_t
+        resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
+        assert resp.status_code == 202
+        data = json.loads(resp.data)
+        assert data["status"] == "started"
+        assert data["variant_id"] == ids["variant_id"]
+        mock_t.start.assert_called_once()
+
+    @patch("threading.Thread")
+    def test_scan_already_running(self, mock_thread, client, ids):
+        mock_t = MagicMock()
+        mock_thread.return_value = mock_t
+        resp1 = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
+        assert resp1.status_code == 202
+        resp2 = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
+        assert resp2.status_code == 409
+        assert b"already in progress" in resp2.data
+
+
+# ---------------------------------------------------------------------------
+# OSV scan — status
+# ---------------------------------------------------------------------------
+
+class TestOsvScanStatus:
+    def test_invalid_variant_id(self, client):
+        resp = client.get("/api/variants/not-a-uuid/osv-scan/status")
+        assert resp.status_code == 400
+        assert b"Invalid variant id" in resp.data
+
+    def test_idle_when_never_started(self, client):
+        fake_id = str(uuid.uuid4())
+        resp = client.get(f"/api/variants/{fake_id}/osv-scan/status")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "idle"
+
+    @patch("threading.Thread")
+    def test_running_after_trigger(self, mock_thread, client, ids):
+        mock_t = MagicMock()
+        mock_thread.return_value = mock_t
+        client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
+        resp = client.get(f"/api/variants/{ids['variant_id']}/osv-scan/status")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["status"] == "running"

--- a/tests/webapp_tests/test_scan_triggers.py
+++ b/tests/webapp_tests/test_scan_triggers.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
 """Tests for Grype / NVD / OSV scan trigger & status endpoints in scans.py."""

--- a/vulnscout
+++ b/vulnscout
@@ -64,6 +64,8 @@ Input commands (can be chained, triggers scan automatically):
   --add-cdx <path>                Add a CycloneDX file
   --add-grype <path>              Add a Grype results file
   --perform-grype-scan            Run Grype on the current DB content (after merging any added inputs)
+  --perform-nvd-scan              Run an NVD CPE-based vulnerability scan
+  --perform-osv-scan              Run an OSV PURL-based vulnerability scan
 
 Scan & output commands:
   --match-condition <expr>        Run vulnerability scan
@@ -307,6 +309,10 @@ parse_and_run() {
                 ensure_running; add_input "${1#--}" "$2"; shift 2 ;;
             perform-grype-scan|--perform-grype-scan)
                 ensure_running; PENDING_ARGS+=(--perform-grype-scan); shift ;;
+            perform-nvd-scan|--perform-nvd-scan)
+                ensure_running; PENDING_ARGS+=(--perform-nvd-scan); shift ;;
+            perform-osv-scan|--perform-osv-scan)
+                ensure_running; PENDING_ARGS+=(--perform-osv-scan); shift ;;
             export-spdx|--export-spdx)
                 ensure_running; EXPORT_ARGS+=(--export-spdx); shift ;;
             export-cdx|--export-cdx)


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Scan tab: Add new scan buttons for Grype/NVD/OSV scanner
* Scan tab: delete scans option
* CLI: add the commands `--perform-nvd-scan` and `--perform-osv-scan`
* Fix: SPDX3 persistence: Get CVSS/Description/Severity from the SPDX3 file if present

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Build a container with this changes:

```
docker build -t sfl:scan .
```

And export `VULNSCOUT_IMAGE` variable:

```
export VULNSCOUT_IMAGE=sfl:scan
```

Then laod a project and go to Scan tab and try to interact with it 