### PR TITLE
Fix: Create a new helper for "active scans"

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -794,6 +794,9 @@ type AssessmentGroup = {
                                             if (source === 'grype') return 'Grype';
                                             if (source === 'cyclonedx') return 'CycloneDx';
                                             if (source === 'local_user_data') return 'Local User Data';
+                                            if (source === 'spdx3') return 'SPDX3';
+                                            if (source === 'nvd_cpe') return 'NVD CPE';
+                                            if (source === 'osv') return 'OSV';
                                             return source;
                                         })
                                         .join(', ')

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -18,6 +18,7 @@ import ConfirmationModal from "./ConfirmationModal";
 import EditAssessment from "./EditAssessment";
 import type { EditAssessmentData } from "./EditAssessment";
 import Variants from '../handlers/variant';
+import { formatSourceName } from '../helpers/sourceNames';
 import type { Variant } from '../handlers/variant';
 import { useState, useEffect, useRef, useCallback } from "react";
 
@@ -788,17 +789,7 @@ type AssessmentGroup = {
                                 <li key="sources">
                                     <span className="font-bold mr-1">Found by:</span>
                                     {vuln.found_by
-                                        .map(source => {
-                                            if (source === 'openvex') return 'OpenVex';
-                                            if (source === 'yocto') return 'Yocto';
-                                            if (source === 'grype') return 'Grype';
-                                            if (source === 'cyclonedx') return 'CycloneDx';
-                                            if (source === 'local_user_data') return 'Local User Data';
-                                            if (source === 'spdx3') return 'SPDX3';
-                                            if (source === 'nvd_cpe') return 'NVD CPE';
-                                            if (source === 'osv') return 'OSV';
-                                            return source;
-                                        })
+                                        .map(formatSourceName)
                                         .join(', ')
                                     }
                                 </li>

--- a/frontend/src/helpers/sourceNames.ts
+++ b/frontend/src/helpers/sourceNames.ts
@@ -1,0 +1,24 @@
+/** Canonical mapping from backend source keys to display names. */
+export const SOURCE_DISPLAY_NAMES: Record<string, string> = {
+    openvex: 'OpenVex',
+    local_user_data: 'Local User Data',
+    yocto: 'Yocto',
+    grype: 'Grype',
+    cyclonedx: 'CycloneDx',
+    spdx3: 'SPDX3',
+    nvd_cpe: 'NVD CPE',
+    osv: 'OSV',
+};
+
+/** Reverse mapping: display name → backend key. */
+export const SOURCE_KEYS: Record<string, string> = Object.fromEntries(
+    Object.entries(SOURCE_DISPLAY_NAMES).map(([k, v]) => [v, k])
+);
+
+/** Convert a backend source key to its human-readable display name. */
+export const formatSourceName = (source: string): string =>
+    SOURCE_DISPLAY_NAMES[source] ?? source;
+
+/** Convert a display name back to the original backend source key. */
+export const getOriginalSourceName = (displayName: string): string =>
+    SOURCE_KEYS[displayName] ?? displayName;

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -8,6 +8,7 @@ import { useMemo, useState } from "react";
         import TableGeneric from "../components/TableGeneric";
         import SeverityTag from "../components/SeverityTag";
         import VulnModal from "../components/VulnModal";
+        import { formatSourceName } from "../helpers/sourceNames";
         import type { Assessment } from "../handlers/assessments";
 
         ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement, BarElement, LogarithmicScale);
@@ -109,20 +110,7 @@ import { useMemo, useState } from "react";
             return date;
         }
 
-        function formatSourceName(source: string): string {
-            const map: Record<string, string> = {
-                openvex: 'OpenVex',
-                local_user_data: 'Local User Data',
-                yocto: 'Yocto',
-                spdx3: 'SPDX3',
-                grype: 'Grype',
-                cyclonedx: 'CycloneDx',
-                nvd_cpe: 'NVD CPE',
-                osv: 'OSV',
-            };
 
-            return map[source] || source;
-        }
 
 
 

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -116,7 +116,9 @@ import { useMemo, useState } from "react";
                 yocto: 'Yocto',
                 spdx3: 'SPDX3',
                 grype: 'Grype',
-                cyclonedx: 'CycloneDx'
+                cyclonedx: 'CycloneDx',
+                nvd_cpe: 'NVD CPE',
+                osv: 'OSV',
             };
 
             return map[source] || source;
@@ -466,19 +468,40 @@ const packageColumns = [
     };
 
               const dataSetVulnBySource = useMemo(() => {
-                const uniqueSources = Array.from(
-                    new Set(vulnerabilities.flatMap(vuln => vuln.found_by))
-                ).sort((a, b) =>
-                    vulnerabilities.filter(vuln => vuln.found_by.includes(b)).length -
-                    vulnerabilities.filter(vuln => vuln.found_by.includes(a)).length
+                // Each vulnerability is attributed to exactly ONE primary source
+                // so that the sum of all bars equals the total vulnerability count.
+                const SOURCE_PRIORITY: Record<string, number> = {
+                    grype: 1,
+                    yocto: 2,
+                    nvd_cpe: 3,
+                    osv: 4,
+                    cyclonedx: 5,
+                    spdx3: 6,
+                    openvex: 7,
+                    local_user_data: 8,
+                };
+
+                const countBySource: Record<string, number> = {};
+                vulnerabilities.forEach(vuln => {
+                    if (!vuln.found_by.length) return;
+                    // Pick the highest-priority (lowest number) source
+                    const primary = vuln.found_by.reduce((best, src) => {
+                        const bestPri = SOURCE_PRIORITY[best] ?? 99;
+                        const srcPri = SOURCE_PRIORITY[src] ?? 99;
+                        return srcPri < bestPri ? src : best;
+                    });
+                    countBySource[primary] = (countBySource[primary] || 0) + 1;
+                });
+
+                const sources = Object.keys(countBySource).sort(
+                    (a, b) => countBySource[b] - countBySource[a]
                 );
+
                 return {
-                    labels: uniqueSources.map(formatSourceName),
+                    labels: sources.map(formatSourceName),
                     datasets: [{
                         label: '# of Vulnerabilities',
-                        data: uniqueSources.map(source =>
-                            vulnerabilities.filter(vuln => vuln.found_by.includes(source)).length
-                        ),
+                        data: sources.map(source => countBySource[source]),
                         backgroundColor: 'rgba(0, 150, 150, 0.7)',
                         hoverOffset: 4
                     }]

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -475,6 +475,10 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             ? 'CycloneDx'
             : source === 'spdx3'
             ? 'SPDX3'
+            : source === 'nvd_cpe'
+            ? 'NVD CPE'
+            : source === 'osv'
+            ? 'OSV'
             : source;
 
     const getOriginalSourceName = (displayName: string) =>
@@ -490,6 +494,10 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             ? 'cyclonedx'
             : displayName === 'SPDX3'
             ? 'spdx3'
+            : displayName === 'NVD CPE'
+            ? 'nvd_cpe'
+            : displayName === 'OSV'
+            ? 'osv'
             : displayName;
 
     const handleEditClick = useCallback((vuln: Vulnerability) => {

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -457,6 +457,10 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     ? 'CycloneDx'
                     : source === 'spdx3'
                     ? 'SPDX3'
+                    : source === 'nvd_cpe'
+                    ? 'NVD CPE'
+                    : source === 'osv'
+                    ? 'OSV'
                     : source
             ),
         [sources_list]
@@ -825,6 +829,10 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                                 ? 'CycloneDx'
                                 : source === 'spdx3'
                                 ? 'SPDX3'
+                                : source === 'nvd_cpe'
+                                ? 'NVD CPE'
+                                : source === 'osv'
+                                ? 'OSV'
                                 : source
                         )
                         .join(', ')}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -12,6 +12,7 @@ import VulnModal from "../components/VulnModal";
 import MultiEditBar from "../components/MultiEditBar";
 import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
+import { formatSourceName, getOriginalSourceName } from "../helpers/sourceNames";
 
 import MessageBanner from "../components/MessageBanner";
 import NVDProgressHandler from "../handlers/nvd_progress";
@@ -443,66 +444,9 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     }, []), [vulnerabilities])
 
     const sources_display_list = useMemo(
-        () =>
-            sources_list.map(source =>
-                source === 'openvex'
-                    ? 'OpenVex'
-                    : source === 'local_user_data'
-                    ? 'Local User Data'
-                    : source === 'yocto'
-                    ? 'Yocto'
-                    : source === 'grype'
-                    ? 'Grype'
-                    : source === 'cyclonedx'
-                    ? 'CycloneDx'
-                    : source === 'spdx3'
-                    ? 'SPDX3'
-                    : source === 'nvd_cpe'
-                    ? 'NVD CPE'
-                    : source === 'osv'
-                    ? 'OSV'
-                    : source
-            ),
+        () => sources_list.map(formatSourceName),
         [sources_list]
     );
