### PR TITLE
Handle cpe23Type in BOM and normalize purl epoch qualifier

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 cyclonedx-python-lib==11.7.0
+packageurl-python==0.17.6
 Flask==3.0.3
 jinja2==3.1.4
 pyparsing==3.1.2

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -22,15 +22,19 @@ from packageurl import PackageURL
 def _normalize_purl(purl: str) -> str:
     """Normalize PURL to a canonical form.
 
-    Handles two normalizations for ``deb`` type PURLs:
+    Handles two normalizations for ``deb`` and ``rpm`` type PURLs:
     - URL-decodes percent-encoded characters in the version (e.g. ``2%3A`` → ``2:``)
     - Moves ``epoch=N`` qualifier into the version field as ``N:version``
+
+    ``epoch`` is the only qualifier that requires this special treatment per the PURL spec.
+    All other standard normalizations (qualifier ordering, component encoding) are handled
+    transparently by the ``packageurl-python`` library during parse and re-serialisation.
 
     Falls back to the original string if parsing fails.
     """
     try:
         p = PackageURL.from_string(purl)
-        if p.type == "deb" and p.qualifiers and "epoch" in p.qualifiers and p.version is not None:
+        if p.type in ("deb", "rpm") and p.qualifiers and "epoch" in p.qualifiers and p.version is not None:
             epoch = p.qualifiers["epoch"]
             new_qualifiers = {k: v for k, v in p.qualifiers.items() if k != "epoch"}
             new_version = f"{epoch}:{p.version}"

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -16,6 +16,31 @@ from ..extensions import db, Base
 
 if typing.TYPE_CHECKING:
     from ..models import SBOMPackage, Finding
+from packageurl import PackageURL
+
+
+def _normalize_purl(purl: str) -> str:
+    """Normalize PURL to a canonical form.
+
+    Handles two normalizations for ``deb`` type PURLs:
+    - URL-decodes percent-encoded characters in the version (e.g. ``2%3A`` → ``2:``)
+    - Moves ``epoch=N`` qualifier into the version field as ``N:version``
+
+    Falls back to the original string if parsing fails.
+    """
+    try:
+        p = PackageURL.from_string(purl)
+        if p.type == "deb" and p.qualifiers and "epoch" in p.qualifiers and p.version is not None:
+            epoch = p.qualifiers["epoch"]
+            new_qualifiers = {k: v for k, v in p.qualifiers.items() if k != "epoch"}
+            new_version = f"{epoch}:{p.version}"
+            p = PackageURL(
+                type=p.type, namespace=p.namespace, name=p.name,
+                version=new_version, qualifiers=new_qualifiers or None, subpath=p.subpath
+            )
+        return str(p)
+    except Exception:
+        return purl
 
 
 class Package(Base):
@@ -114,6 +139,7 @@ class Package(Base):
         """Add a PURL identifier if not already present."""
         if not purl:
             return
+        purl = _normalize_purl(purl)
         current = list(self.purl or [])
         if purl not in current:
             current.append(purl)

--- a/src/views/fast_spdx.py
+++ b/src/views/fast_spdx.py
@@ -36,22 +36,20 @@ class FastSPDX ():
         if name is None:
             return None
         version = _get_field(pkg, ["version", "Version", "packageVersion", "PackageVersion", "versionInfo"])
-        primary_package_purpose = _get_field(pkg, ["primaryPackagePurpose", "PrimaryPackagePurpose"])
         licences = _get_field(pkg, ["licenseDeclared", "LicenseDeclared"])
 
         package = Package(name, version or "", [], [], licences or "")
-        cpe_type = "a"
-        if primary_package_purpose == "OPERATING-SYSTEM" or primary_package_purpose == "OPERATING_SYSTEM":
-            cpe_type = "o"
-        if primary_package_purpose == "DEVICE":
-            cpe_type = "h"
-        package.add_cpe(f"cpe:2.3:{cpe_type}:*:{name}:{version or '*'}:*:*:*:*:*:*:*")
 
         for external_ref in _get_field(pkg, ["externalRefs"]) or []:
-            if _get_field(external_ref, ["referenceType"]) == "purl":
+            ref_type = _get_field(external_ref, ["referenceType"])
+            if ref_type == "purl":
                 purl = _get_field(external_ref, ["referenceLocator"])
                 assert isinstance(purl, str)
                 package.add_purl(purl)
+            elif ref_type == "cpe23Type":
+                cpe = _get_field(external_ref, ["referenceLocator"])
+                if isinstance(cpe, str):
+                    package.add_cpe(cpe)
 
         package.generate_generic_cpe()
         package.generate_generic_purl()

