### PR TITLE
Fix: Only check the actives pkg in new assessments

### DIFF
--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -22,9 +22,10 @@ type Props = {
     defaultStatus?: string;
     variants?: Variant[];
     availablePackages?: string[];
+    defaultSelectedPackages?: string[];
 }
 
-function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants, availablePackages}: Readonly<Props>) {
+function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants, availablePackages, defaultSelectedPackages}: Readonly<Props>) {
     const [status, setStatus] = useState(defaultStatus);
     const [justification, setJustification] = useState("none");
     const [statusNotes, setStatusNotes] = useState("");
@@ -33,7 +34,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
     const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>(
         variants?.length === 1 ? [variants[0].id] : []
     );
-    const [selectedPackages, setSelectedPackages] = useState<string[]>(availablePackages ?? []);
+    const [selectedPackages, setSelectedPackages] = useState<string[]>(defaultSelectedPackages ?? availablePackages ?? []);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -50,8 +51,8 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
 
     // Reset selected packages when the available list changes (e.g. navigating to a different vuln)
     useEffect(() => {
-        setSelectedPackages(availablePackages ?? []);
-    }, [availablePackages]);
+        setSelectedPackages(defaultSelectedPackages ?? availablePackages ?? []);
+    }, [availablePackages, defaultSelectedPackages]);
 
     // Auto-select single variant when variants load asynchronously (e.g. Edit from Actions column)
     useEffect(() => {
@@ -128,8 +129,8 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         setWorkaround("");
         setImpact("");
         setSelectedVariantIds(variants?.length === 1 ? [variants[0].id] : []);
-        setSelectedPackages(availablePackages ?? []);
-    }, [defaultStatus, availablePackages, variants]);
+        setSelectedPackages(defaultSelectedPackages ?? availablePackages ?? []);
+    }, [defaultStatus, availablePackages, defaultSelectedPackages, variants]);
 
     useEffect(() => {
         if (shouldClearFields) {
@@ -207,7 +208,9 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             <div className="mt-2 mb-2 ml-1">
                 <p className="text-sm font-medium text-gray-300 mb-1">Apply to packages:</p>
                 <div className="flex flex-wrap gap-x-4 gap-y-1">
-                    {availablePackages.map(pkg => (
+                    {availablePackages.map(pkg => {
+                        const isActive = !defaultSelectedPackages || defaultSelectedPackages.includes(pkg);
+                        return (
                         <label key={pkg} className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
                             <input
                                 type="checkbox"
@@ -221,9 +224,11 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                                 }}
                                 className="accent-blue-400"
                             />
-                            <span className="font-mono text-gray-200">{pkg}</span>
+                            <span className={`font-mono ${isActive ? 'text-gray-200' : 'text-gray-500 italic'}`}
+                                  title={isActive ? undefined : 'Not in active SBOM'}>{pkg}</span>
                         </label>
-                    ))}
+                        );
+                    })}
                 </div>
             </div>
         )}

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import MessageBanner from './MessageBanner';
 import type { Variant } from '../handlers/variant';
 
