### PR TITLE
Use --project and --variant for import/export custom assessment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,16 @@ FROM node:20 AS buildfront
 
 RUN mkdir -p /frontend /src/static
 WORKDIR /frontend
-COPY frontend .
+
+# First install packages so the layer can be reused when code changes
+COPY frontend/package.json frontend/package-lock.json .
+RUN npm ci
 
 # Create build .env with API_URL set as blank. This way, fetch call are made to '/api/...' on same origin.
 RUN echo "VITE_API_URL=\"\"" > .env
 
-RUN npm ci && \
-    npm run build
+COPY frontend .
+RUN npm run build
 
 
 FROM alpine:3.20

--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -33,8 +33,8 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 
 | Flag | Description |
 |------|-------------|
-| `--project <name>` | Project name for subsequent input commands (default: `default`) |
-| `--variant <name>` | Variant name for subsequent input commands (default: `default`) |
+| `--project <name>` | Project name for subsequent commands (default: `default`) |
+| `--variant <name>` | Variant name for subsequent commands (default: `default`) |
 
 ### Input Commands
 
@@ -57,7 +57,7 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 | `--export-spdx` | Export project as SPDX 3.0 SBOM to `/scan/outputs/` |
 | `--export-cdx` | Export project as CycloneDX 1.6 SBOM to `/scan/outputs/` |
 | `--export-openvex` | Export project as OpenVEX document to `/scan/outputs/` |
-| `--export-custom-assessments` | Export custom (review) assessments as `.tar.gz` to `/scan/outputs/` |
+| `--export-custom-assessments` | Export custom (review) assessments of the project as `.tar.gz` (or `.json` if `--variant` is specified) to `/scan/outputs/` |
 | `--import-custom-assessments <path>` | Import custom assessments from `.json` or `.tar.gz` |
 | `--match-condition <expr>` | Exit with code 2 if expression matches any vulnerability. Incompatible with `--serve` |
 | `--delete-scan <id>` | Delete a past scan by its ID |

--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -272,13 +272,22 @@ The `--export-custom-assessments` flag produces a `.tar.gz` archive containing o
 ./vulnscout --project demo --export-custom-assessments
 ```
 
+You can also use the `--variant` flag to select from which variant to export an OpenVEX file. In this case, the exported file is a simple `.json` file:
+
+```bash
+./vulnscout --project demo --variant x86 --export-custom-assessments
+```
+
 ### Importing Custom Assessments
 
-The `--import-custom-assessments` flag reads a `.json` or `.tar.gz` file and replays the assessment statements into the database:
+The `--import-custom-assessments` flag reads a `.json` or `.tar.gz` file and replays the assessment statements into the database. If `--variant` is not specified, the variant is inferred from the file name.
 
 ```bash
 # Import from a single OpenVEX JSON file
-./vulnscout --project demo --import-custom-assessments /path/to/assessments.json
+./vulnscout --project demo --variant x86 --import-custom-assessments /path/to/assessments.json
+
+# Import from a single OpenVEX JSON file without specifying the variant
+./vulnscout --project demo --import-custom-assessments /path/to/assessments/x86.json
 
 # Import from a tar.gz archive previously exported
 ./vulnscout --project demo --import-custom-assessments /path/to/custom_assessments.tar.gz
@@ -403,4 +412,3 @@ Once migration is complete, start VulnScout normally:
 ```bash
 ./vulnscout --serve
 ```
-

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -705,8 +705,10 @@ def export_custom_assessments_command(output_dir: str) -> None:
 
 @click.command("import-custom-assessments")
 @click.argument("file_path")
+@click.option("--project", "-p", required=True, help="Project name.")
+@click.option("--variant", "-v", default=None, help="Variant name. Defaults to the file name.")
 @with_appcontext
-def import_custom_assessments_command(file_path: str) -> None:
+def import_custom_assessments_command(file_path: str, project: str, variant: str | None) -> None:
     """Import custom assessments from a .json or .tar.gz OpenVEX file."""
     import tarfile
     import json as _json
@@ -724,12 +726,23 @@ def import_custom_assessments_command(file_path: str) -> None:
         click.echo(f"Error: file not found: {file_path}", err=True)
         raise SystemExit(1)
 
-    all_variants = DBVariant.get_all()
-    variant_by_name: dict[str, "DBVariant"] = {}
-    for v in all_variants:
-        sanitised = v.name.replace("/", "_").replace("\\", "_")
-        variant_by_name[sanitised] = v
-        variant_by_name[v.name] = v
+    project_obj = ProjectController.get_by_name(project)
+    if not project_obj:
+        click.echo(f"Error: project not found: {project}")
+        raise SystemExit(1)
+
+    if variant:
+        variant_obj = DBVariant.get_by_name_and_project(variant, project_obj.id)
+        if not variant_obj:
+            click.echo(f"Error: variant not found: {variant}")
+            raise SystemExit(1)
+    else:
+        all_variants = DBVariant.get_by_project(project_obj.id)
+        variant_by_name: dict[str, "DBVariant"] = {}
+        for v in all_variants:
+            sanitised = v.name.replace("/", "_").replace("\\", "_")
+            variant_by_name[sanitised] = v
+            variant_by_name[v.name] = v
 
     def _is_openvex(doc: dict) -> bool:
         ctx = doc.get("@context", "")