--- a/src/views/spdx.py
+++ b/src/views/spdx.py
@@ -102,21 +102,16 @@ class SPDX:
                 verbose(f"[SPDX.merge_components] failed to read supplier for {package.name!r}")
 
             pkg = Package(package.name, package.version or "", [], [], "", supplier=supplier)
-            cpe_type = "a"
-
-            if package.primary_package_purpose == PackagePurpose.OPERATING_SYSTEM:
-                cpe_type = "o"
-            if package.primary_package_purpose == PackagePurpose.DEVICE:
-                cpe_type = "h"
             license_declared = package.license_declared
             if license_declared is not None:
                 license_str = str(license_declared)
                 pkg.licences = license_str
-            pkg.add_cpe(f"cpe:2.3:{cpe_type}:*:{package.name or '*'}:{package.version or '*'}:*:*:*:*:*:*:*")
 
             for external_ref in package.external_references:
                 if external_ref.reference_type == "purl":
                     pkg.add_purl(external_ref.locator)
+                elif external_ref.reference_type == "cpe23Type":
+                    pkg.add_cpe(external_ref.locator)
 
             pkg.generate_generic_cpe()
             pkg.generate_generic_purl()

--- a/tests/integration_tests/test_fastsdpx_parsing.py
+++ b/tests/integration_tests/test_fastsdpx_parsing.py
@@ -112,3 +112,128 @@ def test_parse_components_json(spdx_parser):
     assert "cpe:2.3:a:*:xyz:rev2.3:*:*:*:*:*:*:*" in board
     linux = spdx_parser.packagesCtrl.get("linux@6.8.0-40-generic")
     assert "cpe:2.3:a:*:linux:6.8.0-40-generic:*:*:*:*:*:*:*" in linux
+
+
+def test_parse_cpe23type_externalrefs(spdx_parser):
+    """BOM cpe23Type externalRefs must be stored and appear before the generic CPE."""
+    spdx_parser.parse_from_dict({
+        "spdxVersion": "SPDX-2.3",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "test",
+        "creationInfo": {"created": "2022-11-03T07:10:10Z", "creators": ["Tool: test"]},
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://example.com/test",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-libtasn1",
+                "name": "libtasn1-6",
+                "versionInfo": "4.13-2",
+                "filesAnalyzed": False,
+                "downloadLocation": "NOASSERTION",
+                "externalRefs": [
+                    {
+                        "referenceCategory": "SECURITY",
+                        "referenceType": "cpe23Type",
+                        "referenceLocator": "cpe:2.3:a:libtasn1:libtasn1_6:4.13-2:*:*:*:*:*:*:*"
+                    },
+                    {
+                        "referenceCategory": "SECURITY",
+                        "referenceType": "cpe23Type",
+                        "referenceLocator": "cpe:2.3:a:libtasn1-6:libtasn1-6:4.13-2:*:*:*:*:*:*:*"
+                    },
+                    {
+                        "referenceCategory": "PACKAGE-MANAGER",
+                        "referenceType": "purl",
+                        "referenceLocator": "pkg:deb/ubuntu/libtasn1-6@4.13-2?arch=arm64"
+                    }
+                ]
+            }
+        ]
+    })
+
+    pkg = spdx_parser.packagesCtrl.get("libtasn1-6@4.13-2")
+    assert pkg is not None
+
+    # BOM CPEs must be present
+    assert "cpe:2.3:a:libtasn1:libtasn1_6:4.13-2:*:*:*:*:*:*:*" in pkg.cpe
+    assert "cpe:2.3:a:libtasn1-6:libtasn1-6:4.13-2:*:*:*:*:*:*:*" in pkg.cpe
+
+    # First CPE must be a BOM CPE (not the generic wildcard)
+    assert pkg.cpe[0] == "cpe:2.3:a:libtasn1:libtasn1_6:4.13-2:*:*:*:*:*:*:*"
+
+    # Generic fallback must still be present (as last entry)
+    generic = "cpe:2.3:a:*:libtasn1-6:4.13-2:*:*:*:*:*:*:*"
+    assert generic in pkg.cpe
+    assert pkg.cpe[-1] == generic
+
+    # PURL must also be parsed
+    assert "pkg:deb/ubuntu/libtasn1-6@4.13-2?arch=arm64" in pkg.purl
+
+
+def test_parse_no_cpe23type_still_gets_generic(spdx_parser):
+    """Packages without cpe23Type externalRefs must still receive the generic CPE fallback."""
+    spdx_parser.parse_from_dict({
+        "spdxVersion": "SPDX-2.3",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "test",
+        "creationInfo": {"created": "2022-11-03T07:10:10Z", "creators": ["Tool: test"]},
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://example.com/test",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-binutils",
+                "name": "binutils",
+                "versionInfo": "2.38",
+                "filesAnalyzed": False,
+                "downloadLocation": "NOASSERTION"
+            }
+        ]
+    })
+
+    pkg = spdx_parser.packagesCtrl.get("binutils@2.38")
+    assert pkg is not None
+    assert len(pkg.cpe) == 1
+    assert pkg.cpe[0] == "cpe:2.3:a:*:binutils:2.38:*:*:*:*:*:*:*"
+
+
+def test_device_and_os_packages_get_type_a_generic_cpe(spdx_parser):
+    """DEVICE and OPERATING-SYSTEM packages without cpe23Type refs get a type-a generic CPE.
+
+    primaryPackagePurpose is not used to generate h/o CPEs — BOM cpe23Type externalRefs
+    are the authoritative source for hardware/OS CPE types. When no cpe23Type refs are
+    present, the generic fallback (type a, wildcard vendor) is used for all packages.
+    """
+    spdx_parser.parse_from_dict({
+        "spdxVersion": "SPDX-2.3",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "test",
+        "creationInfo": {"created": "2022-11-03T07:10:10Z", "creators": ["Tool: test"]},
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://example.com/test",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-board",
+                "name": "my-board",
+                "versionInfo": "rev1",
+                "filesAnalyzed": False,
+                "downloadLocation": "NOASSERTION",
+                "primaryPackagePurpose": "DEVICE"
+            },
+            {
+                "SPDXID": "SPDXRef-kernel",
+                "name": "linux",
+                "versionInfo": "6.8.0",
+                "filesAnalyzed": False,
+                "downloadLocation": "NOASSERTION",
+                "primaryPackagePurpose": "OPERATING-SYSTEM"
+            }
+        ]
+    })
+
+    board = spdx_parser.packagesCtrl.get("my-board@rev1")
+    assert board is not None
+    assert board.cpe == ["cpe:2.3:a:*:my-board:rev1:*:*:*:*:*:*:*"]
+
+    kernel = spdx_parser.packagesCtrl.get("linux@6.8.0")
+    assert kernel is not None
+    assert kernel.cpe == ["cpe:2.3:a:*:linux:6.8.0:*:*:*:*:*:*:*"]

