### PR TITLE
Add documentation for interactive mode

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -5,6 +5,50 @@ All endpoints return JSON unless otherwise noted. Routes are registered directly
 
 ---
 
+## Version & Status
+
+### Get Server Version
+
+```
+GET /api/version
+```
+
+Returns the running VulnScout version.
+
+**Response:**
+```json
+{ "version": "1.2.3" }
+```
+
+The value comes from the `VULNSCOUT_VERSION` environment variable (`"unknown"` when unset).
+
+### Get Initial Scan Status
+
+```
+GET /api/scan/status
+```
+
+Returns the progress of the container entrypoint import script. This endpoint is available even while the import is still running (all other `/api/*` routes return `503` until the script finishes).
+
+**Response:**
+```json
+{
+  "status": "running",
+  "maxsteps": 8,
+  "step": 3,
+  "message": "Merging SBOMs"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | `"running"` or `"done"` |
+| `maxsteps` | int | Total number of import steps |
+| `step` | int | Current step number |
+| `message` | string | Human-readable progress label |
+
+---
+
 ## Config
 
 ### Get Current Config
@@ -180,6 +224,8 @@ GET /api/vulnerabilities
 | `format` | string | `"list"` (default) or `"dict"` |
 
 **Response:** JSON array of vulnerability objects enriched with `packages_current`, `variants`, `first_scan_date` and `found_by`.
+
+> **Note:** When `variant_id` or `project_id` is provided, findings from tool scans (Grype, NVD, OSV) are automatically filtered to only include packages present in the variant's active SBOM. This prevents stale or cross-variant vulnerabilities from appearing. SBOM-scan findings are always included unconditionally.
 
 ### Get Single Vulnerability
 
@@ -527,18 +573,40 @@ PATCH /api/scans/<scan_id>
 
 **Response:** Updated scan object.
 
+### Delete Scan
+
+```
+DELETE /api/scans/<scan_id>
+```
+
+Deletes the scan and its observations. Findings that are no longer referenced by any observation are also removed.
+
+**Response:**
+```json
+{
+  "deleted": true,
+  "scan_id": "...",
+  "orphaned_findings_removed": 3
+}
+```
+
 ### Get Scan Diff
 
 ```
 GET /api/scans/<scan_id>/diff
 ```
 
-Returns a detailed diff between this scan and the previous scan of the same variant.
+Returns a detailed diff between this scan and the previous scan of the same type (and source) for the same variant.
+
+For **SBOM scans**, the diff is computed against the *scan result* — that is, the merged union of the SBOM and active tool-scan findings filtered by SBOM packages. This means the numbers are consistent with the Scan Result badges shown in the list view.
+
+For **tool scans**, the diff reflects the change in the *global result* (SBOM ∪ tool scans) caused by this scan. Additionally, `newly_detected_*` and `all_*` fields provide the raw tool-scan contents.
 
 **Response:**
 ```
 {
   "scan_id": "...",
+  "scan_type": "sbom",
   "previous_scan_id": "...",
   "is_first": false,
   "finding_count": 120,
@@ -547,13 +615,130 @@ Returns a detailed diff between this scan and the previous scan of the same vari
   "findings_added": [...],
   "findings_removed": [...],
   "findings_upgraded": [...],
+  "findings_unchanged": [...],
   "packages_added": [...],
   "packages_removed": [...],
   "packages_upgraded": [...],
+  "packages_unchanged": [...],
   "vulns_added": [...],
-  "vulns_removed": [...]
+  "vulns_removed": [...],
+  "vulns_unchanged": [...],
+  "newly_detected_findings": null,
+  "newly_detected_vulns": null,
+  "newly_detected_findings_list": null,
+  "newly_detected_vulns_list": null,
+  "all_findings": null,
+  "all_vulns": null
 }
 ```
+
+| Field | Type | Scope | Description |
+|-------|------|-------|-------------|
+| `scan_type` | string | all | `"sbom"` or `"tool"` |
+| `findings_unchanged` | array | all | Findings present in both the current and previous scan result |
+| `packages_unchanged` | array | SBOM | Packages present in both scans |
+| `vulns_unchanged` | array | all | Vulnerability IDs present in both scan results |
+| `newly_detected_findings` | int\|null | tool | Count of findings new in the global result |
+| `newly_detected_vulns` | int\|null | tool | Count of vulnerabilities new in the global result |
+| `newly_detected_findings_list` | array\|null | tool | Finding objects newly detected in the global result |
+| `newly_detected_vulns_list` | array\|null | tool | Vulnerability IDs newly detected |
+| `all_findings` | array\|null | tool | All raw findings from this tool scan |
+| `all_vulns` | array\|null | tool | All vulnerability IDs from this tool scan |
+
+### Get Scan Global Result
+
+```
+GET /api/scans/<scan_id>/global-result
+```
+
+Returns every active finding, vulnerability, and package at the time of the given scan, combining SBOM and tool-scan data with source attribution. Tool-scan findings are filtered to packages present in the SBOM.
+
+**Response:** JSON object with `findings`, `vulnerabilities`, and `packages` arrays, each entry enriched with an `origin` field indicating the source (SBOM document name/format or tool scan source).
+
+---
+
+## Scan Triggers
+
+These endpoints trigger asynchronous vulnerability scans for a specific variant. Each returns `202 Accepted` immediately; use the corresponding `/status` endpoint to poll progress.
+
+All trigger endpoints return `409 Conflict` if a scan of the same type is already running for the variant, `404` if the variant is not found, and `503` if the required tool is unavailable (Grype only).
+
+### Trigger Grype Scan
+
+```
+POST /api/variants/<variant_id>/grype-scan
+```
+
+Exports the variant's packages as CycloneDX, runs Grype on the export, filters the results to only the variant's SBOM packages, and merges findings back as a tool scan.
+
+**Response:** `202 Accepted`
+```json
+{ "status": "started", "variant_id": "..." }
+```
+
+Progress steps: `1/4 Exporting CycloneDX` → `2/4 Running Grype` → `3/4 Merging results` → `4/4 Processing`.
+
+### Check Grype Scan Status
+
+```
+GET /api/variants/<variant_id>/grype-scan/status
+```
+
+**Response:**
+```json
+{
+  "status": "running",
+  "error": null,
+  "progress": "2/4 Running Grype",
+  "logs": ["[1/4] CycloneDX export complete", "..."],
+  "total": 4,
+  "done_count": 1
+}
+```
+
+Status values: `"idle"` (no scan started), `"running"`, `"done"`, `"error"`.
+
+### Trigger NVD Scan
+
+```
+POST /api/variants/<variant_id>/nvd-scan
+```
+
+For every active package with CPE identifiers, queries the NVD CVE API and creates findings for any matched CVEs. Respects the `NVD_API_KEY` environment variable for higher rate limits.
+
+**Response:** `202 Accepted`
+```json
+{ "status": "started", "variant_id": "..." }
+```
+
+### Check NVD Scan Status
+
+```
+GET /api/variants/<variant_id>/nvd-scan/status
+```
+
+Same response shape as Grype status. `total` is the number of unique CPEs to query, `done_count` tracks progress.
+
+### Trigger OSV Scan
+
+```
+POST /api/variants/<variant_id>/osv-scan
+```
+
+For every active package with PURL identifiers, queries the OSV API. All PURLs per package are queried (e.g. generic + ecosystem-specific) so no vulnerabilities are missed.
+
+**Response:** `202 Accepted`
+```json
+{ "status": "started", "variant_id": "..." }
+```
+
+### Check OSV Scan Status
+
+```
+GET /api/variants/<variant_id>/osv-scan/status
+```
+
+Same response shape as Grype status. `total` is the number of unique PURLs to query.
 
 ---
 

--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -669,7 +669,7 @@ All trigger endpoints return `409 Conflict` if a scan of the same type is alread
 POST /api/variants/<variant_id>/grype-scan
 ```
 
