### PR TITLE
Fix the project scope correctly for vulnerability edit

### DIFF
--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -208,7 +208,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                 </div>
             </div>
         )}
-        {availablePackages && availablePackages.length > 1 && (
+        {availablePackages && availablePackages.length >= 1 && (
             <div className="mt-2 mb-2 ml-1">
                 <p className="text-sm font-medium text-gray-300 mb-1">Apply to packages:</p>
                 <div className="flex flex-wrap gap-x-4 gap-y-1">

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -35,6 +35,7 @@ type Props = {
     currentIndex?: number;
     onNavigate?: (index: number) => void;
     variantId?: string;
+    projectId?: string;
 };
 
 const dt_options: Intl.DateTimeFormatOptions = {
@@ -54,7 +55,7 @@ type AssessmentGroup = {
 };
 
   function VulnModal(props: Readonly<Props>) {
-    const { vuln, isEditing: initialIsEditing, readOnly = false, onClose, appendAssessment, appendCVSS, patchVuln, vulnerabilities, currentIndex, onNavigate, variantId } = props;
+    const { vuln, isEditing: initialIsEditing, readOnly = false, onClose, appendAssessment, appendCVSS, patchVuln, vulnerabilities, currentIndex, onNavigate, variantId, projectId } = props;
     const docUrl = useDocUrl("interactive-mode.html#vulnerability-details");
     const [isEditing, setIsEditing] = useState(initialIsEditing);
     const [showCustomCvss, setShowCustomCvss] = useState(false);
@@ -72,11 +73,22 @@ type AssessmentGroup = {
     const [submittingMessage, setSubmittingMessage] = useState<string | null>(null);
     const [editingGroup, setEditingGroup] = useState<AssessmentGroup | null>(null);
 
-    // Fetch variants that have a finding for this specific vulnerability
+    // Project-scoped package list: prefer packages_current (scoped to
+    // the active scan context) and fall back to the full list.
+    const projectPackages = (vuln.packages_current?.length > 0) ? vuln.packages_current : vuln.packages;
+
+    // Fetch variants that have a finding for this specific vulnerability,
+    // filtered to the current project when a projectId is provided.
     useEffect(() => {
         setAvailableVariants([]);
-        Variants.listByVuln(vuln.id).then(setAvailableVariants).catch(() => {});
-    }, [vuln.id]);
+        Variants.listByVuln(vuln.id).then(variants => {
+            if (projectId) {
+                setAvailableVariants(variants.filter(v => v.project_id === projectId));
+            } else {
+                setAvailableVariants(variants);
+            }
+        }).catch(() => {});
+    }, [vuln.id, projectId]);
 
     // Fetch ALL assessments for this vuln (unfiltered) so variant tags are
     // complete even when a variant filter is active in the explorer.
@@ -509,9 +521,9 @@ type AssessmentGroup = {
 
     const addAssessment = async (content: PostAssessment) => {
         content.vuln_id = vuln.id;
-        // packages come from StatusEditor selection; fall back to all vuln packages
+        // packages come from StatusEditor selection; fall back to project-scoped packages
         if (!content.packages || content.packages.length === 0) {
-            content.packages = vuln.packages;
+            content.packages = projectPackages;
         }
 
         // Determine which variants to post to. If none selected, post once without a variant_id.
@@ -920,7 +932,7 @@ type AssessmentGroup = {
                                             triggerBanner={showMessage}
                                             defaultStatus={defaultStatus}
                                             variants={availableVariants}
-                                            availablePackages={vuln.packages}
+                                            availablePackages={projectPackages}
                                             defaultSelectedPackages={vuln.packages_current}
                                         />
                                     </li>
@@ -1019,7 +1031,7 @@ type AssessmentGroup = {
                                                                 .map(a => a.variant_id)
                                                                 .filter((v): v is string => !!v)
                                                         )]}
-                                                        availablePackages={vuln.packages}
+                                                        availablePackages={projectPackages}
                                                         defaultSelectedPackages={group.packages}
                                                     />
                                                 </div>

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -292,6 +292,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     patchVuln={patchVuln}
                     setTab={setTab}
                     appendCVSS={appendCVSS}
+                    projectId={currentProjectId}
                 />}
                 {tab === 'packages' && <TablePackages packages={pkgs} onShowVulns={showVulnsForPackage} />}
                 {tab === 'vulnerabilities' &&
@@ -303,6 +304,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     filterLabel={filterLabel}
                     filterValue={filterValue}
                     variantId={currentVariantId}
+                    projectId={currentProjectId}
                     baseVariantId={currentBaseVariantId}
                     compareOperation={currentOperation}
                 />}

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -21,6 +21,7 @@ import { useMemo, useState } from "react";
             patchVuln: (vulnId: string, data: any) => void;
             setTab: (tab: string) => void;
             appendCVSS: (vulnId: string, vector: string) => CVSS | null;
+            projectId?: string;
         };
 
         const pieOptions = {
@@ -114,7 +115,7 @@ import { useMemo, useState } from "react";
 
 
 
-function Metrics({ vulnerabilities, goToVulnsTabWithFilter, appendAssessment, appendCVSS, patchVuln, setTab }: Readonly<Props>) {
+function Metrics({ vulnerabilities, goToVulnsTabWithFilter, appendAssessment, appendCVSS, patchVuln, setTab, projectId }: Readonly<Props>) {
             const defaultPieHandler = ChartJS.overrides.pie.plugins.legend.onClick
 
             const [timeScale, setTimeScale] = useState<string>("6_months")
@@ -712,6 +713,7 @@ const packageColumns = [
             vulnerabilities={TopVulns.map(item => item.original)}
             currentIndex={modalVulnIndex}
             onNavigate={handleModalNavigation}
+            projectId={projectId}
           />
         )}
         </div>

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -30,6 +30,7 @@ type Props = {
     filterLabel?: "Source" | "Severity" | "Status" | "Package";
     filterValue?: string;
     variantId?: string;
+    projectId?: string;
     /** Origin variant when compare mode is active */
     baseVariantId?: string;
     /** 'difference' or 'intersection' when compare mode is active */
@@ -271,7 +272,7 @@ function PublishedDateFilter({
 const SEVERITY_RANGE_MIN = 0;
 const SEVERITY_RANGE_MAX = 10;
 
-function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln, variantId, baseVariantId, compareOperation }: Readonly<Props>) {
+function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln, variantId, projectId, baseVariantId, compareOperation }: Readonly<Props>) {
 
     const docUrl = useDocUrl("interactive-mode.html#vulnerability-table");
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);
@@ -1361,6 +1362,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             currentIndex={modalVulnIndex}
             onNavigate={handleModalNavigation}
             variantId={variantId}
+            projectId={projectId}
         ></VulnModal>}
     </>)
 }

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -360,6 +360,14 @@ describe('StatusEditor', () => {
         );
     });
 
+    test('should render package section even with a single package', () => {
+        const packages = ['only-pkg@1.0.0'];
+        render(<StatusEditor {...defaultProps} availablePackages={packages} />);
+
+        expect(screen.getByText('Apply to packages:')).toBeInTheDocument();
+        expect(screen.getByText('only-pkg@1.0.0')).toBeInTheDocument();
+    });
+
     test('should render package checkboxes when more than one package is available', () => {
         const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
         render(<StatusEditor {...defaultProps} availablePackages={packages} />);

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -1982,4 +1982,110 @@ describe('Vulnerability Modal', () => {
         await screen.findByText('Production');
         expect(screen.getByText('Staging')).toBeInTheDocument();
     });
+
+    test('projectId prop filters variants to only show those from the current project', async () => {
+        fetchMock.resetMocks();
+        // Variants endpoint returns variants from two different projects
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'v1', name: 'Variant A', project_id: 'proj-alpha' },
+            { id: 'v2', name: 'Variant B', project_id: 'proj-alpha' },
+            { id: 'v3', name: 'Variant Other', project_id: 'proj-beta' }
+        ]));
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+
+        render(<VulnModal
+            vuln={{...vulnerability, assessments: []}}
+            isEditing={true}
+            onClose={() => {}}
+            appendAssessment={() => {}}
+            appendCVSS={() => null}
+            patchVuln={() => {}}
+            projectId="proj-alpha"
+        />);
+
+        // Wait for variants to load
+        await screen.findByText('Variant A');
+        expect(screen.getByText('Variant B')).toBeInTheDocument();
+        // Variant from the other project should NOT be shown
+        expect(screen.queryByText('Variant Other')).not.toBeInTheDocument();
+    });
+
+    test('without projectId prop all variants are shown', async () => {
+        fetchMock.resetMocks();
+        // Variants endpoint returns variants from two different projects
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'v1', name: 'Variant A', project_id: 'proj-alpha' },
+            { id: 'v2', name: 'Variant Other', project_id: 'proj-beta' }
+        ]));
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+
+        render(<VulnModal
+            vuln={{...vulnerability, assessments: []}}
+            isEditing={true}
+            onClose={() => {}}
+            appendAssessment={() => {}}
+            appendCVSS={() => null}
+            patchVuln={() => {}}
+        />);
+
+        // Wait for variants to load — both should be shown without projectId filter
+        await screen.findByText('Variant A');
+        expect(screen.getByText('Variant Other')).toBeInTheDocument();
+    });
+
+    test('packages_current scopes available packages to current project', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+
+        // vuln.packages has all packages (cross-project), packages_current has only project-scoped
+        const vulnMultiProject = {
+            ...vulnerability,
+            packages: ['pkg-alpha@1.0.0', 'pkg-beta@2.0.0', 'pkg-gamma@3.0.0'],
+            packages_current: ['pkg-alpha@1.0.0'],
+            assessments: []
+        };
+
+        render(<VulnModal
+            vuln={vulnMultiProject}
+            isEditing={true}
+            onClose={() => {}}
+            appendAssessment={() => {}}
+            appendCVSS={() => null}
+            patchVuln={() => {}}
+            projectId="proj-alpha"
+        />);
+
+        // Only the project-scoped package (from packages_current) should appear as checkbox
+        await screen.findByText('pkg-alpha@1.0.0');
+        expect(screen.queryByText('pkg-beta@2.0.0')).not.toBeInTheDocument();
+        expect(screen.queryByText('pkg-gamma@3.0.0')).not.toBeInTheDocument();
+    });
+
+    test('falls back to all packages when packages_current is empty', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+
+        const vulnEmptyCurrent = {
+            ...vulnerability,
+            packages: ['pkg-x@1.0.0', 'pkg-y@2.0.0'],
+            packages_current: [],
+            assessments: []
+        };
+
+        render(<VulnModal
+            vuln={vulnEmptyCurrent}
+            isEditing={true}
+            onClose={() => {}}
+            appendAssessment={() => {}}
+            appendCVSS={() => null}
+            patchVuln={() => {}}
+            projectId="proj-1"
+        />);
+
+        // Both packages should appear since packages_current is empty (fallback)
+        await screen.findByText('pkg-x@1.0.0');
+        expect(screen.getByText('pkg-y@2.0.0')).toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

Based on the issue: https://github.com/savoirfairelinux/vulnscout/issues/312

### Changes proposed in this pull request:

* Fix the project scope correctly for vulnerability edit with "Apply to Variants" and "Apply to packages" fields.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Create two projects with differents SBOM but with some CVEs in common. When you edit a CVE, you shouldn't see any Variants/Packages related to the other project