--- a/tests/integration_tests/test_spdx_parsing.py
+++ b/tests/integration_tests/test_spdx_parsing.py
@@ -150,3 +150,131 @@ def test_parse_invalid_tagvalue(spdx_parser, spdx_tagvalue_file):
     with pytest.raises(Exception):
         spdx_parser.load_from_file(str(spdx_tagvalue_file))
         spdx_parser.parse_and_merge()
+
+
+def test_parse_cpe23type_externalrefs(spdx_parser):
+    """BOM cpe23Type externalRefs must be stored and appear before the generic CPE."""
+    spdx_parser.load_from_dict({
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "test",
+        "spdxVersion": "SPDX-2.3",
+        "creationInfo": {"created": "2022-11-03T07:10:10Z", "creators": ["Tool: test"]},
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://example.com/test",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-libtasn1",
+                "name": "libtasn1-6",
+                "versionInfo": "4.13-2",
+                "filesAnalyzed": False,
+                "downloadLocation": "NOASSERTION",
+                "externalRefs": [
+                    {
+                        "referenceCategory": "SECURITY",
+                        "referenceType": "cpe23Type",
+                        "referenceLocator": "cpe:2.3:a:libtasn1:libtasn1_6:4.13-2:*:*:*:*:*:*:*"
+                    },
+                    {
+                        "referenceCategory": "SECURITY",
+                        "referenceType": "cpe23Type",
+                        "referenceLocator": "cpe:2.3:a:libtasn1-6:libtasn1-6:4.13-2:*:*:*:*:*:*:*"
+                    },
+                    {
+                        "referenceCategory": "PACKAGE-MANAGER",
+                        "referenceType": "purl",
+                        "referenceLocator": "pkg:deb/ubuntu/libtasn1-6@4.13-2?arch=arm64"
+                    }
+                ]
+            }
+        ]
+    })
+    spdx_parser.parse_and_merge()
+
+    pkg = spdx_parser.packagesCtrl.get("libtasn1-6@4.13-2")
+    assert pkg is not None
+
+    # BOM CPEs must be present
+    assert "cpe:2.3:a:libtasn1:libtasn1_6:4.13-2:*:*:*:*:*:*:*" in pkg.cpe
+    assert "cpe:2.3:a:libtasn1-6:libtasn1-6:4.13-2:*:*:*:*:*:*:*" in pkg.cpe
+
+    # First CPE must be a BOM CPE (not the generic wildcard)
+    assert pkg.cpe[0] == "cpe:2.3:a:libtasn1:libtasn1_6:4.13-2:*:*:*:*:*:*:*"
+
+    # Generic fallback must still be present (as last entry)
+    generic = "cpe:2.3:a:*:libtasn1-6:4.13-2:*:*:*:*:*:*:*"
+    assert generic in pkg.cpe
+    assert pkg.cpe[-1] == generic
+
+    # PURL must also be parsed
+    assert "pkg:deb/ubuntu/libtasn1-6@4.13-2?arch=arm64" in pkg.purl
+
+
+def test_parse_no_cpe23type_still_gets_generic(spdx_parser):
+    """Packages without cpe23Type externalRefs must still receive the generic CPE fallback."""
+    spdx_parser.load_from_dict({
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "test",
+        "spdxVersion": "SPDX-2.3",
+        "creationInfo": {"created": "2022-11-03T07:10:10Z", "creators": ["Tool: test"]},
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://example.com/test",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-binutils",
+                "name": "binutils",
+                "versionInfo": "2.38",
+                "filesAnalyzed": False,
+                "downloadLocation": "NOASSERTION"
+            }
+        ]
+    })
+    spdx_parser.parse_and_merge()
+
+    pkg = spdx_parser.packagesCtrl.get("binutils@2.38")
+    assert pkg is not None
+    assert len(pkg.cpe) == 1
+    assert pkg.cpe[0] == "cpe:2.3:a:*:binutils:2.38:*:*:*:*:*:*:*"
+
+
+def test_device_and_os_packages_get_type_a_generic_cpe(spdx_parser):
+    """DEVICE and OPERATING-SYSTEM packages without cpe23Type refs get a type-a generic CPE.
+
+    primaryPackagePurpose is not used to generate h/o CPEs — BOM cpe23Type externalRefs
+    are the authoritative source for hardware/OS CPE types. When no cpe23Type refs are
+    present, the generic fallback (type a, wildcard vendor) is used for all packages.
+    """
+    spdx_parser.load_from_dict({
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "test",
+        "spdxVersion": "SPDX-2.3",
+        "creationInfo": {"created": "2022-11-03T07:10:10Z", "creators": ["Tool: test"]},
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://example.com/test",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-board",
+                "name": "my-board",
+                "versionInfo": "rev1",
+                "filesAnalyzed": False,
+                "downloadLocation": "NOASSERTION",
+                "primaryPackagePurpose": "DEVICE"
+            },
+            {
+                "SPDXID": "SPDXRef-kernel",
+                "name": "linux",
+                "versionInfo": "6.8.0",
+                "filesAnalyzed": False,
+                "downloadLocation": "NOASSERTION",
+                "primaryPackagePurpose": "OPERATING-SYSTEM"
+            }
+        ]
+    })
+    spdx_parser.parse_and_merge()
+
+    board = spdx_parser.packagesCtrl.get("my-board@rev1")
+    assert board is not None
+    assert board.cpe == ["cpe:2.3:a:*:my-board:rev1:*:*:*:*:*:*:*"]
+
+    kernel = spdx_parser.packagesCtrl.get("linux@6.8.0")
+    assert kernel is not None
+    assert kernel.cpe == ["cpe:2.3:a:*:linux:6.8.0:*:*:*:*:*:*:*"]

