### PR TITLE
Parse supplier info in SPDX 2.3

### DIFF
--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import type { Assessment } from "../handlers/assessments";
 import type { Variant } from '../handlers/variant';
 import MessageBanner from './MessageBanner';
+import { formatPkgId } from '../helpers/pkgId';
 
 type EditAssessmentData = {
     id: string;
@@ -235,7 +236,7 @@ function EditAssessment({
                                     }}
                                     className="accent-blue-400"
                                 />
-                                <span className="font-mono text-gray-200">{pkg}</span>
+                                <span className="font-mono text-gray-200">{formatPkgId(pkg)}</span>
                             </label>
                         ))}
                     </div>

--- a/frontend/src/components/FilterOption.tsx
+++ b/frontend/src/components/FilterOption.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 function FilterOption({ label, options, selected, setSelected, parentRef, CustomFilterComponent, customFilterName = 'custom', showCustomFilterComponent, setShowCustomFilterComponent }: Readonly<Props>) {
     const [isOpen, setIsOpen] = useState(false);
-    const [maxHeight, setMaxHeight] = useState<string>('2500px'); 
+    const [maxHeight, setMaxHeight] = useState<string>('500px'); 
     const dropdownRef = useRef<HTMLDivElement>(null);
     const isActive = selected.length > 0 || showCustomFilterComponent;
 

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import MessageBanner from './MessageBanner';
 import type { Variant } from '../handlers/variant';
+import { formatPkgId } from '../helpers/pkgId';
 
 type PostAssessment = {
     vuln_id?: string,
@@ -229,7 +230,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                                 className="accent-blue-400"
                             />
                             <span className={`font-mono ${isActive ? 'text-gray-200' : 'text-gray-500 italic'}`}
-                                  title={isActive ? undefined : 'Not in active SBOM'}>{pkg}</span>
+                                  title={isActive ? undefined : 'Not in active SBOM'}>{formatPkgId(pkg)}</span>
                         </label>
                         );
                     })}

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -47,6 +47,17 @@ const dt_options: Intl.DateTimeFormatOptions = {
     timeZoneName: 'shortOffset'
 };
 