@@ -841,6 +854,10 @@ def import_custom_assessments_command(file_path: str) -> None:
     total_skipped = 0
 
     if file_path.endswith(".tar.gz") or file_path.endswith(".tgz"):
+        if variant:
+            click.echo("Error: cannot use the --variant argument with an archive of custom assessments.")
+            raise SystemExit(1)
+
         try:
             tar = tarfile.open(file_path, mode='r:gz')
         except Exception:
@@ -857,8 +874,8 @@ def import_custom_assessments_command(file_path: str) -> None:
                 continue
             base = os.path.basename(member.name)
             variant_name = base[:-len(".json")]
-            variant = variant_by_name.get(variant_name)
-            if variant is None:
+            variant_obj = variant_by_name.get(variant_name)
+            if variant_obj is None:
                 total_errors.append({
                     "file": member.name,
                     "error": (
@@ -889,7 +906,7 @@ def import_custom_assessments_command(file_path: str) -> None:
 
             variant_files_found += 1
             c, e, s = _import_statements(
-                doc["statements"], variant.id
+                doc["statements"], variant_obj.id
             )
             total_created.extend(c)
             total_errors.extend(e)
@@ -907,16 +924,22 @@ def import_custom_assessments_command(file_path: str) -> None:
             raise SystemExit(1)
 
     elif file_path.endswith(".json"):
-        variant_name = basename[:-len(".json")]
-        variant = variant_by_name.get(variant_name)
-        if variant is None:
-            click.echo(
-                f"Error: no variant found matching filename "
-                f"'{variant_name}'. The JSON filename must "
-                f"correspond to an existing variant name.",
-                err=True,
-            )
-            raise SystemExit(1)
+        if variant:
+            assert variant_obj
+            # Declared above, assert here so type checker no longer
+            # considers it possibly Unbound
+        else:
+            variant_name = variant if variant else basename[:-len(".json")]
+            variant_obj = variant_by_name.get(variant_name)
+            if variant_obj is None:
+                click.echo(
+                    f"Error: no variant found matching filename "
+                    f"'{variant_name}'. The JSON filename must "
+                    f"correspond to an existing variant name. "
+                    "Hint: use --variant to specify another name.",
+                    err=True,
+                )
+                raise SystemExit(1)
 
         try:
             with open(file_path) as fh:
@@ -932,7 +955,7 @@ def import_custom_assessments_command(file_path: str) -> None:
             raise SystemExit(1)
 
         c, e, s = _import_statements(
-            data["statements"], variant.id
+            data["statements"], variant_obj.id
         )
         total_created.extend(c)
         total_errors.extend(e)

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -555,10 +555,13 @@ def report_command(template_name: str, output_dir: str, output_format: str | Non
 
 @click.command("export-custom-assessments")
 @click.option("--output-dir", default="/scan/outputs", show_default=True,
-              help="Directory where the exported tar.gz is written.")
+              help="Directory where the exported file is written.")
+@click.option("--project", "-p", required=True, help="Project name.")
+@click.option("--variant", "-v", default=None,
+              help="Variant name. If empty, all variants will be exported in an archive.")
 @with_appcontext
-def export_custom_assessments_command(output_dir: str) -> None:
-    """Export handmade (custom) assessments as a tar.gz of OpenVEX files."""
+def export_custom_assessments_command(output_dir: str, project: str, variant: str | None) -> None:
+    """Export handmade (custom) assessments as an (archive of) OpenVEX file(s)."""
     import io
     import tarfile
     import uuid as _uuid
@@ -571,17 +574,23 @@ def export_custom_assessments_command(output_dir: str) -> None:
     from ..models.variant import Variant as DBVariant
     from ..models.vulnerability import Vulnerability as DBVuln
 
-    handmade = DBAssessment.get_handmade()
-    if not handmade:
-        click.echo("No custom assessments to export.", err=True)
-        raise SystemExit(1)
-
     author = os.getenv("AUTHOR_NAME", "Savoir-faire Linux")
     now_iso = _dt.now(_tz.utc).isoformat()
 
-    variant_names: dict[str, str] = {}
-    for v in DBVariant.get_all():
-        variant_names[str(v.id)] = v.name
+    project_obj = ProjectController.get_by_name(project)
+    if not project_obj:
+        click.echo(f"Error: project not found: {project}")
+        raise SystemExit(1)
+
+    variants: list[DBVariant]
+    if variant:
+        variant_obj = DBVariant.get_by_name_and_project(variant, project_obj.id)
+        if not variant_obj:
+            click.echo(f"Error: variant not found: {variant}")
+            raise SystemExit(1)
+        variants = [variant_obj]
+    else:
+        variants = DBVariant.get_by_project(project_obj.id)
 
     vuln_cache: dict[str, DBVuln | None] = {}
 
@@ -590,116 +599,136 @@ def export_custom_assessments_command(output_dir: str) -> None:
             vuln_cache[vuln_id] = DBVuln.get_by_id(vuln_id)
         return vuln_cache[vuln_id]
 
-    by_variant: dict[str | None, list] = defaultdict(list)
-    for assess in handmade:
-        vid = str(assess.variant_id) if assess.variant_id else None
-        by_variant[vid].append(assess)
+    handmade = DBAssessment.get_handmade([variant_obj.id for variant_obj in variants])
+    if not handmade:
+        click.echo("No custom assessments to export.", err=True)
+        raise SystemExit(1)
 
     os.makedirs(output_dir, exist_ok=True)
 
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode='w:gz') as tar:
-        for vid, assessments in by_variant.items():
-            filename = (
-                variant_names.get(vid, "unassigned")
-                if vid else "unassigned"
-            ) + ".json"
-            filename = filename.replace("/", "_").replace("\\", "_")
+    def generate_doc(assessments: list[DBAssessment]) -> dict:
+        statements = []
+        for assess in assessments:
+            stmt = assess.to_openvex_dict()
+            if stmt is None:
+                continue
 
-            statements = []
-            for assess in assessments:
-                stmt = assess.to_openvex_dict()
-                if stmt is None:
-                    continue
-
-                vuln_obj = (
-                    _get_vuln(assess.vuln_id)
-                    if assess.vuln_id else None
+            vuln_obj = (
+                _get_vuln(assess.vuln_id)
+                if assess.vuln_id else None
+            )
+            description = ""
+            aliases: list[str] = []
+            vuln_url = ""
+            if vuln_obj:
+                desc = vuln_obj.texts.get("description", "")
+                yocto_desc = vuln_obj.texts.get(
+                    "yocto description", ""
                 )
-                description = ""
-                aliases: list[str] = []
-                vuln_url = ""
-                if vuln_obj:
-                    desc = vuln_obj.texts.get("description", "")
-                    yocto_desc = vuln_obj.texts.get(
-                        "yocto description", ""
+                description = desc or yocto_desc or ""
+                aliases = list(vuln_obj.aliases or [])
+                urls = (
+                    list(vuln_obj.urls) if vuln_obj.urls
+                    else list(vuln_obj.links or [])
+                )
+                vuln_url = urls[0] if urls else ""
+                if (
+                    not vuln_url
+                    and assess.vuln_id.startswith("CVE-")
+                ):
+                    vuln_url = (
+                        "https://nvd.nist.gov/vuln/detail/"
+                        + assess.vuln_id
                     )
-                    description = desc or yocto_desc or ""
-                    aliases = list(vuln_obj.aliases or [])
-                    urls = (
-                        list(vuln_obj.urls) if vuln_obj.urls
-                        else list(vuln_obj.links or [])
+                elif (
+                    not vuln_url
+                    and assess.vuln_id.startswith("GHSA-")
+                ):
+                    vuln_url = (
+                        "https://github.com/advisories/"
+                        + assess.vuln_id
                     )
-                    vuln_url = urls[0] if urls else ""
-                    if (
-                        not vuln_url
-                        and assess.vuln_id.startswith("CVE-")
-                    ):
-                        vuln_url = (
-                            "https://nvd.nist.gov/vuln/detail/"
-                            + assess.vuln_id
-                        )
-                    elif (
-                        not vuln_url
-                        and assess.vuln_id.startswith("GHSA-")
-                    ):
-                        vuln_url = (
-                            "https://github.com/advisories/"
-                            + assess.vuln_id
-                        )
 
-                stmt["vulnerability"] = {
-                    "name": assess.vuln_id,
-                    "description": description,
-                    "aliases": aliases,
-                    "@id": vuln_url,
-                }
-
-                products = []
-                for pkg_str in assess.packages:
-                    if "@" in pkg_str:
-                        name, version = pkg_str.rsplit("@", 1)
-                    else:
-                        name, version = pkg_str, ""
-                    products.append({
-                        "@id": pkg_str,
-                        "identifiers": {
-                            "cpe23": (
-                                "cpe:2.3:*:*:"
-                                f"{name}:{version}"
-                                ":*:*:*:*:*:*:*"
-                            ),
-                            "purl": f"pkg:generic/{name}@{version}",
-                        }
-                    })
-                stmt["products"] = products
-                stmt.setdefault("action_statement_timestamp", "")
-                stmt["scanners"] = list({
-                    assess.source or "local_user_data",
-                    assess.origin or "local_user_data",
-                })
-                statements.append(stmt)
-
-            doc = {
-                "@context": "https://openvex.dev/ns/v0.2.0",
-                "@id": (
-                    "https://savoirfairelinux.com/sbom/openvex/"
-                    + str(_uuid.uuid4())
-                ),
-                "author": author,
-                "timestamp": now_iso,
-                "version": 1,
-                "statements": statements,
+            stmt["vulnerability"] = {
+                "name": assess.vuln_id,
+                "description": description,
+                "aliases": aliases,
+                "@id": vuln_url,
             }
 
-            json_bytes = _json.dumps(doc, indent=2).encode("utf-8")
-            info = tarfile.TarInfo(name=filename)
-            info.size = len(json_bytes)
-            tar.addfile(info, io.BytesIO(json_bytes))
+            products = []
+            for pkg_str in assess.packages:
+                if "@" in pkg_str:
+                    name, version = pkg_str.rsplit("@", 1)
+                else:
+                    name, version = pkg_str, ""
+                products.append({
+                    "@id": pkg_str,
+                    "identifiers": {
+                        "cpe23": (
+                            "cpe:2.3:*:*:"
+                            f"{name}:{version}"
+                            ":*:*:*:*:*:*:*"
+                        ),
+                        "purl": f"pkg:generic/{name}@{version}",
+                    }
+                })
+            stmt["products"] = products
+            stmt.setdefault("action_statement_timestamp", "")
+            stmt["scanners"] = list({
+                assess.source or "local_user_data",
+                assess.origin or "local_user_data",
+            })
+            statements.append(stmt)
 
-    out_path = os.path.join(output_dir, "custom_assessments.tar.gz")
-    with open(out_path, "wb") as fh:
-        fh.write(buf.getvalue())
+        doc = {
+            "@context": "https://openvex.dev/ns/v0.2.0",
+            "@id": (
+                "https://savoirfairelinux.com/sbom/openvex/"
+                + str(_uuid.uuid4())
+            ),
+            "author": author,
+            "timestamp": now_iso,
+            "version": 1,
+            "statements": statements,
+        }
+        return doc
+
+    if variant is None:
+        # export all variants from project as archive
+        by_variant: dict[uuid.UUID, list[DBAssessment]] = defaultdict(list)
+        for assess in handmade:
+            by_variant[assess.variant_id].append(assess)
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode='w:gz') as tar:
+            for vid, assessments in by_variant.items():
+                variant_obj = DBVariant.get_by_id(vid)
+                assert variant_obj  # Variant cannot be null since we filtrered by variant before
+                filename = variant_obj.name + ".json"
+                filename = filename.replace("/", "_").replace("\\", "_")
+
+                doc = generate_doc(assessments)
+                json_bytes = _json.dumps(doc, indent=2).encode("utf-8")
+                info = tarfile.TarInfo(name=filename)
+                info.size = len(json_bytes)
+                tar.addfile(info, io.BytesIO(json_bytes))
+
+        out_path = os.path.join(output_dir, "custom_assessments.tar.gz")
+        with open(out_path, "wb") as fh:
+            fh.write(buf.getvalue())
+    else:
+        assert variant_obj
+        # Declared above, assert here so type checker no longer
+        # considers it possibly Unbound
+        filename = variant_obj.name + ".json"
+        filename = filename.replace("/", "_").replace("\\", "_")
+
+        doc = generate_doc(handmade)
+        out_path = os.path.join(output_dir, filename)
+        with open(out_path, "w") as file:
+            _json.dump(doc, file)
+
     click.echo(f"Custom assessments exported: {out_path}")
 
 

--- a/src/controllers/projects.py
+++ b/src/controllers/projects.py
@@ -44,6 +44,19 @@ class ProjectController:
         return Project.get_by_id(project_id)
 
     @staticmethod
+    def get_by_name(name: str) -> Project | None:
+        """
+        Return an existing project whose name matches *name* (case-sensitive),
+        or None if no project with the name exists.
+
+        :raises ValueError: if *name* is empty or blank.
+        """
+        name = name.strip()
+        if not name:
+            raise ValueError("Project name must not be empty.")
+        return Project.get_by_name(name)
+
+    @staticmethod
     def get_all() -> list[Project]:
         """Return all projects ordered by name."""
         return Project.get_all()

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -422,6 +422,12 @@ cmd_export_custom_assessments() {
 
 cmd_import_custom_assessments() {
     local file="$1"
+
+    import_args=(--project "$PROJECT_NAME")
+    if [[ -n "$VARIANT_NAME" ]]; then
+        import_args+=(--variant "$VARIANT_NAME")
+    fi
+
     cd "$BASE_DIR"
     local raw_basename dest_name dest_file
     raw_basename="$(basename "$file")"
@@ -429,11 +435,11 @@ cmd_import_custom_assessments() {
     if [[ "$dest_name" != "$raw_basename" ]]; then
         dest_file="$(dirname "$file")/$dest_name"
         mv "$file" "$dest_file"
-        file="$dest_file"
+        import_args+=("$dest_file")
     fi
 
     flask --app src.bin.webapp db upgrade
-    flask --app src.bin.webapp import-custom-assessments "$file"
+    flask --app src.bin.webapp import-custom-assessments "${import_args[@]}"
     setup_user
 }
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -413,10 +413,17 @@ cmd_export() {
 }
 
 cmd_export_custom_assessments() {
+    export_args=(--project "$PROJECT_NAME")
+    if [[ -n "$VARIANT_NAME" ]]; then
+        export_args+=(--variant "$VARIANT_NAME")
+    fi
+
     cd "$BASE_DIR"
     local output_dir="${OUTPUTS_DIR:-/scan/outputs}"
+    export_args+=(--output-dir "$output_dir")
+
     flask --app src.bin.webapp db upgrade
-    flask --app src.bin.webapp export-custom-assessments --output-dir "$output_dir"
+    flask --app src.bin.webapp export-custom-assessments "${export_args[@]}"
     setup_user
 }
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -7,8 +7,8 @@ set -m # enable job control to allow `fg` command
 
 CONFIG_FILE="${VULNSCOUT_CONFIG:-/etc/vulnscout/config.env}"
 INPUTS_DIR="/scan/inputs"
-VARIANT_NAME="default"
 PROJECT_NAME="default"
+VARIANT_NAME=""
 
 readonly BASE_DIR="/scan"
 INTERACTIVE_MODE="${INTERACTIVE_MODE:-false}"
@@ -241,10 +241,16 @@ cmd_scan() {
 
     # All input files belong to a single variant set for this invocation
     PROJECT_NAME=${PROJECT_NAME:-"$PRODUCT_NAME"}
-    VARIANT_NAME=${VARIANT_NAME:-"default"}
-    INIT_APP_ARGS=(--project "$PROJECT_NAME" --variant "$VARIANT_NAME")
+    INIT_APP_ARGS=(--project "$PROJECT_NAME")
+    if [[ -n "$VARIANT_NAME" ]]; then
+        INIT_APP_ARGS+=(--variant "$VARIANT_NAME")
+    fi
+    local has_inputs=false
+
     if [[ -d "$INPUTS_DIR/spdx" ]]; then
-        for f in "$INPUTS_DIR/spdx"/*.spdx.json; do [[ -f "$f" ]] && INIT_APP_ARGS+=(--spdx "$f"); done
+        for f in "$INPUTS_DIR/spdx"/*.spdx.json; do
+            [[ -f "$f" ]] && INIT_APP_ARGS+=(--spdx "$f") && has_inputs=true
+        done
         # Warn about files that don't match the SPDX naming convention
         for f in "$INPUTS_DIR/spdx"/*; do
             [[ -f "$f" ]] || continue
@@ -256,10 +262,14 @@ cmd_scan() {
         done
     fi
     if [[ -d "$INPUTS_DIR/cdx" ]]; then
-        for f in "$INPUTS_DIR/cdx"/*.json; do [[ -f "$f" ]] && INIT_APP_ARGS+=(--cdx "$f"); done
+        for f in "$INPUTS_DIR/cdx"/*.json; do
+            [[ -f "$f" ]] && INIT_APP_ARGS+=(--cdx "$f") && has_inputs=true
+        done
     fi
     if [[ -d "$INPUTS_DIR/openvex" ]]; then
-        for f in "$INPUTS_DIR/openvex"/*openvex*.json; do [[ -f "$f" ]] && INIT_APP_ARGS+=(--openvex "$f"); done
+        for f in "$INPUTS_DIR/openvex"/*openvex*.json; do
+            [[ -f "$f" ]] && INIT_APP_ARGS+=(--openvex "$f") && has_inputs=true
+        done
         # Warn about files that don't match the OpenVEX naming convention
         for f in "$INPUTS_DIR/openvex"/*; do
             [[ -f "$f" ]] || continue
@@ -270,10 +280,14 @@ cmd_scan() {
         done
     fi
     if [[ -d "$INPUTS_DIR/yocto_cve_check" ]]; then
-        for f in "$INPUTS_DIR/yocto_cve_check"/*.json; do [[ -f "$f" ]] && INIT_APP_ARGS+=(--yocto-cve "$f"); done
+        for f in "$INPUTS_DIR/yocto_cve_check"/*.json; do
+            [[ -f "$f" ]] && INIT_APP_ARGS+=(--yocto-cve "$f") && has_inputs=true
+        done
     fi
     if [[ -d "$INPUTS_DIR/grype" ]]; then
-        for f in "$INPUTS_DIR/grype"/*.grype.json; do [[ -f "$f" ]] && INIT_APP_ARGS+=(--grype "$f"); done
+        for f in "$INPUTS_DIR/grype"/*.grype.json; do
+            [[ -f "$f" ]] && INIT_APP_ARGS+=(--grype "$f") && has_inputs=true
+        done
         # Warn about files that don't match the Grype naming convention
         for f in "$INPUTS_DIR/grype"/*; do
             [[ -f "$f" ]] || continue
@@ -285,12 +299,8 @@ cmd_scan() {
     fi
     (cd "$BASE_DIR" && flask --app src.bin.webapp db upgrade)
 
-    # INIT_APP_ARGS always starts with --project <name> --variant <name> (4 elements).
-    # Has new input files when length > 4.
-    local has_inputs=false
     local has_condition=false
     local _cmd_scan_exit=0
-    [[ ${#INIT_APP_ARGS[@]} -gt 4 ]]     && has_inputs=true
     [[ -n "${MATCH_CONDITION:-}" ]]       && has_condition=true
 
     if [[ "$has_inputs" == "true" ]] || [[ "$has_condition" == "true" ]] || [[ "${GRYPE_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${NVD_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${OSV_SCAN_REQUESTED:-false}" == "true" ]]; then

--- a/src/models/assessment.py
+++ b/src/models/assessment.py
@@ -126,7 +126,7 @@ class Assessment(Base):
     )
     responses = db.Column(db.JSON, nullable=True)
     finding_id = db.Column(db.Uuid, db.ForeignKey("findings.id"), nullable=True, index=True)
-    variant_id = db.Column(db.Uuid, db.ForeignKey("variants.id"), nullable=True, index=True)
+    variant_id: Mapped[uuid.UUID] = db.Column(db.Uuid, db.ForeignKey("variants.id"), nullable=True, index=True)
 
     finding: Mapped["Finding"] = relationship("Finding", back_populates="assessments")
     variant: Mapped["Variant"] = relationship("Variant", back_populates="assessments")
@@ -715,18 +715,16 @@ class Assessment(Base):
         ).scalars().all())
 
     @staticmethod
-    def get_handmade(variant_id: Optional["uuid.UUID | str"] = None) -> list["Assessment"]:
+    def get_handmade(variant_ids: list[uuid.UUID] | None = None) -> list["Assessment"]:
         """Return assessments created/edited via the web UI (``origin='custom'``)."""
-        if isinstance(variant_id, str):
-            variant_id = uuid.UUID(variant_id)
         query = (
             db.select(Assessment)
             .where(Assessment.origin == "custom")
             .options(joinedload(Assessment.finding).joinedload(Finding.package))
             .order_by(Assessment.timestamp.desc())
         )
-        if variant_id is not None:
-            query = query.where(Assessment.variant_id == variant_id)
+        if variant_ids:
+            query = query.where(Assessment.variant_id.in_(variant_ids))
         return list(db.session.execute(query).scalars().unique().all())
 
     def update(

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -59,6 +59,13 @@ class Project(Base):
         return db.session.get(Project, project_id)
 
     @staticmethod
+    def get_by_name(name: str) -> "Project | None":
+        """Return the project matching *name*, or ``None`` if not found."""
+        return db.session.execute(
+            db.select(Project).where(Project.name == name)
+        ).scalar_one_or_none()
+
+    @staticmethod
     def get_all() -> list["Project"]:
         """Return all projects ordered by name."""
         return list(db.session.execute(

--- a/src/models/variant.py
+++ b/src/models/variant.py
@@ -79,6 +79,13 @@ class Variant(Base):
         ).scalars().all())
 
     @staticmethod
+    def get_by_name_and_project(name: str, project_id: uuid.UUID) -> "Variant | None":
+        """Return an existing variant by *name* under *project_id*, or None if it does not exist."""
+        return db.session.execute(
+            db.select(Variant).where(Variant.name == name, Variant.project_id == project_id)
+        ).scalar_one_or_none()
+
+    @staticmethod
     def get_or_create(name: str, project_id: uuid.UUID) -> "Variant":
         """Return an existing variant by *name* under *project_id*, or create and persist a new one."""
 

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -92,16 +92,14 @@ def init_app(app):
                 vid = _uuid.UUID(variant_id)
             except ValueError:
                 return {"error": "Invalid variant_id"}, 400
-            assessments = [a.to_dict() for a in DBAssessment.get_handmade(vid)]
+            assessments = [a.to_dict() for a in DBAssessment.get_handmade([vid])]
         elif project_id:
             try:
                 pid = _uuid.UUID(project_id)
             except ValueError:
                 return {"error": "Invalid project_id"}, 400
-            variants = DBVariant.get_by_project(pid)
-            assessments = []
-            for v in variants:
-                assessments.extend(a.to_dict() for a in DBAssessment.get_handmade(v.id))
+            variant_ids = [variant.id for variant in DBVariant.get_by_project(pid)]
+            assessments = [a.to_dict() for a in DBAssessment.get_handmade(variant_ids)]
         else:
             assessments = [a.to_dict() for a in DBAssessment.get_handmade()]
 

--- a/tests/end_to_end_tests/test_merger_ci.py
+++ b/tests/end_to_end_tests/test_merger_ci.py
@@ -23,6 +23,10 @@ from src.bin.merger_ci import _run_main, _ts_key, post_treatment, main
 from . import write_demo_files
 
 
+_PROJECT_NAME = "TestProject"
+_VARIANT_NAME = "TestVariant"
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -59,8 +63,8 @@ def app(init_files, monkeypatch):
         runner = application.test_cli_runner()
         result = runner.invoke(args=[
             "merge",
-            "--project", "TestProject",
-            "--variant", "TestVariant",
+            "--project", _PROJECT_NAME,
+            "--variant", _VARIANT_NAME,
             "--cdx", str(init_files["CDX_PATH"]),
             "--spdx", str(init_files["SPDX_PATH"]),
             "--grype", str(init_files["GRYPE_CDX_PATH"]),
@@ -472,6 +476,7 @@ def test_import_custom_assessments_file_not_found(app, tmp_path):
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "import-custom-assessments",
+            "--project", _PROJECT_NAME,
             str(tmp_path / "nonexistent.tar.gz"),
         ])
     assert result.exit_code == 1
@@ -485,7 +490,9 @@ def test_import_custom_assessments_unsupported_type(app, tmp_path):
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "import-custom-assessments", str(bad_file),
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(bad_file),
         ])
     assert result.exit_code == 1
     assert "unsupported file type" in result.output.lower()
@@ -498,7 +505,9 @@ def test_import_custom_assessments_invalid_targz(app, tmp_path):
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "import-custom-assessments", str(bad_archive),
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(bad_archive),
         ])
     assert result.exit_code == 1
     assert "unable to open" in result.output.lower()
@@ -515,7 +524,9 @@ def test_import_custom_assessments_json_unknown_variant(app, tmp_path):
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "import-custom-assessments", str(json_file),
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(json_file),
         ])
     assert result.exit_code == 1
     assert "no variant found" in result.output.lower()
@@ -523,12 +534,14 @@ def test_import_custom_assessments_json_unknown_variant(app, tmp_path):
 
 def test_import_custom_assessments_json_invalid_json(app, tmp_path):
     """Import a .json with invalid JSON exits with error code 1."""
-    json_file = tmp_path / "TestVariant.json"
+    json_file = tmp_path / f"{_VARIANT_NAME}.json"
     json_file.write_text("{invalid json")
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "import-custom-assessments", str(json_file),
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(json_file),
         ])
     assert result.exit_code == 1
     assert "invalid json" in result.output.lower()
@@ -536,12 +549,14 @@ def test_import_custom_assessments_json_invalid_json(app, tmp_path):
 
 def test_import_custom_assessments_json_not_openvex(app, tmp_path):
     """Import a .json that is not OpenVEX exits with error code 1."""
-    json_file = tmp_path / "TestVariant.json"
+    json_file = tmp_path / f"{_VARIANT_NAME}.json"
     json_file.write_text(json.dumps({"hello": "world"}))
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "import-custom-assessments", str(json_file),
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(json_file),
         ])
     assert result.exit_code == 1
     assert "not a valid openvex" in result.output.lower()
@@ -558,12 +573,39 @@ def test_import_custom_assessments_json_success(app, tmp_path):
             "status_notes": "imported via CLI",
         }],
     }
-    json_file = tmp_path / "TestVariant.json"
+    json_file = tmp_path / f"{_VARIANT_NAME}.json"
     json_file.write_text(json.dumps(doc))
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "import-custom-assessments", str(json_file),
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(json_file),
+        ])
+    assert result.exit_code == 0, result.output
+    assert "Imported 1 assessments" in result.output
+
+
+def test_import_custom_assessments_json_success_variant_flag(app, tmp_path):
+    """Import a .json with a filename that doesn't match any variant."""
+    doc = {
+        "@context": "https://openvex.dev/ns/v0.2.0",
+        "statements": [{
+            "vulnerability": {"name": "CVE-2020-35492"},
+            "status": "affected",
+            "products": [{"@id": "cairo@1.16.0"}],
+            "status_notes": "imported via CLI",
+        }],
+    }
+    json_file = tmp_path / "nonexistent_variant.json"
+    json_file.write_text(json.dumps(doc))
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            "--variant", _VARIANT_NAME,
+            str(json_file),
         ])
     assert result.exit_code == 0, result.output
     assert "Imported 1 assessments" in result.output
@@ -589,10 +631,29 @@ def test_import_custom_assessments_targz_no_matching(app, tmp_path):
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "import-custom-assessments", str(archive),
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(archive),
         ])
     assert result.exit_code == 1
     assert "no valid openvex" in result.output.lower()
+
+
+def test_import_custom_assessments_targz_variant_flag(app, tmp_path):
+    """Import a tar.gz with --variant fails."""
+    archive = tmp_path / "assessments.tar.gz"
+    archive.touch()
+
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            "--variant", _VARIANT_NAME,
+            str(archive),
+        ])
+    assert result.exit_code == 1
+    assert "cannot use the --variant" in result.output.lower()
 
 
 def test_export_import_roundtrip(app, tmp_path):
@@ -619,6 +680,7 @@ def test_export_import_roundtrip(app, tmp_path):
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "import-custom-assessments",
+            "--project", _PROJECT_NAME,
             str(tmp_path / "custom_assessments.tar.gz"),
         ])
     assert result.exit_code == 0, result.output
@@ -642,6 +704,7 @@ def test_import_custom_assessments_skips_duplicates(app, tmp_path):
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "import-custom-assessments",
+            "--project", _PROJECT_NAME,
             str(tmp_path / "custom_assessments.tar.gz"),
         ])
     assert result.exit_code == 0, result.output
@@ -657,7 +720,7 @@ def test_import_custom_assessments_targz_invalid_json_inside(
     buf = io.BytesIO()
     with _tf.open(fileobj=buf, mode='w:gz') as tar:
         content = b"{"
-        info = _tf.TarInfo(name="TestVariant.json")
+        info = _tf.TarInfo(name=f"{_VARIANT_NAME}.json")
         info.size = len(content)
         tar.addfile(info, io.BytesIO(content))
 
@@ -667,7 +730,9 @@ def test_import_custom_assessments_targz_invalid_json_inside(
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "import-custom-assessments", str(archive),
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(archive),
         ])
     assert result.exit_code == 1
 
@@ -681,7 +746,7 @@ def test_import_custom_assessments_targz_not_openvex_inside(
     buf = io.BytesIO()
     with _tf.open(fileobj=buf, mode='w:gz') as tar:
         content = json.dumps({"hello": "world"}).encode()
-        info = _tf.TarInfo(name="TestVariant.json")
+        info = _tf.TarInfo(name=f"{_VARIANT_NAME}.json")
         info.size = len(content)
         tar.addfile(info, io.BytesIO(content))
 
@@ -691,7 +756,9 @@ def test_import_custom_assessments_targz_not_openvex_inside(
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "import-custom-assessments", str(archive),
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(archive),
         ])
     assert result.exit_code == 1
 
@@ -702,8 +769,8 @@ def test_list_projects(cli_runner):
     ])
 
     assert out.exit_code == 0
-    assert "TestProject" in out.stdout
-    assert "TestVariant" in out.stdout
+    assert _PROJECT_NAME in out.stdout
+    assert _VARIANT_NAME in out.stdout
 
 
 def test_list_projects_json(cli_runner):
@@ -720,14 +787,14 @@ def test_list_projects_json(cli_runner):
 
     project = data[0]
     assert isinstance(project, dict)
-    assert project["name"] == "TestProject"
+    assert project["name"] == _PROJECT_NAME
 
     variants = project["variants"]
     assert isinstance(variants, list)
     assert len(variants) == 1
 
     variant = variants[0]
-    assert variant["name"] == "TestVariant"
+    assert variant["name"] == _VARIANT_NAME
 
 
 def test_list_scans(cli_runner):
@@ -736,8 +803,8 @@ def test_list_scans(cli_runner):
     ])
 
     assert out.exit_code == 0
-    assert "TestProject" in out.stdout
-    assert "TestVariant" in out.stdout
+    assert _PROJECT_NAME in out.stdout
+    assert _VARIANT_NAME in out.stdout
 
 
 def test_list_scans_json(cli_runner):
@@ -762,11 +829,11 @@ def test_list_scans_json(cli_runner):
 
     variant = scan["variant"]
     assert isinstance(variant, dict)
-    assert variant["name"] == "TestVariant"
+    assert variant["name"] == _VARIANT_NAME
 
     project = variant["project"]
     assert isinstance(project, dict)
-    assert project["name"] == "TestProject"
+    assert project["name"] == _PROJECT_NAME
 
 
 def test_delete_scan(cli_runner):

--- a/tests/end_to_end_tests/test_merger_ci.py
+++ b/tests/end_to_end_tests/test_merger_ci.py
@@ -440,6 +440,7 @@ def test_export_custom_assessments_no_data(app, tmp_path):
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "export-custom-assessments",
+            "--project", _PROJECT_NAME,
             "--output-dir", str(tmp_path),
         ])
     assert result.exit_code == 1
@@ -453,6 +454,7 @@ def test_export_custom_assessments_success(app, tmp_path):
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "export-custom-assessments",
+            "--project", _PROJECT_NAME,
             "--output-dir", str(tmp_path),
         ])
     assert result.exit_code == 0, result.output
@@ -468,6 +470,22 @@ def test_export_custom_assessments_success(app, tmp_path):
         doc = json.loads(f.read())
         assert "openvex" in doc["@context"]
         assert len(doc["statements"]) >= 1
+
+
+def test_export_custom_assessments_success_variant(app, tmp_path):
+    """Export creates variant.json OpenVEX."""
+    _create_custom_assessment(app)
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "export-custom-assessments",
+            "--project", _PROJECT_NAME,
+            "--variant", _VARIANT_NAME,
+            "--output-dir", str(tmp_path),
+        ])
+    assert result.exit_code == 0, result.output
+    out_file = tmp_path / f"{_VARIANT_NAME}.json"
+    assert out_file.exists()
 
 
 def test_import_custom_assessments_file_not_found(app, tmp_path):
@@ -665,6 +683,7 @@ def test_export_import_roundtrip(app, tmp_path):
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "export-custom-assessments",
+            "--project", _PROJECT_NAME,
             "--output-dir", str(tmp_path),
         ])
     assert result.exit_code == 0, result.output
@@ -696,6 +715,7 @@ def test_import_custom_assessments_skips_duplicates(app, tmp_path):
         runner = app.test_cli_runner()
         runner.invoke(args=[
             "export-custom-assessments",
+            "--project", _PROJECT_NAME,
             "--output-dir", str(tmp_path),
         ])
 

--- a/vulnscout
+++ b/vulnscout
@@ -31,8 +31,8 @@ call_container_engine() {
     $CONTAINER_ENGINE "$@"
 }
 
-VARIANT="default"
 PROJECT="default"
+VARIANT=""
 MATCH_CONDITION=""
 PENDING_ARGS=()
 DEV_MODE=false


### PR DESCRIPTION
## Fixes #315

### Changes proposed in this pull request:

* refactored how the `--variant` flag is handled in the vulnscout and entrypoint scripts so the Python code can distinguish between `--variant default` and no `--variant` flag at all.
* added `--project` and `--variant` flags to `--import-custom-assessment`
  * `--project` is required
  * `--variant` is only allowed when importing a single JSON file and takes precedence over the file name to determine which variant to import assessments in
* added `--project` and `--variant` flags to `--export-custom-assessment`
  * `--project` is required
    * the command no longer exports the assessments for all created projects (and it is no longer possible to do so - it caused name clashes in the archive when multiple variants with the same name exist)
    * Potential regression: assessments that are not tied to any variant/project can no longer be exported. They were previously exported with the "unassigned" filename, but this is incompatible with the new filtering architecture
  * when using `--variant`, a single JSON file is exported with the variant name as filename
### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