-
-    const formatSourceName = (source: string) =>
-        source === 'openvex'
-            ? 'OpenVex'
-            : source === 'local_user_data'
-            ? 'Local User Data'
-            : source === 'yocto'
-            ? 'Yocto'
-            : source === 'grype'
-            ? 'Grype'
-            : source === 'cyclonedx'
-            ? 'CycloneDx'
-            : source === 'spdx3'
-            ? 'SPDX3'
-            : source === 'nvd_cpe'
-            ? 'NVD CPE'
-            : source === 'osv'
-            ? 'OSV'
-            : source;
-
-    const getOriginalSourceName = (displayName: string) =>
-        displayName === 'OpenVex'
-            ? 'openvex'
-            : displayName === 'Yocto'
-            ? 'yocto'
-            : displayName === 'Local User Data'
-            ? 'local_user_data'
-            : displayName === 'Grype'
-            ? 'grype'
-            : displayName === 'CycloneDx'
-            ? 'cyclonedx'
-            : displayName === 'SPDX3'
-            ? 'spdx3'
-            : displayName === 'NVD CPE'
-            ? 'nvd_cpe'
-            : displayName === 'OSV'
-            ? 'osv'
-            : displayName;
 
     const handleEditClick = useCallback((vuln: Vulnerability) => {
         const index = searchFilteredData.findIndex(v => v.id === vuln.id);
@@ -816,25 +760,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             cell: info => (
                 <div className="flex items-center justify-center h-full text-center">
                     {info.renderValue()
-                        ?.map((source: string) =>
-                            source === 'openvex'
-                                ? 'OpenVex'
-                                : source === 'local_user_data'
-                                ? 'Local User Data'
-                                : source === 'yocto'
-                                ? 'Yocto'
-                                : source === 'grype'
-                                ? 'Grype'
-                                : source === 'cyclonedx'
-                                ? 'CycloneDx'
-                                : source === 'spdx3'
-                                ? 'SPDX3'
-                                : source === 'nvd_cpe'
-                                ? 'NVD CPE'
-                                : source === 'osv'
-                                ? 'OSV'
-                                : source
-                        )
+                        ?.map(formatSourceName)
                         .join(', ')}
                 </div>
             ),

--- a/src/helpers/active_scans.py
+++ b/src/helpers/active_scans.py
@@ -1,0 +1,121 @@
+#
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Centralised helpers for determining which scans are "active".
+
+Every route that needs to scope its data to the current view (vulns,
+packages, findings, …) should use these functions instead of rolling
+their own logic.  This avoids subtle count differences between tabs.
+
+Active-scan strategy
+--------------------
+For a given variant the *active set* is:
+
+* The **latest SBOM scan**, plus
+* The **latest tool scan per source** (nvd, osv, …).
+
+This ensures that:
+  • Running an OSV enrichment doesn't hide NVD results.
+  • The count of vulnerabilities / packages is consistent across all
+    pages (Metrics, Vulnerabilities, Packages, Scan History).
+
+When querying by project the same logic is applied to *every* variant
+in the project.
+
+Active-package filtering
+------------------------
+Tool scans can reference packages that are no longer present in the
+latest SBOM.  ``active_package_ids_for_scans()`` returns the set of
+package IDs from the SBOM scans in the active set so that callers can
+optionally restrict tool-scan results to those packages.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from ..extensions import db
+from ..models.scan import Scan
+from ..models.variant import Variant
+from ..models.sbom_document import SBOMDocument
+from ..models.sbom_package import SBOMPackage
+
+
+# ------------------------------------------------------------------
+# Active scan IDs
+# ------------------------------------------------------------------
+
+def active_scan_ids_for_variant(variant_uuid: uuid.UUID) -> list:
+    """Return the active Scan IDs for *variant_uuid*.
+
+    ``[latest_sbom, latest_tool:nvd, latest_tool:osv, …]``
+    """
+    rows = db.session.execute(
+        db.select(Scan.id, Scan.scan_type, Scan.scan_source)
+        .where(Scan.variant_id == variant_uuid)
+        .order_by(Scan.timestamp.desc())
+    ).all()
+    ids: list = []
+    seen_keys: set = set()  # "sbom" or "tool:<source>"
+    for scan_id, scan_type, scan_source in rows:
+        st = scan_type or "sbom"
+        key = f"tool:{scan_source}" if st == "tool" else "sbom"
+        if key not in seen_keys:
+            seen_keys.add(key)
+            ids.append(scan_id)
+    return ids
+
+
+def active_scan_ids_for_project(project_uuid: uuid.UUID) -> list:
+    """Return the active Scan IDs for every variant in *project_uuid*."""
+    rows = db.session.execute(
+        db.select(Scan.id, Scan.variant_id, Scan.scan_type, Scan.scan_source, Scan.timestamp)
+        .join(Variant, Scan.variant_id == Variant.id)
+        .where(Variant.project_id == project_uuid)
+        .order_by(Scan.variant_id, Scan.timestamp.desc())
+    ).all()
+    ids: list = []
+    seen: dict = {}  # variant_id -> set of keys already picked
+    for scan_id, vid, scan_type, scan_source, _ts in rows:
+        st = scan_type or "sbom"
+        key = f"tool:{scan_source}" if st == "tool" else "sbom"
+        variant_seen = seen.setdefault(vid, set())
+        if key not in variant_seen:
+            variant_seen.add(key)
+            ids.append(scan_id)
+    return ids
+
+
+# ------------------------------------------------------------------
+# Active package IDs (from SBOM scans only)
+# ------------------------------------------------------------------
+
+def active_package_ids_for_scans(scan_ids: list) -> set:
+    """Return the set of package IDs present in the SBOM documents of *scan_ids*.
+
+    Packages listed by SBOM scans form the "active" package set.
+    Tool-scan findings for packages outside this set are stale
+    (the package was upgraded or removed) and should be excluded.
+    """
+    if not scan_ids:
+        return set()
+    # Filter to SBOM-type scans only
+    sbom_scan_ids = [
+        sid for (sid,) in db.session.execute(
+            db.select(Scan.id)
+            .where(Scan.id.in_(scan_ids))
+            .where(
+                db.or_(Scan.scan_type == "sbom", Scan.scan_type.is_(None))
+            )
+        ).all()
+    ]
+    if not sbom_scan_ids:
+        return set()
+    rows = db.session.execute(
+        db.select(SBOMPackage.package_id)
+        .join(SBOMDocument, SBOMDocument.id == SBOMPackage.sbom_document_id)
+        .where(SBOMDocument.scan_id.in_(sbom_scan_ids))
+        .distinct()
+    ).all()
+    return {r[0] for r in rows}

--- a/src/helpers/active_scans.py
+++ b/src/helpers/active_scans.py
@@ -88,6 +88,48 @@ def active_scan_ids_for_project(project_uuid: uuid.UUID) -> list:
 
 
 # ------------------------------------------------------------------
+# SBOM-only scan IDs (for package queries)
+# ------------------------------------------------------------------
+
+def active_sbom_scan_ids_for_variant(variant_uuid: uuid.UUID) -> list:
+    """Return only the SBOM-type scan ID(s) from the active set for *variant_uuid*.
+
+    Packages come exclusively from SBOM scans (tool scans don't create
+    SBOMDocuments), so the packages route should use this instead of
+    ``active_scan_ids_for_variant``.
+    """
+    rows = db.session.execute(
+        db.select(Scan.id, Scan.scan_type)
+        .where(Scan.variant_id == variant_uuid)
+        .where(db.or_(Scan.scan_type == "sbom", Scan.scan_type.is_(None)))
+        .order_by(Scan.timestamp.desc())
+        .limit(1)
+    ).all()
+    return [r[0] for r in rows]
+
+
+def active_sbom_scan_ids_for_project(project_uuid: uuid.UUID) -> list:
+    """Return only the SBOM-type scan ID(s) from the active set for *project_uuid*.
+
+    One latest SBOM scan per variant.
+    """
+    rows = db.session.execute(
+        db.select(Scan.id, Scan.variant_id, Scan.timestamp)
+        .join(Variant, Scan.variant_id == Variant.id)
+        .where(Variant.project_id == project_uuid)
+        .where(db.or_(Scan.scan_type == "sbom", Scan.scan_type.is_(None)))
+        .order_by(Scan.variant_id, Scan.timestamp.desc())
+    ).all()
+    ids: list = []
+    seen_variants: set = set()
+    for scan_id, vid, _ts in rows:
+        if vid not in seen_variants:
+            seen_variants.add(vid)
+            ids.append(scan_id)
+    return ids
+
+
+# ------------------------------------------------------------------
 # Active package IDs (from SBOM scans only)
 # ------------------------------------------------------------------
 

--- a/src/helpers/active_scans.py
+++ b/src/helpers/active_scans.py
@@ -99,7 +99,7 @@ def active_sbom_scan_ids_for_variant(variant_uuid: uuid.UUID) -> list:
     ``active_scan_ids_for_variant``.
     """
     rows = db.session.execute(
-        db.select(Scan.id, Scan.scan_type)
+        db.select(Scan.id)
         .where(Scan.variant_id == variant_uuid)
         .where(db.or_(Scan.scan_type == "sbom", Scan.scan_type.is_(None)))
         .order_by(Scan.timestamp.desc())

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -10,48 +10,10 @@ from ..models.variant import Variant
 from ..models.sbom_document import SBOMDocument
 from ..models.sbom_package import SBOMPackage
 from ..extensions import db
-
-
-def _latest_scan_id_for_variant(variant_uuid):
-    """Return the active Scan IDs for the given variant.
-
-    The current view is the union of the latest SBOM scan and the latest tool
-    scan (if any).  Returns a list of 0–2 scan IDs.
-    """
-    rows = db.session.execute(
-        db.select(Scan.id, Scan.scan_type)
-        .where(Scan.variant_id == variant_uuid)
-        .order_by(Scan.timestamp.desc())
-    ).all()
-    ids: list = []
-    seen_types: set = set()
-    for scan_id, scan_type in rows:
-        st = scan_type or "sbom"
-        if st not in seen_types:
-            seen_types.add(st)
-            ids.append(scan_id)
-        if len(seen_types) >= 2:
-            break
-    return ids
-
-
-def _latest_scan_ids_for_project(project_uuid):
-    """Return the active Scan IDs for each variant in the project."""
-    rows = db.session.execute(
-        db.select(Scan.id, Scan.variant_id, Scan.scan_type, Scan.timestamp)
-        .join(Variant, Scan.variant_id == Variant.id)
-        .where(Variant.project_id == project_uuid)
-        .order_by(Scan.variant_id, Scan.timestamp.desc())
-    ).all()
-    ids: list = []
-    seen: dict = {}
-    for scan_id, vid, scan_type, _ts in rows:
-        st = scan_type or "sbom"
-        variant_seen = seen.setdefault(vid, set())
-        if st not in variant_seen:
-            variant_seen.add(st)
-            ids.append(scan_id)
-    return ids
+from ..helpers.active_scans import (
+    active_scan_ids_for_variant,
+    active_scan_ids_for_project,
+)
 
 
 def init_app(app):
@@ -111,7 +73,7 @@ def init_app(app):
                 variant_uuid = uuid.UUID(variant_id)
             except ValueError:
                 return {"error": "Invalid variant_id"}, 400
-            latest_ids = _latest_scan_id_for_variant(variant_uuid)
+            latest_ids = active_scan_ids_for_variant(variant_uuid)
             if not latest_ids:
                 pkgs = []
             else:
@@ -132,7 +94,7 @@ def init_app(app):
                 project_uuid = uuid.UUID(project_id)
             except ValueError:
                 return {"error": "Invalid project_id"}, 400
-            latest_ids = _latest_scan_ids_for_project(project_uuid)
+            latest_ids = active_scan_ids_for_project(project_uuid)
             if not latest_ids:
                 pkgs = []
             else:

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -11,8 +11,8 @@ from ..models.sbom_document import SBOMDocument
 from ..models.sbom_package import SBOMPackage
 from ..extensions import db
 from ..helpers.active_scans import (
-    active_scan_ids_for_variant,
-    active_scan_ids_for_project,
+    active_sbom_scan_ids_for_variant,
+    active_sbom_scan_ids_for_project,
 )
 
 
@@ -73,15 +73,15 @@ def init_app(app):
                 variant_uuid = uuid.UUID(variant_id)
             except ValueError:
                 return {"error": "Invalid variant_id"}, 400
-            latest_ids = active_scan_ids_for_variant(variant_uuid)
-            if not latest_ids:
+            sbom_ids = active_sbom_scan_ids_for_variant(variant_uuid)
+            if not sbom_ids:
                 pkgs = []
             else:
                 pkg_ids_sub = (
                     db.select(Package.id)
                     .join(SBOMPackage, Package.id == SBOMPackage.package_id)
                     .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
-                    .where(SBOMDocument.scan_id.in_(latest_ids))
+                    .where(SBOMDocument.scan_id.in_(sbom_ids))
                     .distinct()
                 )
                 pkgs = list(db.session.execute(
@@ -94,15 +94,15 @@ def init_app(app):
                 project_uuid = uuid.UUID(project_id)
             except ValueError:
                 return {"error": "Invalid project_id"}, 400
-            latest_ids = active_scan_ids_for_project(project_uuid)
-            if not latest_ids:
+            sbom_ids = active_sbom_scan_ids_for_project(project_uuid)
+            if not sbom_ids:
                 pkgs = []
             else:
                 pkg_ids_sub = (
                     db.select(Package.id)
                     .join(SBOMPackage, Package.id == SBOMPackage.package_id)
                     .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
-                    .where(SBOMDocument.scan_id.in_(latest_ids))
+                    .where(SBOMDocument.scan_id.in_(sbom_ids))
                     .distinct()
                 )
                 pkgs = list(db.session.execute(

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -21,57 +21,13 @@ from ..models.sbom_document import SBOMDocument
 from ..models.sbom_package import SBOMPackage
 from ..extensions import db
 from ..helpers.verbose import verbose
+from ..helpers.active_scans import (
+    active_scan_ids_for_variant,
+    active_scan_ids_for_project,
+    active_package_ids_for_scans,
+)
 
 TIME_ESTIMATES_PATH = "/scan/outputs/time_estimates.json"
-
-
-def _latest_scan_id_for_variant(variant_uuid):
-    """Return the active Scan IDs for the given variant.
-
-    The current view is the union of the latest SBOM scan and the latest
-    tool scan **per source** (nvd, osv, grype, …).  This ensures that
-    running an OSV scan does not hide CVEs discovered by a previous NVD
-    scan.
-    """
-    rows = db.session.execute(
-        db.select(Scan.id, Scan.scan_type, Scan.scan_source)
-        .where(Scan.variant_id == variant_uuid)
-        .order_by(Scan.timestamp.desc())
-    ).all()
-    ids: list = []
-    seen_keys: set = set()  # "sbom" or "tool:<source>"
-    for scan_id, scan_type, scan_source in rows:
-        st = scan_type or "sbom"
-        key = f"tool:{scan_source}" if st == "tool" else "sbom"
-        if key not in seen_keys:
-            seen_keys.add(key)
-            ids.append(scan_id)
-    return ids
-
-
-def _latest_scan_ids_for_project(project_uuid):
-    """Return the active Scan IDs for each variant in the project.
-
-    For every variant the latest SBOM scan and the latest tool scan **per
-    source** (nvd, osv, grype, …) are included so the view =
-    latest SBOM ∪ latest tool scans from all sources.
-    """
-    rows = db.session.execute(
-        db.select(Scan.id, Scan.variant_id, Scan.scan_type, Scan.scan_source, Scan.timestamp)
-        .join(Variant, Scan.variant_id == Variant.id)
-        .where(Variant.project_id == project_uuid)
-        .order_by(Scan.variant_id, Scan.timestamp.desc())
-    ).all()
-    ids: list = []
-    seen: dict = {}  # variant_id -> set of keys already picked
-    for scan_id, vid, scan_type, scan_source, _ts in rows:
-        st = scan_type or "sbom"
-        key = f"tool:{scan_source}" if st == "tool" else "sbom"
-        variant_seen = seen.setdefault(vid, set())
-        if key not in variant_seen:
-            variant_seen.add(key)
-            ids.append(scan_id)
-    return ids
 
 
 def _parse_effort_hours(value) -> int:
@@ -95,35 +51,50 @@ _FORMAT_TO_FOUND_BY: dict[str, str] = {
     "yocto_cve_check": "yocto",
 }
 
+# Mapping from Scan.scan_source to the found_by string for tool scans
+_TOOL_SOURCE_TO_FOUND_BY: dict[str, str] = {
+    "nvd": "nvd_cpe",
+    "osv": "osv",
+}
+
 
 def _populate_found_by(
     records: list,
     variant_uuid=None,
     project_uuid=None,
 ) -> None:
-    """Populate the transient found_by list on each record from SBOMDocument.format.
+    """Populate the transient found_by list on each record.
 
-    Walks the Finding -> SBOMPackage -> SBOMDocument chain to discover which
-    SBOM document formats are linked to each vulnerability's affected packages,
-    then maps them to the legacy found_by strings consumed by the frontend chart.
+    Two complementary sources of attribution are combined:
 
-    Attribution logic to avoid false-positives from package-list SBOM files:
-    - ``grype`` and ``yocto_cve_check`` are dedicated scanners: they only list
-      packages that are affected by a vulnerability, so their presence is always
-      authoritative.
-    - ``spdx``, ``cdx``, ``openvex`` are dual-purpose (package list OR security
-      file): they are only attributed as a source for a given
-      (vulnerability, package) pair when NO dedicated scanner document also
-      contains that same package.  This prevents a plain SPDX package BOM from
-      being incorrectly credited as a vulnerability discovery source.
+    1. **SBOM documents** — walks Finding → SBOMPackage → SBOMDocument to
+       discover which SBOM-document formats are linked to each vulnerability's
+       affected packages, then maps them to the legacy found_by strings
+       consumed by the frontend chart.
 
-    When variant_uuid or project_uuid is provided, only SBOM documents
-    belonging to that variant or project are considered.
+       Attribution logic to avoid false-positives from package-list SBOM files:
+       - ``grype`` and ``yocto_cve_check`` are dedicated scanners: their
+         presence is always authoritative.
+       - ``spdx``, ``cdx``, ``openvex`` are dual-purpose: they are only
+         attributed when NO dedicated scanner document also contains that same
+         package.
+
+    2. **Tool scans** — walks Finding → Observation → Scan where
+       ``scan_type='tool'`` to discover enrichment sources (NVD CPE, OSV, …).
+       These scans create Observation records but no SBOMDocument, so they
+       must be queried separately.
+
+    When variant_uuid or project_uuid is provided, only data belonging to
+    that variant or project is considered.
     """
     if not records:
         return
 
     vuln_ids = [r.id for r in records]
+
+    # ------------------------------------------------------------------
+    # 1. SBOM-document attribution
+    # ------------------------------------------------------------------
 
     # Build the base query explicitly from Finding so that SBOMDocument does not
     # end up in the implicit FROM clause (which would happen if we referenced
@@ -151,12 +122,11 @@ def _populate_found_by(
             .where(Variant.project_id == project_uuid)
         )
     else:
-        base_query = base_query.where(Finding.vulnerability_id.in_(vuln_ids))  # no need for full query on all variants
+        base_query = base_query.where(Finding.vulnerability_id.in_(vuln_ids))
 
     rows = db.session.execute(base_query.distinct()).all()
 
     # Group collected formats by (vuln_id, package_id)
-    # pkg_formats: {(vuln_id, package_id): set of formats}
     pkg_formats: dict[tuple, set[str]] = {}
     for vuln_id, pkg_id, fmt in rows:
         key = (vuln_id, str(pkg_id))
@@ -166,12 +136,43 @@ def _populate_found_by(
     found_by_map: dict[str, set[str]] = {}
     for (vuln_id, _pkg_id), formats in pkg_formats.items():
         dedicated = formats & _DEDICATED_SCANNER_FORMATS
-        # Only use dedicated scanners when present; fall back to all formats otherwise
         sources = dedicated if dedicated else formats
         for fmt in sources:
             mapped = _FORMAT_TO_FOUND_BY.get(fmt, fmt)
             found_by_map.setdefault(vuln_id, set()).add(mapped)
 
+    # ------------------------------------------------------------------
+    # 2. Tool-scan attribution (NVD CPE, OSV, …)
+    # ------------------------------------------------------------------
+    tool_query = (
+        db.select(Finding.vulnerability_id, Scan.scan_source)
+        .select_from(Finding)
+        .join(Observation, Finding.id == Observation.finding_id)
+        .join(Scan, Observation.scan_id == Scan.id)
+        .where(Scan.scan_type == "tool")
+        .where(Scan.scan_source.isnot(None))
+    )
+
+    if variant_uuid is not None:
+        tool_query = tool_query.where(Scan.variant_id == variant_uuid)
+    elif project_uuid is not None:
+        tool_query = (
+            tool_query
+            .join(Variant, Variant.id == Scan.variant_id)
+            .where(Variant.project_id == project_uuid)
+        )
+    else:
+        tool_query = tool_query.where(Finding.vulnerability_id.in_(vuln_ids))
+
+    tool_rows = db.session.execute(tool_query.distinct()).all()
+
+    for vuln_id, scan_source in tool_rows:
+        mapped = _TOOL_SOURCE_TO_FOUND_BY.get(scan_source, scan_source)
+        found_by_map.setdefault(vuln_id, set()).add(mapped)
+
+    # ------------------------------------------------------------------
+    # Apply found_by to records
+    # ------------------------------------------------------------------
     for record in records:
         for scanner in found_by_map.get(record.id, set()):
             record.add_found_by(scanner)
@@ -194,8 +195,8 @@ def init_app(app):
                 compare_uuid = uuid.UUID(compare_variant_id)
             except ValueError:
                 return {"error": "Invalid variant_id or compare_variant_id"}, 400
-            base_latest_ids = _latest_scan_id_for_variant(base_uuid)
-            compare_latest_ids = _latest_scan_id_for_variant(compare_uuid)
+            base_latest_ids = active_scan_ids_for_variant(base_uuid)
+            compare_latest_ids = active_scan_ids_for_variant(compare_uuid)
             current_scan_ids = compare_latest_ids
             _scope_variant = compare_uuid
             _scope_project = None
@@ -204,28 +205,36 @@ def init_app(app):
                 selectinload(Vulnerability.findings).selectinload(Finding.time_estimate),
                 selectinload(Vulnerability.metrics),
             )
-            if not base_latest_ids:
-                base_ids = set()
-            else:
-                base_ids = set(db.session.execute(
+
+            def _vuln_ids_for_scans(scan_ids):
+                """Vuln IDs from *scan_ids*, filtering tool scans to active packages."""
+                if not scan_ids:
+                    return set()
+                _pkg_ids = active_package_ids_for_scans(scan_ids)
+                q = (
                     db.select(Vulnerability.id)
                     .join(Finding, Vulnerability.id == Finding.vulnerability_id)
                     .join(Observation, Finding.id == Observation.finding_id)
-                    .where(Observation.scan_id.in_(base_latest_ids))
-                    .distinct()
-                ).scalars().all())
+                    .join(Scan, Observation.scan_id == Scan.id)
+                    .where(Observation.scan_id.in_(scan_ids))
+                )
+                if _pkg_ids:
+                    q = q.where(
+                        db.or_(
+                            Scan.scan_type.is_(None),
+                            Scan.scan_type == "sbom",
+                            Finding.package_id.in_(_pkg_ids),
+                        )
+                    )
+                return set(db.session.execute(q.distinct()).scalars().all())
+
+            base_ids = _vuln_ids_for_scans(base_latest_ids)
             operation = request.args.get('operation', 'difference')
             if operation == 'intersection':
                 if not compare_latest_ids:
                     records = []
                 else:
-                    compare_ids = set(db.session.execute(
-                        db.select(Vulnerability.id)
-                        .join(Finding, Vulnerability.id == Finding.vulnerability_id)
-                        .join(Observation, Finding.id == Observation.finding_id)
-                        .where(Observation.scan_id.in_(compare_latest_ids))
-                        .distinct()
-                    ).scalars().all())
+                    compare_ids = _vuln_ids_for_scans(compare_latest_ids)
                     intersection_ids = list(base_ids & compare_ids)
                     records = list(db.session.execute(
                         db.select(Vulnerability)
@@ -237,15 +246,24 @@ def init_app(app):
                 if not compare_latest_ids:
                     records = []
                 else:
+                    compare_pkg_ids = active_package_ids_for_scans(compare_latest_ids)
                     query = (
                         db.select(Vulnerability)
                         .options(*opts)
                         .join(Finding, Vulnerability.id == Finding.vulnerability_id)
                         .join(Observation, Finding.id == Observation.finding_id)
+                        .join(Scan, Observation.scan_id == Scan.id)
                         .where(Observation.scan_id.in_(compare_latest_ids))
-                        .distinct()
-                        .order_by(Vulnerability.id)
                     )
+                    if compare_pkg_ids:
+                        query = query.where(
+                            db.or_(
+                                Scan.scan_type.is_(None),
+                                Scan.scan_type == "sbom",
+                                Finding.package_id.in_(compare_pkg_ids),
+                            )
+                        )
+                    query = query.distinct().order_by(Vulnerability.id)
                     if base_ids:
                         query = query.where(~Vulnerability.id.in_(list(base_ids)))
                     records = list(db.session.execute(query).scalars().all())
@@ -256,11 +274,24 @@ def init_app(app):
                 return {"error": "Invalid variant_id"}, 400
             _scope_variant = variant_uuid
             _scope_project = None
-            latest_ids = _latest_scan_id_for_variant(variant_uuid)
+            latest_ids = active_scan_ids_for_variant(variant_uuid)
             current_scan_ids = latest_ids
             if not latest_ids:
                 records = []
             else:
+                # Restrict tool-scan findings to packages still in the SBOM
+                _active_pkg_ids = active_package_ids_for_scans(latest_ids)
+                _obs_filter = Observation.scan_id.in_(latest_ids)
+                if _active_pkg_ids:
+                    # Include observation when: SBOM scan, OR package in SBOM
+                    _obs_filter = db.and_(
+                        _obs_filter,
+                        db.or_(
+                            Scan.scan_type.is_(None),
+                            Scan.scan_type == "sbom",
+                            Finding.package_id.in_(_active_pkg_ids),
+                        ),
+                    )
                 records = list(db.session.execute(
                     db.select(Vulnerability)
                     .options(
@@ -270,7 +301,8 @@ def init_app(app):
                     )
                     .join(Finding, Vulnerability.id == Finding.vulnerability_id)
                     .join(Observation, Finding.id == Observation.finding_id)
-                    .where(Observation.scan_id.in_(latest_ids))
+                    .join(Scan, Observation.scan_id == Scan.id)
+                    .where(_obs_filter)
                     .distinct()
                     .order_by(Vulnerability.id)
                 ).scalars().all())
@@ -281,7 +313,7 @@ def init_app(app):
                 return {"error": "Invalid project_id"}, 400
             _scope_variant = None
             _scope_project = project_uuid
-            latest_ids = _latest_scan_ids_for_project(project_uuid)
+            latest_ids = active_scan_ids_for_project(project_uuid)
             current_scan_ids = latest_ids
             if not latest_ids:
                 records = []
@@ -290,13 +322,23 @@ def init_app(app):
 
                 # Subquery for vulnerability IDs visible in these scans,
                 # used to avoid huge literal IN-lists in secondary queries.
-                vuln_ids_subq = (
+                # Restrict tool-scan findings to packages still in the SBOM.
+                _active_pkg_ids = active_package_ids_for_scans(latest_ids)
+                vuln_ids_base = (
                     db.select(Finding.vulnerability_id)
                     .join(Observation, Finding.id == Observation.finding_id)
+                    .join(Scan, Observation.scan_id == Scan.id)
                     .where(Observation.scan_id.in_(latest_ids))
-                    .distinct()
-                    .scalar_subquery()
                 )
+                if _active_pkg_ids:
+                    vuln_ids_base = vuln_ids_base.where(
+                        db.or_(
+                            Scan.scan_type.is_(None),
+                            Scan.scan_type == "sbom",
+                            Finding.package_id.in_(_active_pkg_ids),
+                        )
+                    )
+                vuln_ids_subq = vuln_ids_base.distinct().scalar_subquery()
 
                 records = list(db.session.execute(
                     db.select(Vulnerability)
@@ -399,9 +441,9 @@ def init_app(app):
                 # Fallback (no variant/project scope): compute active scans
                 # for every variant using the same multi-source logic.
                 if _scope_variant is not None:
-                    active_scan_ids = _latest_scan_id_for_variant(_scope_variant)
+                    active_scan_ids = active_scan_ids_for_variant(_scope_variant)
                 elif _scope_project is not None:
-                    active_scan_ids = _latest_scan_ids_for_project(_scope_project)
+                    active_scan_ids = active_scan_ids_for_project(_scope_project)
                 else:
                     # All variants across all projects
                     all_variant_ids = [
@@ -411,7 +453,7 @@ def init_app(app):
                     ]
                     active_scan_ids = []
                     for vid in all_variant_ids:
-                        active_scan_ids.extend(_latest_scan_id_for_variant(vid))
+                        active_scan_ids.extend(active_scan_ids_for_variant(vid))
             if active_scan_ids:
                 rows = db.session.execute(
                     db.select(Finding.vulnerability_id, Variant.name)

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -18,7 +18,6 @@ from ..models.metrics import Metrics
 from ..models.cvss import CVSS
 from ..models.iso8601_duration import Iso8601Duration
 from ..models.sbom_document import SBOMDocument
-from ..models.sbom_package import SBOMPackage
 from ..extensions import db
 from ..helpers.verbose import verbose
 from ..helpers.active_scans import (

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -66,119 +66,82 @@ def _populate_found_by(
 ) -> None:
     """Populate the transient found_by list on each record.
 
-    Two complementary sources of attribution are combined:
-
-    1. **SBOM documents** — walks Finding → SBOMPackage → SBOMDocument to
-       discover which SBOM-document formats are linked to each vulnerability's
-       affected packages, then maps them to the legacy found_by strings
-       consumed by the frontend chart.
-
-       Attribution logic to avoid false-positives from package-list SBOM files:
-       - ``grype`` and ``yocto_cve_check`` are dedicated scanners: their
-         presence is always authoritative.
-       - ``spdx``, ``cdx``, ``openvex`` are dual-purpose: they are only
-         attributed when NO dedicated scanner document also contains that same
-         package.
-
-    2. **Tool scans** — walks Finding → Observation → Scan where
-       ``scan_type='tool'`` to discover enrichment sources (NVD CPE, OSV, …).
-       These scans create Observation records but no SBOMDocument, so they
-       must be queried separately.
-
-    When *active_scan_ids* is provided the queries are scoped to exactly
-    those scans — this prevents historical scan data from leaking into the
-    attribution (e.g. an old grype scan incorrectly claiming credit for
-    vulnerabilities actually discovered via a newer SPDX import).
-
-    Otherwise variant_uuid / project_uuid are used as a broader scope.
+    For each vulnerability, find the **earliest** scan that first observed
+    it and attribute it to that scan's source (SBOMDocument format or
+    tool scan_source).  The first scan that introduced a CVE gets credit.
     """
     if not records:
         return
 
     vuln_ids = [r.id for r in records]
 
-    # ------------------------------------------------------------------
-    # 1. SBOM-document attribution
-    # ------------------------------------------------------------------
+    # For every vuln, get the scan that first observed it (min timestamp).
+    first_scan_subq = (
+        db.select(
+            Finding.vulnerability_id,
+            func.min(Scan.timestamp).label("min_ts"),
+        )
+        .join(Observation, Observation.finding_id == Finding.id)
+        .join(Scan, Scan.id == Observation.scan_id)
+        .where(Finding.vulnerability_id.in_(vuln_ids))
+        .group_by(Finding.vulnerability_id)
+    ).subquery()
 
-    base_query = (
-        db.select(Finding.vulnerability_id, Finding.package_id, SBOMDocument.format)
+    # Now join back to get the scan details for that earliest observation.
+    rows = db.session.execute(
+        db.select(
+            Finding.vulnerability_id,
+            Scan.scan_type,
+            Scan.scan_source,
+            SBOMDocument.format.label("doc_format"),
+        )
         .select_from(Finding)
-        .join(SBOMPackage, SBOMPackage.package_id == Finding.package_id)
-        .join(SBOMDocument, SBOMDocument.id == SBOMPackage.sbom_document_id)
-        .where(SBOMDocument.format.isnot(None))
-    )
-
-    if active_scan_ids:
-        # Scope to the exact active scans — most precise
-        base_query = base_query.where(SBOMDocument.scan_id.in_(active_scan_ids))
-    elif variant_uuid is not None:
-        base_query = (
-            base_query
-            .join(Scan, Scan.id == SBOMDocument.scan_id)
-            .where(Scan.variant_id == variant_uuid)
+        .join(Observation, Observation.finding_id == Finding.id)
+        .join(Scan, Scan.id == Observation.scan_id)
+        .join(
+            first_scan_subq,
+            db.and_(
+                first_scan_subq.c.vulnerability_id == Finding.vulnerability_id,
+                first_scan_subq.c.min_ts == Scan.timestamp,
+            ),
         )
-    elif project_uuid is not None:
-        base_query = (
-            base_query
-            .join(Scan, Scan.id == SBOMDocument.scan_id)
-            .join(Variant, Variant.id == Scan.variant_id)
-            .where(Variant.project_id == project_uuid)
+        .outerjoin(
+            SBOMDocument,
+            db.and_(
+                SBOMDocument.scan_id == Scan.id,
+                SBOMDocument.format.isnot(None),
+            ),
         )
-    else:
-        base_query = base_query.where(Finding.vulnerability_id.in_(vuln_ids))
+        .distinct()
+    ).all()
 
-    rows = db.session.execute(base_query.distinct()).all()
+    # When a scan has multiple SBOMDocuments (e.g. spdx + grype in same
+    # merge), collect all formats and prefer non-dedicated scanner formats
+    # (spdx, cdx) over dedicated ones (grype) for attribution.
+    vuln_formats: dict[str, dict] = {}
+    for vuln_id, scan_type, scan_source, doc_format in rows:
+        entry = vuln_formats.setdefault(vuln_id, {
+            "doc_formats": set(),
+            "scan_type": scan_type,
+            "scan_source": scan_source,
+        })
+        if doc_format is not None:
+            entry["doc_formats"].add(doc_format)
 
-    # Group collected formats by (vuln_id, package_id)
-    pkg_formats: dict[tuple, set[str]] = {}
-    for vuln_id, pkg_id, fmt in rows:
-        key = (vuln_id, str(pkg_id))
-        pkg_formats.setdefault(key, set()).add(fmt)
-
-    # Determine the sources to attribute for each vulnerability
     found_by_map: dict[str, set[str]] = {}
-    for (vuln_id, _pkg_id), formats in pkg_formats.items():
-        dedicated = formats & _DEDICATED_SCANNER_FORMATS
-        sources = dedicated if dedicated else formats
-        for fmt in sources:
-            mapped = _FORMAT_TO_FOUND_BY.get(fmt, fmt)
+    for vuln_id, entry in vuln_formats.items():
+        doc_formats = entry["doc_formats"]
+        if doc_formats:
+            # Prefer non-dedicated (spdx, cdx, openvex) over dedicated (grype, yocto)
+            non_dedicated = doc_formats - _DEDICATED_SCANNER_FORMATS
+            chosen = non_dedicated if non_dedicated else doc_formats
+            for fmt in chosen:
+                mapped = _FORMAT_TO_FOUND_BY.get(fmt, fmt)
+                found_by_map.setdefault(vuln_id, set()).add(mapped)
+        elif entry["scan_source"] is not None:
+            mapped = _TOOL_SOURCE_TO_FOUND_BY.get(entry["scan_source"], entry["scan_source"])
             found_by_map.setdefault(vuln_id, set()).add(mapped)
 
-    # ------------------------------------------------------------------
-    # 2. Tool-scan attribution (NVD CPE, OSV, …)
-    # ------------------------------------------------------------------
-    tool_query = (
-        db.select(Finding.vulnerability_id, Scan.scan_source)
-        .select_from(Finding)
-        .join(Observation, Finding.id == Observation.finding_id)
-        .join(Scan, Observation.scan_id == Scan.id)
-        .where(Scan.scan_type == "tool")
-        .where(Scan.scan_source.isnot(None))
-    )
-
-    if active_scan_ids:
-        tool_query = tool_query.where(Observation.scan_id.in_(active_scan_ids))
-    elif variant_uuid is not None:
-        tool_query = tool_query.where(Scan.variant_id == variant_uuid)
-    elif project_uuid is not None:
-        tool_query = (
-            tool_query
-            .join(Variant, Variant.id == Scan.variant_id)
-            .where(Variant.project_id == project_uuid)
-        )
-    else:
-        tool_query = tool_query.where(Finding.vulnerability_id.in_(vuln_ids))
-
-    tool_rows = db.session.execute(tool_query.distinct()).all()
-
-    for vuln_id, scan_source in tool_rows:
-        mapped = _TOOL_SOURCE_TO_FOUND_BY.get(scan_source, scan_source)
-        found_by_map.setdefault(vuln_id, set()).add(mapped)
-
-    # ------------------------------------------------------------------
-    # Apply found_by to records
-    # ------------------------------------------------------------------
     for record in records:
         for scanner in found_by_map.get(record.id, set()):
             record.add_found_by(scanner)

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -247,19 +247,7 @@ def init_app(app):
             if not latest_ids:
                 records = []
             else:
-                # Restrict tool-scan findings to packages still in the SBOM
-                _active_pkg_ids = active_package_ids_for_scans(latest_ids)
                 _obs_filter = Observation.scan_id.in_(latest_ids)
-                if _active_pkg_ids:
-                    # Include observation when: SBOM scan, OR package in SBOM
-                    _obs_filter = db.and_(
-                        _obs_filter,
-                        db.or_(
-                            Scan.scan_type.is_(None),
-                            Scan.scan_type == "sbom",
-                            Finding.package_id.in_(_active_pkg_ids),
-                        ),
-                    )
                 records = list(db.session.execute(
                     db.select(Vulnerability)
                     .options(
@@ -269,7 +257,6 @@ def init_app(app):
                     )
                     .join(Finding, Vulnerability.id == Finding.vulnerability_id)
                     .join(Observation, Finding.id == Observation.finding_id)
-                    .join(Scan, Observation.scan_id == Scan.id)
                     .where(_obs_filter)
                     .distinct()
                     .order_by(Vulnerability.id)
@@ -290,22 +277,11 @@ def init_app(app):
 
                 # Subquery for vulnerability IDs visible in these scans,
                 # used to avoid huge literal IN-lists in secondary queries.
-                # Restrict tool-scan findings to packages still in the SBOM.
-                _active_pkg_ids = active_package_ids_for_scans(latest_ids)
                 vuln_ids_base = (
                     db.select(Finding.vulnerability_id)
                     .join(Observation, Finding.id == Observation.finding_id)
-                    .join(Scan, Observation.scan_id == Scan.id)
                     .where(Observation.scan_id.in_(latest_ids))
                 )
-                if _active_pkg_ids:
-                    vuln_ids_base = vuln_ids_base.where(
-                        db.or_(
-                            Scan.scan_type.is_(None),
-                            Scan.scan_type == "sbom",
-                            Finding.package_id.in_(_active_pkg_ids),
-                        )
-                    )
                 vuln_ids_subq = vuln_ids_base.distinct().scalar_subquery()
 
                 records = list(db.session.execute(

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -62,6 +62,7 @@ def _populate_found_by(
     records: list,
     variant_uuid=None,
     project_uuid=None,
+    active_scan_ids: list | None = None,
 ) -> None:
     """Populate the transient found_by list on each record.
 
@@ -84,8 +85,12 @@ def _populate_found_by(
        These scans create Observation records but no SBOMDocument, so they
        must be queried separately.
 
-    When variant_uuid or project_uuid is provided, only data belonging to
-    that variant or project is considered.
+    When *active_scan_ids* is provided the queries are scoped to exactly
+    those scans — this prevents historical scan data from leaking into the
+    attribution (e.g. an old grype scan incorrectly claiming credit for
+    vulnerabilities actually discovered via a newer SPDX import).
+
+    Otherwise variant_uuid / project_uuid are used as a broader scope.
     """
     if not records:
         return
@@ -96,10 +101,6 @@ def _populate_found_by(
     # 1. SBOM-document attribution
     # ------------------------------------------------------------------
 
-    # Build the base query explicitly from Finding so that SBOMDocument does not
-    # end up in the implicit FROM clause (which would happen if we referenced
-    # SBOMDocument.format without select_from(), causing a cartesian product or
-    # a silent no-op when the second .join(SBOMDocument) is evaluated).
     base_query = (
         db.select(Finding.vulnerability_id, Finding.package_id, SBOMDocument.format)
         .select_from(Finding)
@@ -108,7 +109,10 @@ def _populate_found_by(
         .where(SBOMDocument.format.isnot(None))
     )
 
-    if variant_uuid is not None:
+    if active_scan_ids:
+        # Scope to the exact active scans — most precise
+        base_query = base_query.where(SBOMDocument.scan_id.in_(active_scan_ids))
+    elif variant_uuid is not None:
         base_query = (
             base_query
             .join(Scan, Scan.id == SBOMDocument.scan_id)
@@ -153,7 +157,9 @@ def _populate_found_by(
         .where(Scan.scan_source.isnot(None))
     )
 
-    if variant_uuid is not None:
+    if active_scan_ids:
+        tool_query = tool_query.where(Observation.scan_id.in_(active_scan_ids))
+    elif variant_uuid is not None:
         tool_query = tool_query.where(Scan.variant_id == variant_uuid)
     elif project_uuid is not None:
         tool_query = (
@@ -407,7 +413,8 @@ def init_app(app):
             records = Vulnerability.get_all()
             _scope_variant = None
             _scope_project = None
-        _populate_found_by(records, _scope_variant, _scope_project)
+        _populate_found_by(records, _scope_variant, _scope_project,
+                           active_scan_ids=current_scan_ids or None)
         vulns = [r.to_dict() for r in records]
 
         vuln_ids = [v["id"] for v in vulns]

--- a/tests/webapp_tests/__init__.py
+++ b/tests/webapp_tests/__init__.py
@@ -20,6 +20,7 @@ def setup_demo_db(app):
     from src.models.scan import Scan
     from src.models.sbom_document import SBOMDocument
     from src.models.sbom_package import SBOMPackage
+    from src.models.observation import Observation
 
     with app.app_context():
         db.drop_all()
@@ -97,6 +98,7 @@ def setup_demo_db(app):
         )
         db.session.add(sbom_doc)
         db.session.add(SBOMPackage(sbom_document_id=sbom_doc.id, package_id=pkg.id))
+        db.session.add(Observation(finding_id=finding.id, scan_id=scan.id))
         db.session.commit()
 
 

--- a/tests/webapp_tests/test_variant_features.py
+++ b/tests/webapp_tests/test_variant_features.py
@@ -174,22 +174,24 @@ def test_list_all_variants_multiple_projects(app_with_variants, init_files):
 # ---------------------------------------------------------------------------
 
 def test_variants_by_vuln_no_observations(client):
-    """CVE with a finding but no observations → no variants linked."""
+    """CVE with a finding and the demo observation → only the demo variant."""
     response = client.get("/api/vulnerabilities/CVE-2020-35492/variants")
     assert response.status_code == 200
     data = json.loads(response.data)
-    assert data == []
+    # setup_demo_db creates one observation linking to the "default" variant
+    assert len(data) == 1
+    assert data[0]["name"] == "default"
 
 
 def test_variants_by_vuln_returns_linked_variants(client_with_variants):
-    """Both variants observed for CVE-2020-35492 are returned."""
+    """All three variants observed for CVE-2020-35492 are returned (demo + a + b)."""
     response = client_with_variants.get("/api/vulnerabilities/CVE-2020-35492/variants")
     assert response.status_code == 200
     data = json.loads(response.data)
     assert isinstance(data, list)
-    assert len(data) == 2
+    assert len(data) == 3
     names = {v["name"] for v in data}
-    assert names == {"variant-a", "variant-b"}
+    assert names == {"default", "variant-a", "variant-b"}
 
 
 def test_variants_by_vuln_fields(client_with_variants):

--- a/tests/webapp_tests/test_vulnerabilities_coverage.py
+++ b/tests/webapp_tests/test_vulnerabilities_coverage.py
@@ -669,3 +669,226 @@ def test_patch_batch_vulnerability_effort_invalid_variant_id(client):
     assert data["error_count"] >= 1
     assert any("variant_id" in str(e).lower() or "invalid" in str(e).lower()
                for e in data["errors"])
+
+
+# ---------------------------------------------------------------------------
+# _populate_found_by: non-dedicated format (SPDX) and tool-source paths
+# ---------------------------------------------------------------------------
+
+def test_found_by_spdx_format(app, client):
+    """When earliest scan has an SPDX SBOMDocument, found_by should contain 'spdx3'."""
+    from src.extensions import db
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.observation import Observation
+    from src.models.finding import Finding
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.sbom_package import SBOMPackage
+    from datetime import datetime, timezone
+
+    with app.app_context():
+        # Create an alternate package & vulnerability
+        pkg = Package.find_or_create("spdx-test-pkg", "2.0.0", [], [], "")
+        db.session.commit()
+        vuln = Vulnerability.create_record(
+            id="CVE-SPDX-0001",
+            description="Test vuln for spdx found_by path",
+            status="medium",
+        )
+        db.session.commit()
+        finding = Finding.get_or_create(pkg.id, "CVE-SPDX-0001")
+
+        # Create a scan with a SPDX SBOMDocument (non-dedicated format)
+        import uuid as _uuid
+        scan = Scan(
+            id=_uuid.uuid4(),
+            variant_id=_uuid.UUID("22222222-2222-2222-2222-222222222222"),
+            timestamp=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        )
+        db.session.add(scan)
+        spdx_doc = SBOMDocument(
+            id=_uuid.uuid4(),
+            path="/demo/spdx.spdx.json",
+            source_name="spdx.spdx.json",
+            format="spdx",
+            scan_id=scan.id,
+        )
+        db.session.add(spdx_doc)
+        db.session.add(SBOMPackage(sbom_document_id=spdx_doc.id, package_id=pkg.id))
+        db.session.add(Observation(finding_id=finding.id, scan_id=scan.id))
+        db.session.commit()
+
+    # Query the vulnerability through the API
+    response = client.get("/api/vulnerabilities")
+    data = json.loads(response.data)
+    spdx_vuln = next((v for v in data if v["id"] == "CVE-SPDX-0001"), None)
+    assert spdx_vuln is not None
+    assert "spdx3" in spdx_vuln["found_by"]
+
+
+def test_found_by_tool_scan_nvd(app, client):
+    """When earliest scan is a tool scan with scan_source='nvd', found_by should contain 'nvd_cpe'."""
+    from src.extensions import db
+    from src.models.scan import Scan
+    from src.models.observation import Observation
+    from src.models.finding import Finding
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from datetime import datetime, timezone
+
+    with app.app_context():
+        pkg = Package.find_or_create("nvd-test-pkg", "3.0.0", [], [], "")
+        db.session.commit()
+        vuln = Vulnerability.create_record(
+            id="CVE-NVD-0001",
+            description="Test vuln for NVD tool scan path",
+            status="low",
+        )
+        db.session.commit()
+        finding = Finding.get_or_create(pkg.id, "CVE-NVD-0001")
+
+        import uuid as _uuid
+        scan = Scan(
+            id=_uuid.uuid4(),
+            variant_id=_uuid.UUID("22222222-2222-2222-2222-222222222222"),
+            scan_type="tool",
+            scan_source="nvd",
+            timestamp=datetime(2019, 1, 1, tzinfo=timezone.utc),
+        )
+        db.session.add(scan)
+        db.session.add(Observation(finding_id=finding.id, scan_id=scan.id))
+        db.session.commit()
+
+    response = client.get("/api/vulnerabilities")
+    data = json.loads(response.data)
+    nvd_vuln = next((v for v in data if v["id"] == "CVE-NVD-0001"), None)
+    assert nvd_vuln is not None
+    assert "nvd_cpe" in nvd_vuln["found_by"]
+
+
+def test_found_by_mixed_formats_prefers_non_dedicated(app, client):
+    """When a scan has both spdx + grype docs, found_by should prefer the non-dedicated (spdx) format."""
+    from src.extensions import db
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.observation import Observation
+    from src.models.finding import Finding
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.sbom_package import SBOMPackage
+    from datetime import datetime, timezone
+
+    with app.app_context():
+        pkg = Package.find_or_create("mixed-test-pkg", "4.0.0", [], [], "")
+        db.session.commit()
+        vuln = Vulnerability.create_record(
+            id="CVE-MIXED-0001",
+            description="Test vuln for mixed format preference",
+            status="high",
+        )
+        db.session.commit()
+        finding = Finding.get_or_create(pkg.id, "CVE-MIXED-0001")
+
+        import uuid as _uuid
+        scan = Scan(
+            id=_uuid.uuid4(),
+            variant_id=_uuid.UUID("22222222-2222-2222-2222-222222222222"),
+            timestamp=datetime(2018, 1, 1, tzinfo=timezone.utc),
+        )
+        db.session.add(scan)
+        # Two docs in the same scan: spdx + grype
+        spdx_doc = SBOMDocument(
+            id=_uuid.uuid4(), path="/demo/spdx.json", source_name="spdx.json",
+            format="spdx", scan_id=scan.id,
+        )
+        grype_doc = SBOMDocument(
+            id=_uuid.uuid4(), path="/demo/grype.json", source_name="grype.json",
+            format="grype", scan_id=scan.id,
+        )
+        db.session.add(spdx_doc)
+        db.session.add(grype_doc)
+        db.session.add(SBOMPackage(sbom_document_id=spdx_doc.id, package_id=pkg.id))
+        db.session.add(SBOMPackage(sbom_document_id=grype_doc.id, package_id=pkg.id))
+        db.session.add(Observation(finding_id=finding.id, scan_id=scan.id))
+        db.session.commit()
+
+    response = client.get("/api/vulnerabilities")
+    data = json.loads(response.data)
+    mixed_vuln = next((v for v in data if v["id"] == "CVE-MIXED-0001"), None)
+    assert mixed_vuln is not None
+    # Should prefer spdx (non-dedicated) over grype (dedicated)
+    assert "spdx3" in mixed_vuln["found_by"]
+    assert "grype" not in mixed_vuln["found_by"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/vulnerabilities — variant/project with no scans → empty list
+# ---------------------------------------------------------------------------
+
+def test_get_vulns_variant_no_scans(app, client):
+    """GET with variant_id of a variant that has no scans returns []."""
+    from src.extensions import db
+    from src.models.project import Project
+    from src.models.variant import Variant
+    import uuid as _uuid
+
+    with app.app_context():
+        project = Project.create("NoScanProject")
+        variant = Variant.create("noscan-variant", project.id)
+        vid = str(variant.id)
+    response = client.get(f"/api/vulnerabilities?variant_id={vid}")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data == []
+
+
+def test_get_vulns_project_no_scans(app, client):
+    """GET with project_id of a project that has no scans returns []."""
+    from src.extensions import db
+    from src.models.project import Project
+    import uuid as _uuid
+
+    with app.app_context():
+        project = Project.create("NoScanProject2")
+        pid = str(project.id)
+    response = client.get(f"/api/vulnerabilities?project_id={pid}")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data == []
+
+
+# ---------------------------------------------------------------------------
+# GET /api/vulnerabilities?project_id=... (with data — covers bulk-load paths)
+# ---------------------------------------------------------------------------
+
+def test_get_vulns_by_project_id_with_data(app, client):
+    """GET with a valid project_id that has scans returns vulns with metrics/packages/effort."""
+    # The demo project "11111111..." has a scan with a CVE
+    pid = "11111111-1111-1111-1111-111111111111"
+    response = client.get(f"/api/vulnerabilities?project_id={pid}")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    vuln = data[0]
+    assert "id" in vuln
+    assert "packages" in vuln
+    assert "severity" in vuln
+
+
+# ---------------------------------------------------------------------------
+# GET /api/vulnerabilities (no scope) — covers fallback scope
+# ---------------------------------------------------------------------------
+
+def test_get_vulns_global_no_scope(client):
+    """GET without variant_id or project_id returns all vulns (fallback)."""
+    response = client.get("/api/vulnerabilities")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    # Check enrichment fields
+    vuln = data[0]
+    assert "variants" in vuln
+    assert "first_scan_date" in vuln


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

- Each tab reinvented the wheel calculating actives elements Packages/Findings/Vulnerabilities which leads to a lot of inconsistency. Set a new common mechanism `src/helpers/active_scans.py`. 

- Update the Metrics tab to fix the graph `Vulnerabilities by Database` with the new Scan types `OSV` and `NVD CPE`

- Update the Vulnerability tab to fix the filter `Source` to add the new Scan types `OSV` and `NVD CPE`.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Perform various scans/SBOM imports and look at the results provided on `Scan Result:` in `Scan` tab. The other tabs should be consistent with it.