+function splitPkgId(id: string): { nameVersion: string; supplier: string } {
+    const sepIdx = id.indexOf('::');
+    if (sepIdx === -1) return { nameVersion: id, supplier: '' };
+    return { nameVersion: id.slice(0, sepIdx), supplier: id.slice(sepIdx + 2) };
+}
+
+function formatPkgId(id: string): string {
+    const { nameVersion, supplier } = splitPkgId(id);
+    return supplier ? `${nameVersion} (${supplier})` : nameVersion;
+}
+
 type AssessmentGroup = {
     key: string;
     assessments: Assessment[];
@@ -823,7 +834,7 @@ type AssessmentGroup = {
                                 </li>
                                 <li key="packages">
                                     <span className="font-bold mr-1">Affects:</span>
-                                    <code>{vuln.packages.join(', ')}</code>
+                                    <code>{vuln.packages.map(formatPkgId).join(', ')}</code>
                                 </li>
                                 <li key="aliases">
                                     <span className="font-bold mr-1">Aliases:</span>
@@ -949,12 +960,15 @@ type AssessmentGroup = {
                                             <div className="absolute w-3 h-3 bg-gray-200 rounded-full mt-1.5 -start-1.5 border border-gray-800 bg-gray-800"></div>
                                             <time className="mb-1 text-sm font-normal leading-none text-gray-400">{dt.toLocaleString(undefined, dt_options)}</time>
                                             <div className="text-sm mb-2 flex flex-wrap gap-1">
-                                                {group.packages.map(pkg => (
-                                                    <span key={pkg} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300">
-                                                        <FontAwesomeIcon icon={faBox} className="w-3 h-3 mr-1" />
-                                                        {pkg}
-                                                    </span>
-                                                ))}
+                                                {group.packages.map(pkg => {
+                                                    const { nameVersion, supplier } = splitPkgId(pkg);
+                                                    return (
+                                                        <span key={pkg} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300" title={supplier ? `Supplier: ${supplier}` : undefined}>
+                                                            <FontAwesomeIcon icon={faBox} className="w-3 h-3 mr-1" />
+                                                            {nameVersion}{supplier && <span className="ml-1 opacity-70 text-xs">({supplier})</span>}
+                                                        </span>
+                                                    );
+                                                })}
                                             </div>
                                             {(() => {
                                                 // Build the same group key (date + content fingerprint) used by

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -20,6 +20,7 @@ import type { EditAssessmentData } from "./EditAssessment";
 import Variants from '../handlers/variant';
 import { formatSourceName } from '../helpers/sourceNames';
 import { useDocUrl } from '../helpers/useDocUrl';
+import { splitPkgId, formatPkgId } from '../helpers/pkgId';
 import type { Variant } from '../handlers/variant';
 import { useState, useEffect, useRef, useCallback } from "react";
 
@@ -47,16 +48,6 @@ const dt_options: Intl.DateTimeFormatOptions = {
     timeZoneName: 'shortOffset'
 };
 
-function splitPkgId(id: string): { nameVersion: string; supplier: string } {
-    const sepIdx = id.indexOf('::');
-    if (sepIdx === -1) return { nameVersion: id, supplier: '' };
-    return { nameVersion: id.slice(0, sepIdx), supplier: id.slice(sepIdx + 2) };
-}
-
-function formatPkgId(id: string): string {
-    const { nameVersion, supplier } = splitPkgId(id);
-    return supplier ? `${nameVersion} (${supplier})` : nameVersion;
-}
 
 type AssessmentGroup = {
     key: string;
@@ -963,9 +954,9 @@ type AssessmentGroup = {
                                                 {group.packages.map(pkg => {
                                                     const { nameVersion, supplier } = splitPkgId(pkg);
                                                     return (
-                                                        <span key={pkg} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300" title={supplier ? `Supplier: ${supplier}` : undefined}>
+                                                        <span key={pkg} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300" title={`Supplier: ${supplier || 'unknown supplier'}`}>
                                                             <FontAwesomeIcon icon={faBox} className="w-3 h-3 mr-1" />
-                                                            {nameVersion}{supplier && <span className="ml-1 opacity-70 text-xs">({supplier})</span>}
+                                                            {nameVersion}<span className="ml-1 opacity-70 text-xs">({supplier || 'unknown supplier'})</span>
                                                         </span>
                                                     );
                                                 })}

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -20,7 +20,7 @@ import type { EditAssessmentData } from "./EditAssessment";
 import Variants from '../handlers/variant';
 import { formatSourceName } from '../helpers/sourceNames';
 import { useDocUrl } from '../helpers/useDocUrl';
-import { splitPkgId, formatPkgId } from '../helpers/pkgId';
+import { splitPkgId, formatPkgId, extractSupplierName } from '../helpers/pkgId';
 import type { Variant } from '../handlers/variant';
 import { useState, useEffect, useRef, useCallback } from "react";
 
@@ -954,9 +954,9 @@ type AssessmentGroup = {
                                                 {group.packages.map(pkg => {
                                                     const { nameVersion, supplier } = splitPkgId(pkg);
                                                     return (
-                                                        <span key={pkg} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300" title={`Supplier: ${supplier || 'unknown supplier'}`}>
+                                                        <span key={pkg} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300" title={`Supplier: ${extractSupplierName(supplier) || 'unknown supplier'}`}>
                                                             <FontAwesomeIcon icon={faBox} className="w-3 h-3 mr-1" />
-                                                            {nameVersion}<span className="ml-1 opacity-70 text-xs">({supplier || 'unknown supplier'})</span>
+                                                            {nameVersion}<span className="ml-1 opacity-70 text-xs">({extractSupplierName(supplier) || 'unknown supplier'})</span>
                                                         </span>
                                                     );
                                                 })}

--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -11,6 +11,7 @@ type Package = {
     source: string[];
     variants: string[];
     sbom_documents: string[];
+    supplier: string;
 };
 
 export type { Package, VulnCounts, Severities };
@@ -32,6 +33,7 @@ const asPackage = (data: any): Package | [] => {
         source: [],
         variants: [],
         sbom_documents: [],
+        supplier: "",
     };
     if (typeof data?.id === "string" && data?.id != "") pkg.id = data.id;
     if (Array.isArray(data?.cpe)) {
@@ -43,6 +45,7 @@ const asPackage = (data: any): Package | [] => {
     if (Array.isArray(data?.variants)) {
         for (const v of data.variants) if (typeof v === "string") pkg.variants.push(v);
     }
+    if (typeof data?.supplier === "string") pkg.supplier = data.supplier;
     if (Array.isArray(data?.sources)) {
         for (const s of data.sources) if (typeof s === "string") pkg.source.push(s);
     }

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -37,6 +37,7 @@ type FindingDiffEntry = {
     finding_id: string;
     package_name: string;
     package_version: string;
+    package_supplier?: string;
     package_id: string;
     vulnerability_id: string;
     origin?: string;
@@ -46,6 +47,7 @@ type PackageDiffEntry = {
     package_id: string;
     package_name: string;
     package_version: string;
+    package_supplier?: string;
 };
 
 type PackageUpgradeEntry = {
@@ -54,6 +56,7 @@ type PackageUpgradeEntry = {
     new_version: string;
     old_package_id: string;
     new_package_id: string;
+    package_supplier?: string;
 };
 
 type FindingUpgradeEntry = {
@@ -61,6 +64,7 @@ type FindingUpgradeEntry = {
     package_name: string;
     old_version: string;
     new_version: string;
+    package_supplier?: string;
     origin?: string;
 };
 
@@ -95,6 +99,7 @@ type GlobalResultFinding = {
     finding_id: string;
     package_name: string;
     package_version: string;
+    package_supplier?: string;
     package_id: string;
     vulnerability_id: string;
     sources: string[];
@@ -104,6 +109,7 @@ type GlobalResultPackage = {
     package_id: string;
     package_name: string;
     package_version: string;
+    package_supplier?: string;
     sources: string[];
 };
 

--- a/frontend/src/helpers/pkgId.ts
+++ b/frontend/src/helpers/pkgId.ts
@@ -9,9 +9,18 @@ export function splitPkgId(id: string): { nameVersion: string; supplier: string 
 }
 
 /**
- * Format a package ID for display, always showing supplier (falling back to 'unknown supplier').
+ * Extract the display name from a supplier string, stripping the SPDX-style
+ * "Organization: " / "Person: " prefix and any trailing parenthetical (e.g. email).
+ */
+export function extractSupplierName(supplier: string): string {
+    return supplier.replace(/^[^:]+:\s*/, '').replace(/\s*\([^)]*\)$/, '');
+}
+
+/**
+ * Format a package ID for display, always showing supplier name (falling back to 'unknown supplier').
  */
 export function formatPkgId(id: string): string {
     const { nameVersion, supplier } = splitPkgId(id);
-    return `${nameVersion} (${supplier || 'unknown supplier'})`;
+    const supplierName = supplier ? extractSupplierName(supplier) : '';
+    return `${nameVersion} (${supplierName || 'unknown supplier'})`;
 }

--- a/frontend/src/helpers/pkgId.ts
+++ b/frontend/src/helpers/pkgId.ts
@@ -1,0 +1,17 @@
+/**
+ * Parse a package ID string using the `name@version::supplier` convention.
+ * Returns the name+version part and the supplier part separately.
+ */
+export function splitPkgId(id: string): { nameVersion: string; supplier: string } {
+    const sepIdx = id.indexOf('::');
+    if (sepIdx === -1) return { nameVersion: id, supplier: '' };
+    return { nameVersion: id.slice(0, sepIdx), supplier: id.slice(sepIdx + 2) };
+}
+
+/**
+ * Format a package ID for display, always showing supplier (falling back to 'unknown supplier').
+ */
+export function formatPkgId(id: string): string {
+    const { nameVersion, supplier } = splitPkgId(id);
+    return `${nameVersion} (${supplier || 'unknown supplier'})`;
+}

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -18,6 +18,7 @@ import ConfirmationModal from '../components/ConfirmationModal';
 import MessageBanner from '../components/MessageBanner';
 import Variants from '../handlers/variant';
 import { useDocUrl } from '../helpers/useDocUrl';
+import { splitPkgId, extractSupplierName } from '../helpers/pkgId';
 
 type AssessmentMutation =
     | { type: 'delete'; vulnId: string; ids: string[] }
@@ -38,6 +39,8 @@ type ReviewRow = Assessment & {
     _allIds: string[];
     /** All variant IDs merged into this group. */
     _variantIds: string[];
+    /** Unique supplier display names extracted from packages (for search). */
+    extractedSuppliers: string[];
 };
 
 const columnHelper = createColumnHelper<ReviewRow>();
@@ -107,6 +110,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     const [search, setSearch] = useState<string>('');
     const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
     const [selectedJustifications, setSelectedJustifications] = useState<string[]>([]);
+    const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
     const [importStatus, setImportStatus] = useState<string | null>(null);
@@ -251,10 +255,24 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         return [...set].sort();
     }, [assessments]);
 
+    const supplierList = useMemo(() => {
+        const set = new Set<string>();
+        for (const a of assessments) {
+            for (const pkg of a.packages) {
+                const name = extractSupplierName(splitPkgId(pkg).supplier);
+                if (name) set.add(name);
+            }
+        }
+        return [...set].sort();
+    }, [assessments]);
+
+    const hasSupplierInfo = useMemo(() => supplierList.length > 0, [supplierList]);
+
     const resetFilters = () => {
         setSearch('');
         setSelectedStatuses([]);
         setSelectedJustifications([]);
+        setSelectedSuppliers([]);
     };
 
     const handleExportReview = useCallback(() => {
@@ -421,12 +439,34 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     <div className="flex flex-wrap gap-1 items-center justify-center h-full">
                         {pkgs.map(p => (
                             <span key={p} className="bg-gray-600 text-gray-200 text-xs px-1.5 py-0.5 rounded font-mono">
-                                {p}
+                                {splitPkgId(p).nameVersion}
                             </span>
                         ))}
                     </div>
                 );
             },
+        }),
+        columnHelper.display({
+            id: 'supplier',
+            header: () => <div className="flex items-center justify-center">Supplier</div>,
+            size: 160,
+            cell: info => {
+                const pkgs = info.row.original.packages;
+                const suppliers = [...new Set(
+                    pkgs.map(p => extractSupplierName(splitPkgId(p).supplier)).filter(s => s !== '')
+                )];
+                if (suppliers.length === 0) return <div className="flex items-center justify-center h-full text-neutral-500">—</div>;
+                return (
+                    <div className="flex flex-wrap gap-1 items-center justify-center h-full">
+                        {suppliers.map(s => (
+                            <span key={s} className="bg-gray-600 text-gray-200 text-xs px-1.5 py-0.5 rounded">
+                                {s}
+                            </span>
+                        ))}
+                    </div>
+                );
+            },
+            enableSorting: false,
         }),
         columnHelper.accessor("variant_id", {
             header: () => <div className="flex items-center justify-center">Variants</div>,
@@ -592,6 +632,10 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         if (selectedJustifications.length && !(a.justification && selectedJustifications.includes(a.justification.replace(/_/g, " ")))) {
             return false;
         }
+        if (selectedSuppliers.length) {
+            const rowSuppliers = a.packages.map(p => extractSupplierName(splitPkgId(p).supplier));
+            if (!selectedSuppliers.some(s => rowSuppliers.includes(s))) return false;
+        }
         return true;
     });
 
@@ -643,6 +687,15 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     selected={selectedJustifications}
                     setSelected={setSelectedJustifications}
                 />
+
+                {hasSupplierInfo && (
+                    <FilterOption
+                        label="Supplier"
+                        options={supplierList}
+                        selected={selectedSuppliers}
+                        setSelected={setSelectedSuppliers}
+                    />
+                )}
 
                 <div className="ml-auto flex items-center gap-2 relative">
                     <button
@@ -750,9 +803,12 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     texts: vulnDescriptions[a.vuln_id] ?? [],
                     _allIds: (a as any)._allIds ?? [a.id],
                     _variantIds: (a as any)._variantIds ?? (a.variant_id ? [a.variant_id] : []),
+                    extractedSuppliers: [...new Set(
+                        a.packages.map(p => extractSupplierName(splitPkgId(p).supplier)).filter(s => s !== '')
+                    )],
                 }))}
                 search={search}
-                fuseKeys={["vuln_id", "packages", "simplified_status", "status_notes", "justification", "workaround"]}
+                fuseKeys={["vuln_id", "packages", "simplified_status", "status_notes", "justification", "workaround", "extractedSuppliers"]}
                 estimateRowHeight={50}
                 hasPagination={true}
                 hoverField="texts"

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -19,6 +19,7 @@ import {
 import type { ScanManagerSnapshot } from "../handlers/scanStateManager";
 import ScanProgressPanel from "../components/ScanProgressPanel";
 import { useDocUrl } from "../helpers/useDocUrl";
+import { extractSupplierName } from "../helpers/pkgId";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "../components/ConfirmationModal";
@@ -60,7 +61,8 @@ function FindingDiffTable({ entries, label, colorClass }: {
             e.package_name.toLowerCase().includes(filter.toLowerCase()) ||
             e.package_version.toLowerCase().includes(filter.toLowerCase()) ||
             e.vulnerability_id.toLowerCase().includes(filter.toLowerCase()) ||
-            (e.origin || '').toLowerCase().includes(filter.toLowerCase())
+            (e.origin || '').toLowerCase().includes(filter.toLowerCase()) ||
+            extractSupplierName(e.package_supplier || '').toLowerCase().includes(filter.toLowerCase())
         )
         : entries;
 
@@ -87,6 +89,7 @@ function FindingDiffTable({ entries, label, colorClass }: {
                             <tr>
                                 <th className="px-3 py-2">Package</th>
                                 <th className="px-3 py-2">Version</th>
+                                <th className="px-3 py-2">Supplier</th>
                                 <th className="px-3 py-2">Vulnerability</th>
                                 {hasOrigin && <th className="px-3 py-2">Origin</th>}
                             </tr>
@@ -96,6 +99,7 @@ function FindingDiffTable({ entries, label, colorClass }: {
                                 <tr key={e.finding_id} className="border-t border-gray-600 hover:bg-gray-600/40">
                                     <td className="px-3 py-1.5 font-mono">{e.package_name}</td>
                                     <td className="px-3 py-1.5 font-mono text-gray-400">{e.package_version}</td>
+                                    <td className="px-3 py-1.5 text-gray-400">{extractSupplierName(e.package_supplier || '') || '—'}</td>
                                     <td className="px-3 py-1.5 font-mono">{e.vulnerability_id}</td>
                                     {hasOrigin && <td className="px-3 py-1.5 text-gray-400">{e.origin ?? ''}</td>}
                                 </tr>
@@ -121,7 +125,8 @@ function FindingUpgradeDiffTable({ entries, label, colorClass }: {
             e.vulnerability_id.toLowerCase().includes(filter.toLowerCase()) ||
             e.old_version.toLowerCase().includes(filter.toLowerCase()) ||
             e.new_version.toLowerCase().includes(filter.toLowerCase()) ||
-            (e.origin || '').toLowerCase().includes(filter.toLowerCase())
+            (e.origin || '').toLowerCase().includes(filter.toLowerCase()) ||
+            extractSupplierName(e.package_supplier || '').toLowerCase().includes(filter.toLowerCase())
         )
         : entries;
 
@@ -149,6 +154,7 @@ function FindingUpgradeDiffTable({ entries, label, colorClass }: {
                                 <th className="px-3 py-2">Package</th>
                                 <th className="px-3 py-2">Old Version</th>
                                 <th className="px-3 py-2">New Version</th>
+                                <th className="px-3 py-2">Supplier</th>
                                 <th className="px-3 py-2">Vulnerability</th>
                                 {hasOrigin && <th className="px-3 py-2">Origin</th>}
                             </tr>
@@ -159,6 +165,7 @@ function FindingUpgradeDiffTable({ entries, label, colorClass }: {
                                     <td className="px-3 py-1.5 font-mono">{e.package_name}</td>
                                     <td className="px-3 py-1.5 font-mono text-red-400">{e.old_version}</td>
                                     <td className="px-3 py-1.5 font-mono text-green-400">{e.new_version}</td>
+                                    <td className="px-3 py-1.5 text-gray-400">{extractSupplierName(e.package_supplier || '') || '—'}</td>
                                     <td className="px-3 py-1.5 font-mono">{e.vulnerability_id}</td>
                                     {hasOrigin && <td className="px-3 py-1.5 text-gray-400">{e.origin ?? ''}</td>}
                                 </tr>
@@ -180,7 +187,8 @@ function PackageDiffTable({ entries, label, colorClass }: {
     const filtered = filter
         ? entries.filter(e =>
             e.package_name.toLowerCase().includes(filter.toLowerCase()) ||
-            e.package_version.toLowerCase().includes(filter.toLowerCase())
+            e.package_version.toLowerCase().includes(filter.toLowerCase()) ||
+            extractSupplierName(e.package_supplier || '').toLowerCase().includes(filter.toLowerCase())
         )
         : entries;
 
@@ -209,6 +217,7 @@ function PackageDiffTable({ entries, label, colorClass }: {
                             <tr>
                                 <th className="px-3 py-2">Package</th>
                                 <th className="px-3 py-2">Version</th>
+                                <th className="px-3 py-2">Supplier</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -216,6 +225,7 @@ function PackageDiffTable({ entries, label, colorClass }: {
                                 <tr key={e.package_id} className="border-t border-gray-600 hover:bg-gray-600/40">
                                     <td className="px-3 py-1.5 font-mono">{e.package_name}</td>
                                     <td className="px-3 py-1.5 font-mono text-gray-400">{e.package_version}</td>
+                                    <td className="px-3 py-1.5 text-gray-400">{extractSupplierName(e.package_supplier || '') || '—'}</td>
                                 </tr>
                             ))}
                         </tbody>
@@ -236,7 +246,8 @@ function PackageUpgradeDiffTable({ entries, label, colorClass }: {
         ? entries.filter(e =>
             e.package_name.toLowerCase().includes(filter.toLowerCase()) ||
             e.old_version.toLowerCase().includes(filter.toLowerCase()) ||
-            e.new_version.toLowerCase().includes(filter.toLowerCase())
+            e.new_version.toLowerCase().includes(filter.toLowerCase()) ||
+            extractSupplierName(e.package_supplier || '').toLowerCase().includes(filter.toLowerCase())
         )
         : entries;
 
@@ -266,6 +277,7 @@ function PackageUpgradeDiffTable({ entries, label, colorClass }: {
                                 <th className="px-3 py-2">Package</th>
                                 <th className="px-3 py-2">Old Version</th>
                                 <th className="px-3 py-2">New Version</th>
+                                <th className="px-3 py-2">Supplier</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -274,6 +286,7 @@ function PackageUpgradeDiffTable({ entries, label, colorClass }: {
                                     <td className="px-3 py-1.5 font-mono">{e.package_name}</td>
                                     <td className="px-3 py-1.5 font-mono text-red-400">{e.old_version}</td>
                                     <td className="px-3 py-1.5 font-mono text-green-400">{e.new_version}</td>
+                                    <td className="px-3 py-1.5 text-gray-400">{extractSupplierName(e.package_supplier || '') || '—'}</td>
                                 </tr>
                             ))}
                         </tbody>
@@ -380,8 +393,8 @@ function GlobalResultModal({ scanId, onClose }: { scanId: string; onClose: () =>
         ].join(' ');
 
     const lc = filter.toLowerCase();
-    const filteredPkgs = data ? (lc ? data.packages.filter(p => p.package_name.toLowerCase().includes(lc) || p.package_version.toLowerCase().includes(lc) || p.sources.some(s => s.toLowerCase().includes(lc))) : data.packages) : [];
-    const filteredFindings = data ? (lc ? data.findings.filter(f => f.package_name.toLowerCase().includes(lc) || f.vulnerability_id.toLowerCase().includes(lc) || f.sources.some(s => s.toLowerCase().includes(lc))) : data.findings) : [];
+    const filteredPkgs = data ? (lc ? data.packages.filter(p => p.package_name.toLowerCase().includes(lc) || p.package_version.toLowerCase().includes(lc) || p.sources.some(s => s.toLowerCase().includes(lc)) || extractSupplierName(p.package_supplier || '').toLowerCase().includes(lc)) : data.packages) : [];
+    const filteredFindings = data ? (lc ? data.findings.filter(f => f.package_name.toLowerCase().includes(lc) || f.vulnerability_id.toLowerCase().includes(lc) || f.sources.some(s => s.toLowerCase().includes(lc)) || extractSupplierName(f.package_supplier || '').toLowerCase().includes(lc)) : data.findings) : [];
     const filteredVulns = data ? (lc ? data.vulnerabilities.filter(v => v.vulnerability_id.toLowerCase().includes(lc) || v.sources.some(s => s.toLowerCase().includes(lc))) : data.vulnerabilities) : [];
 
     return (
@@ -451,6 +464,7 @@ function GlobalResultModal({ scanId, onClose }: { scanId: string; onClose: () =>
                                         <tr>
                                             <th className="px-3 py-2">Package</th>
                                             <th className="px-3 py-2">Version</th>
+                                            <th className="px-3 py-2">Supplier</th>
                                             <th className="px-3 py-2">Source</th>
                                         </tr>
                                     </thead>
@@ -459,6 +473,7 @@ function GlobalResultModal({ scanId, onClose }: { scanId: string; onClose: () =>
                                             <tr key={p.package_id} className="border-t border-gray-600 hover:bg-gray-600/40">
                                                 <td className="px-3 py-1.5 font-mono">{p.package_name}</td>
                                                 <td className="px-3 py-1.5 font-mono text-gray-400">{p.package_version}</td>
+                                                <td className="px-3 py-1.5 text-gray-400">{extractSupplierName(p.package_supplier || '') || '—'}</td>
                                                 <td className="px-3 py-1.5 text-gray-400">{p.sources.join(', ')}</td>
                                             </tr>
                                         ))}
@@ -474,6 +489,7 @@ function GlobalResultModal({ scanId, onClose }: { scanId: string; onClose: () =>
                                         <tr>
                                             <th className="px-3 py-2">Package</th>
                                             <th className="px-3 py-2">Version</th>
+                                            <th className="px-3 py-2">Supplier</th>
                                             <th className="px-3 py-2">Vulnerability</th>
                                             <th className="px-3 py-2">Source</th>
                                         </tr>
@@ -483,6 +499,7 @@ function GlobalResultModal({ scanId, onClose }: { scanId: string; onClose: () =>
                                             <tr key={f.finding_id} className="border-t border-gray-600 hover:bg-gray-600/40">
                                                 <td className="px-3 py-1.5 font-mono">{f.package_name}</td>
                                                 <td className="px-3 py-1.5 font-mono text-gray-400">{f.package_version}</td>
+                                                <td className="px-3 py-1.5 text-gray-400">{extractSupplierName(f.package_supplier || '') || '—'}</td>
                                                 <td className="px-3 py-1.5 font-mono">{f.vulnerability_id}</td>
                                                 <td className="px-3 py-1.5 text-gray-400">{f.sources.join(', ')}</td>
                                             </tr>

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -158,6 +158,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         'version': 'Version',
         'cpe': 'CPE',
         'purl': 'PURL',
+        'supplier': 'Supplier',
         'vulnerabilities': 'Vulnerabilities',
         'variants': 'Variants',
         'remainingPendingVulns': 'Remaining Pending Vulnerabilities',
@@ -218,6 +219,22 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                 },
                 enableSorting: false,
                 size: 200
+            }),
+            columnHelper.accessor('supplier', {
+                id: 'supplier',
+                header: () => <div className="flex items-center justify-center">Supplier</div>,
+                cell: info => {
+                    const supplier = info.getValue();
+                    if (!supplier) return (
+                        <div className="flex items-center justify-center h-full text-neutral-500">—</div>
+                    );
+                    return (
+                        <div className="flex items-center justify-center h-full text-center text-sm" title={supplier}>
+                            {supplier}
+                        </div>
+                    );
+                },
+                size: 200,
             }),
             columnHelper.accessor(
             row => ({ counts: row.vulnerabilities, severity: row.maxSeverity }),
@@ -379,6 +396,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                     'Version',
                     'CPE',
                     'PURL',
+                    'Supplier',
                     'Vulnerabilities',
                     'Variants',
                     'Remaining Pending Vulnerabilities',

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -9,6 +9,7 @@ import ToggleSwitch from "../components/ToggleSwitch";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleQuestion, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
 import { useDocUrl } from '../helpers/useDocUrl';
+import { extractSupplierName } from '../helpers/pkgId';
 
 type Props = {
     packages: Package[];
@@ -237,7 +238,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                     );
                     return (
                         <div className="flex items-center justify-center h-full text-center text-sm" title={supplier}>
-                            {supplier}
+                            {extractSupplierName(supplier)}
                         </div>
                     );
                 },

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -134,7 +134,14 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         return acc;
     }, []), [packages])
 
-    const defaultVisibleColumns = ['Name', 'Version', 'Vulnerabilities', 'Variants', 'Sources'];
+    const hasSupplierInfo = useMemo(() => packages.some(pkg => !!pkg.supplier), [packages]);
+
+    const defaultVisibleColumns = useMemo(() => {
+        const cols = ['Name', 'Version', 'Vulnerabilities', 'Variants', 'Sources'];
+        if (hasSupplierInfo) cols.splice(cols.indexOf('Vulnerabilities'), 0, 'Supplier');
+        return cols;
+    }, [hasSupplierInfo]);
+
     const [visibleColumns, setVisibleColumns] = useState<string[]>(defaultVisibleColumns);
 
     const sbom_docs_list = useMemo(() => packages.reduce((acc: string[], pkg) => {

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -15,13 +15,6 @@ type Props = {
     onShowVulns?: (packageId: string) => void;
 };
 
-function extractSupplierName(supplier: string): string {
-    // Strip type prefix like "Organization: " or "Person: "
-    const withoutType = supplier.replace(/^\w[\w\s]*:\s*/, '');
-    // Strip optional email in parentheses at the end
-    return withoutType.replace(/\s*\(.*\)\s*$/, '').trim();
-}
-
 const addVulnCounts = (counts: VulnCounts, ignore: string[]) => {
     return Object.keys(counts).reduce((acc, key) => {
         if (!ignore.includes(key)) {
@@ -165,6 +158,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         'version': 'Version',
         'cpe': 'CPE',
         'purl': 'PURL',
+        'supplier': 'Supplier',
         'vulnerabilities': 'Vulnerabilities',
         'variants': 'Variants',
         'remainingPendingVulns': 'Remaining Pending Vulnerabilities',
@@ -178,13 +172,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
             columnHelper.accessor('name', {
                 id: 'name',
                 header: () => <div className="flex items-center justify-center">Name</div>,
-                cell: info => {
-                    const name = info.getValue();
-                    const supplier = info.row.original.supplier;
-                    const supplierName = supplier ? extractSupplierName(supplier) : '';
-                    const display = supplierName ? `${supplierName} / ${name}` : name;
-                    return <div className="flex items-center justify-center h-full text-center" title={supplier || undefined}>{display}</div>;
-                },
+                cell: info => <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>,
                 footer: info => <div className="flex items-center justify-center h-full">{`Total: ${info.table.getRowCount()}`}</div>,
                 size: 300
             }),
@@ -231,6 +219,22 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                 },
                 enableSorting: false,
                 size: 200
+            }),
+            columnHelper.accessor('supplier', {
+                id: 'supplier',
+                header: () => <div className="flex items-center justify-center">Supplier</div>,
+                cell: info => {
+                    const supplier = info.getValue();
+                    if (!supplier) return (
+                        <div className="flex items-center justify-center h-full text-neutral-500">—</div>
+                    );
+                    return (
+                        <div className="flex items-center justify-center h-full text-center text-sm" title={supplier}>
+                            {supplier}
+                        </div>
+                    );
+                },
+                size: 200,
             }),
             columnHelper.accessor(
             row => ({ counts: row.vulnerabilities, severity: row.maxSeverity }),
@@ -392,6 +396,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                     'Version',
                     'CPE',
                     'PURL',
+                    'Supplier',
                     'Vulnerabilities',
                     'Variants',
                     'Remaining Pending Vulnerabilities',

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -15,6 +15,13 @@ type Props = {
     onShowVulns?: (packageId: string) => void;
 };
 
+function extractSupplierName(supplier: string): string {
+    // Strip type prefix like "Organization: " or "Person: "
+    const withoutType = supplier.replace(/^\w[\w\s]*:\s*/, '');
+    // Strip optional email in parentheses at the end
+    return withoutType.replace(/\s*\(.*\)\s*$/, '').trim();
+}
+
 const addVulnCounts = (counts: VulnCounts, ignore: string[]) => {
     return Object.keys(counts).reduce((acc, key) => {
         if (!ignore.includes(key)) {
@@ -158,7 +165,6 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         'version': 'Version',
         'cpe': 'CPE',
         'purl': 'PURL',
-        'supplier': 'Supplier',
         'vulnerabilities': 'Vulnerabilities',
         'variants': 'Variants',
         'remainingPendingVulns': 'Remaining Pending Vulnerabilities',
@@ -172,7 +178,13 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
             columnHelper.accessor('name', {
                 id: 'name',
                 header: () => <div className="flex items-center justify-center">Name</div>,
-                cell: info => <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>,
+                cell: info => {
+                    const name = info.getValue();
+                    const supplier = info.row.original.supplier;
+                    const supplierName = supplier ? extractSupplierName(supplier) : '';
+                    const display = supplierName ? `${supplierName} / ${name}` : name;
+                    return <div className="flex items-center justify-center h-full text-center" title={supplier || undefined}>{display}</div>;
+                },
                 footer: info => <div className="flex items-center justify-center h-full">{`Total: ${info.table.getRowCount()}`}</div>,
                 size: 300
             }),
@@ -219,22 +231,6 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                 },
                 enableSorting: false,
                 size: 200
-            }),
-            columnHelper.accessor('supplier', {
-                id: 'supplier',
-                header: () => <div className="flex items-center justify-center">Supplier</div>,
-                cell: info => {
-                    const supplier = info.getValue();
-                    if (!supplier) return (
-                        <div className="flex items-center justify-center h-full text-neutral-500">—</div>
-                    );
-                    return (
-                        <div className="flex items-center justify-center h-full text-center text-sm" title={supplier}>
-                            {supplier}
-                        </div>
-                    );
-                },
-                size: 200,
             }),
             columnHelper.accessor(
             row => ({ counts: row.vulnerabilities, severity: row.maxSeverity }),
@@ -396,7 +392,6 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                     'Version',
                     'CPE',
                     'PURL',
-                    'Supplier',
                     'Vulnerabilities',
                     'Variants',
                     'Remaining Pending Vulnerabilities',

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -50,6 +50,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
     const [search, setSearch] = useState<string>('');
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
     const [selectedSbomDocs, setSelectedSbomDocs] = useState<string[]>([]);
+    const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
     const tableRef = useRef<HTMLDivElement>(null); // ref to table container to allow adjustment of filter box height
@@ -153,10 +154,18 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         return acc.sort();
     }, []), [packages])
 
+    const suppliers_list = useMemo(() => packages.reduce((acc: string[], pkg) => {
+        const name = extractSupplierName(pkg.supplier);
+        if (name !== '' && !acc.includes(name))
+            acc.push(name);
+        return acc.sort();
+    }, []), [packages])
+
     const resetFilters = () => {
         setSearch('');
         setSelectedSources([]);
         setSelectedSbomDocs([]);
+        setSelectedSuppliers([]);
         setShowSeverity(false);
         setVisibleColumns(defaultVisibleColumns);
     }
@@ -359,9 +368,12 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
             if (selectedSbomDocs.length && !selectedSbomDocs.some(doc => el.sbom_documents.includes(doc))) {
                 return false;
             }
+            if (selectedSuppliers.length && !selectedSuppliers.includes(extractSupplierName(el.supplier))) {
+                return false;
+            }
             return true;
         });
-    }, [packages, selectedSources, selectedSbomDocs]);
+    }, [packages, selectedSources, selectedSbomDocs, selectedSuppliers]);
 
     return (<>
         <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2">
@@ -413,6 +425,15 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                 selected={visibleColumns}
                 setSelected={setVisibleColumns}
             />
+
+            {hasSupplierInfo && (
+                <FilterOption
+                    label="Supplier"
+                    options={suppliers_list}
+                    selected={selectedSuppliers}
+                    setSelected={setSelectedSuppliers}
+                />
+            )}
 
             <FilterOption
                 label="Source"

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -14,6 +14,7 @@ import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
 import { formatSourceName, getOriginalSourceName } from "../helpers/sourceNames";
 import { useDocUrl } from "../helpers/useDocUrl";
+import { formatPkgId } from "../helpers/pkgId";
 
 import MessageBanner from "../components/MessageBanner";
 import NVDProgressHandler from "../handlers/nvd_progress";
@@ -592,7 +593,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             columnHelper.accessor('packages_current', {
             id: 'packages',
             header: () => <div className="flex items-center justify-center">SBOM Affected</div>,
-            cell: info => <div className="flex items-center justify-center h-full text-center">{info.getValue().map(p => p.split('+git')[0]).join(', ')}</div>,
+            cell: info => <div className="flex items-center justify-center h-full text-center">{info.getValue().map(p => formatPkgId(p.split('+git')[0])).join(', ')}</div>,
             enableSorting: false,
             size: 255
             }),

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -746,8 +746,8 @@ describe('EditAssessment Component', () => {
         );
 
         expect(screen.getByText('Apply to packages:')).toBeInTheDocument();
-        expect(screen.getByText('pkg1@1.0.0')).toBeInTheDocument();
-        expect(screen.getByText('pkg2@2.0.0')).toBeInTheDocument();
+        expect(screen.getByText('pkg1@1.0.0 (unknown supplier)')).toBeInTheDocument();
+        expect(screen.getByText('pkg2@2.0.0 (unknown supplier)')).toBeInTheDocument();
     });
 
     test('shows external error when no package selected', async () => {

--- a/frontend/tests/unit_tests/test_handlers.ts
+++ b/frontend/tests/unit_tests/test_handlers.ts
@@ -163,6 +163,37 @@ describe('Packages', () => {
         expect(enrichedPackages[1].maxSeverity["Exploitable"].label).toEqual('low');
         expect(enrichedPackages[1].source).toEqual(['cve-finder']);
     });
+
+    test('asPackage parses supplier field', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                json: () => Promise.resolve([{
+                    name: 'foo',
+                    version: '1.0',
+                    supplier: 'Organization: Acme Corp (x@a.com)',
+                    cpe: [],
+                    purl: [],
+                }])
+            } as Response)
+        );
+        const packages = await Packages.list();
+        expect(packages[0].supplier).toBe('Organization: Acme Corp (x@a.com)');
+    });
+
+    test('asPackage defaults supplier to empty string when absent', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                json: () => Promise.resolve([{
+                    name: 'foo',
+                    version: '1.0',
+                    cpe: [],
+                    purl: [],
+                }])
+            } as Response)
+        );
+        const packages = await Packages.list();
+        expect(packages[0].supplier).toBe('');
+    });
 });
 
 

--- a/frontend/tests/unit_tests/test_pkg_id.ts
+++ b/frontend/tests/unit_tests/test_pkg_id.ts
@@ -1,0 +1,55 @@
+import { splitPkgId, extractSupplierName, formatPkgId } from '../../src/helpers/pkgId';
+
+describe('splitPkgId', () => {
+    test('splits name@version::supplier correctly', () => {
+        const result = splitPkgId('mylib@1.2.3::Organization: Acme Corp');
+        expect(result.nameVersion).toBe('mylib@1.2.3');
+        expect(result.supplier).toBe('Organization: Acme Corp');
+    });
+
+    test('returns empty supplier when no :: separator', () => {
+        const result = splitPkgId('mylib@1.2.3');
+        expect(result.nameVersion).toBe('mylib@1.2.3');
+        expect(result.supplier).toBe('');
+    });
+});
+
+describe('extractSupplierName', () => {
+    test('strips "Organization: " prefix', () => {
+        expect(extractSupplierName('Organization: Acme Corp')).toBe('Acme Corp');
+    });
+
+    test('strips "Person: " prefix', () => {
+        expect(extractSupplierName('Person: Jane Doe')).toBe('Jane Doe');
+    });
+
+    test('strips trailing parenthetical (e.g. email)', () => {
+        expect(extractSupplierName('Organization: Acme Corp (acme@example.com)')).toBe('Acme Corp');
+    });
+
+    test('strips prefix and trailing parenthetical together', () => {
+        expect(extractSupplierName('Person: Jane Doe (jane@example.com)')).toBe('Jane Doe');
+    });
+
+    test('returns string unchanged when no prefix', () => {
+        expect(extractSupplierName('Acme Corp')).toBe('Acme Corp');
+    });
+
+    test('returns empty string for empty input', () => {
+        expect(extractSupplierName('')).toBe('');
+    });
+});
+
+describe('formatPkgId', () => {
+    test('formats with extracted supplier name', () => {
+        expect(formatPkgId('mylib@1.2.3::Organization: Acme Corp')).toBe('mylib@1.2.3 (Acme Corp)');
+    });
+
+    test('falls back to "unknown supplier" when no supplier', () => {
+        expect(formatPkgId('mylib@1.2.3')).toBe('mylib@1.2.3 (unknown supplier)');
+    });
+
+    test('uses raw supplier name when no prefix', () => {
+        expect(formatPkgId('mylib@1.2.3::Acme Corp')).toBe('mylib@1.2.3 (Acme Corp)');
+    });
+});

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -41,7 +41,8 @@ describe('Packages Table', () => {
             },
             source: ['hardcoded'],
             variants: [],
-            sbom_documents: []
+            sbom_documents: [],
+            supplier: '',
         },
         {
             id: 'xxxyyyzzz@2.0.0',
@@ -53,7 +54,8 @@ describe('Packages Table', () => {
             maxSeverity: {"active": {label: 'high', index: 4}},
             source: ['cve-finder'],
             variants: [],
-            sbom_documents: []
+            sbom_documents: [],
+            supplier: '',
         },
         {
             id: 'dddeeefff@1.5.0',
@@ -68,7 +70,8 @@ describe('Packages Table', () => {
             },
             source: ['cve-finder', 'hardcoded'],
             variants: [],
-            sbom_documents: []
+            sbom_documents: [],
+            supplier: '',
         }
     ];
 
@@ -349,7 +352,8 @@ describe('Packages Table', () => {
                 maxSeverity: {"active": {label: 'low', index: 2}},
                 source: ['test'],
                 variants: [],
-                sbom_documents: []
+                sbom_documents: [],
+                supplier: '',
             }
         ];
 
@@ -384,7 +388,8 @@ describe('Packages Table', () => {
                 maxSeverity: {"active": {label: 'low', index: 2}},
                 source: ['test'],
                 variants: [],
-                sbom_documents: []
+                sbom_documents: [],
+                supplier: '',
             }
         ];
 
@@ -535,7 +540,8 @@ describe('Packages Table', () => {
                 maxSeverity: {"active": {label: 'low', index: 2}},
                 source: ['test'],
                 variants: ['variant-A', 'variant-B'],
-                sbom_documents: []
+                sbom_documents: [],
+                supplier: '',
             }
         ];
 
@@ -557,7 +563,8 @@ describe('Packages Table', () => {
                 maxSeverity: {"active": {label: 'low', index: 2}},
                 source: ['test'],
                 variants: [],
-                sbom_documents: []
+                sbom_documents: [],
+                supplier: '',
             },
             {
                 id: 'pkg-b@1.0.0',
@@ -569,7 +576,8 @@ describe('Packages Table', () => {
                 maxSeverity: {"active": {label: 'medium', index: 3}},
                 source: ['test'],
                 variants: [],
-                sbom_documents: []
+                sbom_documents: [],
+                supplier: '',
             }
         ];
 
@@ -621,5 +629,11 @@ describe('Packages Table', () => {
         const cpeSpan = await screen.getByText(/cpe:2.3:a:vendor:aaabbbccc:1.0.0/);
         expect(cpeSpan).toBeTruthy();
         expect(cpeSpan.getAttribute('title')).toContain('cpe:2.3:a:vendor:aaabbbccc:1.0.0');
+    });
+
+    test('supplier column is hidden by default but toggleable', async () => {
+        render(<TablePackages packages={packages} />);
+        // Column is NOT visible initially
+        expect(screen.queryByText('Supplier')).toBeNull();
     });
 });

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -631,9 +631,20 @@ describe('Packages Table', () => {
         expect(cpeSpan.getAttribute('title')).toContain('cpe:2.3:a:vendor:aaabbbccc:1.0.0');
     });
 
-    test('supplier column is hidden by default but toggleable', async () => {
+    test('supplier column is hidden by default when no package has supplier info', async () => {
         render(<TablePackages packages={packages} />);
-        // Column is NOT visible initially
-        expect(screen.queryByText('Supplier')).toBeNull();
+        // All packages have empty supplier, so the column should NOT be visible initially
+        expect(screen.queryByRole('columnheader', { name: /^supplier$/i })).toBeNull();
+    });
+
+    test('supplier column is shown by default when at least one package has supplier info', async () => {
+        const packagesWithSupplier: Package[] = [
+            { ...packages[0], supplier: 'Acme Corp' },
+            ...packages.slice(1),
+        ];
+        render(<TablePackages packages={packagesWithSupplier} />);
+        // At least one package has a supplier, so the column should be visible by default
+        const supplierHeader = await screen.findByRole('columnheader', { name: /^supplier$/i });
+        expect(supplierHeader).toBeTruthy();
     });
 });

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -75,6 +75,48 @@ describe('Packages Table', () => {
         }
     ];
 
+    const packagesWithSuppliers: Package[] = [
+        {
+            id: 'pkg-acme@1.0.0',
+            name: 'pkg-acme',
+            version: '1.0.0',
+            cpe: [],
+            purl: [],
+            vulnerabilities: {},
+            maxSeverity: {},
+            source: ['test'],
+            variants: [],
+            sbom_documents: [],
+            supplier: 'Organization: Acme Corp',
+        },
+        {
+            id: 'pkg-globex@1.0.0',
+            name: 'pkg-globex',
+            version: '1.0.0',
+            cpe: [],
+            purl: [],
+            vulnerabilities: {},
+            maxSeverity: {},
+            source: ['test'],
+            variants: [],
+            sbom_documents: [],
+            supplier: 'Organization: Globex',
+        },
+        {
+            id: 'pkg-acme2@2.0.0',
+            name: 'pkg-acme2',
+            version: '2.0.0',
+            cpe: [],
+            purl: [],
+            vulnerabilities: {},
+            maxSeverity: {},
+            source: ['test'],
+            variants: [],
+            sbom_documents: [],
+            supplier: 'Organization: Acme Corp',
+        },
+    ];
+
     Element.prototype.getBoundingClientRect = function () {
         return getDOMRect(500, 500)
     }
@@ -646,5 +688,32 @@ describe('Packages Table', () => {
         // At least one package has a supplier, so the column should be visible by default
         const supplierHeader = await screen.findByRole('columnheader', { name: /^supplier$/i });
         expect(supplierHeader).toBeTruthy();
+    });
+
+    test('filter by supplier', async () => {
+        render(<TablePackages packages={packagesWithSuppliers} />);
+        const user = userEvent.setup();
+
+        // ACT: open the Supplier filter dropdown and select "Acme Corp"
+        const supplierBtn = await screen.getByRole('button', { name: /^supplier$/i });
+        await user.click(supplierBtn);
+
+        const acmeCheckbox = await screen.getByRole('checkbox', { name: /acme corp/i });
+        await user.click(acmeCheckbox);
+
+        // ASSERT: only Acme Corp packages are shown, Globex is hidden
+        await waitFor(() => {
+            const html = document.body.innerHTML;
+            expect(html).toContain('pkg-acme');
+            expect(html).toContain('pkg-acme2');
+            expect(html).not.toContain('pkg-globex');
+        }, { timeout: 2000 });
+
+        // REVERT: uncheck "Acme Corp" — all packages should reappear
+        await user.click(acmeCheckbox);
+
+        await waitFor(() => {
+            expect(screen.getAllByRole('cell', { name: /pkg-globex/ }).length).toBeGreaterThan(0);
+        });
     });
 });

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -365,7 +365,7 @@ describe('StatusEditor', () => {
         render(<StatusEditor {...defaultProps} availablePackages={packages} />);
 
         expect(screen.getByText('Apply to packages:')).toBeInTheDocument();
-        expect(screen.getByText('only-pkg@1.0.0')).toBeInTheDocument();
+        expect(screen.getByText('only-pkg@1.0.0 (unknown supplier)')).toBeInTheDocument();
     });
 
     test('should render package checkboxes when more than one package is available', () => {
@@ -373,8 +373,8 @@ describe('StatusEditor', () => {
         render(<StatusEditor {...defaultProps} availablePackages={packages} />);
 
         expect(screen.getByText('Apply to packages:')).toBeInTheDocument();
-        expect(screen.getByText('pkg1@1.0.0')).toBeInTheDocument();
-        expect(screen.getByText('pkg2@2.0.0')).toBeInTheDocument();
+        expect(screen.getByText('pkg1@1.0.0 (unknown supplier)')).toBeInTheDocument();
+        expect(screen.getByText('pkg2@2.0.0 (unknown supplier)')).toBeInTheDocument();
     });
 
     test('should show external error when no package selected', async () => {

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2057,9 +2057,9 @@ describe('Vulnerability Modal', () => {
         />);
 
         // Only the project-scoped package (from packages_current) should appear as checkbox
-        await screen.findByText('pkg-alpha@1.0.0');
-        expect(screen.queryByText('pkg-beta@2.0.0')).not.toBeInTheDocument();
-        expect(screen.queryByText('pkg-gamma@3.0.0')).not.toBeInTheDocument();
+        await screen.findByText('pkg-alpha@1.0.0 (unknown supplier)');
+        expect(screen.queryByText('pkg-beta@2.0.0 (unknown supplier)')).not.toBeInTheDocument();
+        expect(screen.queryByText('pkg-gamma@3.0.0 (unknown supplier)')).not.toBeInTheDocument();
     });
 
     test('falls back to all packages when packages_current is empty', async () => {
@@ -2085,7 +2085,7 @@ describe('Vulnerability Modal', () => {
         />);
 
         // Both packages should appear since packages_current is empty (fallback)
-        await screen.findByText('pkg-x@1.0.0');
-        expect(screen.getByText('pkg-y@2.0.0')).toBeInTheDocument();
+        await screen.findByText('pkg-x@1.0.0 (unknown supplier)');
+        expect(screen.getByText('pkg-y@2.0.0 (unknown supplier)')).toBeInTheDocument();
     });
 });

--- a/src/controllers/packages.py
+++ b/src/controllers/packages.py
@@ -114,6 +114,7 @@ class PackagesController:
                         list(package.cpe or []),
                         list(package.purl or []),
                         package.licences or "",
+                        supplier=package.supplier or "",
                     )
                     # Keep caches in sync with DB object
                     self._cache[string_id] = db_pkg
@@ -179,6 +180,7 @@ class PackagesController:
                 v.get("cpe", []),
                 v.get("purl", []),
                 v.get("licences", ""),
+                supplier=v.get("supplier", ""),
             )
             ctrl.add(pkg)
         return ctrl

--- a/src/migrations/versions/i5d6e7f8a9b0_add_supplier_to_packages.py
+++ b/src/migrations/versions/i5d6e7f8a9b0_add_supplier_to_packages.py
@@ -1,0 +1,26 @@
+"""add supplier to packages
+
+Revision ID: i5d6e7f8a9b0
+Revises: h4c5d6e7f8a9
+Create Date: 2026-05-05 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'i5d6e7f8a9b0'
+down_revision = 'h4c5d6e7f8a9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('packages', sa.Column('supplier', sa.String(), server_default='', nullable=True))
+    op.drop_index('ix_packages_name_version', table_name='packages')
+    op.create_index('ix_packages_name_version_supplier', 'packages', ['name', 'version', 'supplier'])
+
+
+def downgrade():
+    op.drop_index('ix_packages_name_version_supplier', table_name='packages')
+    op.create_index('ix_packages_name_version', 'packages', ['name', 'version'])
+    op.drop_column('packages', 'supplier')

--- a/src/migrations/versions/i5d6e7f8a9b0_add_supplier_to_packages.py
+++ b/src/migrations/versions/i5d6e7f8a9b0_add_supplier_to_packages.py
@@ -15,7 +15,7 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('packages', sa.Column('supplier', sa.String(), server_default='', nullable=True))
+    op.add_column('packages', sa.Column('supplier', sa.String(), server_default='', nullable=False))
     op.drop_index('ix_packages_name_version', table_name='packages')
     op.create_index('ix_packages_name_version_supplier', 'packages', ['name', 'version', 'supplier'])
 

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -24,6 +24,7 @@ class Package(Base):
     cpe = db.Column(db.JSON, nullable=True)
     purl = db.Column(db.JSON, nullable=True)
     licences = db.Column(db.String, nullable=True)
+    supplier = db.Column(db.String, nullable=True, default="")
 
     __table_args__ = (
         db.Index('ix_packages_name_version', 'name', 'version'),
@@ -44,6 +45,7 @@ class Package(Base):
         cpe: Optional[list] = None,
         purl: Optional[list] = None,
         licences: str = "",
+        supplier: str = "",
         **kwargs,
     ):
         version = str(version).strip().split("+git")[0]
@@ -63,6 +65,7 @@ class Package(Base):
         self.cpe = []
         self.purl = []
         self.licences = licences or ""
+        self.supplier = supplier or ""
         for c in cpes:
             self.add_cpe(c)
         for p in purls:
@@ -74,7 +77,9 @@ class Package(Base):
 
     @property
     def string_id(self) -> str:
-        """Return the human-readable ``'name@version'`` identifier."""
+        """Return the human-readable identifier, including supplier when present."""
+        if self.supplier:
+            return f"{self.name}@{self.version}::{self.supplier}"
         return f"{self.name}@{self.version}"
 
     # TODO: Remove in-memory logic in parsers to use DB directly. The following are concerned
@@ -130,12 +135,16 @@ class Package(Base):
         if not isinstance(other, Package):
             return NotImplemented
         try:
-            return self.name == other.name and self._parse_version() == other._parse_version()
+            return (self.name == other.name
+                    and self._parse_version() == other._parse_version()
+                    and (self.supplier or "") == (other.supplier or ""))
         except Exception:
-            return self.name == other.name and self.version == other.version
+            return (self.name == other.name
+                    and self.version == other.version
+                    and (self.supplier or "") == (other.supplier or ""))
 
     def __hash__(self) -> int:
-        return hash((self.name, self.version))
+        return hash((self.name, self.version, self.supplier or ""))
 
     def __str__(self) -> str:
         return self.string_id
@@ -147,17 +156,23 @@ class Package(Base):
         if self.name != other.name:
             return self.name < other.name
         try:
-            return self._parse_version() < other._parse_version()
+            if self._parse_version() != other._parse_version():
+                return self._parse_version() < other._parse_version()
         except Exception:
-            return self.version < other.version
+            if self.version != other.version:
+                return self.version < other.version
+        return (self.supplier or "") < (other.supplier or "")
 
     def __gt__(self, other) -> bool:
         if self.name != other.name:
             return self.name > other.name
         try:
-            return self._parse_version() > other._parse_version()
+            if self._parse_version() != other._parse_version():
+                return self._parse_version() > other._parse_version()
         except Exception:
-            return self.version > other.version
+            if self.version != other.version:
+                return self.version > other.version
+        return (self.supplier or "") > (other.supplier or "")
 
     def __le__(self, other) -> bool:
         return self < other or self == other
@@ -191,6 +206,7 @@ class Package(Base):
             "cpe": list(self.cpe or []),
             "purl": list(self.purl or []),
             "licences": self.licences or "",
+            "supplier": self.supplier or "",
         }
 
     @staticmethod
@@ -201,6 +217,7 @@ class Package(Base):
             cpe=data.get("cpe", []),
             purl=data.get("purl", []),
             licences=data.get("licences", ""),
+            supplier=data.get("supplier", ""),
         )
 
     # ------------------------------------------------------------------

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import uuid
+import re
+import hashlib
 import semver
 from typing import Optional
 from ..extensions import db, Base
@@ -110,7 +112,15 @@ class Package(Base):
 
     def generate_generic_purl(self) -> str:
         """Build a generic purl string for the package, add it to the purl list and return it."""
-        item = f"pkg:generic/{self.name}@{self.version}"
+        if self.supplier:
+            name_part = re.sub(r'^[^:]+:\s*', '', self.supplier)   # strip "Organization: "
+            name_part = re.sub(r'\s*\(.*\)$', '', name_part).strip()  # strip email
+            slug = re.sub(r'[^\w]+', '-', name_part).strip('-').lower()
+            if not slug:
+                slug = "supplier-" + hashlib.sha1(self.supplier.encode()).hexdigest()[:8]
+            item = f"pkg:generic/{slug}/{self.name}@{self.version}"
+        else:
+            item = f"pkg:generic/{self.name}@{self.version}"
         self.add_purl(item)
         return item
 

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -24,7 +24,7 @@ class Package(Base):
     cpe = db.Column(db.JSON, nullable=True)
     purl = db.Column(db.JSON, nullable=True)
     licences = db.Column(db.String, nullable=True)
-    supplier = db.Column(db.String, nullable=True, default="")
+    supplier = db.Column(db.String, nullable=False, default="")
 
     __table_args__ = (
         db.Index('ix_packages_name_version_supplier', 'name', 'version', 'supplier'),
@@ -65,7 +65,7 @@ class Package(Base):
         self.cpe = []
         self.purl = []
         self.licences = licences or ""
-        self.supplier = supplier or ""
+        self.supplier = supplier
         for c in cpes:
             self.add_cpe(c)
         for p in purls:
@@ -137,14 +137,14 @@ class Package(Base):
         try:
             return (self.name == other.name
                     and self._parse_version() == other._parse_version()
-                    and (self.supplier or "") == (other.supplier or ""))
+                    and (self.supplier) == (other.supplier))
         except Exception:
             return (self.name == other.name
                     and self.version == other.version
-                    and (self.supplier or "") == (other.supplier or ""))
+                    and (self.supplier) == (other.supplier))
 
     def __hash__(self) -> int:
-        return hash((self.name, self.version, self.supplier or ""))
+        return hash((self.name, self.version, self.supplier))
 
     def __str__(self) -> str:
         return self.string_id
@@ -161,7 +161,7 @@ class Package(Base):
         except Exception:
             if self.version != other.version:
                 return self.version < other.version
-        return (self.supplier or "") < (other.supplier or "")
+        return self.supplier < other.supplier
 
     def __gt__(self, other) -> bool:
         if self.name != other.name:
@@ -172,7 +172,7 @@ class Package(Base):
         except Exception:
             if self.version != other.version:
                 return self.version > other.version
-        return (self.supplier or "") > (other.supplier or "")
+        return self.supplier > other.supplier
 
     def __le__(self, other) -> bool:
         return self < other or self == other
@@ -206,7 +206,7 @@ class Package(Base):
             "cpe": list(self.cpe or []),
             "purl": list(self.purl or []),
             "licences": self.licences or "",
-            "supplier": self.supplier or "",
+            "supplier": self.supplier,
         }
 
     @staticmethod
@@ -305,7 +305,7 @@ class Package(Base):
             ).scalars().all()
         )
         by_key: dict[tuple, Package] = {
-            (p.name, p.version, p.supplier or ""): p for p in existing_rows
+            (p.name, p.version, p.supplier): p for p in existing_rows
         }
 
         result: dict[str, Package] = {}

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -27,7 +27,7 @@ class Package(Base):
     supplier = db.Column(db.String, nullable=True, default="")
 
     __table_args__ = (
-        db.Index('ix_packages_name_version', 'name', 'version'),
+        db.Index('ix_packages_name_version_supplier', 'name', 'version', 'supplier'),
     )
 
     sbom_packages = db.relationship("SBOMPackage", back_populates="package", cascade="all, delete-orphan")

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -245,14 +245,23 @@ class Package(Base):
         cpe: Optional[list] = None,
         purl: Optional[list] = None,
         licences: str = "",
+        supplier: str = "",
     ) -> "Package":
-        """Return an existing Package for (name, version) or create a new one, merging identifiers."""
+        """Return an existing Package for (name, version, supplier) or create a new one."""
         existing = db.session.execute(
-            db.select(Package).where(Package.name == name, Package.version == version)
+            db.select(Package).where(
+                Package.name == name,
+                Package.version == version,
+                Package.supplier == (supplier or ""),
+            )
         ).scalar_one_or_none()
 
         if existing is None:
-            existing = Package(name=name, version=version, cpe=cpe or [], purl=purl or [], licences=licences)
+            existing = Package(
+                name=name, version=version,
+                cpe=cpe or [], purl=purl or [],
+                licences=licences, supplier=supplier or "",
+            )
             db.session.add(existing)
             db.session.flush()
         else:
@@ -277,35 +286,31 @@ class Package(Base):
         """Resolve many packages in two queries instead of N.
 
         *items* is a list of dicts with keys ``name``, ``version`` and
-        optionally ``cpe``, ``purl``, ``licences``.
+        optionally ``cpe``, ``purl``, ``licences``, ``supplier``.
 
         Returns a ``{string_id: Package}`` mapping.
-
-        1. One SELECT fetches all existing rows matching the requested
-           ``(name, version)`` pairs.
-        2. Missing packages are bulk-inserted in a single flush.
-        3. CPE/PURL identifiers are merged into existing records.
         """
         from sqlalchemy import tuple_
 
         if not items:
             return {}
 
-        pairs = [(d["name"], d["version"]) for d in items]
+        triples = [(d["name"], d["version"], d.get("supplier", "")) for d in items]
 
-        # Single SELECT for all requested packages
         existing_rows = list(
             db.session.execute(
                 db.select(Package).where(
-                    tuple_(Package.name, Package.version).in_(pairs)
+                    tuple_(Package.name, Package.version, Package.supplier).in_(triples)
                 )
             ).scalars().all()
         )
-        by_key: dict[tuple, Package] = {(p.name, p.version): p for p in existing_rows}
+        by_key: dict[tuple, Package] = {
+            (p.name, p.version, p.supplier or ""): p for p in existing_rows
+        }
 
         result: dict[str, Package] = {}
         for d in items:
-            key = (d["name"], d["version"])
+            key = (d["name"], d["version"], d.get("supplier", ""))
             pkg = by_key.get(key)
             if pkg is None:
                 pkg = Package(
@@ -314,11 +319,11 @@ class Package(Base):
                     cpe=d.get("cpe", []),
                     purl=d.get("purl", []),
                     licences=d.get("licences", ""),
+                    supplier=d.get("supplier", ""),
                 )
                 db.session.add(pkg)
                 by_key[key] = pkg
             else:
-                # Merge identifiers
                 for c in (d.get("cpe") or []):
                     if c not in (pkg.cpe or []):
                         pkg.add_cpe(c)
@@ -331,22 +336,31 @@ class Package(Base):
         return result
 
     @staticmethod
-    def exists(name: str, version: str) -> bool:
-        """Check whether a package with (name, version) exists — lightweight, no full row load."""
+    def exists(name: str, version: str, supplier: str = "") -> bool:
+        """Check whether a package with (name, version, supplier) exists."""
         return db.session.query(
             db.session.query(Package).filter(
-                Package.name == name, Package.version == version
+                Package.name == name,
+                Package.version == version,
+                Package.supplier == (supplier or ""),
             ).exists()
         ).scalar()
 
     @staticmethod
     def get_by_string_id(string_id: str) -> Optional["Package"]:
-        """Return a package by ``'name@version'`` string id, or ``None``."""
+        """Return a package by string_id (``'name@version'`` or ``'name@version::supplier'``)."""
         if "@" not in string_id:
             return None
+        supplier = ""
+        if "::" in string_id:
+            string_id, supplier = string_id.split("::", 1)
         name, version = string_id.split("@", 1)
         return db.session.execute(
-            db.select(Package).where(Package.name == name, Package.version == version)
+            db.select(Package).where(
+                Package.name == name,
+                Package.version == version,
+                Package.supplier == supplier,
+            )
         ).scalar_one_or_none()
 
     @staticmethod

--- a/src/routes/_scan_diff.py
+++ b/src/routes/_scan_diff.py
@@ -392,7 +392,7 @@ def _global_result_full(
     # --- Packages (from SBOM only) ---
     pkg_rows = db.session.execute(
         db.select(
-            Package.id, Package.name, Package.version,
+            Package.id, Package.name, Package.version, Package.supplier,
             SBOMDocument.source_name, SBOMDocument.format,
         )
         .join(SBOMPackage, SBOMPackage.package_id == Package.id)
@@ -401,7 +401,7 @@ def _global_result_full(
     ).all()
     pkg_map: dict = {}
     sbom_pkg_ids: set = set()
-    for pid, pname, pversion, src_name, src_fmt in pkg_rows:
+    for pid, pname, pversion, psupplier, src_name, src_fmt in pkg_rows:
         sbom_pkg_ids.add(pid)
         source_label = f"{src_name} ({src_fmt})" if src_fmt else src_name
         if pid not in pkg_map:
@@ -409,6 +409,7 @@ def _global_result_full(
                 "package_id": str(pid),
                 "package_name": pname or "unknown",
                 "package_version": pversion or "",
+                "package_supplier": psupplier or "",
                 "sources": [source_label],
             }
         else:
@@ -443,7 +444,7 @@ def _global_result_full(
         db.select(
             Observation.scan_id, Observation.finding_id,
             Finding.package_id, Finding.vulnerability_id,
-            Package.name, Package.version,
+            Package.name, Package.version, Package.supplier,
         )
         .join(Finding, Finding.id == Observation.finding_id)
         .join(Package, Package.id == Finding.package_id)
@@ -452,7 +453,7 @@ def _global_result_full(
 
     finding_map: dict = {}
     vuln_set: dict = {}
-    for sid, fid, pkg_id, vid, pname, pversion in obs_rows:
+    for sid, fid, pkg_id, vid, pname, pversion, psupplier in obs_rows:
         # Skip tool-scan findings whose package is not in the SBOM
         if sid in tool_scan_ids and pkg_id not in sbom_pkg_ids:
             continue
@@ -462,6 +463,7 @@ def _global_result_full(
                 "finding_id": str(fid),
                 "package_name": pname or "unknown",
                 "package_version": pversion or "",
+                "package_supplier": psupplier or "",
                 "package_id": str(pkg_id),
                 "vulnerability_id": vid,
                 "sources": [source_label],

--- a/src/routes/_scan_queries.py
+++ b/src/routes/_scan_queries.py
@@ -93,6 +93,7 @@ def _pkg_to_dict(pkg: Package) -> dict:
         "package_id": str(pkg.id),
         "package_name": pkg.name or "unknown",
         "package_version": pkg.version or "",
+        "package_supplier": pkg.supplier or "",
     }
 
 
@@ -146,6 +147,7 @@ def _obs_to_dict(obs: Observation, origin: str = "Imported SBOM") -> dict:
         "finding_id": str(f.id),
         "package_name": pkg.name if pkg else "unknown",
         "package_version": pkg.version if pkg else "",
+        "package_supplier": pkg.supplier if pkg else "",
         "package_id": str(f.package_id),
         "vulnerability_id": f.vulnerability_id,
         "origin": origin,

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -25,6 +25,15 @@ from ..helpers.assessment_io import (
 OPENVEX_FILE = "/scan/outputs/openvex.json"
 
 
+def _resolve_package(pkg_string_id: str) -> "Package":
+    """Parse 'name@version::supplier' and look up or create the Package record."""
+    _parts = pkg_string_id.split("::", 1)
+    _base = _parts[0]
+    _supplier = _parts[1] if len(_parts) > 1 else ""
+    name, version = _base.rsplit("@", 1) if "@" in _base else (_base, "")
+    return Package.find_or_create(name, version, supplier=_supplier)
+
+
 def init_app(app):
 
     if "OPENVEX_FILE" not in app.config:
@@ -221,12 +230,7 @@ def init_app(app):
 
                 for pkg_string_id in pkg_ids:
                     try:
-                        _parts = pkg_string_id.split("::", 1)
-                        _base = _parts[0]
-                        _supplier = _parts[1] if len(_parts) > 1 else ""
-                        name, version = (_base.rsplit("@", 1)
-                                         if "@" in _base else (_base, ""))
-                        db_pkg = Package.find_or_create(name, version, supplier=_supplier)
+                        db_pkg = _resolve_package(pkg_string_id)
                         DBVuln.get_or_create(vuln_name)
                         finding = Finding.get_or_create(db_pkg.id, vuln_name)
 
@@ -396,11 +400,7 @@ def init_app(app):
             with batch_session():
                 for pkg_string_id in (assessment.packages or []):
                     # find_or_create handles both lookup and creation in one query
-                    _parts = pkg_string_id.split("::", 1)
-                    _base = _parts[0]
-                    _supplier = _parts[1] if len(_parts) > 1 else ""
-                    name, version = _base.rsplit("@", 1) if "@" in _base else (_base, "")
-                    db_pkg = Package.find_or_create(name, version, supplier=_supplier)
+                    db_pkg = _resolve_package(pkg_string_id)
                     # Ensure vulnerability record exists before creating Finding (FK constraint)
                     DBVuln.get_or_create(vuln_id)
                     finding = Finding.get_or_create(db_pkg.id, vuln_id)
@@ -475,13 +475,7 @@ def init_app(app):
                         # Resolve package from cache first, then DB
                         db_pkg = pkg_cache.get(pkg_string_id)
                         if db_pkg is None:
-                            _parts = pkg_string_id.split("::", 1)
-                            _base = _parts[0]
-                            _supplier = _parts[1] if len(_parts) > 1 else ""
-                            name, version = (_base.rsplit("@", 1)
-                                             if "@" in _base
-                                             else (_base, ""))
-                            db_pkg = Package.find_or_create(name, version, supplier=_supplier)
+                            db_pkg = _resolve_package(pkg_string_id)
                             pkg_cache[pkg_string_id] = db_pkg
                         # Ensure vulnerability record exists before creating Finding (FK constraint)
                         DBVuln.get_or_create(vuln_id)

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -221,9 +221,12 @@ def init_app(app):
 
                 for pkg_string_id in pkg_ids:
                     try:
-                        name, version = (pkg_string_id.rsplit("@", 1)
-                                         if "@" in pkg_string_id else (pkg_string_id, ""))
-                        db_pkg = Package.find_or_create(name, version)
+                        _parts = pkg_string_id.split("::", 1)
+                        _base = _parts[0]
+                        _supplier = _parts[1] if len(_parts) > 1 else ""
+                        name, version = (_base.rsplit("@", 1)
+                                         if "@" in _base else (_base, ""))
+                        db_pkg = Package.find_or_create(name, version, supplier=_supplier)
                         DBVuln.get_or_create(vuln_name)
                         finding = Finding.get_or_create(db_pkg.id, vuln_name)
 
@@ -393,8 +396,11 @@ def init_app(app):
             with batch_session():
                 for pkg_string_id in (assessment.packages or []):
                     # find_or_create handles both lookup and creation in one query
-                    name, version = pkg_string_id.rsplit("@", 1) if "@" in pkg_string_id else (pkg_string_id, "")
-                    db_pkg = Package.find_or_create(name, version)
+                    _parts = pkg_string_id.split("::", 1)
+                    _base = _parts[0]
+                    _supplier = _parts[1] if len(_parts) > 1 else ""
+                    name, version = _base.rsplit("@", 1) if "@" in _base else (_base, "")
+                    db_pkg = Package.find_or_create(name, version, supplier=_supplier)
                     # Ensure vulnerability record exists before creating Finding (FK constraint)
                     DBVuln.get_or_create(vuln_id)
                     finding = Finding.get_or_create(db_pkg.id, vuln_id)
@@ -469,10 +475,13 @@ def init_app(app):
                         # Resolve package from cache first, then DB
                         db_pkg = pkg_cache.get(pkg_string_id)
                         if db_pkg is None:
-                            name, version = (pkg_string_id.rsplit("@", 1)
-                                             if "@" in pkg_string_id
-                                             else (pkg_string_id, ""))
-                            db_pkg = Package.find_or_create(name, version)
+                            _parts = pkg_string_id.split("::", 1)
+                            _base = _parts[0]
+                            _supplier = _parts[1] if len(_parts) > 1 else ""
+                            name, version = (_base.rsplit("@", 1)
+                                             if "@" in _base
+                                             else (_base, ""))
+                            db_pkg = Package.find_or_create(name, version, supplier=_supplier)
                             pkg_cache[pkg_string_id] = db_pkg
                         # Ensure vulnerability record exists before creating Finding (FK constraint)
                         DBVuln.get_or_create(vuln_id)

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -298,6 +298,7 @@ def init_app(app):
                     "new_version": (new_pkg.version or ""),
                     "old_package_id": str(old_pkg.id),
                     "new_package_id": str(new_pkg.id),
+                    "package_supplier": (old_pkg.supplier or ""),
                 }
                 for old_pkg, new_pkg in upgraded_pairs
             ]
@@ -383,6 +384,7 @@ def init_app(app):
                             "package_name": old_pkg.name or "unknown",
                             "old_version": old_pkg.version or "",
                             "new_version": new_pkg.version or "",
+                            "package_supplier": old_pkg.supplier or "",
                             "origin": obs_dict.get("origin", scan_origin),
                         })
 

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -5,7 +5,7 @@ import uuid
 
 from flask import request
 from sqlalchemy import func
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import selectinload, aliased
 from ..models.vulnerability import Vulnerability
 from ..models.finding import Finding
 from ..models.observation import Observation
@@ -17,6 +17,7 @@ from ..models.metrics import Metrics
 from ..models.cvss import CVSS
 from ..models.iso8601_duration import Iso8601Duration
 from ..models.sbom_document import SBOMDocument
+from ..models.sbom_package import SBOMPackage
 from ..extensions import db
 from ..helpers.verbose import verbose
 from ..helpers.active_scans import (
@@ -273,6 +274,29 @@ def init_app(app):
                 records = list(db.session.execute(
                     query.distinct().order_by(Vulnerability.id)
                 ).scalars().all())
+                # Bulk-load packages expanded to all same-name+version supplier variants.
+                # to_dict() falls back to findings, but those only contain the directly-linked
+                # package (no supplier from Grype). Pre-populate r.packages instead.
+                if records:
+                    _PkgVariant = aliased(Package)
+                    _pkg_var_rows = db.session.execute(
+                        db.select(
+                            Finding.vulnerability_id, _PkgVariant.name,
+                            _PkgVariant.version, _PkgVariant.supplier
+                        )
+                        .join(Package, Finding.package_id == Package.id)
+                        .join(_PkgVariant, (
+                            (_PkgVariant.name == Package.name) & (_PkgVariant.version == Package.version)
+                        ))
+                        .where(Finding.vulnerability_id.in_([r.id for r in records]))
+                        .distinct()
+                    ).all()
+                    _pkgs_by_vuln_var: dict[str, list[str]] = {}
+                    for _vid, _pname, _pver, _psup in _pkg_var_rows:
+                        _sid = f"{_pname}@{_pver}::{_psup}" if _psup else f"{_pname}@{_pver}"
+                        _pkgs_by_vuln_var.setdefault(str(_vid), []).append(_sid)
+                    for r in records:
+                        r.packages = _pkgs_by_vuln_var.get(str(r.id), [])
         elif project_id:
             try:
                 project_uuid = uuid.UUID(project_id)
@@ -323,16 +347,21 @@ def init_app(app):
                 for m in metric_rows:
                     metrics_by_vuln.setdefault(m.vulnerability_id, []).append(m)
 
-                # Bulk-load packages per vulnerability
+                # Bulk-load packages per vulnerability, expanding to all same-name+version
+                # supplier variants so that Grype-linked packages (no supplier) also surface
+                # SBOM packages that carry supplier information.
+                _PkgVariant = aliased(Package)
                 pkg_rows = db.session.execute(
-                    db.select(Finding.vulnerability_id, Package.name, Package.version)
+                    db.select(Finding.vulnerability_id, _PkgVariant.name, _PkgVariant.version, _PkgVariant.supplier)
                     .join(Package, Finding.package_id == Package.id)
+                    .join(_PkgVariant, (_PkgVariant.name == Package.name) & (_PkgVariant.version == Package.version))
                     .where(Finding.vulnerability_id.in_(vuln_ids_subq))
                     .distinct()
                 ).all()
                 pkgs_by_vuln: dict[str, list[str]] = {}
-                for vid, pname, pver in pkg_rows:
-                    pkgs_by_vuln.setdefault(vid, []).append(f"{pname}@{pver}")
+                for vid, pname, pver, psup in pkg_rows:
+                    sid = f"{pname}@{pver}::{psup}" if psup else f"{pname}@{pver}"
+                    pkgs_by_vuln.setdefault(vid, []).append(sid)
 
                 # Bulk-load effort (time estimates) per vulnerability
                 te_rows = db.session.execute(
@@ -381,19 +410,30 @@ def init_app(app):
 
         vuln_ids = [v["id"] for v in vulns]
         if vuln_ids:
-            # packages_current: packages from the specific scan(s) used for this query
+            # packages_current: packages from the specific scan(s), expanded to include all
+            # same-name+version supplier variants present in the active SBOM scans.
+            # This ensures that Grype-linked packages (no supplier) also surface SBOM packages.
             if current_scan_ids:
+                _PkgVariant2 = aliased(Package)
                 pkg_rows = db.session.execute(
-                    db.select(Finding.vulnerability_id, Package.name, Package.version)
+                    db.select(Finding.vulnerability_id, _PkgVariant2.name, _PkgVariant2.version, _PkgVariant2.supplier)
                     .join(Observation, Finding.id == Observation.finding_id)
                     .join(Package, Finding.package_id == Package.id)
+                    .join(_PkgVariant2, (_PkgVariant2.name == Package.name) & (_PkgVariant2.version == Package.version))
+                    .outerjoin(SBOMPackage, SBOMPackage.package_id == _PkgVariant2.id)
+                    .outerjoin(SBOMDocument, SBOMDocument.id == SBOMPackage.sbom_document_id)
                     .where(Observation.scan_id.in_(current_scan_ids))
                     .where(Finding.vulnerability_id.in_(vuln_ids))
+                    .where(db.or_(
+                        SBOMDocument.scan_id.in_(current_scan_ids),
+                        _PkgVariant2.id == Package.id,
+                    ))
                     .distinct()
                 ).all()
                 pkgs_current_by_vuln: dict = {}
-                for vuln_id, pkg_name, pkg_version in pkg_rows:
-                    pkgs_current_by_vuln.setdefault(str(vuln_id), []).append(f"{pkg_name}@{pkg_version}")
+                for vuln_id, pkg_name, pkg_version, pkg_sup in pkg_rows:
+                    sid = f"{pkg_name}@{pkg_version}::{pkg_sup}" if pkg_sup else f"{pkg_name}@{pkg_version}"
+                    pkgs_current_by_vuln.setdefault(str(vuln_id), []).append(sid)
                 for v in vulns:
                     v["packages_current"] = sorted(pkgs_current_by_vuln.get(v["id"], []))
             else:

--- a/src/views/openvex.py
+++ b/src/views/openvex.py
@@ -8,18 +8,7 @@ from ..helpers.verbose import verbose
 from uuid_extensions import uuid7
 from datetime import datetime, timezone
 import re
-import hashlib
 from typing import Optional
-
-
-def _supplier_at_id(pkg) -> str:
-    """Return a supplier-qualified product @id unique to *pkg*'s supplier string."""
-    name_part = re.sub(r'^[^:]+:\s*', '', pkg.supplier)   # strip "Organization: "
-    name_part = re.sub(r'\s*\(.*\)$', '', name_part).strip()  # strip email
-    slug = re.sub(r'[^\w]+', '-', name_part).strip('-').lower()
-    if not slug:
-        slug = "supplier-" + hashlib.sha1(pkg.supplier.encode()).hexdigest()[:8]
-    return f"pkg:generic/{slug}/{pkg.name}@{pkg.version}"
 
 
 class OpenVex:
@@ -155,9 +144,8 @@ class OpenVex:
                         pkg.generate_generic_cpe()
                     if len(pkg.purl) < 1:
                         pkg.generate_generic_purl()
-                    at_id = _supplier_at_id(pkg) if pkg.supplier else pkg.purl[0]
                     product = {
-                        "@id": at_id,
+                        "@id": pkg.purl[0],
                         "identifiers": {
                             "cpe23": pkg.cpe[0],
                             "purl": pkg.purl[0]

--- a/src/views/openvex.py
+++ b/src/views/openvex.py
@@ -8,7 +8,18 @@ from ..helpers.verbose import verbose
 from uuid_extensions import uuid7
 from datetime import datetime, timezone
 import re
+import hashlib
 from typing import Optional
+
+
+def _supplier_at_id(pkg) -> str:
+    """Return a supplier-qualified product @id unique to *pkg*'s supplier string."""
+    name_part = re.sub(r'^[^:]+:\s*', '', pkg.supplier)   # strip "Organization: "
+    name_part = re.sub(r'\s*\(.*\)$', '', name_part).strip()  # strip email
+    slug = re.sub(r'[^\w]+', '-', name_part).strip('-').lower()
+    if not slug:
+        slug = "supplier-" + hashlib.sha1(pkg.supplier.encode()).hexdigest()[:8]
+    return f"pkg:generic/{slug}/{pkg.name}@{pkg.version}"
 
 
 class OpenVex:
@@ -144,8 +155,9 @@ class OpenVex:
                         pkg.generate_generic_cpe()
                     if len(pkg.purl) < 1:
                         pkg.generate_generic_purl()
+                    at_id = _supplier_at_id(pkg) if pkg.supplier else pkg.purl[0]
                     product = {
-                        "@id": pkg.purl[0],
+                        "@id": at_id,
                         "identifiers": {
                             "cpe23": pkg.cpe[0],
                             "purl": pkg.purl[0]

--- a/src/views/spdx.py
+++ b/src/views/spdx.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 from ..models.package import Package
+from ..helpers.verbose import verbose
 from spdx_tools.spdx.parser.parse_anything import parse_file
 from spdx_tools.spdx.parser.jsonlikedict.json_like_dict_parser import JsonLikeDictParser
 from spdx_tools.spdx.writer.json.json_writer import write_document_to_stream as write_document_to_json_stream
@@ -21,6 +22,13 @@ from uuid_extensions import uuid7
 from datetime import datetime, timezone
 from io import StringIO
 from os import getenv
+
+
+_ACTOR_TYPE_LABELS = {
+    ActorType.ORGANIZATION: "Organization",
+    ActorType.PERSON: "Person",
+    ActorType.TOOL: "Tool",
+}
 
 
 class SPDX:
@@ -55,7 +63,18 @@ class SPDX:
         Merge components from SBOM into controller.
         """
         for package in self.sbom.packages:
-            pkg = Package(package.name, package.version or "", [], [], "")
+            supplier = ""
+            try:
+                if package.supplier is not None and not isinstance(package.supplier, SpdxNoAssertion):
+                    actor = package.supplier
+                    actor_label = _ACTOR_TYPE_LABELS.get(actor.actor_type, actor.actor_type.name.capitalize())
+                    supplier = f"{actor_label}: {actor.name}"
+                    if actor.email:
+                        supplier += f" ({actor.email})"
+            except Exception:
+                verbose(f"[SPDX.merge_components] failed to read supplier for {package.name!r}")
+
+            pkg = Package(package.name, package.version or "", [], [], "", supplier=supplier)
             cpe_type = "a"
 
             if package.primary_package_purpose == PackagePurpose.OPERATING_SYSTEM:

--- a/src/views/spdx.py
+++ b/src/views/spdx.py
@@ -4,6 +4,7 @@
 from ..models.package import Package
 from ..helpers.verbose import verbose
 from spdx_tools.spdx.parser.parse_anything import parse_file
+from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.json_like_dict_parser import JsonLikeDictParser
 from spdx_tools.spdx.writer.json.json_writer import write_document_to_stream as write_document_to_json_stream
 from spdx_tools.spdx.writer.xml.xml_writer import write_document_to_stream as write_document_to_xml_stream
@@ -22,6 +23,22 @@ from uuid_extensions import uuid7
 from datetime import datetime, timezone
 from io import StringIO
 from os import getenv
+import json
+import re
+
+
+def _normalize_spdx_dict(doc_dict: dict) -> None:
+    """Normalize an SPDX JSON dict to fix known spdx_tools parser compat issues.
+
+    The spdx_tools Version class only accepts "X.Y" format, but real-world SPDX
+    files may use three-part semver for licenseListVersion (e.g. "3.28.0").
+    This trims such values to "X.Y" so the parser does not reject the document.
+    """
+    creation_info = doc_dict.get("creationInfo") or {}
+    license_list_version = creation_info.get("licenseListVersion", "")
+    if re.match(r"^\d+\.\d+\.\d", license_list_version):
+        major, minor = license_list_version.split(".")[:2]
+        creation_info["licenseListVersion"] = f"{major}.{minor}"
 
 
 _ACTOR_TYPE_LABELS = {
@@ -50,8 +67,18 @@ class SPDX:
         self.sbom = parser.parse(spdx)
 
     def load_from_file(self, spdx_file: str):
-        """Read data from SPDX file, detecting format automaticaly."""
-        try_reading = parse_file(spdx_file)
+        """Read data from SPDX file, detecting format automatically."""
+        try:
+            try_reading = parse_file(spdx_file)
+        except SPDXParsingError as original_err:
+            # Fallback: pre-process JSON to fix known compat issues (e.g. 3-part licenseListVersion)
+            try:
+                with open(spdx_file) as f:
+                    doc_dict = json.load(f)
+                _normalize_spdx_dict(doc_dict)
+                try_reading = JsonLikeDictParser().parse(doc_dict)
+            except Exception:
+                raise original_err
         if try_reading:
             self.sbom = try_reading
         else:

--- a/tests/unit_tests/test_openvex_output.py
+++ b/tests/unit_tests/test_openvex_output.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for supplier-qualified OpenVEX product @id generation."""
+
+from unittest.mock import MagicMock, patch
+from src.views.openvex import OpenVex
+from src.models.package import Package
+from src.models.assessment import Assessment
+
+
+def _make_pkg(name, version, supplier=""):
+    pkg = Package(name, version, supplier=supplier)
+    pkg.generate_generic_cpe()
+    pkg.generate_generic_purl()
+    return pkg
+
+
+def _make_assessment(vuln_id, pkg):
+    assess = Assessment.new_dto(vuln_id, [pkg.string_id])
+    assess.set_status("affected")
+    return assess
+
+
+def _run_to_dict(pkgs, assessments):
+    pkg_ctrl = MagicMock()
+    pkg_ctrl.get = MagicMock(side_effect=lambda pid: next(
+        (p for p in pkgs if p.string_id == pid), None
+    ))
+    vuln_ctrl = MagicMock()
+    vuln_ctrl.get = MagicMock(return_value=None)
+    assess_ctrl = MagicMock()
+    assess_ctrl.assessments = {a.vuln_id: a for a in assessments}
+    ctrl = {
+        "packages": pkg_ctrl,
+        "vulnerabilities": vuln_ctrl,
+        "assessments": assess_ctrl,
+    }
+    with patch('src.views.openvex.Assessment.get_all', return_value=[]):
+        view = OpenVex(ctrl)
+        return view.to_dict()
+
+
+def test_openvex_no_supplier_uses_generic_purl():
+    pkg = _make_pkg("foo", "1.0")
+    assess = _make_assessment("CVE-2024-1", pkg)
+    result = _run_to_dict([pkg], [assess])
+    product = result["statements"][0]["products"][0]
+    assert product["@id"] == "pkg:generic/foo@1.0"
+
+
+def test_openvex_supplier_uses_qualified_id():
+    pkg = _make_pkg("foo", "1.0", supplier="Organization: Acme Corp (x@a.com)")
+    assess = _make_assessment("CVE-2024-1", pkg)
+    result = _run_to_dict([pkg], [assess])
+    product = result["statements"][0]["products"][0]
+    assert product["@id"] == "pkg:generic/acme-corp/foo@1.0"
+    # identifiers.purl must remain generic
+    assert product["identifiers"]["purl"] == "pkg:generic/foo@1.0"
+
+
+def test_openvex_two_suppliers_produce_different_ids():
+    pkg_a = _make_pkg("foo", "1.0", supplier="Organization: Acme Corp")
+    pkg_b = _make_pkg("foo", "1.0", supplier="Organization: Bar Inc")
+    assess_a = _make_assessment("CVE-2024-1", pkg_a)
+    assess_b = _make_assessment("CVE-2024-2", pkg_b)
+    result = _run_to_dict([pkg_a, pkg_b], [assess_a, assess_b])
+    at_ids = [
+        product["@id"]
+        for stmt in result["statements"]
+        for product in stmt["products"]
+    ]
+    assert len(set(at_ids)) == 2, f"Expected 2 distinct @ids, got: {at_ids}"
+
+
+def test_openvex_empty_slug_uses_hash_fallback():
+    """Supplier with no extractable name gets hash-based @id, not generic purl."""
+    pkg = _make_pkg("foo", "1.0", supplier="Organization: ")
+    assess = _make_assessment("CVE-2024-1", pkg)
+    result = _run_to_dict([pkg], [assess])
+    at_id = result["statements"][0]["products"][0]["@id"]
+    assert at_id != "pkg:generic/foo@1.0"   # must NOT collide with no-supplier case
+    assert "supplier-" in at_id             # hash-based fallback

--- a/tests/unit_tests/test_openvex_output.py
+++ b/tests/unit_tests/test_openvex_output.py
@@ -56,9 +56,9 @@ def test_openvex_supplier_uses_qualified_id():
     assess = _make_assessment("CVE-2024-1", pkg)
     result = _run_to_dict([pkg], [assess])
     product = result["statements"][0]["products"][0]
-    assert product["@id"] == "pkg:generic/acme-corp/foo@1.0"
-    # identifiers.purl must remain generic
-    assert product["identifiers"]["purl"] == "pkg:generic/foo@1.0"
+    # @id encodes the supplier slug and differ from the no-supplier case
+    assert "acme-corp" in product["@id"]
+    assert product["@id"] != "pkg:generic/foo@1.0"
 
 
 def test_openvex_two_suppliers_produce_different_ids():

--- a/tests/unit_tests/test_package.py
+++ b/tests/unit_tests/test_package.py
@@ -214,3 +214,49 @@ def test_lt_fallback_same_name_invalid_versions():
     assert not b < a
     assert b > a
     assert not a > b
+
+
+# --- Supplier tests ---
+
+def test_supplier_in_string_id():
+    pkg = Package("foo", "1.0", supplier="Organization: Acme Corp (x@a.com)")
+    assert pkg.string_id == "foo@1.0::Organization: Acme Corp (x@a.com)"
+
+
+def test_no_supplier_string_id():
+    pkg = Package("foo", "1.0")
+    assert pkg.string_id == "foo@1.0"
+
+
+def test_packages_same_name_version_different_supplier_not_equal():
+    pkg_a = Package("foo", "1.0", supplier="Organization: Acme Corp")
+    pkg_b = Package("foo", "1.0", supplier="Organization: Bar Inc")
+    assert pkg_a != pkg_b
+    assert hash(pkg_a) != hash(pkg_b)
+
+
+def test_packages_same_name_version_same_supplier_equal():
+    pkg_a = Package("foo", "1.0", supplier="Organization: Acme Corp")
+    pkg_b = Package("foo", "1.0", supplier="Organization: Acme Corp")
+    assert pkg_a == pkg_b
+    assert hash(pkg_a) == hash(pkg_b)
+
+
+def test_supplier_in_to_dict_from_dict():
+    pkg = Package("foo", "1.0", supplier="Organization: Acme Corp")
+    data = pkg.to_dict()
+    assert data["supplier"] == "Organization: Acme Corp"
+    restored = Package.from_dict(data)
+    assert restored.supplier == "Organization: Acme Corp"
+    assert restored.string_id == "foo@1.0::Organization: Acme Corp"
+
+
+def test_sort_packages_mixed_suppliers():
+    pkg_acme = Package("foo", "1.0", supplier="Organization: Acme Corp")
+    pkg_bar  = Package("foo", "1.0", supplier="Organization: Bar Inc")
+    pkg_none = Package("foo", "1.0")
+    result = sorted([pkg_bar, pkg_none, pkg_acme])
+    # No-supplier (empty string) sorts before any named supplier
+    assert result[0].supplier == ""
+    # Remaining two are deterministic (alphabetical)
+    assert result[1].supplier < result[2].supplier

--- a/tests/unit_tests/test_package_db.py
+++ b/tests/unit_tests/test_package_db.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""DB-backed tests for Package supplier identity."""
+
+import os
+import pytest
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+from src.models.package import Package
+
+
+@pytest.fixture()
+def app():
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    os.environ["SCAN_FILE"] = "/dev/null"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True})
+        with application.app_context():
+            _db.create_all()
+            yield application
+            _db.drop_all()
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+        os.environ.pop("SCAN_FILE", None)
+
+
+def test_find_or_create_different_supplier_creates_new_row(app):
+    with app.app_context():
+        pkg_a = Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp")
+        pkg_b = Package.find_or_create("foo", "1.0", supplier="Organization: Bar Inc")
+        pkg_none = Package.find_or_create("foo", "1.0")
+        _db.session.flush()
+        assert pkg_a.id != pkg_b.id
+        assert pkg_a.id != pkg_none.id
+        assert pkg_b.id != pkg_none.id
+
+
+def test_find_or_create_same_supplier_returns_same_row(app):
+    with app.app_context():
+        pkg_a = Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp")
+        _db.session.flush()
+        pkg_b = Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp")
+        assert pkg_a.id == pkg_b.id
+
+
+def test_get_by_string_id_with_supplier(app):
+    with app.app_context():
+        Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp (x@a.com)")
+        _db.session.flush()
+        found = Package.get_by_string_id("foo@1.0::Organization: Acme Corp (x@a.com)")
+        assert found is not None
+        assert found.supplier == "Organization: Acme Corp (x@a.com)"
+
+
+def test_get_by_string_id_email_at_sign_doesnt_corrupt(app):
+    """@ in supplier email must not corrupt name/version split."""
+    with app.app_context():
+        Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp (contact@acme.com)")
+        _db.session.flush()
+        found = Package.get_by_string_id("foo@1.0::Organization: Acme Corp (contact@acme.com)")
+        assert found is not None
+        assert found.name == "foo"
+        assert found.version == "1.0"
+
+
+def test_get_by_string_id_backward_compat(app):
+    """Old name@version string_ids (no ::) still resolve correctly."""
+    with app.app_context():
+        Package.find_or_create("foo", "1.0")
+        _db.session.flush()
+        found = Package.get_by_string_id("foo@1.0")
+        assert found is not None
+        assert found.name == "foo"
+        assert found.supplier == ""
+
+
+def test_bulk_find_or_create_with_suppliers(app):
+    with app.app_context():
+        items = [
+            {"name": "foo", "version": "1.0", "supplier": "Organization: Acme Corp"},
+            {"name": "foo", "version": "1.0", "supplier": "Organization: Bar Inc"},
+            {"name": "bar", "version": "2.0"},
+        ]
+        result = Package.bulk_find_or_create(items)
+        assert len(result) == 3
+        acme_key = "foo@1.0::Organization: Acme Corp"
+        bar_key = "foo@1.0::Organization: Bar Inc"
+        plain_key = "bar@2.0"
+        assert acme_key in result
+        assert bar_key in result
+        assert plain_key in result
+        assert result[acme_key].id != result[bar_key].id
+
+
+def test_controller_from_dict_roundtrip_preserves_supplier(app):
+    with app.app_context():
+        from src.controllers.packages import PackagesController
+        ctrl = PackagesController()
+        ctrl.add(Package("foo", "1.0", supplier="Organization: Acme Corp"))
+        serialised = ctrl.to_dict()
+        ctrl2 = PackagesController.from_dict(serialised)
+        key = "foo@1.0::Organization: Acme Corp"
+        assert key in ctrl2.packages
+        assert ctrl2.packages[key].supplier == "Organization: Acme Corp"

--- a/tests/unit_tests/test_package_db.py
+++ b/tests/unit_tests/test_package_db.py
@@ -5,7 +5,6 @@
 
 """DB-backed tests for Package supplier identity."""
 
-import os
 import pytest
 from src.bin.webapp import create_app
 from src.extensions import db as _db
@@ -13,19 +12,15 @@ from src.models.package import Package
 
 
 @pytest.fixture()
-def app():
-    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-    os.environ["SCAN_FILE"] = "/dev/null"
-    try:
-        application = create_app()
-        application.config.update({"TESTING": True})
-        with application.app_context():
-            _db.create_all()
-            yield application
-            _db.drop_all()
-    finally:
-        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
-        os.environ.pop("SCAN_FILE", None)
+def app(monkeypatch):
+    monkeypatch.setenv("FLASK_SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
+    monkeypatch.setenv("SCAN_FILE", "/dev/null")
+    application = create_app()
+    application.config.update({"TESTING": True})
+    with application.app_context():
+        _db.create_all()
+        yield application
+        _db.drop_all()
 
 
 def test_find_or_create_different_supplier_creates_new_row(app):

--- a/tests/unit_tests/test_package_db.py
+++ b/tests/unit_tests/test_package_db.py
@@ -24,80 +24,73 @@ def app(monkeypatch):
 
 
 def test_find_or_create_different_supplier_creates_new_row(app):
-    with app.app_context():
-        pkg_a = Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp")
-        pkg_b = Package.find_or_create("foo", "1.0", supplier="Organization: Bar Inc")
-        pkg_none = Package.find_or_create("foo", "1.0")
-        _db.session.flush()
-        assert pkg_a.id != pkg_b.id
-        assert pkg_a.id != pkg_none.id
-        assert pkg_b.id != pkg_none.id
+    pkg_a = Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp")
+    pkg_b = Package.find_or_create("foo", "1.0", supplier="Organization: Bar Inc")
+    pkg_none = Package.find_or_create("foo", "1.0")
+    _db.session.flush()
+    assert pkg_a.id != pkg_b.id
+    assert pkg_a.id != pkg_none.id
+    assert pkg_b.id != pkg_none.id
 
 
 def test_find_or_create_same_supplier_returns_same_row(app):
-    with app.app_context():
-        pkg_a = Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp")
-        _db.session.flush()
-        pkg_b = Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp")
-        assert pkg_a.id == pkg_b.id
+    pkg_a = Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp")
+    _db.session.flush()
+    pkg_b = Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp")
+    assert pkg_a.id == pkg_b.id
 
 
 def test_get_by_string_id_with_supplier(app):
-    with app.app_context():
-        Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp (x@a.com)")
-        _db.session.flush()
-        found = Package.get_by_string_id("foo@1.0::Organization: Acme Corp (x@a.com)")
-        assert found is not None
-        assert found.supplier == "Organization: Acme Corp (x@a.com)"
+    Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp (x@a.com)")
+    _db.session.flush()
+    found = Package.get_by_string_id("foo@1.0::Organization: Acme Corp (x@a.com)")
+    assert found is not None
+    assert found.supplier == "Organization: Acme Corp (x@a.com)"
 
 
 def test_get_by_string_id_email_at_sign_doesnt_corrupt(app):
     """@ in supplier email must not corrupt name/version split."""
-    with app.app_context():
-        Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp (contact@acme.com)")
-        _db.session.flush()
-        found = Package.get_by_string_id("foo@1.0::Organization: Acme Corp (contact@acme.com)")
-        assert found is not None
-        assert found.name == "foo"
-        assert found.version == "1.0"
+    Package.find_or_create("foo", "1.0", supplier="Organization: Acme Corp (contact@acme.com)")
+    _db.session.flush()
+    found = Package.get_by_string_id("foo@1.0::Organization: Acme Corp (contact@acme.com)")
+    assert found is not None
+    assert found.name == "foo"
+    assert found.version == "1.0"
 
 
 def test_get_by_string_id_backward_compat(app):
     """Old name@version string_ids (no ::) still resolve correctly."""
-    with app.app_context():
-        Package.find_or_create("foo", "1.0")
-        _db.session.flush()
-        found = Package.get_by_string_id("foo@1.0")
-        assert found is not None
-        assert found.name == "foo"
-        assert found.supplier == ""
+    Package.find_or_create("foo", "1.0")
+    _db.session.flush()
+    found = Package.get_by_string_id("foo@1.0")
+    assert found is not None
+    assert found.name == "foo"
+    assert found.supplier == ""
 
 
 def test_bulk_find_or_create_with_suppliers(app):
-    with app.app_context():
-        items = [
-            {"name": "foo", "version": "1.0", "supplier": "Organization: Acme Corp"},
-            {"name": "foo", "version": "1.0", "supplier": "Organization: Bar Inc"},
-            {"name": "bar", "version": "2.0"},
-        ]
-        result = Package.bulk_find_or_create(items)
-        assert len(result) == 3
-        acme_key = "foo@1.0::Organization: Acme Corp"
-        bar_key = "foo@1.0::Organization: Bar Inc"
-        plain_key = "bar@2.0"
-        assert acme_key in result
-        assert bar_key in result
-        assert plain_key in result
-        assert result[acme_key].id != result[bar_key].id
+    items = [
+        {"name": "foo", "version": "1.0", "supplier": "Organization: Acme Corp"},
+        {"name": "foo", "version": "1.0", "supplier": "Organization: Bar Inc"},
+        {"name": "bar", "version": "2.0"},
+    ]
+    result = Package.bulk_find_or_create(items)
+    assert len(result) == 3
+    acme_key = "foo@1.0::Organization: Acme Corp"
+    bar_key = "foo@1.0::Organization: Bar Inc"
+    plain_key = "bar@2.0"
+    assert acme_key in result
+    assert bar_key in result
+    assert plain_key in result
+    assert result[acme_key].id != result[bar_key].id
 
 
 def test_controller_from_dict_roundtrip_preserves_supplier(app):
-    with app.app_context():
-        from src.controllers.packages import PackagesController
-        ctrl = PackagesController()
-        ctrl.add(Package("foo", "1.0", supplier="Organization: Acme Corp"))
-        serialised = ctrl.to_dict()
-        ctrl2 = PackagesController.from_dict(serialised)
-        key = "foo@1.0::Organization: Acme Corp"
-        assert key in ctrl2.packages
-        assert ctrl2.packages[key].supplier == "Organization: Acme Corp"
+    from src.controllers.packages import PackagesController
+    ctrl = PackagesController()
+    ctrl.add(Package("foo", "1.0", supplier="Organization: Acme Corp"))
+    serialised = ctrl.to_dict()
+    ctrl2 = PackagesController.from_dict(serialised)
+    key = "foo@1.0::Organization: Acme Corp"
+    assert key in ctrl2.packages
+    assert ctrl2.packages[key].supplier == "Organization: Acme Corp"

--- a/tests/unit_tests/test_spdx_parser.py
+++ b/tests/unit_tests/test_spdx_parser.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for SPDX v2.3 supplier field parsing."""
+
+from unittest.mock import MagicMock
+from spdx_tools.spdx.model.actor import Actor, ActorType
+from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from src.views.spdx import SPDX
+from src.controllers.packages import PackagesController
+
+
+def _make_controllers():
+    pkg_ctrl = PackagesController()
+    vuln_ctrl = MagicMock()
+    assess_ctrl = MagicMock()
+    return {
+        "packages": pkg_ctrl,
+        "vulnerabilities": vuln_ctrl,
+        "assessments": assess_ctrl,
+    }
+
+
+def _make_spdx_pkg(name, version, supplier=None):
+    """Build a minimal spdx_tools Package object."""
+    from spdx_tools.spdx.model.package import Package as SpdxPkg
+    from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion as NoAssert
+    return SpdxPkg(
+        spdx_id=f"SPDXRef-{name}",
+        name=name,
+        download_location=NoAssert(),
+        version=version,
+        supplier=supplier,
+    )
+
+
+def _make_sbom(packages):
+    """Wrap a list of spdx_tools Packages in a minimal Document mock."""
+    doc = MagicMock()
+    doc.packages = packages
+    return doc
+
+
+def _make_view():
+    ctrl = _make_controllers()
+    view = SPDX(ctrl)
+    return view, ctrl
+
+
+def test_parse_supplier_organization():
+    view, ctrl = _make_view()
+    supplier_actor = Actor(ActorType.ORGANIZATION, "Acme Corp", "contact@acme.com")
+    view.sbom = _make_sbom([_make_spdx_pkg("foo", "1.0", supplier=supplier_actor)])
+    view.merge_components_into_controller()
+    pkg = ctrl["packages"].get("foo@1.0::Organization: Acme Corp (contact@acme.com)")
+    assert pkg is not None
+    assert pkg.supplier == "Organization: Acme Corp (contact@acme.com)"
+
+
+def test_parse_supplier_person_no_email():
+    view, ctrl = _make_view()
+    supplier_actor = Actor(ActorType.PERSON, "Jane Doe")
+    view.sbom = _make_sbom([_make_spdx_pkg("foo", "1.0", supplier=supplier_actor)])
+    view.merge_components_into_controller()
+    pkg = ctrl["packages"].get("foo@1.0::Person: Jane Doe")
+    assert pkg is not None
+    assert pkg.supplier == "Person: Jane Doe"
+
+
+def test_parse_supplier_noassertion():
+    view, ctrl = _make_view()
+    view.sbom = _make_sbom([_make_spdx_pkg("foo", "1.0", supplier=SpdxNoAssertion())])
+    view.merge_components_into_controller()
+    pkg = ctrl["packages"].get("foo@1.0")
+    assert pkg is not None
+    assert pkg.supplier == ""
+
+
+def test_parse_supplier_absent():
+    view, ctrl = _make_view()
+    view.sbom = _make_sbom([_make_spdx_pkg("foo", "1.0", supplier=None)])
+    view.merge_components_into_controller()
+    pkg = ctrl["packages"].get("foo@1.0")
+    assert pkg is not None
+    assert pkg.supplier == ""
+
+
+def test_two_packages_distinct_suppliers_both_stored():
+    """Two same-name+version packages with different suppliers become separate entries."""
+    view, ctrl = _make_view()
+    acme = Actor(ActorType.ORGANIZATION, "Acme Corp")
+    bar = Actor(ActorType.ORGANIZATION, "Bar Inc")
+    pkg1 = _make_spdx_pkg("foo", "1.0", supplier=acme)
+    pkg2 = _make_spdx_pkg("foo", "1.0", supplier=bar)
+    pkg2.spdx_id = "SPDXRef-foo-bar"  # must differ
+    view.sbom = _make_sbom([pkg1, pkg2])
+    view.merge_components_into_controller()
+    key_acme = "foo@1.0::Organization: Acme Corp"
+    key_bar = "foo@1.0::Organization: Bar Inc"
+    assert ctrl["packages"].get(key_acme) is not None
+    assert ctrl["packages"].get(key_bar) is not None
+    assert ctrl["packages"].get(key_acme) is not ctrl["packages"].get(key_bar)

--- a/tests/unit_tests/test_spdx_parser.py
+++ b/tests/unit_tests/test_spdx_parser.py
@@ -8,7 +8,7 @@
 from unittest.mock import MagicMock
 from spdx_tools.spdx.model.actor import Actor, ActorType
 from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from src.views.spdx import SPDX
+from src.views.spdx import SPDX, _normalize_spdx_dict
 from src.controllers.packages import PackagesController
 
 
@@ -102,3 +102,46 @@ def test_two_packages_distinct_suppliers_both_stored():
     assert ctrl["packages"].get(key_acme) is not None
     assert ctrl["packages"].get(key_bar) is not None
     assert ctrl["packages"].get(key_acme) is not ctrl["packages"].get(key_bar)
+
+
+def test_normalize_spdx_dict_trims_three_part_license_list_version():
+    """licenseListVersion with X.Y.Z is trimmed to X.Y for spdx_tools compatibility."""
+    doc = {"creationInfo": {"licenseListVersion": "3.28.0"}}
+    _normalize_spdx_dict(doc)
+    assert doc["creationInfo"]["licenseListVersion"] == "3.28"
+
+
+def test_normalize_spdx_dict_leaves_two_part_version_unchanged():
+    doc = {"creationInfo": {"licenseListVersion": "3.28"}}
+    _normalize_spdx_dict(doc)
+    assert doc["creationInfo"]["licenseListVersion"] == "3.28"
+
+
+def test_normalize_spdx_dict_handles_missing_license_list_version():
+    doc = {"creationInfo": {}}
+    _normalize_spdx_dict(doc)  # should not raise
+
+
+def test_load_from_file_accepts_three_part_license_list_version(tmp_path):
+    """load_from_file succeeds on a JSON SPDX file with licenseListVersion X.Y.Z."""
+    import json
+    spdx_doc = {
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "spdxVersion": "SPDX-2.3",
+        "creationInfo": {
+            "creators": ["Tool: test"],
+            "created": "2024-01-01T00:00:00Z",
+            "licenseListVersion": "3.28.0",
+        },
+        "name": "test-doc",
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://example.com/test",
+        "packages": [],
+        "relationships": [],
+    }
+    spdx_file = tmp_path / "test.spdx.json"
+    spdx_file.write_text(json.dumps(spdx_doc))
+
+    view, _ = _make_view()
+    view.load_from_file(str(spdx_file))
+    assert view.sbom is not None

--- a/tests/webapp_tests/test_scan.py
+++ b/tests/webapp_tests/test_scan.py
@@ -421,6 +421,7 @@ class TestGetScanDiff:
             assert "package_id" in p
             assert "package_name" in p
             assert "package_version" in p
+            assert "package_supplier" in p
 
     def test_diff_count_fields(self, client, ids):
         """Diff response includes finding_count, package_count, vuln_count."""
@@ -574,6 +575,7 @@ class TestHelperFunctions:
             assert "finding_id" in d
             assert "package_name" in d
             assert "package_version" in d
+            assert "package_supplier" in d
             assert "package_id" in d
             assert "vulnerability_id" in d
 
@@ -587,6 +589,7 @@ class TestHelperFunctions:
             assert d["package_name"] == "testpkg"
             assert d["package_version"] == "9.9.9"
             assert "package_id" in d
+            assert "package_supplier" in d
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Changes proposed in this pull request:

This PR brings support for parsing the supplier info in SPDX 2.3 and addresses #276.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

You may use the following files to run VulnScout:

[test-supplier-vulns.grype.json](https://github.com/user-attachments/files/27446521/test-supplier-vulns.grype.json)
[test-supplier-distinction.spdx.json](https://github.com/user-attachments/files/27446527/test-supplier-distinction.spdx.json)

Move these files to `/example/spdx2/`, then run: 
```
 ./vulnscout --dev \
   --add-spdx example/spdx2/test-supplier-distinction.spdx.json \
   --add-grype example/spdx2/test-supplier-vulns.grype.json \
   --serve
```

You should see an extra toggle for  suppliers in the columns dropdown for the SBOM table:

<img width="333" height="354" alt="image" src="https://github.com/user-attachments/assets/7f24cd04-644a-46a5-9ba7-bb2a5817b8e6" />

<img width="1856" height="551" alt="image" src="https://github.com/user-attachments/assets/0eadbcf2-3e9b-48b6-ae30-67924061725b" />


You can see the supplier info in the Vulnerability modal:

<img width="1811" height="419" alt="image" src="https://github.com/user-attachments/assets/d6a947f4-decd-4b8a-a730-901bf79beb6b" />

<img width="1132" height="571" alt="image" src="https://github.com/user-attachments/assets/743d9e98-5cf2-42fb-bad1-9114bf524e8e" />


The openvex file will also contain the supplier info in the PURL:

<img width="664" height="193" alt="image" src="https://github.com/user-attachments/assets/70df49f3-d53d-4872-9d07-efba7db07821" />


### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [x] Added necessary reviewers


