### PR TITLE
Export custom assessments as individual OpenVEX files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -278,11 +278,15 @@ VulnScout lets you export and re-import the assessments you have manually create
 
 ==== Exporting Custom Assessments
 
-The `--export-custom-assessments` flag produces a `.tar.gz` archive containing one OpenVEX JSON file per variant. The archive is written to the outputs directory (default: `.vulnscout/outputs/`).
+The `--export-custom-assessments` flag produces one OpenVEX JSON file per variant, written individually to the outputs directory (default: `.vulnscout/outputs/`).
 
 [source,shell]
 ----
+# Export as individual files (one per variant)
 ./vulnscout --project demo --export-custom-assessments
+
+# Export as a compressed .tar.gz archive
+./vulnscout --project demo --export-custom-assessments --compress
 ----
 
 ==== Importing Custom Assessments

--- a/README.adoc
+++ b/README.adoc
@@ -291,15 +291,18 @@ The `--export-custom-assessments` flag produces one OpenVEX JSON file per varian
 
 ==== Importing Custom Assessments
 
-The `--import-custom-assessments` flag reads a `.json` or `.tar.gz` file and replays the assessment statements into the database, matching them to existing vulnerabilities and packages.
+The `--import-custom-assessments` flag reads a `.json` file, `.tar.gz` archive, or a directory of OpenVEX JSON files and replays the assessment statements into the database, matching them to existing vulnerabilities and packages.
 
 [source,shell]
 ----
 # Import from a single OpenVEX JSON file
 ./vulnscout --project demo --import-custom-assessments /path/to/assessments.json
 
-# Import from a tar.gz archive previously exported
+# Import from a tar.gz archive
 ./vulnscout --project demo --import-custom-assessments /path/to/custom_assessments.tar.gz
+
+# Import from a directory of OpenVEX JSON files (one per variant)
+./vulnscout --project demo --import-custom-assessments /path/to/assessments/
 ----
 
 Both commands can be combined with other flags:

--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -266,13 +266,19 @@ VulnScout lets you export and re-import the assessments you have manually create
 
 ### Exporting Custom Assessments
 
-The `--export-custom-assessments` flag produces a `.tar.gz` archive containing one OpenVEX JSON file per variant:
+The `--export-custom-assessments` flag produces one OpenVEX JSON file per variant, written directly to the outputs directory:
 
 ```bash
 ./vulnscout --project demo --export-custom-assessments
 ```
 
-You can also use the `--variant` flag to select from which variant to export an OpenVEX file. In this case, the exported file is a simple `.json` file:
+To bundle the exported files into a `.tar.gz` archive instead, add the `--compress` flag:
+
+```bash
+./vulnscout --project demo --export-custom-assessments --compress
+```
+
+You can also use the `--variant` flag to export only a single variant:
 
 ```bash
 ./vulnscout --project demo --variant x86 --export-custom-assessments
@@ -280,7 +286,7 @@ You can also use the `--variant` flag to select from which variant to export an 
 
 ### Importing Custom Assessments
 
-The `--import-custom-assessments` flag reads a `.json` or `.tar.gz` file and replays the assessment statements into the database. If `--variant` is not specified, the variant is inferred from the file name.
+The `--import-custom-assessments` flag reads a `.json` file, `.tar.gz` archive, or a directory of OpenVEX JSON files and replays the assessment statements into the database. If `--variant` is not specified, the variant is inferred from the file name.
 
 ```bash
 # Import from a single OpenVEX JSON file
@@ -289,8 +295,11 @@ The `--import-custom-assessments` flag reads a `.json` or `.tar.gz` file and rep
 # Import from a single OpenVEX JSON file without specifying the variant
 ./vulnscout --project demo --import-custom-assessments /path/to/assessments/x86.json
 
-# Import from a tar.gz archive previously exported
+# Import from a tar.gz archive
 ./vulnscout --project demo --import-custom-assessments /path/to/custom_assessments.tar.gz
