### PR TITLE
fix: Remove the unknown URL

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -878,7 +878,7 @@ type AssessmentGroup = {
                         <div className="mb-6 mt-6">
                             <h3 className="font-bold mb-2">Links</h3>
                             <ul>
-                                {[...new Set([vuln.datasource, ...vuln.urls])].map(url => (
+                                {vuln.urls.map(url => (
                                     <li key={encodeURIComponent(url)}><a className="underline" href={encodeURI(url)} target="_blank">{url}</a></li>
                                 ))}
                             </ul>

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -106,17 +106,17 @@ describe('Vulnerability Modal', () => {
         expect(desc).toBeInTheDocument();
     })
 
-    test('render urls and datasource', async () => {
+    test('render urls without datasource', async () => {
         // ARRANGE
         render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         // ACT
-        const datasource = await screen.getByText(/nvd\.nist\.gov\/vuln\/detail\/CVE-2010-1234/i);
         const url = await screen.getByText(/security-tracker\.debian\.org\/tracker\/CVE-2010-1234/i);
 
         // ASSERT
-        expect(datasource).toBeInTheDocument();
         expect(url).toBeInTheDocument();
+        // datasource is metadata, not a link — it should NOT appear in the Links section
+        expect(screen.queryByText(/nvd\.nist\.gov\/vuln\/detail\/CVE-2010-1234/i)).not.toBeInTheDocument();
     })
 
     test('render efforts estimations', async () => {


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Links provided wrong "unokown" URL due to datasource is a metadata field (values like "unknown", "nvd:cpe", etc.) not a URL.

The code was incorrectly spreading it into the links list with [vuln.datasource, ...vuln.urls]. Since vuln.urls already contains all actual link URLs from the backend, the fix is to simply use vuln.urls directly.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open any CVEs and you shouldn't see any `unknown` URL