-Exports the variant's packages as CycloneDX, runs Grype on the export, filters the results to only the variant's SBOM packages, and merges findings back as a tool scan.
+Runs Grype on the export, filters the results to only the variant's SBOM packages, and merges findings back as a tool scan.
 
 **Response:** `202 Accepted`
 ```json

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,6 +7,7 @@ VulnScout Documentation
 
    introduction
    getting-started
+   interactive-mode
    vulnscout-script
    container-entrypoint
    templates

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,9 +7,9 @@ VulnScout Documentation
 
    introduction
    getting-started
-   interactive-mode
    vulnscout-script
    container-entrypoint
+   interactive-mode
    templates
    ci_conditions
    api

--- a/doc/source/interactive-mode.md
+++ b/doc/source/interactive-mode.md
@@ -1,43 +1,38 @@
 # Interactive Mode
 
-VulnScout's web interface is the way most users interact with vulnerability data day-to-day. Once an SBOM has been imported and enriched, the interactive mode gives you everything needed to explore, filter, assess, and track vulnerabilities without leaving the application.
+VulnScout's web interface can be used to visualize, analyse, and classify your project vulnerabilities.
 
-## How Assessments Works
+## Getting Started with vulnerability analysis
 
 ### Starting a New Project
 
-When you first import an SBOM into VulnScout, the application scans its contents and creates a finding for every vulnerability-to-package association it discovers.
+When you first import an SBOM into VulnScout, the application scans its contents to load vulnerabilities, assessments (if present), and the package list.
 
-If the SBOM source does not include any assessment data, those findings start with a **Pending assessment**, which means you will need to review the finding and make a decision about it (either it affects your system, or it doesn't or it was already fixed).
+Vulnerabilities which are considered active or unpatched are set as **Pending assessment**. Based on the context of your product, the user will have to classify them as **Exploitable** or **Not affected**/**Fixed**. This classification using the product environment and scope is named **Threat model**.
 
-However, many SBOM sources carry assessments / triage decisions. Yocto CVE-check results, for example, mark vulnerabilities as Patched, Ignored, or Unpatched; CycloneDX and SPDX 3 documents often include full VEX analysis blocks; and OpenVEX files provide standalone assessment records. When VulnScout ingests these, it creates assessments automatically, so you may see some CVEs already labelled as **Fixed** or **Not affected** before you have done any manual triage.
+### Threat Model
 
-### Scanners
+Vulnerabilities present in your SBOM do not necessarily represent a real danger to your device. A Vulnerability describes a potential weakness — whether it is actually exploitable depends on how the affected component is built, configured, and used in your specific environment.
 
-An SBOM lists the packages that make up your system, but a single vulnerability source rarely provides complete coverage. Different databases track different ecosystems, use different matching strategies, and update at different speeds. VulnScout cross-references your SBOM against several scanners to offer a wider set of information:
+For example, a network-facing vulnerability has no impact on a system that is never connected to a network.
 
-- **NVD** correlates packages with NIST's National Vulnerability Database using CPE identifiers. It offers broad coverage across many ecosystems.
-- **Grype** leverages Anchore's vulnerability database, which combines multiple upstream feeds and applies its own matching heuristics. It is particularly effective at catching vulnerabilities in container and OS-level packages.
-- **OSV-Scanner** queries the open-source OSV database, which aggregates advisories from language-specific ecosystems (PyPI, npm, Go, Rust, etc.) and Linux distributions. Its PURL matching tends to be more precise than CPE-based lookup.
+The objective of the vulnerability classification is to not patch every CVE blindly. Only keep the ones which are relevant given your threat model.
 
-By combining these sources, VulnScout reduces the chance of missing a relevant CVE while giving you the **Sources** column and filter to trace exactly where each finding originated. If a vulnerability is reported by multiple scanners, you can have higher confidence that it genuinely applies; if only one scanner flags it, that context helps you prioritise your triage effort.
+Threat modeling is a process by which potential threats, such as structural vulnerabilities or the absence of appropriate safeguards, can be identified and enumerated, and countermeasures prioritized.
 
-### Assessment Status in Vulnscout
+Threat model example: All the vulnerabilities which can be exploitable via the serial port and which lead to privilege escalation or arbitrary code execution.
+
+In this example, a vulnerability which only leads to a data leak of the product, exploitable from the serial port, would not be considered exploitable and would be classified as **Not affected** even if the vulnerability exists and is present on the device.
+
+### Assessment Status in VulnScout
 
 VulnScout groups all assessment statuses into four simplified categories:
 
-- **Pending Assessment**: the vulnerability has not been assessed yet. 
+- **Pending Assessment**: the vulnerability has not been assessed yet.
 - **Exploitable**: the vulnerability is confirmed to affect your product in its current configuration and represents danger for it as defined in the threat model.
 - **Not affected**: the vulnerability does not apply — even if the vulnerable package is present on the device, the CVE may not match your threat model (for example, the vulnerable code path is not reachable, or the attack vector does not exist in your environment). A justification is required when selecting this status.
 - **Fixed**: the vulnerability has been patched or resolved.
 
-### Threat Model
-
-A vulnerability present in Vulnscout does not necessarily mean they represent a real danger to your device. A CVE describes a potential weakness whether it is actually exploitable depends on how the affected component is built, configured, and used in your specific environment.
-
-For example, consider a CVE that can only be triggered when a particular compile-time flag is enabled. If your build does not use that flag, the vulnerable code path is never included, and the CVE cannot be exploited on your device. Similarly, a network-facing vulnerability has no impact on a system that is never connected to a network.
-
-This is why triage matters: the goal is not to patch every CVE blindly, but to determine which ones are relevant given your threat model and mark the rest as **Not affected** with a clear justification.
 
 ### Goal of the Interactive Mode
 
@@ -47,13 +42,48 @@ The interactive mode is where you investigate each CVE and record your triage de
 1. Review the vulnerability details: read the description, check the CVSS score and EPSS probability, inspect which packages are affected, and follow the reference links for advisories and patches.
 2. Assess: set a status, provide a justification when required, add notes explaining your reasoning, and optionally document a workaround or estimate remediation effort.
 
-Assessments you create through the web dashboard are stored with a `custom` origin, which distinguishes them from the  assessments that were imported automatically. On subsequent SBOM re-imports, upstream assessments may be updated by newer VEX data, but your own assessments are always preserved as separate records.
+---
+
+## SBOM Table
+
+The SBOM table lists every package present in the imported SBOMs within your current scope. It provides a package-centric view of your software bill of materials, complementing the vulnerability-centric Vulnerability Table.
+
+### Search
+
+The search bar accepts free-text queries that match against package name, version, CPE, and PURL identifiers. Typing at least two characters triggers a fuzzy search powered by Fuse.js. The search supports the same expression language as the vulnerability table:
+
+- **`term`** — rows containing the term are shown.
+- **`term1 term2`** — AND semantics: both terms must match.
+- **`term1 | term2`** — OR semantics: either term matches.
+- **`-term`** — NOT: rows containing the term are excluded.
+
+A small **info icon** next to the search bar opens a quick-reference panel for this syntax. A **keyboard shortcut icon** on the right side of the toolbar shows available keyboard shortcuts (press `/` to focus the search bar, `↑`/`↓` to navigate rows, `Home`/`End` to jump to the first or last row).
+
+### Column Visibility
+
+The **Columns** dropdown lets you toggle which columns are displayed. The default set includes Name, Version, Vulnerabilities, Variants, and Sources. Additional columns available are:
+
+- **CPE** — Common Platform Enumeration identifiers for the package. These are used by the NVD scanner to match vulnerabilities.
+- **PURL** — Package URL identifiers. These are used by the OSV scanner for more precise ecosystem-level matching.
+- **Remaining Pending Vulnerabilities** — the count of vulnerabilities still awaiting triage for this package.
+
+### Filters
+
+- **Source**: restrict the table to packages originating from a specific SBOM source (e.g. a particular SPDX or CycloneDX document).
+
+### Severity Toggle
+
+The **Severity** toggle switch in the toolbar adds a colour-coded severity tag next to each package's vulnerability count, showing the highest severity among the package's associated vulnerabilities. This gives an at-a-glance view of which packages carry the most critical exposure.
+
+### Actions
+
+Each row has a **Show Vulnerabilities** button that navigates to the Vulnerability Table pre-filtered to show only the vulnerabilities associated with that specific package.
 
 ---
 
 ## Vulnerability Table
 
-Every vulnerability detected across imported SBOMs in your scope is listed here, and the toolbar across the top provides a rich set of controls to narrow down what you see and act on what matters.
+Every vulnerability detected across imported SBOMs in your scope is listed here, and the toolbar across the top provides a rich set of controls to narrow down what you see and act on what matters. The vulnerability pool is scoped to the **current scan result** — only vulnerabilities whose findings belong to packages present in the active SBOM are shown, ensuring that stale or cross-variant findings do not appear.
 
 ### Search
 
@@ -91,7 +121,7 @@ Each row has a checkbox on the left. Selecting one or more rows reveals the **mu
 
 ### Sorting
 
-Every sortable column header is clickable. Severity sorts by the standard ordering (Critical -> None) or by numeric score when the score-based filter is active. Status sorts by triage progression. Published Date and Last Updated sort chronologically. EPSS and Estimated Effort sort numerically. Clicking the same header again reverses the direction.
+Every sortable column header is clickable. Severity sorts by the standard ordering (Critical → None) or by numeric score when the score-based filter is active. Status sorts by triage progression. Published Date and Last Updated sort chronologically. EPSS and Estimated Effort sort numerically. Clicking the same header again reverses the direction.
 
 ### Opening a Vulnerability
 
@@ -101,7 +131,7 @@ Clicking a vulnerability's **ID cell** opens the detail modal in read-only mode.
 
 ## Vulnerability Details
 
-The Vulnerability Details is where individual vulnerability triage happens. It presents all the information VulnScout has gathered about a single CVE, and lets you modify assessments, CVSS vectors, and time estimates.
+The Vulnerability Details modal is where individual vulnerability triage happens. It presents all the information VulnScout has gathered about a single CVE, and lets you modify assessments, CVSS vectors, and time estimates.
 
 ### Header and Metadata
 
@@ -117,7 +147,7 @@ The modal header shows the CVE identifier and a set of action buttons. Below it,
 
 ### CVSS Vectors
 
-Each CVSS vector associated with the vulnerability is rendered as a gauge card showing the version, base score, and a visual breakdown of the vector's metrics. When editing is enabled, a **plus** button appears next to the CVSS heading, allowing you to add a custom CVSS vector string. This is useful when the upstream score doesn't reflect your environment — for instance, if a network-based vulnerability only affects an air-gapped system.
+Each CVSS vector associated with the vulnerability is rendered as a gauge card showing the version, base score, and a visual breakdown of the vector's metrics. When editing is enabled, a **plus** button appears next to the CVSS heading, allowing you to add a custom CVSS vector string (versions 2.0, 3.0, 3.1, and 4.0 are supported). This is useful when the upstream score doesn't reflect your environment — for instance, if a network-based vulnerability only affects an air-gapped system.
 
 ### Descriptions and Links
 
@@ -141,30 +171,32 @@ The modal footer contains **previous** and **next** buttons that move through th
 
 ---
 
-## Keyboard Shortcut Helper
-
-Both the vulnerability table and the modal header feature a **question-mark** icon that opens a floating panel listing the keyboard shortcuts available in the current context.
-
-### Table Shortcuts
-
-- **`/`** — focus the search bar.
-- **`↑` / `↓`** — move the row focus up or down.
-- **`Home` / `End`** — jump to the first or last row.
-- **`v`** — open the focused vulnerability in view mode.
-- **`e`** — open the focused vulnerability in edit mode.
-
-### Modal Shortcuts
-
-- **`←` / `→`** — navigate to the previous or next vulnerability.
-- **`Esc`** — close the modal (with confirmation if there are unsaved changes).
-
-The panel dismisses automatically when you click outside it.
-
----
-
 ## Scan History
 
-The scan history page provides a chronological record of every SBOM import that VulnScout has processed. Each time you load a new SBOM, VulnScout creates a scan entry that captures exactly what changed compared to the previous import. This makes it straightforward to track how your vulnerability landscape evolves over time, across builds, and across variants.
+The Scan History page provides a chronological record of every SBOM import and vulnerability scan that VulnScout has processed. Each time you load a new SBOM or run a scanner, VulnScout creates a scan entry that captures exactly what changed compared to the previous state. This makes it straightforward to track how your vulnerability landscape evolves over time, across builds, and across variants.
+
+### Scanners
+
+An SBOM lists the packages that make up your system, but a single vulnerability source rarely provides complete coverage. Different databases track different ecosystems, use different matching strategies, and update at different speeds. VulnScout cross-references your SBOM against several scanners to offer a wider set of information:
+
+- **NVD** correlates packages with NIST's National Vulnerability Database using CPE identifiers. It queries every CPE attached to each package, ensuring broad coverage across many ecosystems.
+- **Grype** leverages Anchore's vulnerability database, which combines multiple upstream feeds and applies its own matching heuristics. It is particularly effective at catching vulnerabilities in container and OS-level packages. Grype scans run serially (one at a time) because the underlying export process is global.
+- **OSV** queries the open-source OSV database, which aggregates advisories from language-specific ecosystems (PyPI, npm, Go, Rust, etc.) and Linux distributions. It queries every PURL attached to each package, providing precise ecosystem-level matching.
+
+By combining these sources, VulnScout reduces the chance of missing a relevant CVE while giving you the **Sources** column and filter to trace exactly where each finding originated. If a vulnerability is reported by multiple scanners, you can have higher confidence that it genuinely applies; if only one scanner flags it, that context helps you prioritise your triage effort.
+
+### Running Scans
+
+The **Run Scans** button in the top-right corner of the Scan History page opens a dropdown menu with two sections:
+
+- **Scan types** — checkboxes for Grype, NVD CPE, and OSV. Select which scanners you want to run.
+- **Variants** — checkboxes for the available variants. When a specific variant is selected in the project scope, only that variant appears here. When viewing a project, all variants within the project are listed. "Select all" and "Select none" shortcuts help when managing many variants.
+
+The bottom of the menu shows a summary button ("Run N scans on M variants") that launches the selected scans. Each scan runs independently and displays a per-variant progress panel below the toolbar, showing real-time logs, a progress bar, and the current step. Grype scans are queued and run one at a time; NVD and OSV scans can run in parallel.
+
+### Source Visibility Toggles
+
+Three coloured toggle buttons in the toolbar (Grype, NVD, OSV) let you show or hide scan entries by source. This is useful when you only want to see SBOM imports or a specific scanner's results without the others cluttering the timeline.
 
 ### Timeline Layout
 
@@ -174,7 +206,7 @@ Scans are displayed in a vertical timeline, most recent first. Each entry shows 
 - **Red** badges indicate removals: packages, findings, or vulnerabilities that were present before but are no longer in the SBOM.
 - **Yellow** badges indicate upgrades: packages whose version changed between scans, along with findings that shifted to a different package version.
 
-For the very first scan of a variant, the badges simply show total counts (packages, findings, vulnerabilities) since there is no prior scan to compare against.
+For the very first scan of a variant, the badges simply show total counts (packages, findings, vulnerabilities) since there is no prior scan to compare against. A **Hide empty scans** toggle filters out entries where nothing changed.
 
 ### Scan Descriptions
 
@@ -182,23 +214,24 @@ Each scan entry has an editable description field. Hovering over the entry revea
 
 ### Diff Details Modal
 
-Clicking the **Details** button on any scan entry opens a full diff modal. The modal is organised into three tabbed sections:
+Clicking the **Details** button on any scan entry opens a full diff modal. The modal is organised into tabbed sections:
 
 - **Packages** — lists every package that was added, removed, or upgraded between this scan and the previous one. Each table shows the package name and version, and upgraded packages display both the old and new version side by side.
 - **Findings** — shows the individual vulnerability-to-package associations that changed. Added findings are new detections; removed findings are associations that no longer apply (because the package was removed or the vulnerability was resolved upstream). Upgraded findings track cases where the same vulnerability now maps to a different package version.
 - **Vulnerabilities** — a higher-level view listing just the CVE identifiers that appeared or disappeared. This is the quickest way to see which new CVEs were introduced by a build change.
+- **Newly Detected** — lists findings and vulnerabilities that are net additions to the global scan result (i.e. not present in any previous scan). This section is especially relevant for tool scans where the distinction between "new to this tool" and "new overall" matters.
 
 Each tab header carries its own badge counts, and every table inside supports a text filter so you can search for a specific package or CVE without scrolling through long lists.
 
-### Documentation Link
+### Scan Result Modal
 
-A **book** icon sits next to the "Scan History" heading. It links to the [Scan History](https://vulnscout.readthedocs.io/en/latest/interactive-mode.html#scan-history) section of the VulnScout documentation on ReadTheDocs. The documentation site is not yet online — the link will become active once the docs are published.
+Clicking the **Scan Result** button on a scan entry opens a modal showing the complete state of the global result at that point in time — the union of SBOM packages and all tool-scan findings. The modal displays packages, findings, and vulnerabilities tabs, each with their total counts. This is useful for understanding the full picture at a given snapshot rather than just the delta.
 
 ---
 
 ## Review
 
-The review page gives you a consolidated view of every assessment that was created directly within VulnScout (as opposed to assessments imported from upstream SBOM documents). It is designed for auditing and exporting the triage decisions your team has made.
+The Review page gives you a consolidated view of every assessment that was created directly within VulnScout (as opposed to assessments imported from upstream SBOM documents). It is designed for auditing and exporting the triage decisions your team has made.
 
 ### Assessment Table
 

--- a/doc/source/interactive-mode.md
+++ b/doc/source/interactive-mode.md
@@ -10,16 +10,34 @@ When you first import an SBOM into VulnScout, the application scans its contents
 
 If the SBOM source does not include any assessment data, those findings start with a **Pending assessment**, which means you will need to review the finding and make a decision about it (either it affects your system, or it doesn't or it was already fixed).
 
-However, many SBOM sources carry assessments / triage decisions. Yocto CVE-check results, for example, mark vulnerabilities as Patched, Ignored, or Unpatched; CycloneDX and SPDX 3 documents often include full VEX analysis blocks; and OpenVEX files provide standalone assessment records. When VulnScout ingests these, it creates assessments automatically with an `sbom` origin, so you may see some CVEs already labelled as **Fixed** or **Not affected** before you have done any manual triage.
+However, many SBOM sources carry assessments / triage decisions. Yocto CVE-check results, for example, mark vulnerabilities as Patched, Ignored, or Unpatched; CycloneDX and SPDX 3 documents often include full VEX analysis blocks; and OpenVEX files provide standalone assessment records. When VulnScout ingests these, it creates assessments automatically, so you may see some CVEs already labelled as **Fixed** or **Not affected** before you have done any manual triage.
 
-### What "Pending Assessment" Means
+### Scanners
+
+An SBOM lists the packages that make up your system, but a single vulnerability source rarely provides complete coverage. Different databases track different ecosystems, use different matching strategies, and update at different speeds. VulnScout cross-references your SBOM against several scanners to offer a wider set of information:
+
+- **NVD** correlates packages with NIST's National Vulnerability Database using CPE identifiers. It offers broad coverage across many ecosystems.
+- **Grype** leverages Anchore's vulnerability database, which combines multiple upstream feeds and applies its own matching heuristics. It is particularly effective at catching vulnerabilities in container and OS-level packages.
+- **OSV-Scanner** queries the open-source OSV database, which aggregates advisories from language-specific ecosystems (PyPI, npm, Go, Rust, etc.) and Linux distributions. Its PURL matching tends to be more precise than CPE-based lookup.
+
+By combining these sources, VulnScout reduces the chance of missing a relevant CVE while giving you the **Sources** column and filter to trace exactly where each finding originated. If a vulnerability is reported by multiple scanners, you can have higher confidence that it genuinely applies; if only one scanner flags it, that context helps you prioritise your triage effort.
+
+### Assessment Status in Vulnscout
 
 VulnScout groups all assessment statuses into four simplified categories:
 
 - **Pending Assessment**: the vulnerability has not been assessed yet. 
-- **Exploitable**: the vulnerability is confirmed to affect your product in its current configuration.
-- **Not affected**: the vulnerability does not apply (the vulnerable code is not present, not reachable, or already mitigated). A justification is required when selecting this status.
+- **Exploitable**: the vulnerability is confirmed to affect your product in its current configuration and represents danger for it as defined in the threat model.
+- **Not affected**: the vulnerability does not apply — even if the vulnerable package is present on the device, the CVE may not match your threat model (for example, the vulnerable code path is not reachable, or the attack vector does not exist in your environment). A justification is required when selecting this status.
 - **Fixed**: the vulnerability has been patched or resolved.
+
+### Threat Model
+
+A vulnerability present in Vulnscout does not necessarily mean they represent a real danger to your device. A CVE describes a potential weakness whether it is actually exploitable depends on how the affected component is built, configured, and used in your specific environment.
+
+For example, consider a CVE that can only be triggered when a particular compile-time flag is enabled. If your build does not use that flag, the vulnerable code path is never included, and the CVE cannot be exploited on your device. Similarly, a network-facing vulnerability has no impact on a system that is never connected to a network.
+
+This is why triage matters: the goal is not to patch every CVE blindly, but to determine which ones are relevant given your threat model and mark the rest as **Not affected** with a clear justification.
 
 ### Goal of the Interactive Mode
 

--- a/doc/source/interactive-mode.md
+++ b/doc/source/interactive-mode.md
@@ -2,6 +2,35 @@
 
 VulnScout's web interface is the way most users interact with vulnerability data day-to-day. Once an SBOM has been imported and enriched, the interactive mode gives you everything needed to explore, filter, assess, and track vulnerabilities without leaving the application.
 
+## How Assessments Works
+
+### Starting a New Project
+
+When you first import an SBOM into VulnScout, the application scans its contents and creates a finding for every vulnerability-to-package association it discovers.
+
+If the SBOM source does not include any assessment data, those findings start with a **Pending assessment**, which means you will need to review the finding and make a decision about it (either it affects your system, or it doesn't or it was already fixed).
+
+However, many SBOM sources carry assessments / triage decisions. Yocto CVE-check results, for example, mark vulnerabilities as Patched, Ignored, or Unpatched; CycloneDX and SPDX 3 documents often include full VEX analysis blocks; and OpenVEX files provide standalone assessment records. When VulnScout ingests these, it creates assessments automatically with an `sbom` origin, so you may see some CVEs already labelled as **Fixed** or **Not affected** before you have done any manual triage.
+
+### What "Pending Assessment" Means
+
+VulnScout groups all assessment statuses into four simplified categories:
+
+- **Pending Assessment**: the vulnerability has not been assessed yet. 
+- **Exploitable**: the vulnerability is confirmed to affect your product in its current configuration.
+- **Not affected**: the vulnerability does not apply (the vulnerable code is not present, not reachable, or already mitigated). A justification is required when selecting this status.
+- **Fixed**: the vulnerability has been patched or resolved.
+
+### Goal of the Interactive Mode
+
+The interactive mode is where you investigate each CVE and record your triage decisions. The typical workflow is:
+
+0. Look for vulnerabilities that are **Pending assessment**: you can directly click on the orange part of the pie chart in the home page, or use the filters in the Vulnerabilities tab to see these CVEs.
+1. Review the vulnerability details: read the description, check the CVSS score and EPSS probability, inspect which packages are affected, and follow the reference links for advisories and patches.
+2. Assess: set a status, provide a justification when required, add notes explaining your reasoning, and optionally document a workaround or estimate remediation effort.
+
+Assessments you create through the web dashboard are stored with a `custom` origin, which distinguishes them from the  assessments that were imported automatically. On subsequent SBOM re-imports, upstream assessments may be updated by newer VEX data, but your own assessments are always preserved as separate records.
+
 ---
 
 ## Vulnerability Table
@@ -82,7 +111,7 @@ The time-estimate editor lets you record optimistic, likely, and pessimistic dur
 
 ### Assessments
 
-Assessments are the core triage artefact. Each assessment captures a status (under investigation, exploitable, not affected, fixed, false positive), an optional justification, impact statement, status notes, and workaround. Assessments are displayed in a timeline, grouped by date and content, with the most recent at the top.
+Assessments are the core triage artefact. Each assessment captures a status (pending assessment, exploitable, not affected, fixed), an optional justification, impact statement, status notes, and workaround. Assessments are displayed in a timeline, grouped by date and content, with the most recent at the top.
 
 In editing mode, a form at the top of the timeline lets you create a new assessment. You can select which packages and which variants the assessment applies to, and VulnScout will create the appropriate records. Existing assessments can be edited inline or deleted.
 

--- a/doc/source/interactive-mode.md
+++ b/doc/source/interactive-mode.md
@@ -1,0 +1,181 @@
+# Interactive Mode
+
+VulnScout's web interface is the way most users interact with vulnerability data day-to-day. Once an SBOM has been imported and enriched, the interactive mode gives you everything needed to explore, filter, assess, and track vulnerabilities without leaving the application.
+
+---
+
+## Vulnerability Table
+
+Every vulnerability detected across imported SBOMs in your scope is listed here, and the toolbar across the top provides a rich set of controls to narrow down what you see and act on what matters.
+
+### Search
+
+The search bar accepts free-text queries that match against CVE identifiers, package names, and vulnerability descriptions. Typing at least two characters triggers a fuzzy search powered by Fuse.js. The search supports a small expression language:
+
+- **`term`** — rows containing the term are shown.
+- **`term1 term2`** — AND semantics: both terms must match.
+- **`term1 | term2`** — OR semantics: either term matches.
+- **`-term`** — NOT: rows containing the term are excluded.
+
+A small **info icon** next to the search bar opens a quick-reference panel for this syntax, so you don't need to memorise it.
+
+### Column Visibility
+
+The **Columns** dropdown lets you toggle which columns are displayed. The default set includes ID, Severity, EPSS Score, SBOM Affected, Variants, Status, Last Updated, and Published Date, but you can also enable Attack Vector, Estimated Effort, First Scan Date, and Sources.
+
+### Filters
+
+VulnScout provides several filter categories, each accessible from a dedicated dropdown in the toolbar:
+
+- **Source**: restrict the table to vulnerabilities found by a specific scanner or import source (Yocto, Grype, CycloneDX, SPDX3, OpenVEX, or Local User Data).
+- **Severity**: select one or more severity levels (Critical, High, Medium, Low, None). You can also switch to a continuous **score-based** filter using a range slider, which filters by the underlying CVSS max score rather than the categorical label.
+- **Status**: filter by triage status: Pending Assessment, Exploitable, Not affected, or Fixed.
+- **Published Date**: filter vulnerabilities by their NVD publication date. The dropdown supports exact-date matching, before/after comparisons, date ranges, and a "within the last N days" shorthand. This filter becomes active once the NVD sync has completed.
+- **More Filters**: groups less common filters together:
+  - **EPSS Range**: a percentage-based range slider that narrows the list to vulnerabilities whose Exploit Prediction Scoring System score falls within the specified band.
+  - **Attack Vector**: checkboxes for Network, Adjacent, Local, and Physical, reflecting the CVSS attack-vector metric.
+  - **First Scan Date**: multi-select by scan timestamp, useful for identifying which vulnerabilities appeared in a particular import run.
+
+When any filter is active, a small checkmark badge appears on its button so you can tell at a glance which filters are engaged. A **Reset Filters** button in the top-right corner clears everything back to defaults.
+
+### Row Selection and Bulk Editing
+
+Each row has a checkbox on the left. Selecting one or more rows reveals the **multi-edit bar**, which lets you apply a single assessment (status, justification, notes) to all selected vulnerabilities at once. This is particularly valuable when triaging a batch of related CVEs (for example, marking a group of low-severity findings as "Not affected" with a shared justification).
+
+### Sorting
+
+Every sortable column header is clickable. Severity sorts by the standard ordering (Critical -> None) or by numeric score when the score-based filter is active. Status sorts by triage progression. Published Date and Last Updated sort chronologically. EPSS and Estimated Effort sort numerically. Clicking the same header again reverses the direction.
+
+### Opening a Vulnerability
+
+Clicking a vulnerability's **ID cell** opens the detail modal in read-only mode. Clicking the **Edit** button in the actions column opens it directly in editing mode. Both actions capture a snapshot of the currently filtered and sorted list so that you can navigate between vulnerabilities within the modal without leaving the dialog box.
+
+---
+
+## Vulnerability Details
+
+The Vulnerability Details is where individual vulnerability triage happens. It presents all the information VulnScout has gathered about a single CVE, and lets you modify assessments, CVSS vectors, and time estimates.
+
+### Header and Metadata
+
+The modal header shows the CVE identifier and a set of action buttons. Below it, a summary section displays:
+
+- **Severity** with a colour-coded tag.
+- **EPSS Score** as a percentage, when available.
+- **Published date** from NVD.
+- **Found by** — the list of scanners or sources that reported this vulnerability.
+- **Status** — the current triage status.
+- **Affects** — the list of packages in the SBOM that are impacted.
+- **Aliases and Related vulnerabilities** — cross-references to other CVE identifiers.
+
+### CVSS Vectors
+
+Each CVSS vector associated with the vulnerability is rendered as a gauge card showing the version, base score, and a visual breakdown of the vector's metrics. When editing is enabled, a **plus** button appears next to the CVSS heading, allowing you to add a custom CVSS vector string. This is useful when the upstream score doesn't reflect your environment — for instance, if a network-based vulnerability only affects an air-gapped system.
+
+### Descriptions and Links
+
+The vulnerability's textual descriptions (from NVD, the SBOM source, or other feeds) are displayed in full, followed by a list of reference links. Each link opens in a new tab.
+
+### Time Estimation
+
+The time-estimate editor lets you record optimistic, likely, and pessimistic durations for remediation effort. These three-point estimates feed into the Estimated Effort column in the table and can be used for planning and prioritisation.
+
+### Assessments
+
+Assessments are the core triage artefact. Each assessment captures a status (under investigation, exploitable, not affected, fixed, false positive), an optional justification, impact statement, status notes, and workaround. Assessments are displayed in a timeline, grouped by date and content, with the most recent at the top.
+
+In editing mode, a form at the top of the timeline lets you create a new assessment. You can select which packages and which variants the assessment applies to, and VulnScout will create the appropriate records. Existing assessments can be edited inline or deleted.
+
+When you have unsaved changes and attempt to close the modal or navigate away, VulnScout prompts you to confirm, preventing accidental data loss.
+
+### Navigation
+
+The modal footer contains **previous** and **next** buttons that move through the filtered vulnerability list without closing the modal. A counter ("Vulnerability x of y") shows your current position. This sequential navigation is the fastest way to triage a batch.
+
+---
+
+## Keyboard Shortcut Helper
+
+Both the vulnerability table and the modal header feature a **question-mark** icon that opens a floating panel listing the keyboard shortcuts available in the current context.
+
+### Table Shortcuts
+
+- **`/`** — focus the search bar.
+- **`↑` / `↓`** — move the row focus up or down.
+- **`Home` / `End`** — jump to the first or last row.
+- **`v`** — open the focused vulnerability in view mode.
+- **`e`** — open the focused vulnerability in edit mode.
+
+### Modal Shortcuts
+
+- **`←` / `→`** — navigate to the previous or next vulnerability.
+- **`Esc`** — close the modal (with confirmation if there are unsaved changes).
+
+The panel dismisses automatically when you click outside it.
+
+---
+
+## Scan History
+
+The scan history page provides a chronological record of every SBOM import that VulnScout has processed. Each time you load a new SBOM, VulnScout creates a scan entry that captures exactly what changed compared to the previous import. This makes it straightforward to track how your vulnerability landscape evolves over time, across builds, and across variants.
+
+### Timeline Layout
+
+Scans are displayed in a vertical timeline, most recent first. Each entry shows the timestamp of the import, the project and variant it belongs to, and a set of colour-coded badges summarising the delta:
+
+- **Green** badges indicate additions: new packages, new findings, or new vulnerabilities that appeared in this scan.
+- **Red** badges indicate removals: packages, findings, or vulnerabilities that were present before but are no longer in the SBOM.
+- **Yellow** badges indicate upgrades: packages whose version changed between scans, along with findings that shifted to a different package version.
+
+For the very first scan of a variant, the badges simply show total counts (packages, findings, vulnerabilities) since there is no prior scan to compare against.
+
+### Scan Descriptions
+
+Each scan entry has an editable description field. Hovering over the entry reveals a pencil icon that lets you add or modify a free-text note — for example, "nightly build 2026-04-21" or "after openssl bump". Descriptions are saved immediately and persist across sessions. This is especially useful when reviewing the history weeks later and needing context about why a particular scan looks the way it does.
+
+### Diff Details Modal
+
+Clicking the **Details** button on any scan entry opens a full diff modal. The modal is organised into three tabbed sections:
+
+- **Packages** — lists every package that was added, removed, or upgraded between this scan and the previous one. Each table shows the package name and version, and upgraded packages display both the old and new version side by side.
+- **Findings** — shows the individual vulnerability-to-package associations that changed. Added findings are new detections; removed findings are associations that no longer apply (because the package was removed or the vulnerability was resolved upstream). Upgraded findings track cases where the same vulnerability now maps to a different package version.
+- **Vulnerabilities** — a higher-level view listing just the CVE identifiers that appeared or disappeared. This is the quickest way to see which new CVEs were introduced by a build change.
+
+Each tab header carries its own badge counts, and every table inside supports a text filter so you can search for a specific package or CVE without scrolling through long lists.
+
+### Documentation Link
+
+A **book** icon sits next to the "Scan History" heading. It links to the [Scan History](https://vulnscout.readthedocs.io/en/latest/interactive-mode.html#scan-history) section of the VulnScout documentation on ReadTheDocs. The documentation site is not yet online — the link will become active once the docs are published.
+
+---
+
+## Review
+
+The review page gives you a consolidated view of every assessment that was created directly within VulnScout (as opposed to assessments imported from upstream SBOM documents). It is designed for auditing and exporting the triage decisions your team has made.
+
+### Assessment Table
+
+The table presents one row per grouped assessment. Assessments that share the same vulnerability, status, justification, notes, workaround, and impact statement are automatically merged into a single row, with their packages and variants combined. This keeps the view compact even when a single triage decision was applied to many packages at once.
+
+The columns include:
+
+- **Vulnerability**: the CVE identifier. Clicking it opens the vulnerability detail modal in read-only mode, letting you inspect the full context without leaving the review page.
+- **SBOM Affected**: the list of packages this assessment covers.
+- **Variants**: the variant tags associated with the assessment.
+- **Status**: the triage status (e.g. Not affected, Exploitable, Fixed).
+- **Justification**: the VEX justification reason, if one was provided (e.g. "component not present", "vulnerable code not reachable").
+- **Impact**: the impact statement describing how the vulnerability affects (or doesn't affect) the product.
+- **Notes**: free-text status notes attached to the assessment.
+- **Workaround**: any documented workaround.
+- **Assessment Date**: the timestamp of the most recent assessment in the group.
+
+### Search and Filters
+
+The toolbar mirrors the vulnerability table's search bar. Filters are available for **Status** and **Justification**, and a **Reset Filters** button clears everything back to defaults.
+
+### Import and Export
+
+Two buttons in the toolbar handle review portability:
+
+- **Import Review**: accepts an OpenVEX file (JSON or `.tar.gz`) and merges its assessments into the current project. This is useful for receiving triage decisions from another team or from a previous VulnScout instance.
+- **Export Review**: downloads all review assessments as an OpenVEX `.tar.gz` archive. The export captures the full set of handmade assessments so they can be shared, archived, or loaded into another VulnScout deployment.

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -9,3 +9,8 @@ global.fetch = jest.fn(() =>
     json: () => Promise.resolve({ version: '1.0.0-test' }),
   } as Response)
 );
+
+// Mock the useDocUrl hook so it never fires a real fetch during tests
+jest.mock('./src/helpers/useDocUrl', () => ({
+  useDocUrl: (path: string) => `https://vulnscout.readthedocs.io/en/test/${path}`,
+}));

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -19,6 +19,7 @@ import EditAssessment from "./EditAssessment";
 import type { EditAssessmentData } from "./EditAssessment";
 import Variants from '../handlers/variant';
 import { formatSourceName } from '../helpers/sourceNames';