+
+# Import from a directory of OpenVEX JSON files (one per variant)
+./vulnscout --project demo --import-custom-assessments /path/to/assessments/
 ```
 
 ---

--- a/src/bin/cmd_assessments.py
+++ b/src/bin/cmd_assessments.py
@@ -30,10 +30,12 @@ from collections import defaultdict
               help="Directory where the exported file is written.")
 @click.option("--project", "-p", required=True, help="Project name.")
 @click.option("--variant", "-v", default=None,
-              help="Variant name. If empty, all variants will be exported in an archive.")
+              help="Variant name. If empty, all variants will be exported.")
+@click.option("--compress", is_flag=True, default=False,
+              help="Write a .tar.gz archive instead of individual files.")
 @with_appcontext
-def export_custom_assessments_command(output_dir: str, project: str, variant: str | None) -> None:
-    """Export handmade (custom) assessments as an (archive of) OpenVEX file(s)."""
+def export_custom_assessments_command(output_dir: str, project: str, variant: str | None, compress: bool) -> None:
+    """Export handmade (custom) assessments as OpenVEX file(s)."""
 
     author = os.getenv("AUTHOR_NAME", "Savoir-faire Linux")
     now_iso = _dt.now(_tz.utc).isoformat()
@@ -155,43 +157,71 @@ def export_custom_assessments_command(output_dir: str, project: str, variant: st
         }
         return doc
 
+    def _sanitize(name: str) -> str:
+        return name.replace("/", "_").replace("\\", "_")
+
     if variant is None:
-        # export all variants from project as archive
         by_variant: dict[_uuid.UUID, list[DBAssessment]] = defaultdict(list)
         for assess in handmade:
             assert assess.variant_id is not None
             by_variant[assess.variant_id].append(assess)
 
-        buf = io.BytesIO()
-        with tarfile.open(fileobj=buf, mode='w:gz') as tar:
+        if compress:
+            buf = io.BytesIO()
+            with tarfile.open(fileobj=buf, mode='w:gz') as tar:
+                for vid, assessments in by_variant.items():
+                    variant_obj = DBVariant.get_by_id(vid)
+                    assert variant_obj
+                    filename = _sanitize(variant_obj.name) + ".json"
+
+                    doc = generate_doc(assessments)
+                    json_bytes = _json.dumps(doc, indent=2).encode("utf-8")
+                    info = tarfile.TarInfo(name=filename)
+                    info.size = len(json_bytes)
+                    tar.addfile(info, io.BytesIO(json_bytes))
+
+            out_path = os.path.join(output_dir, "custom_assessments.tar.gz")
+            with open(out_path, "wb") as fh:
+                fh.write(buf.getvalue())
+            click.echo(f"Custom assessments exported: {out_path}")
+        else:
+            out_paths = []
             for vid, assessments in by_variant.items():
                 variant_obj = DBVariant.get_by_id(vid)
-                assert variant_obj  # Variant cannot be null since we filtrered by variant before
-                filename = variant_obj.name + ".json"
-                filename = filename.replace("/", "_").replace("\\", "_")
+                assert variant_obj
+                filename = _sanitize(variant_obj.name) + ".json"
 
                 doc = generate_doc(assessments)
-                json_bytes = _json.dumps(doc, indent=2).encode("utf-8")
+                out_path = os.path.join(output_dir, filename)
+                with open(out_path, "w") as file:
+                    _json.dump(doc, file, indent=2)
+                out_paths.append(out_path)
+            for p in out_paths:
+                click.echo(f"Custom assessments exported: {p}")
+    else:
+        assert variant_obj
+        filename = _sanitize(variant_obj.name) + ".json"
+
+        if compress:
+            doc = generate_doc(handmade)
+            json_bytes = _json.dumps(doc, indent=2).encode("utf-8")
+
+            buf = io.BytesIO()
+            with tarfile.open(fileobj=buf, mode='w:gz') as tar:
                 info = tarfile.TarInfo(name=filename)
                 info.size = len(json_bytes)
                 tar.addfile(info, io.BytesIO(json_bytes))
 
-        out_path = os.path.join(output_dir, "custom_assessments.tar.gz")
-        with open(out_path, "wb") as fh:
-            fh.write(buf.getvalue())
-    else:
-        assert variant_obj
-        # Declared above, assert here so type checker no longer
-        # considers it possibly Unbound
-        filename = variant_obj.name + ".json"
-        filename = filename.replace("/", "_").replace("\\", "_")
+            out_path = os.path.join(output_dir, "custom_assessments.tar.gz")
+            with open(out_path, "wb") as fh:
+                fh.write(buf.getvalue())
+        else:
+            doc = generate_doc(handmade)
+            out_path = os.path.join(output_dir, filename)
+            with open(out_path, "w") as file:
+                _json.dump(doc, file, indent=2)
 
-        doc = generate_doc(handmade)
-        out_path = os.path.join(output_dir, filename)
-        with open(out_path, "w") as file:
-            _json.dump(doc, file)
-
-    click.echo(f"Custom assessments exported: {out_path}")
+        click.echo(f"Custom assessments exported: {out_path}")
 
 
 @click.command("import-custom-assessments")

--- a/src/bin/cmd_assessments.py
+++ b/src/bin/cmd_assessments.py
@@ -230,8 +230,8 @@ def export_custom_assessments_command(output_dir: str, project: str, variant: st
 @click.option("--variant", "-v", default=None, help="Variant name. Defaults to the file name.")
 @with_appcontext
 def import_custom_assessments_command(file_path: str, project: str, variant: str | None) -> None:
-    """Import custom assessments from a .json or .tar.gz OpenVEX file."""
-    if not os.path.isfile(file_path):
+    """Import custom assessments from a .json, .tar.gz, or directory of OpenVEX files."""
+    if not os.path.isfile(file_path) and not os.path.isdir(file_path):
         click.echo(f"Error: file not found: {file_path}", err=True)
         raise SystemExit(1)
 
@@ -431,6 +431,68 @@ def import_custom_assessments_command(file_path: str, project: str, variant: str
                 click.echo(f"  {err}", err=True)
             raise SystemExit(1)
 
+    elif os.path.isdir(file_path):
+        if variant:
+            click.echo("Error: cannot use the --variant argument with a directory of custom assessments.")
+            raise SystemExit(1)
+
+        json_files = sorted(f for f in os.listdir(file_path) if f.endswith(".json"))
+        if not json_files:
+            click.echo("Error: no .json files found in directory.", err=True)
+            raise SystemExit(1)
+
+        variant_files_found = 0
+        total_created = []
+        total_errors = []
+        total_skipped = 0
+        for json_name in json_files:
+            variant_name = json_name[:-len(".json")]
+            variant_obj = variant_by_name.get(variant_name)
+            if variant_obj is None:
+                total_errors.append({
+                    "file": json_name,
+                    "error": (
+                        f"No variant found matching name "
+                        f"'{variant_name}'"
+                    ),
+                })
+                continue
+
+            json_path = os.path.join(file_path, json_name)
+            try:
+                with open(json_path) as fh:
+                    doc = _json.load(fh)
+            except Exception:
+                total_errors.append({
+                    "file": json_name,
+                    "error": "Invalid JSON",
+                })
+                continue
+
+            if not _is_openvex(doc):
+                total_errors.append({
+                    "file": json_name,
+                    "error": "Not a valid OpenVEX document",
+                })
+                continue
+
+            variant_files_found += 1
+            c, e, s = _import_statements(
+                doc["statements"], variant_obj.id
+            )
+            total_created.extend(c)
+            total_errors.extend(e)
+            total_skipped += s
+
+        if variant_files_found == 0 and not total_created:
+            click.echo(
+                "Error: no valid OpenVEX files matching known "
+                "variants found in directory.", err=True
+            )
+            for err in total_errors:
+                click.echo(f"  {err}", err=True)
+            raise SystemExit(1)
+
     elif file_path.endswith(".json"):
         if variant:
             assert variant_obj
@@ -466,7 +528,7 @@ def import_custom_assessments_command(file_path: str, project: str, variant: str
     else:
         click.echo(
             "Error: unsupported file type. "
-            "Please provide a .json or .tar.gz file.",
+            "Please provide a .json, .tar.gz file, or directory.",
             err=True,
         )
         raise SystemExit(1)

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -46,8 +46,9 @@ Scan & output commands:
   --export-spdx             Export project as SPDX 3.0 SBOM to /scan/outputs/
   --export-cdx              Export project as CycloneDX 1.6 SBOM to /scan/outputs/
   --export-openvex          Export project as OpenVEX document to /scan/outputs/
-  --export-custom-assessments  Export custom (review) assessments as tar.gz to /scan/outputs/
-  --import-custom-assessments <path>  Import custom assessments from .json or .tar.gz
+  --export-custom-assessments  Export custom (review) assessments as individual OpenVEX files to /scan/outputs/
+  --compress                  Compress export output into a .tar.gz archive
+  --import-custom-assessments <path>  Import custom assessments from .json, .tar.gz, or directory
   --match-condition <expr>  Exit code 2 if condition met (e.g. "cvss >= 9.0")
   --delete-scan <id>        Delete a past scan by its ID
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -417,6 +417,9 @@ cmd_export_custom_assessments() {
     if [[ -n "$VARIANT_NAME" ]]; then
         export_args+=(--variant "$VARIANT_NAME")
     fi
+    if [[ "${COMPRESS:-false}" == "true" ]]; then
+        export_args+=(--compress)
+    fi
 
     cd "$BASE_DIR"
     local output_dir="${OUTPUTS_DIR:-/scan/outputs}"
@@ -661,6 +664,8 @@ while [[ $# -gt 0 ]]; do
             EXPORT_FORMATS+=("openvex"); shift ;;
         --export-custom-assessments)
             EXPORT_CUSTOM_ASSESSMENTS=true; shift ;;
+        --compress)
+            COMPRESS=true; shift ;;
         --import-custom-assessments)
             IMPORT_CUSTOM_ASSESSMENTS_FILE="$2"; shift 2 ;;
         --list-projects|--list-scans)

--- a/tests/end_to_end_tests/test_merger_ci.py
+++ b/tests/end_to_end_tests/test_merger_ci.py
@@ -693,6 +693,111 @@ def test_import_custom_assessments_targz_variant_flag(app, tmp_path):
     assert "cannot use the --variant" in result.output.lower()
 
 
+def test_import_custom_assessments_directory_success(app, tmp_path):
+    """Import from a directory of JSON files."""
+    doc = {
+        "@context": "https://openvex.dev/ns/v0.2.0",
+        "statements": [{
+            "vulnerability": {"name": "CVE-2020-35492"},
+            "status": "affected",
+            "products": [{"@id": "cairo@1.16.0"}],
+            "status_notes": "imported from dir",
+        }],
+    }
+    json_file = tmp_path / f"{_VARIANT_NAME}.json"
+    json_file.write_text(json.dumps(doc))
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(tmp_path),
+        ])
+    assert result.exit_code == 0, result.output
+    assert "Imported 1 assessments" in result.output
+
+
+def test_import_custom_assessments_directory_no_matching(app, tmp_path):
+    """Import from a directory with no matching variant files exits 1."""
+    doc = {
+        "@context": "https://openvex.dev/ns/v0.2.0",
+        "statements": [],
+    }
+    json_file = tmp_path / "unknown_variant.json"
+    json_file.write_text(json.dumps(doc))
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(tmp_path),
+        ])
+    assert result.exit_code == 1
+    assert "no valid openvex" in result.output.lower()
+
+
+def test_import_custom_assessments_directory_variant_flag(app, tmp_path):
+    """Import from a directory with --variant fails."""
+    (tmp_path / f"{_VARIANT_NAME}.json").write_text("{}")
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            "--variant", _VARIANT_NAME,
+            str(tmp_path),
+        ])
+    assert result.exit_code == 1
+    assert "cannot use the --variant" in result.output.lower()
+
+
+def test_import_custom_assessments_directory_empty(app, tmp_path):
+    """Import from an empty directory exits 1."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(empty_dir),
+        ])
+    assert result.exit_code == 1
+    assert "no .json files found" in result.output.lower()
+
+
+def test_export_import_roundtrip_directory(app, tmp_path):
+    """Export individual files then import directory produces same assessments."""
+    _create_custom_assessment(app)
+
+    # Export (individual files)
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "export-custom-assessments",
+            "--project", _PROJECT_NAME,
+            "--output-dir", str(tmp_path),
+        ])
+    assert result.exit_code == 0, result.output
+
+    # Delete all to have a clean slate, then import directory
+    with app.app_context():
+        from src.extensions import db as _db
+        from src.models.assessment import Assessment
+        for a in Assessment.get_handmade():
+            a.delete()
+        _db.session.commit()
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(tmp_path),
+        ])
+    assert result.exit_code == 0, result.output
+    assert "Imported 1 assessments" in result.output
+
+
 def test_export_import_roundtrip(app, tmp_path):
     """Export then import produces same number of assessments."""
     _create_custom_assessment(app)

--- a/tests/end_to_end_tests/test_merger_ci.py
+++ b/tests/end_to_end_tests/test_merger_ci.py
@@ -448,13 +448,33 @@ def test_export_custom_assessments_no_data(app, tmp_path):
 
 
 def test_export_custom_assessments_success(app, tmp_path):
-    """Export creates custom_assessments.tar.gz with a valid OpenVEX inside."""
+    """Export creates individual OpenVEX JSON files per variant."""
     _create_custom_assessment(app)
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "export-custom-assessments",
             "--project", _PROJECT_NAME,
+            "--output-dir", str(tmp_path),
+        ])
+    assert result.exit_code == 0, result.output
+    out_file = tmp_path / f"{_VARIANT_NAME}.json"
+    assert out_file.exists()
+
+    doc = json.loads(out_file.read_text())
+    assert "openvex" in doc["@context"]
+    assert len(doc["statements"]) >= 1
+
+
+def test_export_custom_assessments_compress(app, tmp_path):
+    """Export with --compress creates custom_assessments.tar.gz."""
+    _create_custom_assessment(app)
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "export-custom-assessments",
+            "--project", _PROJECT_NAME,
+            "--compress",
             "--output-dir", str(tmp_path),
         ])
     assert result.exit_code == 0, result.output
@@ -465,7 +485,6 @@ def test_export_custom_assessments_success(app, tmp_path):
     with _tf.open(str(out_file), "r:gz") as tar:
         members = tar.getnames()
         assert len(members) >= 1
-        # Verify the first file is valid OpenVEX
         f = tar.extractfile(members[0])
         doc = json.loads(f.read())
         assert "openvex" in doc["@context"]
@@ -678,12 +697,45 @@ def test_export_import_roundtrip(app, tmp_path):
     """Export then import produces same number of assessments."""
     _create_custom_assessment(app)
 
-    # Export
+    # Export (individual files, new default)
     with app.app_context():
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "export-custom-assessments",
             "--project", _PROJECT_NAME,
+            "--output-dir", str(tmp_path),
+        ])
+    assert result.exit_code == 0, result.output
+
+    # Delete all to have a clean slate, then import the individual file
+    with app.app_context():
+        from src.extensions import db as _db
+        from src.models.assessment import Assessment
+        for a in Assessment.get_handmade():
+            a.delete()
+        _db.session.commit()
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(tmp_path / f"{_VARIANT_NAME}.json"),
+        ])
+    assert result.exit_code == 0, result.output
+    assert "Imported 1 assessments" in result.output
+
+
+def test_export_import_roundtrip_compress(app, tmp_path):
+    """Export with --compress then import tar.gz produces same assessments."""
+    _create_custom_assessment(app)
+
+    # Export (compressed)
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "export-custom-assessments",
+            "--project", _PROJECT_NAME,
+            "--compress",
             "--output-dir", str(tmp_path),
         ])
     assert result.exit_code == 0, result.output
@@ -710,7 +762,7 @@ def test_import_custom_assessments_skips_duplicates(app, tmp_path):
     """Importing the same data twice skips duplicates."""
     _create_custom_assessment(app)
 
-    # Export
+    # Export (individual files)
     with app.app_context():
         runner = app.test_cli_runner()
         runner.invoke(args=[
@@ -725,7 +777,7 @@ def test_import_custom_assessments_skips_duplicates(app, tmp_path):
         result = runner.invoke(args=[
             "import-custom-assessments",
             "--project", _PROJECT_NAME,
-            str(tmp_path / "custom_assessments.tar.gz"),
+            str(tmp_path / f"{_VARIANT_NAME}.json"),
         ])
     assert result.exit_code == 0, result.output
     assert "1 skipped" in result.output

--- a/tests/unit_tests/test_coverage_supplement.py
+++ b/tests/unit_tests/test_coverage_supplement.py
@@ -217,3 +217,35 @@ class TestPersistAssessmentToDB:
 
         result = assess_ctrl.to_dict()
         assert isinstance(result, dict)
+
+
+# ===========================================================================
+# datetime_utils — ensure_utc_iso edge cases (lines 17, 19)
+# ===========================================================================
+
+class TestEnsureUtcIso:
+    def test_none_returns_none(self):
+        from src.helpers.datetime_utils import ensure_utc_iso
+        assert ensure_utc_iso(None) is None
+
+    def test_non_datetime_returns_str(self):
+        from src.helpers.datetime_utils import ensure_utc_iso
+        assert ensure_utc_iso(12345) == "12345"
+
+
+# ===========================================================================
+# EPSSProgressTracker — error() method (lines 72-76)
+# ===========================================================================
+
+class TestEpssProgressTrackerError:
+    def test_error_sets_phase_and_message(self):
+        from src.controllers.epss_progress import EPSSProgressTracker
+        tracker = EPSSProgressTracker()
+        tracker._initialized = False  # force re-init for clean state
+        tracker.__init__()
+        tracker.error("something went wrong")
+        progress = tracker.get_progress()
+        assert progress["in_progress"] is False
+        assert progress["phase"] == "error"
+        assert progress["message"] == "something went wrong"
+        assert progress["last_update"] is not None

--- a/vulnscout
+++ b/vulnscout
@@ -75,8 +75,9 @@ Scan & output commands:
   --export-spdx                   Export project as SPDX 3.0 SBOM
   --export-cdx                    Export project as CycloneDX 1.6 SBOM
   --export-openvex                Export project as OpenVEX document
-  --export-custom-assessments     Export custom (review) assessments as tar.gz
-  --import-custom-assessments <path>  Import custom assessments from .json or .tar.gz
+  --export-custom-assessments     Export custom (review) assessments as individual OpenVEX files
+  --compress                      Compress export output into a .tar.gz archive
+  --import-custom-assessments <path>  Import custom assessments from .json, .tar.gz, or directory
   --delete-scan <id>                Delete a past scan by its ID
 
 Data retrieval commands:
@@ -321,6 +322,8 @@ parse_and_run() {
                 ensure_running; EXPORT_ARGS+=(--export-openvex); shift ;;
             export-custom-assessments|--export-custom-assessments)
                 ensure_running; EXPORT_ARGS+=(--export-custom-assessments); shift ;;
+            compress|--compress)
+                EXPORT_ARGS+=(--compress); shift ;;
             import-custom-assessments|--import-custom-assessments)
                 ensure_running
                 local import_file


### PR DESCRIPTION
### Changes proposed in this pull request:

* Export custom assessments as individual OpenVEX files: added a --compress arg for an archive output.
* Import custom assessments: allow directory of json

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Set up a Vulnscout environment with multiple variants then test the following

Export as compressed archive

`./vulnscout --project demo --export-custom-assessments --compress`

Export as detached files (one per variant)

`./vulnscout --project demo --export-custom-assessments`

Import from directory of files (here I used the files exported above)

`./vulnscout --project demo --import-custom-assessments .vulnscout/outputs/`

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