@@ -26,6 +26,10 @@ type Props = {
 }
 
 function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants, availablePackages, defaultSelectedPackages}: Readonly<Props>) {
+    const initialPackages = useMemo(() =>
+        (defaultSelectedPackages && defaultSelectedPackages.length > 0) ? defaultSelectedPackages : (availablePackages ?? [])
+    , [defaultSelectedPackages, availablePackages]);
+
     const [status, setStatus] = useState(defaultStatus);
     const [justification, setJustification] = useState("none");
     const [statusNotes, setStatusNotes] = useState("");
@@ -34,9 +38,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
     const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>(
         variants?.length === 1 ? [variants[0].id] : []
     );
-    const [selectedPackages, setSelectedPackages] = useState<string[]>(
-        (defaultSelectedPackages && defaultSelectedPackages.length > 0) ? defaultSelectedPackages : (availablePackages ?? [])
-    );
+    const [selectedPackages, setSelectedPackages] = useState<string[]>(initialPackages);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -53,10 +55,8 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
 
     // Reset selected packages when the available list changes (e.g. navigating to a different vuln)
     useEffect(() => {
-        setSelectedPackages(
-            (defaultSelectedPackages && defaultSelectedPackages.length > 0) ? defaultSelectedPackages : (availablePackages ?? [])
-        );
-    }, [availablePackages, defaultSelectedPackages]);
+        setSelectedPackages(initialPackages);
+    }, [initialPackages]);
 
     // Auto-select single variant when variants load asynchronously (e.g. Edit from Actions column)
     useEffect(() => {
@@ -133,10 +133,8 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         setWorkaround("");
         setImpact("");
         setSelectedVariantIds(variants?.length === 1 ? [variants[0].id] : []);
-        setSelectedPackages(
-            (defaultSelectedPackages && defaultSelectedPackages.length > 0) ? defaultSelectedPackages : (availablePackages ?? [])
-        );
-    }, [defaultStatus, availablePackages, defaultSelectedPackages, variants]);
+        setSelectedPackages(initialPackages);
+    }, [defaultStatus, initialPackages, variants]);
 
     useEffect(() => {
         if (shouldClearFields) {

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -34,7 +34,9 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
     const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>(
         variants?.length === 1 ? [variants[0].id] : []
     );
-    const [selectedPackages, setSelectedPackages] = useState<string[]>(defaultSelectedPackages ?? availablePackages ?? []);
+    const [selectedPackages, setSelectedPackages] = useState<string[]>(
+        (defaultSelectedPackages && defaultSelectedPackages.length > 0) ? defaultSelectedPackages : (availablePackages ?? [])
+    );
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -51,7 +53,9 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
 
     // Reset selected packages when the available list changes (e.g. navigating to a different vuln)
     useEffect(() => {
-        setSelectedPackages(defaultSelectedPackages ?? availablePackages ?? []);
+        setSelectedPackages(
+            (defaultSelectedPackages && defaultSelectedPackages.length > 0) ? defaultSelectedPackages : (availablePackages ?? [])
+        );
     }, [availablePackages, defaultSelectedPackages]);
 
     // Auto-select single variant when variants load asynchronously (e.g. Edit from Actions column)
@@ -129,7 +133,9 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         setWorkaround("");
         setImpact("");
         setSelectedVariantIds(variants?.length === 1 ? [variants[0].id] : []);
-        setSelectedPackages(defaultSelectedPackages ?? availablePackages ?? []);
+        setSelectedPackages(
+            (defaultSelectedPackages && defaultSelectedPackages.length > 0) ? defaultSelectedPackages : (availablePackages ?? [])
+        );
     }, [defaultStatus, availablePackages, defaultSelectedPackages, variants]);
 
     useEffect(() => {
@@ -209,7 +215,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                 <p className="text-sm font-medium text-gray-300 mb-1">Apply to packages:</p>
                 <div className="flex flex-wrap gap-x-4 gap-y-1">
                     {availablePackages.map(pkg => {
-                        const isActive = !defaultSelectedPackages || defaultSelectedPackages.includes(pkg);
+                        const isActive = !defaultSelectedPackages || defaultSelectedPackages.length === 0 || defaultSelectedPackages.includes(pkg);
                         return (
                         <label key={pkg} className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
                             <input

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -945,16 +945,18 @@ type AssessmentGroup = {
                                                 ))}
                                             </div>
                                             {(() => {
-                                                // Build the same content fingerprint used by groupAssessments,
-                                                // then find ALL matching records (across all variants) in the
+                                                // Build the same group key (date + content fingerprint) used by
+                                                // groupAssessments, then find ALL matching records in the
                                                 // unfiltered allVulnAssessments so we can show every variant tag
                                                 // even when the explorer is filtered to a single variant.
+                                                const groupDateKey = new Date(group.timestamp).toDateString();
                                                 const fp = `${firstAssess.simplified_status}|${firstAssess.justification || ''}|${firstAssess.impact_statement || ''}|${firstAssess.status_notes || ''}|${firstAssess.workaround || ''}`;
                                                 const allVariantIds = [...new Set(
                                                     allVulnAssessments
                                                         .filter(a => {
+                                                            const aDateKey = new Date(a.timestamp).toDateString();
                                                             const afp = `${a.simplified_status}|${a.justification || ''}|${a.impact_statement || ''}|${a.status_notes || ''}|${a.workaround || ''}`;
-                                                            return afp === fp && !!a.variant_id;
+                                                            return aDateKey === groupDateKey && afp === fp && !!a.variant_id;
                                                         })
                                                         .map(a => a.variant_id as string)
                                                 )];

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -921,6 +921,7 @@ type AssessmentGroup = {
                                             defaultStatus={defaultStatus}
                                             variants={availableVariants}
                                             availablePackages={vuln.packages}
+                                            defaultSelectedPackages={vuln.packages_current}
                                         />
                                     </li>
                                 )}


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Only check active packages in new Assessments of CVEs
* Bugfix variants displays in CVE history

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Go in the Vulnerability tab and look for assessments. If you create a new one, only the current SBOM elements will be check