+import { useDocUrl } from '../helpers/useDocUrl';
 import type { Variant } from '../handlers/variant';
 import { useState, useEffect, useRef, useCallback } from "react";
 
@@ -54,6 +55,7 @@ type AssessmentGroup = {
 
   function VulnModal(props: Readonly<Props>) {
     const { vuln, isEditing: initialIsEditing, readOnly = false, onClose, appendAssessment, appendCVSS, patchVuln, vulnerabilities, currentIndex, onNavigate, variantId } = props;
+    const docUrl = useDocUrl("interactive-mode.html#vulnerability-details");
     const [isEditing, setIsEditing] = useState(initialIsEditing);
     const [showCustomCvss, setShowCustomCvss] = useState(false);
     const [clearTimeFields, setClearTimeFields] = useState(false);
@@ -712,7 +714,7 @@ type AssessmentGroup = {
                                     <FontAwesomeIcon icon={faCircleQuestion} size='lg' />
                                 </button>
                                 <a
-                                    href="https://vulnscout.readthedocs.io/en/latest/interactive-mode.html#vulnerability-details"
+                                    href={docUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     aria-label="documentation"

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -13,7 +13,7 @@ import TimeEstimateEditor from "./TimeEstimateEditor";
 import type { PostTimeEstimate } from "./TimeEstimateEditor";
 import Iso8601Duration from '../handlers/iso8601duration';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBox, faChevronLeft, faChevronRight, faPenToSquare, faTrash, faPlus, faCircleQuestion } from "@fortawesome/free-solid-svg-icons";
+import { faBox, faChevronLeft, faChevronRight, faPenToSquare, faTrash, faPlus, faCircleQuestion, faBook } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "./ConfirmationModal";
 import EditAssessment from "./EditAssessment";
 import type { EditAssessmentData } from "./EditAssessment";
@@ -700,7 +700,7 @@ type AssessmentGroup = {
                         </h3>
                         <div className="flex items-center space-x-2">
                             {/* Keyboard Shortcut Helper */}
-                            <div className="px-2 py-2 flex items-center relative">
+                            <div className="px-2 py-2 flex items-center gap-2 relative">
                                 <button
                                     ref={shortcutButtonRef}
                                     aria-label='shortcut helper'
@@ -711,6 +711,16 @@ type AssessmentGroup = {
                                 >
                                     <FontAwesomeIcon icon={faCircleQuestion} size='lg' />
                                 </button>
+                                <a
+                                    href="https://vulnscout.readthedocs.io/en/latest/interactive-mode.html#vulnerability-details"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    aria-label="documentation"
+                                    title="Open documentation"
+                                    className="hover:text-blue-400 transition-colors"
+                                >
+                                    <FontAwesomeIcon icon={faBook} size='lg' />
+                                </a>
                                 {showShortcutHelper && (
                                     <div
                                         ref={dropdownRef}

--- a/frontend/src/helpers/useDocUrl.ts
+++ b/frontend/src/helpers/useDocUrl.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+const DOC_BASE = "https://vulnscout.readthedocs.io/en";
+
+let cachedVersion: string | null = null;
+
+/**
+ * Returns the full ReadTheDocs URL for the given documentation path,
+ * using the current container version instead of "latest".
+ *
+ * @param path - Path after the version slug, e.g. `"interactive-mode.html#scan-history"`
+ */
+export function useDocUrl(path: string): string {
+  const [version, setVersion] = useState<string>(cachedVersion || "latest");
+
+  useEffect(() => {
+    if (cachedVersion) return;
+    fetch(import.meta.env.VITE_API_URL + "/api/version", { mode: "cors" })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.version && data.version !== "unknown") {
+          cachedVersion = data.version;
+          setVersion(data.version);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  return `${DOC_BASE}/${version}/${path}`;
+}

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -17,6 +17,7 @@ import type { Variant } from '../handlers/variant';
 import ConfirmationModal from '../components/ConfirmationModal';
 import MessageBanner from '../components/MessageBanner';
 import Variants from '../handlers/variant';
+import { useDocUrl } from '../helpers/useDocUrl';
 
 type AssessmentMutation =
     | { type: 'delete'; vulnId: string; ids: string[] }
@@ -98,6 +99,7 @@ function formatDate(iso: string): string {
 }
 
 function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) {
+    const docUrl = useDocUrl("interactive-mode.html#review");
     const [assessments, setAssessments] = useState<Assessment[]>([]);
     const [vulnDescriptions, setVulnDescriptions] = useState<Record<string, { title: string; content: string }[]>>({});
     const [loading, setLoading] = useState(true);
@@ -654,7 +656,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                         <FontAwesomeIcon icon={faCircleQuestion} />
                     </button>
                     <a
-                        href="https://vulnscout.readthedocs.io/en/latest/interactive-mode.html#review"
+                        href={docUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         aria-label="documentation"

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -10,7 +10,7 @@ import VulnModal from "../components/VulnModal";
 import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleQuestion, faCircleInfo, faFileExport, faFileImport, faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faCircleQuestion, faCircleInfo, faFileExport, faFileImport, faPenToSquare, faTrash, faBook } from '@fortawesome/free-solid-svg-icons';
 import EditAssessment from '../components/EditAssessment';
 import type { EditAssessmentData } from '../components/EditAssessment';
 import type { Variant } from '../handlers/variant';
@@ -653,6 +653,16 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     >
                         <FontAwesomeIcon icon={faCircleQuestion} />
                     </button>
+                    <a
+                        href="https://vulnscout.readthedocs.io/en/latest/interactive-mode.html#review"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="documentation"
+                        title="Open documentation"
+                        className="text-white hover:text-blue-300 transition-colors"
+                    >
+                        <FontAwesomeIcon icon={faBook} />
+                    </a>
                     {showShortcutHelper && (
                         <div
                             ref={shortcutDropdownRef}

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -19,7 +19,7 @@ import {
 import type { ScanManagerSnapshot } from "../handlers/scanStateManager";
 import ScanProgressPanel from "../components/ScanProgressPanel";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay } from "@fortawesome/free-solid-svg-icons";
+import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "../components/ConfirmationModal";
 import Variants from "../handlers/variant";
 import type { Variant } from "../handlers/variant";
@@ -1066,6 +1066,16 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     const menuBar = (
         <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2 flex-wrap">
             <h1 className="text-lg font-bold">Scan History</h1>
+            <a
+                href="https://vulnscout.readthedocs.io/en/latest/interactive-mode.html#scan-history"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="documentation"
+                title="Open documentation"
+                className="text-white hover:text-blue-300 transition-colors"
+            >
+                <FontAwesomeIcon icon={faBook} />
+            </a>
 
             {/* Hide empty scans toggle */}
             <button

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -18,6 +18,7 @@ import {
 } from "../handlers/osvScanState";
 import type { ScanManagerSnapshot } from "../handlers/scanStateManager";
 import ScanProgressPanel from "../components/ScanProgressPanel";
+import { useDocUrl } from "../helpers/useDocUrl";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "../components/ConfirmationModal";
@@ -857,6 +858,7 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
 // ---------------------------------------------------------------------------
 
 function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) {
+    const docUrl = useDocUrl("interactive-mode.html#scan-history");
     const [scans, setScans] = useState<Scan[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -1066,16 +1068,6 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     const menuBar = (
         <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2 flex-wrap">
             <h1 className="text-lg font-bold">Scan History</h1>
-            <a
-                href="https://vulnscout.readthedocs.io/en/latest/interactive-mode.html#scan-history"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="documentation"
-                title="Open documentation"
-                className="text-white hover:text-blue-300 transition-colors"
-            >
-                <FontAwesomeIcon icon={faBook} />
-            </a>
 
             {/* Hide empty scans toggle */}
             <button
@@ -1129,8 +1121,18 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                 NVD
             </button>
 
-            {/* Right side: scan menu */}
+            {/* Right side: doc link + scan menu */}
             <div className="ml-auto flex items-center gap-3">
+                <a
+                    href={docUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="documentation"
+                    title="Open documentation"
+                    className="text-white hover:text-blue-300 transition-colors"
+                >
+                    <FontAwesomeIcon icon={faBook} />
+                </a>
                 {/* Run Scans dropdown */}
                 {canTriggerScan && (
                     <div className="relative" ref={scanMenuRef}>

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -7,7 +7,8 @@ import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
 import ToggleSwitch from "../components/ToggleSwitch";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleQuestion, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
+import { faCircleQuestion, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
+import { useDocUrl } from '../helpers/useDocUrl';
 
 type Props = {
     packages: Package[];
@@ -43,6 +44,7 @@ const sortVunerabilitiesFn = (rowA: Row<Package>, rowB: Row<Package>, ignore: st
 const fuseKeys = ['id', 'name', 'version', 'cpe', 'purl']
 
 function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
+    const docUrl = useDocUrl("interactive-mode.html#sbom-table");
     const [showSeverity, setShowSeverity] = useState(false);
     const [search, setSearch] = useState<string>('');
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
@@ -381,6 +383,16 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                 >
                     <FontAwesomeIcon icon={faCircleQuestion} />
                 </button>
+                <a
+                    href={docUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="documentation"
+                    title="Open documentation"
+                    className="text-white hover:text-blue-300 transition-colors"
+                >
+                    <FontAwesomeIcon icon={faBook} />
+                </a>
                 {showShortcutHelper && (
                     <div
                         ref={shortcutDropdownRef}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -13,6 +13,7 @@ import MultiEditBar from "../components/MultiEditBar";
 import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
 import { formatSourceName, getOriginalSourceName } from "../helpers/sourceNames";
+import { useDocUrl } from "../helpers/useDocUrl";
 
 import MessageBanner from "../components/MessageBanner";
 import NVDProgressHandler from "../handlers/nvd_progress";
@@ -272,6 +273,7 @@ const SEVERITY_RANGE_MAX = 10;
 
 function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln, variantId, baseVariantId, compareOperation }: Readonly<Props>) {
 
+    const docUrl = useDocUrl("interactive-mode.html#vulnerability-table");
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);
     const [modalVulnIndex, setModalVulnIndex] = useState<number | undefined>(undefined);
     const [modalVulnSnapshot, setModalVulnSnapshot] = useState<Vulnerability[]>([]);
@@ -1273,7 +1275,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     <FontAwesomeIcon icon={faCircleQuestion} />
                 </button>
                 <a
-                    href="https://vulnscout.readthedocs.io/en/latest/interactive-mode.html#vulnerability-table"
+                    href={docUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label="documentation"

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -18,7 +18,7 @@ import MessageBanner from "../components/MessageBanner";
 import NVDProgressHandler from "../handlers/nvd_progress";
 import EPSSProgressHandler from "../handlers/epss_progress";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes, faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
+import { faTimes, faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
 import RangeSlider from "../components/RangeSlider";
 
 type Props = {
@@ -1272,6 +1272,16 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 >
                     <FontAwesomeIcon icon={faCircleQuestion} />
                 </button>
+                <a
+                    href="https://vulnscout.readthedocs.io/en/latest/interactive-mode.html#vulnerability-table"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="documentation"
+                    title="Open documentation"
+                    className="text-white hover:text-blue-300 transition-colors"
+                >
+                    <FontAwesomeIcon icon={faBook} />
+                </a>
                 {showShortcutHelper && (
                     <div
                         ref={shortcutDropdownRef}

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -154,16 +154,20 @@ describe('Packages Table', () => {
         const user = userEvent.setup();
         const version_header = await screen.getByRole('columnheader', {name: /version/i});
 
+        // Use package names as anchors since version strings may appear in
+        // row IDs/keys before the visible table cells.
         await user.click(version_header); // un-ordoned -> alphabetical order
         await waitFor(() => {
             const html = document.body.innerHTML;
-            expect(html.indexOf('1.0.0')).toBeLessThan(html.indexOf('2.0.0'));
+            expect(html.indexOf('aaabbbccc')).toBeLessThan(html.indexOf('dddeeefff'));
+            expect(html.indexOf('dddeeefff')).toBeLessThan(html.indexOf('xxxyyyzzz'));
         });
 
         await user.click(version_header); // alphabetical order -> reverse alphabetical order
         await waitFor(() => {
             const html = document.body.innerHTML;
-            expect(html.indexOf('2.0.0')).toBeLessThan(html.indexOf('1.0.0'));
+            expect(html.indexOf('xxxyyyzzz')).toBeLessThan(html.indexOf('dddeeefff'));
+            expect(html.indexOf('dddeeefff')).toBeLessThan(html.indexOf('aaabbbccc'));
         });
     })
 


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Add documentation for interactive mode.
* Add icons in the web dashboards to refer to it.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

- Open the web dashboard, docs icons are located in: Vulns table, vuln details, scan andreview tabs
## Pull Request Checklist
- Note that the docs are not public yet so they will show a 404 error.

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