--- a/tests/unit_tests/test_package.py
+++ b/tests/unit_tests/test_package.py
@@ -282,6 +282,20 @@ def test_purl_epoch_forms_deduplicate():
     assert len([p for p in pkg.purl if "procps" in p and "deb" in p]) == 1
 
 
+def test_rpm_purl_epoch_qualifier_normalized_to_version_prefix():
+    pkg = Package("bash", "1:5.1.8-6.el9")
+    pkg.add_purl("pkg:rpm/fedora/bash@5.1.8-6.el9?arch=x86_64&epoch=1")
+    assert "pkg:rpm/fedora/bash@1:5.1.8-6.el9?arch=x86_64" in pkg.purl
+
+
+def test_rpm_purl_epoch_forms_deduplicate():
+    pkg = Package("bash", "1:5.1.8-6.el9")
+    pkg.add_purl("pkg:rpm/fedora/bash@5.1.8-6.el9?arch=x86_64&epoch=1")
+    pkg.add_purl("pkg:rpm/fedora/bash@1:5.1.8-6.el9?arch=x86_64")
+    # Both normalize to the same canonical form — no duplicate
+    assert len([p for p in pkg.purl if "bash" in p and "rpm" in p]) == 1
+
+
 def test_purl_normalization_non_deb_unchanged():
     pkg = Package("mypackage", "1.0.0")
     generic_purl = "pkg:generic/mypackage@1.0.0"

--- a/tests/unit_tests/test_package.py
+++ b/tests/unit_tests/test_package.py
@@ -260,3 +260,44 @@ def test_sort_packages_mixed_suppliers():
     assert result[0].supplier == ""
     # Remaining two are deterministic (alphabetical)
     assert result[1].supplier < result[2].supplier
+
+
+def test_purl_epoch_qualifier_normalized_to_version_prefix():
+    pkg = Package("procps", "2:3.3.12-3ubuntu1.2")
+    pkg.add_purl("pkg:deb/ubuntu/procps@3.3.12-3ubuntu1.2?arch=arm64&distro=ubuntu-18.04&epoch=2")
+    assert "pkg:deb/ubuntu/procps@2:3.3.12-3ubuntu1.2?arch=arm64&distro=ubuntu-18.04" in pkg.purl
+
+
+def test_purl_url_encoded_epoch_normalized():
+    pkg = Package("procps", "2:3.3.12-3ubuntu1.2")
+    pkg.add_purl("pkg:deb/ubuntu/procps@2%3A3.3.12-3ubuntu1.2?arch=arm64&distro=ubuntu-18.04")
+    assert "pkg:deb/ubuntu/procps@2:3.3.12-3ubuntu1.2?arch=arm64&distro=ubuntu-18.04" in pkg.purl
+
+
+def test_purl_epoch_forms_deduplicate():
+    pkg = Package("procps", "2:3.3.12-3ubuntu1.2")
+    pkg.add_purl("pkg:deb/ubuntu/procps@2%3A3.3.12-3ubuntu1.2?arch=arm64&distro=ubuntu-18.04")
+    pkg.add_purl("pkg:deb/ubuntu/procps@3.3.12-3ubuntu1.2?arch=arm64&distro=ubuntu-18.04&epoch=2")
+    # Both normalize to the same canonical form — no duplicate
+    assert len([p for p in pkg.purl if "procps" in p and "deb" in p]) == 1
+
+
+def test_purl_normalization_non_deb_unchanged():
+    pkg = Package("mypackage", "1.0.0")
+    generic_purl = "pkg:generic/mypackage@1.0.0"
+    pkg.add_purl(generic_purl)
+    assert generic_purl in pkg.purl
+
+
+def test_purl_malformed_stored_as_is():
+    pkg = Package("mypackage", "1.0.0")
+    malformed = "not-a-valid-purl-at-all"
+    pkg.add_purl(malformed)
+    assert malformed in pkg.purl
+
+
+def test_purl_epoch_qualifier_without_version_not_corrupted():
+    pkg = Package("procps", "")
+    no_version_purl = "pkg:deb/ubuntu/procps?epoch=2"
+    pkg.add_purl(no_version_purl)
+    assert "None" not in pkg.purl[0]


### PR DESCRIPTION
## Fixes https://github.com/savoirfairelinux/vulnscout/issues/276#issuecomment-4427368398

### Changes proposed in this pull request:

This PR addresses https://github.com/savoirfairelinux/vulnscout/issues/276#issuecomment-4427368398.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Download the files mentioned in the issue comment above and run Vulnscout with the following command after moving the relevant files to the root path of Vulnscout. Also, you need to rename `syft_spdx.json` to `syft.spdx.json` as the `entrypoint` doesn't accept `*_spdx.json` (This should be a careless mistake by the issue author):
```
./vulnscout --dev \
   --add-spdx syft.spdx.json \
   --add-grype syft_spdx.grype.json \
   --serve
```
Then, navigate to the export page and download the OpenVEX file. The * vendor should be gone. For example, the string mentioned in the issue comment should not be found in the new OpenVEX file:
```
cpe:2.3:a:*:libtasn1-6:4.13-2:*:*:*:*:*:*:*
cpe:2.3:a:*:util-linux:2.31.1-0.4ubuntu3.7:*:*:*:*:*:*:*
```

A string like the following in BOM:
```
pkg:deb/ubuntu/procps@2%3A3.3.12-3ubuntu1.2?arch=arm64&distro=ubuntu-18.04
```
It will like this in VEX:
```
pkg:deb/ubuntu/libprocps6@2:3.3.12-3ubuntu1.2?arch=arm64&distro=ubuntu-18.04&upstream=procps
```


### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [x] Added necessary reviewers


