### PR TITLE
NVD info refresh

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -740,6 +740,77 @@ GET /api/variants/<variant_id>/osv-scan/status
 
 Same response shape as Grype status. `total` is the number of unique PURLs to query.
 
+### Trigger NVD CVE Refresh (bulk)
+
+```
+POST /api/variants/<variant_id>/nvd-refresh
+```
+
+Refreshes NVD metadata (description, CVSS scores, links, weaknesses) for existing CVE records without creating new findings. The refresh uses CPE batch lookup as the primary strategy and falls back to per-CVE individual API calls for any CVEs not covered.
+
+By default, all CVEs in *Pending Assessment* status for the variant are refreshed. An explicit list can be provided to refresh only a specific subset (e.g. the CVEs currently shown in the UI after filtering).
+
+**Request body (optional):**
+```json
+{ "cve_ids": ["CVE-2024-12345", "CVE-2023-99999"] }
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve_ids` | string[] | Optional. Explicit list of CVE IDs to refresh. Must be an array. Omit to refresh all Pending Assessment CVEs. |
+
+**Response:** `202 Accepted`
+```json
+{ "status": "started", "variant_id": "..." }
+```
+
+Returns `400` if `cve_ids` is provided but is not an array. Returns `409` if a refresh is already running.
+
+### Check NVD CVE Refresh Status
+
+```
+GET /api/variants/<variant_id>/nvd-refresh/status
+```
+
+**Response:**
+```json
+{
+  "status": "running",
+  "error": null,
+  "progress": "3/10 CPEs",
+  "logs": ["Collecting CVEs to refresh…", "Found 12 CVE(s) to refresh.", "..."],
+  "total": 12,
+  "done_count": 3,
+  "changed_cves": ["CVE-2024-12345"]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | `"idle"`, `"running"`, `"done"`, or `"error"` |
+| `progress` | string | Human-readable progress label |
+| `total` | int | Total number of CVEs to refresh |
+| `done_count` | int | Number of CPE batch iterations completed |
+| `changed_cves` | string[] | CVE IDs whose NVD data was updated during this run |
+| `logs` | string[] | Detailed step log |
+
+### Refresh a Single CVE from NVD
+
+```
+POST /api/vulnerabilities/<cve_id>/nvd-refresh
+```
+
+Synchronously fetches fresh NVD data for a single CVE and updates the local record. Returns the updated vulnerability object on success.
+
+**Response:** `200 OK`
+```json
+{
+  "vulnerabilities": [{ "id": "CVE-2024-12345", "description": "...", ... }]
+}
+```
+
+Returns `404` if the CVE is not in the local database. Returns `503` if the NVD API is unavailable or returns no data for the requested CVE.
+
 ---
 
 ## SBOM Upload

--- a/frontend/src/components/RefreshToast.tsx
+++ b/frontend/src/components/RefreshToast.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faRotate, faTimes } from "@fortawesome/free-solid-svg-icons";
+
+type Props = {
+    changedCves: string[];
+    onClose: () => void;
+};
+
+/**
+ * Non-blocking toast shown after a bulk NVD refresh completes.
+ * Auto-dismisses after 15 seconds; can also be closed manually.
+ */
+function RefreshToast({ changedCves, onClose }: Readonly<Props>) {
+    useEffect(() => {
+        const timer = setTimeout(onClose, 15000);
+        return () => clearTimeout(timer);
+    }, [onClose]);
+
+    return (
+        <div className="fixed bottom-5 right-5 z-50 w-80 rounded-lg border border-sky-600 bg-sky-950 text-neutral-50 shadow-xl p-4">
+            <div className="flex items-start justify-between gap-2">
+                <div className="flex items-center gap-2">
+                    <FontAwesomeIcon icon={faRotate} className="text-sky-400 shrink-0" />
+                    <p className="text-sm font-semibold text-sky-300">NVD Refresh Complete</p>
+                </div>
+                <button
+                    onClick={onClose}
+                    className="text-neutral-400 hover:text-white transition-colors"
+                    aria-label="Dismiss"
+                >
+                    <FontAwesomeIcon icon={faTimes} className="w-3.5 h-3.5" />
+                </button>
+            </div>
+
+            {changedCves.length === 0 ? (
+                <p className="mt-2 text-xs text-neutral-300">No CVEs were updated.</p>
+            ) : (
+                <>
+                    <p className="mt-2 text-xs text-neutral-300">
+                        {changedCves.length} CVE{changedCves.length !== 1 ? "s" : ""} updated with fresh NVD data:
+                    </p>
+                    <ul className="mt-1 max-h-32 overflow-y-auto space-y-0.5">
+                        {changedCves.map(id => (
+                            <li key={id} className="text-xs font-mono text-sky-200 truncate">{id}</li>
+                        ))}
+                    </ul>
+                </>
+            )}
+        </div>
+    );
+}
+
+export default RefreshToast;

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -13,7 +13,7 @@ import TimeEstimateEditor from "./TimeEstimateEditor";
 import type { PostTimeEstimate } from "./TimeEstimateEditor";
 import Iso8601Duration from '../handlers/iso8601duration';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBox, faChevronLeft, faChevronRight, faPenToSquare, faTrash, faPlus, faCircleQuestion, faBook } from "@fortawesome/free-solid-svg-icons";
+import { faBox, faChevronLeft, faChevronRight, faPenToSquare, faTrash, faPlus, faCircleQuestion, faBook, faRotate } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "./ConfirmationModal";
 import EditAssessment from "./EditAssessment";
 import type { EditAssessmentData } from "./EditAssessment";
@@ -23,6 +23,7 @@ import { useDocUrl } from '../helpers/useDocUrl';
 import { splitPkgId, formatPkgId, extractSupplierName } from '../helpers/pkgId';
 import type { Variant } from '../handlers/variant';
 import { useState, useEffect, useRef, useCallback } from "react";
+import NvdRefreshHandler from "../handlers/nvdRefresh";
 
 type Props = {
     vuln: Vulnerability;
@@ -114,6 +115,8 @@ type AssessmentGroup = {
     const [bannerMessage, setBannerMessage] = useState("");
     const [bannerType, setBannerType] = useState<"error" | "success">("error");
     const [showBanner, setShowBanner] = useState(false);
+    const [nvdRefreshing, setNvdRefreshing] = useState(false);
+    const [nvdRefreshError, setNvdRefreshError] = useState<string | null>(null);
 
     const modalRef = useRef<HTMLDivElement>(null);
     const shortcutButtonRef = useRef<HTMLButtonElement>(null);
@@ -148,6 +151,11 @@ type AssessmentGroup = {
         if (modalRef.current) {
             modalRef.current.scrollTop = 0;
         }
+    }, [vuln.id]);
+
+    useEffect(() => {
+        setNvdRefreshing(false);
+        setNvdRefreshError(null);
     }, [vuln.id]);
 
     const showMessage = (message: string, type: "error" | "success") => {
@@ -204,6 +212,23 @@ type AssessmentGroup = {
     const navigationInfo = vulnerabilities && currentIndex !== undefined
         ? `Vulnerability ${currentIndex + 1} of ${vulnerabilities.length}`
         : null;
+
+    const handleNvdRefresh = useCallback(async () => {
+        setNvdRefreshing(true);
+        setNvdRefreshError(null);
+        try {
+            const updated = await NvdRefreshHandler.triggerSingleRefresh(vuln.id);
+            if (updated === null) {
+                setNvdRefreshError("NVD API unavailable. Please try again later.");
+            } else {
+                patchVuln(vuln.id, updated);
+            }
+        } catch {
+            setNvdRefreshError("NVD API unavailable. Please try again later.");
+        } finally {
+            setNvdRefreshing(false);
+        }
+    }, [vuln.id, patchVuln]);
 
     const handleEditAssessment = (assessmentId: string, group: AssessmentGroup) => {
         setEditingAssessmentId(assessmentId);
@@ -1075,9 +1100,40 @@ type AssessmentGroup = {
                                         {navigationInfo}
                                     </span>
                                 )}
+                                <button
+                                    onClick={handleNvdRefresh}
+                                    disabled={nvdRefreshing || readOnly}
+                                    title="Refresh from NVD"
+                                    type="button"
+                                    className="py-2.5 px-5 text-sm font-medium focus:outline-none rounded-lg border disabled:opacity-50 disabled:cursor-not-allowed border-gray-600 hover:bg-gray-700 hover:text-white focus:z-10 focus:ring-4 focus:ring-blue-500 bg-gray-800 text-gray-400"
+                                >
+                                    <FontAwesomeIcon
+                                        icon={faRotate}
+                                        className={nvdRefreshing ? "animate-spin" : ""}
+                                    />
+                                </button>
+                                {nvdRefreshError && (
+                                    <span className="text-xs text-red-400 ml-2">{nvdRefreshError}</span>
+                                )}
                             </div>
                         ) : (
-                            <div></div>
+                            <div>
+                                <button
+                                    onClick={handleNvdRefresh}
+                                    disabled={nvdRefreshing || readOnly}
+                                    title="Refresh from NVD"
+                                    type="button"
+                                    className="py-2.5 px-5 text-sm font-medium focus:outline-none rounded-lg border disabled:opacity-50 disabled:cursor-not-allowed border-gray-600 hover:bg-gray-700 hover:text-white focus:z-10 focus:ring-4 focus:ring-blue-500 bg-gray-800 text-gray-400"
+                                >
+                                    <FontAwesomeIcon
+                                        icon={faRotate}
+                                        className={nvdRefreshing ? "animate-spin" : ""}
+                                    />
+                                </button>
+                                {nvdRefreshError && (
+                                    <span className="text-xs text-red-400 ml-2">{nvdRefreshError}</span>
+                                )}
+                            </div>
                         )}
                         <button
                             onClick={handleClose}

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -117,6 +117,7 @@ type AssessmentGroup = {
     const [showBanner, setShowBanner] = useState(false);
     const [nvdRefreshing, setNvdRefreshing] = useState(false);
     const [nvdRefreshError, setNvdRefreshError] = useState<string | null>(null);
+    const [nvdRefreshSuccess, setNvdRefreshSuccess] = useState(false);
 
     const modalRef = useRef<HTMLDivElement>(null);
     const shortcutButtonRef = useRef<HTMLButtonElement>(null);
@@ -156,6 +157,7 @@ type AssessmentGroup = {
     useEffect(() => {
         setNvdRefreshing(false);
         setNvdRefreshError(null);
+        setNvdRefreshSuccess(false);
     }, [vuln.id]);
 
     const showMessage = (message: string, type: "error" | "success") => {
@@ -216,12 +218,14 @@ type AssessmentGroup = {
     const handleNvdRefresh = useCallback(async () => {
         setNvdRefreshing(true);
         setNvdRefreshError(null);
+        setNvdRefreshSuccess(false);
         try {
             const updated = await NvdRefreshHandler.triggerSingleRefresh(vuln.id);
             if (updated === null) {
                 setNvdRefreshError("NVD API unavailable. Please try again later.");
             } else {
                 patchVuln(vuln.id, updated);
+                setNvdRefreshSuccess(true);
             }
         } catch {
             setNvdRefreshError("NVD API unavailable. Please try again later.");
@@ -1115,6 +1119,9 @@ type AssessmentGroup = {
                                 {nvdRefreshError && (
                                     <span className="text-xs text-red-400 ml-2">{nvdRefreshError}</span>
                                 )}
+                                {nvdRefreshSuccess && !nvdRefreshError && (
+                                    <span className="text-xs text-green-400 ml-2">Updated ✓</span>
+                                )}
                             </div>
                         ) : (
                             <div>
@@ -1132,6 +1139,9 @@ type AssessmentGroup = {
                                 </button>
                                 {nvdRefreshError && (
                                     <span className="text-xs text-red-400 ml-2">{nvdRefreshError}</span>
+                                )}
+                                {nvdRefreshSuccess && !nvdRefreshError && (
+                                    <span className="text-xs text-green-400 ml-2">Updated ✓</span>
                                 )}
                             </div>
                         )}

--- a/frontend/src/handlers/nvdRefresh.ts
+++ b/frontend/src/handlers/nvdRefresh.ts
@@ -7,7 +7,7 @@ import type { Vulnerability } from "./vulnerabilities";
 
 export type RefreshStatus = {
     status: string;
-    progress?: number;
+    progress?: string;
     total?: number;
     error?: string;
 };
@@ -16,7 +16,7 @@ class NvdRefreshHandler {
     static async triggerBulkRefresh(
         variantId: string,
         cveIds?: string[],
-    ): Promise<void> {
+    ): Promise<{ status: string; variant_id?: string }> {
         const url = `${import.meta.env.VITE_API_URL}/api/variants/${encodeURIComponent(variantId)}/nvd-refresh`;
         const body = cveIds ? JSON.stringify({ cve_ids: cveIds }) : undefined;
         const response = await fetch(url, {
@@ -29,6 +29,7 @@ class NvdRefreshHandler {
             const errorData = await response.json().catch(() => ({ message: "Unknown error" }));
             throw new Error(errorData.message || `HTTP ${response.status}`);
         }
+        return response.json();
     }
 
     static async getBulkRefreshStatus(variantId: string): Promise<RefreshStatus> {

--- a/frontend/src/handlers/nvdRefresh.ts
+++ b/frontend/src/handlers/nvdRefresh.ts
@@ -1,0 +1,53 @@
+/**
+ * NVD CVE Refresh handler — typed fetch wrappers for refresh endpoints.
+ */
+
+import { asVulnerability } from "./vulnerabilities";
+import type { Vulnerability } from "./vulnerabilities";
+
+export type RefreshStatus = {
+    status: string;
+    progress?: number;
+    total?: number;
+    error?: string;
+};
+
+class NvdRefreshHandler {
+    static async triggerBulkRefresh(
+        variantId: string,
+        cveIds?: string[],
+    ): Promise<void> {
+        const url = `${import.meta.env.VITE_API_URL}/api/variants/${encodeURIComponent(variantId)}/nvd-refresh`;
+        const body = cveIds ? JSON.stringify({ cve_ids: cveIds }) : undefined;
+        const response = await fetch(url, {
+            method: "POST",
+            headers: body ? { "Content-Type": "application/json" } : {},
+            body,
+            mode: "cors",
+        });
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({ message: "Unknown error" }));
+            throw new Error(errorData.message || `HTTP ${response.status}`);
+        }
+    }
+
+    static async getBulkRefreshStatus(variantId: string): Promise<RefreshStatus> {
+        const url = `${import.meta.env.VITE_API_URL}/api/variants/${encodeURIComponent(variantId)}/nvd-refresh/status`;
+        const response = await fetch(url, { mode: "cors" });
+        if (!response.ok) return { status: "error", error: `HTTP ${response.status}` };
+        return response.json();
+    }
+
+    static async triggerSingleRefresh(cveId: string): Promise<Vulnerability | null> {
+        const url = `${import.meta.env.VITE_API_URL}/api/vulnerabilities/${encodeURIComponent(cveId)}/nvd-refresh`;
+        const response = await fetch(url, { method: "POST", mode: "cors" });
+        if (!response.ok) return null;
+        const data = await response.json().catch(() => null);
+        const vuln = data?.vulnerabilities?.[0];
+        if (!vuln) return null;
+        const parsed = asVulnerability(vuln);
+        return Array.isArray(parsed) ? null : parsed;
+    }
+}
+
+export default NvdRefreshHandler;

--- a/frontend/src/handlers/nvdRefresh.ts
+++ b/frontend/src/handlers/nvdRefresh.ts
@@ -10,6 +10,7 @@ export type RefreshStatus = {
     progress?: string;
     total?: number;
     error?: string;
+    changed_cves?: string[];
 };
 
 class NvdRefreshHandler {

--- a/frontend/src/handlers/nvdRefresh.ts
+++ b/frontend/src/handlers/nvdRefresh.ts
@@ -40,6 +40,32 @@ class NvdRefreshHandler {
         return response.json();
     }
 
+    static async triggerBulkRefreshForProject(
+        projectId: string,
+        cveIds?: string[],
+    ): Promise<{ status: string; project_id?: string }> {
+        const url = `${import.meta.env.VITE_API_URL}/api/projects/${encodeURIComponent(projectId)}/nvd-refresh`;
+        const body = cveIds ? JSON.stringify({ cve_ids: cveIds }) : undefined;
+        const response = await fetch(url, {
+            method: "POST",
+            headers: body ? { "Content-Type": "application/json" } : {},
+            body,
+            mode: "cors",
+        });
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({ message: "Unknown error" }));
+            throw new Error(errorData.message || `HTTP ${response.status}`);
+        }
+        return response.json();
+    }
+
+    static async getBulkRefreshStatusForProject(projectId: string): Promise<RefreshStatus> {
+        const url = `${import.meta.env.VITE_API_URL}/api/projects/${encodeURIComponent(projectId)}/nvd-refresh/status`;
+        const response = await fetch(url, { mode: "cors" });
+        if (!response.ok) return { status: "error", error: `HTTP ${response.status}` };
+        return response.json();
+    }
+
     static async triggerSingleRefresh(cveId: string): Promise<Vulnerability | null> {
         const url = `${import.meta.env.VITE_API_URL}/api/vulnerabilities/${encodeURIComponent(cveId)}/nvd-refresh`;
         const response = await fetch(url, { method: "POST", mode: "cors" });

--- a/frontend/src/handlers/nvdRefresh.ts
+++ b/frontend/src/handlers/nvdRefresh.ts
@@ -66,6 +66,16 @@ class NvdRefreshHandler {
         return response.json();
     }
 
+    static async cancelBulkRefresh(variantId: string): Promise<void> {
+        const url = `${import.meta.env.VITE_API_URL}/api/variants/${encodeURIComponent(variantId)}/nvd-refresh`;
+        await fetch(url, { method: "DELETE", mode: "cors" });
+    }
+
+    static async cancelBulkRefreshForProject(projectId: string): Promise<void> {
+        const url = `${import.meta.env.VITE_API_URL}/api/projects/${encodeURIComponent(projectId)}/nvd-refresh`;
+        await fetch(url, { method: "DELETE", mode: "cors" });
+    }
+
     static async triggerSingleRefresh(cveId: string): Promise<Vulnerability | null> {
         const url = `${import.meta.env.VITE_API_URL}/api/vulnerabilities/${encodeURIComponent(cveId)}/nvd-refresh`;
         const response = await fetch(url, { method: "POST", mode: "cors" });

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -26,6 +26,8 @@ type Vulnerability = {
     variants: string[];
     urls: string[];
     published?: string;
+    nvd_fetched_at?: string;
+    nvd_data_updated_at?: string;
     first_scan_date?: string;
     texts: {
         title: string;
@@ -141,6 +143,8 @@ const asVulnerability = (data: any): Vulnerability | [] => {
     if (typeof data?.effort?.pessimistic === "string") vuln.effort.pessimistic = new Iso8601Duration(data.effort.pessimistic)
     if (typeof data?.fix?.state === "string") vuln.fix.state = data.fix.state
     if (typeof data?.published === "string") vuln.published = data.published
+    if (typeof data?.nvd_fetched_at === "string") vuln.nvd_fetched_at = data.nvd_fetched_at
+    if (typeof data?.nvd_data_updated_at === "string") vuln.nvd_data_updated_at = data.nvd_data_updated_at
     if (typeof data?.first_scan_date === "string") vuln.first_scan_date = data.first_scan_date
     return vuln
 }

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import NavigationBar from "../components/NavigationBar";
 import MessageBanner from "../components/MessageBanner";
+import RefreshToast from "../components/RefreshToast";
 import VersionDisplay from "../components/VersionDisplay";
 import type { Package } from "../handlers/packages";
 import type { CVSS, Vulnerability } from "../handlers/vulnerabilities";
@@ -40,6 +41,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
     const [currentProjectId, setCurrentProjectId] = useState<string | undefined>(undefined);
     const [currentBaseVariantId, setCurrentBaseVariantId] = useState<string | undefined>(undefined);
     const [currentOperation, setCurrentOperation] = useState<string | undefined>(undefined);
+    const [refreshToast, setRefreshToast] = useState<{ changedCves: string[] } | null>(null);
 
     const triggerBanner = (message: string, type: 'error' | 'success') => {
         setBannerMessage(message);
@@ -111,6 +113,11 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
 
     const handleScanComplete = useCallback(() => {
         loadData(currentVariantId, currentVariantId ? undefined : currentProjectId);
+    }, [loadData, currentVariantId, currentProjectId]);
+
+    const handleNvdRefreshComplete = useCallback((changedCves: string[]) => {
+        loadData(currentVariantId, currentVariantId ? undefined : currentProjectId);
+        setRefreshToast({ changedCves });
     }, [loadData, currentVariantId, currentProjectId]);
 
 
@@ -254,6 +261,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     projectId={currentProjectId}
                     baseVariantId={currentBaseVariantId}
                     compareOperation={currentOperation}
+                    onRefreshComplete={handleNvdRefreshComplete}
                 />}
                 {tab === 'scans' && <ScanHistory variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onScanComplete={handleScanComplete} />}
                 {tab === 'review' && <Review variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onAssessmentChanged={handleAssessmentChanged} />}
@@ -274,6 +282,12 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                 }} />}
             </div>
             <VersionDisplay />
+            {refreshToast && (
+                <RefreshToast
+                    changedCves={refreshToast.changedCves}
+                    onClose={() => setRefreshToast(null)}
+                />
+            )}
         </div>
     )
 }

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -20,7 +20,8 @@ import MessageBanner from "../components/MessageBanner";
 import NVDProgressHandler from "../handlers/nvd_progress";
 import EPSSProgressHandler from "../handlers/epss_progress";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes, faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
+import { faTimes, faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo, faBook, faRotate } from '@fortawesome/free-solid-svg-icons';
+import NvdRefreshHandler from "../handlers/nvdRefresh";
 import RangeSlider from "../components/RangeSlider";
 
 type Props = {
@@ -311,6 +312,15 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
     const [showMoreFilters, setShowMoreFilters] = useState(false);
+    const [refreshStatus, setRefreshStatus] = useState<{
+        running: boolean;
+        progress: number | null;
+        total: number | null;
+        error: string | null;
+    } | null>(null);
+    const refreshPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const [showRefreshDropdown, setShowRefreshDropdown] = useState(false);
+    const refreshDropdownRef = useRef<HTMLDivElement>(null);
 
     const searchInputRef = useRef<HTMLInputElement>(null);
     const shortcutButtonRef = useRef<HTMLButtonElement>(null);
@@ -377,6 +387,12 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         return () => clearInterval(interval);
     }, []);
 
+    useEffect(() => {
+        return () => {
+            if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+        };
+    }, []);
+
     const triggerBanner = (message: string, type: 'error' | 'success') => {
         setBannerMessage(message);
         setBannerType(type);
@@ -386,6 +402,52 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const closeBanner = () => {
         setBannerVisible(false);
     };
+
+    const startRefreshPoll = useCallback((vid: string) => {
+        if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+        refreshPollRef.current = setInterval(async () => {
+            try {
+                const status = await NvdRefreshHandler.getBulkRefreshStatus(vid);
+                setRefreshStatus({
+                    running: status.status !== 'done' && status.status !== 'error' && status.status !== 'idle',
+                    progress: status.progress ?? null,
+                    total: status.total ?? null,
+                    error: status.error ?? null,
+                });
+                if (status.status === 'done' || status.status === 'error' || status.status === 'idle') {
+                    if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+                }
+            } catch (e) {
+                if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+                setRefreshStatus({ running: false, progress: null, total: null, error: String(e) });
+            }
+        }, 3000);
+    }, []);
+
+    const handleRefreshPendingCVEs = useCallback(async () => {
+        if (!variantId) return;
+        setShowRefreshDropdown(false);
+        setRefreshStatus({ running: true, progress: null, total: null, error: null });
+        try {
+            await NvdRefreshHandler.triggerBulkRefresh(variantId);
+            startRefreshPoll(variantId);
+        } catch (e) {
+            setRefreshStatus({ running: false, progress: null, total: null, error: String(e) });
+        }
+    }, [variantId, startRefreshPoll]);
+
+    const handleRefreshFilteredCVEs = useCallback(async () => {
+        if (!variantId) return;
+        setShowRefreshDropdown(false);
+        const ids = searchFilteredData.map(v => v.id);
+        setRefreshStatus({ running: true, progress: null, total: null, error: null });
+        try {
+            await NvdRefreshHandler.triggerBulkRefresh(variantId, ids);
+            startRefreshPoll(variantId);
+        } catch (e) {
+            setRefreshStatus({ running: false, progress: null, total: null, error: String(e) });
+        }
+    }, [variantId, searchFilteredData, startRefreshPoll]);
 
     const updateSearch = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
         if (event.target.value.length < 2) {
@@ -472,6 +534,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         'assessments': 'Last Updated',
         'published': 'Published Date',
         'first_scan_date': 'First Scan Date',
+        'nvd_fetched_at': 'Last NVD Check',
+        'nvd_data_updated_at': 'Last NVD Update',
         'found_by': 'Sources',
         'actions': 'Actions'
     }), []);
@@ -740,6 +804,26 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 return dateA - dateB;
             },
             size: 110
+            }),
+            columnHelper.accessor('nvd_fetched_at', {
+                id: 'nvd_fetched_at',
+                header: 'Last NVD Check',
+                cell: info => {
+                    const val = info.getValue();
+                    return val ? new Date(val).toLocaleString(undefined, dt_options) : '—';
+                },
+                enableSorting: true,
+                size: 120
+            }),
+            columnHelper.accessor('nvd_data_updated_at', {
+                id: 'nvd_data_updated_at',
+                header: 'Last NVD Update',
+                cell: info => {
+                    const val = info.getValue();
+                    return val ? new Date(val).toLocaleString(undefined, dt_options) : '—';
+                },
+                enableSorting: true,
+                size: 120
             }),
             columnHelper.accessor('variants', {
             id: 'variants',
@@ -1021,6 +1105,21 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         };
     }, [showMoreFilters]);
 
+    // Close "Refresh CVEs" dropdown on click outside
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (refreshDropdownRef.current && !refreshDropdownRef.current.contains(event.target as Node)) {
+                setShowRefreshDropdown(false);
+            }
+        };
+        if (showRefreshDropdown) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [showRefreshDropdown]);
+
 
 
     return (<>
@@ -1080,6 +1179,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     'Last Updated',
                     'Published Date',
                     'First Scan Date',
+                    'Last NVD Check',
+                    'Last NVD Update',
                     'Sources'
                 ]}
                 selected={visibleColumns}
@@ -1250,6 +1351,43 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 )}
             </div>
 
+            {variantId && (
+                <div ref={refreshDropdownRef} className="ml-1 relative inline-block text-left">
+                    <button
+                        onClick={() => setShowRefreshDropdown(!showRefreshDropdown)}
+                        disabled={refreshStatus?.running ?? false}
+                        className={`py-1 px-2 rounded flex items-center gap-1 ${
+                            showRefreshDropdown ? 'bg-sky-950' : 'bg-sky-900 hover:bg-sky-950'
+                        } text-white disabled:opacity-50`}
+                        title="Refresh CVE data from NVD"
+                    >
+                        <FontAwesomeIcon icon={faRotate} className={(refreshStatus?.running) ? 'animate-spin' : ''} />
+                        Refresh CVEs
+                        <FontAwesomeIcon icon={faCaretDown} />
+                    </button>
+
+                    {showRefreshDropdown && (
+                        <div className="absolute right-0 mt-1 w-64 bg-sky-900 text-white border border-sky-800 rounded-md shadow-lg z-50">
+                            <div className="py-1">
+                                <button
+                                    onClick={handleRefreshPendingCVEs}
+                                    className="w-full text-left px-4 py-2 text-sm hover:bg-sky-800"
+                                >
+                                    Pending Assessment CVEs
+                                </button>
+                                <button
+                                    onClick={handleRefreshFilteredCVEs}
+                                    className="w-full text-left px-4 py-2 text-sm hover:bg-sky-800"
+                                    title="Refresh CVEs matching the current table filters"
+                                >
+                                    CVEs matching current filters
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
+
             {/* Package indicator (no dropdown, just display) */}
             {selectedPackages.length > 0 && (
                 <div className="flex items-center gap-1 bg-sky-900 px-2 py-1 rounded text-white border border-sky-700">
@@ -1324,6 +1462,41 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             baseVariantId={baseVariantId}
             compareOperation={compareOperation}
         />
+
+        {refreshStatus && (
+            <div className={`mx-4 mb-2 px-4 py-2 rounded text-sm ${
+                refreshStatus.error ? 'bg-red-900 text-red-200' : 'bg-sky-900 text-sky-200'
+            }`}>
+                {refreshStatus.running && (
+                    <span>
+                        <FontAwesomeIcon icon={faRotate} className="animate-spin mr-2" />
+                        Refreshing CVEs from NVD…
+                        {refreshStatus.total !== null && refreshStatus.progress !== null && (
+                            <span className="ml-2">{refreshStatus.progress}/{refreshStatus.total}</span>
+                        )}
+                    </span>
+                )}
+                {!refreshStatus.running && !refreshStatus.error && (
+                    <span>✓ NVD refresh complete</span>
+                )}
+                {refreshStatus.error && (
+                    <span>⚠ Refresh error: {refreshStatus.error}</span>
+                )}
+                <button
+                    onClick={() => {
+                        if (refreshPollRef.current) {
+                            clearInterval(refreshPollRef.current);
+                            refreshPollRef.current = null;
+                        }
+                        setRefreshStatus(null);
+                    }}
+                    className="float-right text-gray-400 hover:text-white ml-4"
+                    aria-label="Dismiss"
+                >
+                    <FontAwesomeIcon icon={faTimes} />
+                </button>
+            </div>
+        )}
 
         <TableGeneric
             fuseKeys={fuseKeys}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -1471,8 +1471,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     <span>
                         <FontAwesomeIcon icon={faRotate} className="animate-spin mr-2" />
                         Refreshing CVEs from NVD…
-                        {refreshStatus.total !== null && refreshStatus.progress !== null && (
-                            <span className="ml-2">{refreshStatus.progress}/{refreshStatus.total}</span>
+                        {refreshStatus.progress !== null && (
+                            <span className="ml-2">{refreshStatus.progress}</span>
                         )}
                     </span>
                 )}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -322,6 +322,9 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         error: string | null;
     } | null>(null);
     const refreshPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    // Tracks the currently active refresh scope so cancel calls can target the right endpoint,
+    // even from cleanup closures that may capture stale prop values (e.g. on unmount).
+    const activeRefreshScopeRef = useRef<{ variantId?: string; projectId?: string } | null>(null);
     const [showRefreshDropdown, setShowRefreshDropdown] = useState(false);
     const refreshDropdownRef = useRef<HTMLDivElement>(null);
 
@@ -393,13 +396,24 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     useEffect(() => {
         return () => {
             if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+            const scope = activeRefreshScopeRef.current;
+            if (scope) {
+                if (scope.variantId) NvdRefreshHandler.cancelBulkRefresh(scope.variantId).catch(() => {});
+                else if (scope.projectId) NvdRefreshHandler.cancelBulkRefreshForProject(scope.projectId).catch(() => {});
+            }
         };
     }, []);
 
-    // Cancel stale poll and reset status when the scope (variant/project) changes
+    // Cancel backend process and reset status when the scope (variant/project) changes.
+    // The cancel call uses the OLD variantId/projectId captured by the closure, so it
+    // correctly targets the previous scope's refresh rather than the new one.
     useEffect(() => {
-        if (refreshPollRef.current) clearInterval(refreshPollRef.current);
-        setRefreshStatus(null);
+        return () => {
+            if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+            if (variantId) NvdRefreshHandler.cancelBulkRefresh(variantId).catch(() => {});
+            else if (projectId) NvdRefreshHandler.cancelBulkRefreshForProject(projectId).catch(() => {});
+            setRefreshStatus(null);
+        };
     }, [variantId, projectId]);
 
     const triggerBanner = (message: string, type: 'error' | 'success') => {
@@ -414,23 +428,26 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
 
     const startRefreshPoll = useCallback((fetchStatus: () => Promise<RefreshStatus>) => {
         if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+        const TERMINAL = ['done', 'error', 'idle', 'cancelled'];
         refreshPollRef.current = setInterval(async () => {
             try {
                 const status = await fetchStatus();
                 setRefreshStatus({
-                    running: status.status !== 'done' && status.status !== 'error' && status.status !== 'idle',
+                    running: !TERMINAL.includes(status.status),
                     progress: status.progress ?? null,
                     total: status.total ?? null,
                     error: status.error ?? null,
                 });
-                if (status.status === 'done' || status.status === 'error' || status.status === 'idle') {
+                if (TERMINAL.includes(status.status)) {
                     if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+                    activeRefreshScopeRef.current = null;
                     if (status.status === 'done' && onRefreshComplete) {
                         onRefreshComplete(status.changed_cves ?? []);
                     }
                 }
             } catch (e) {
                 if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+                activeRefreshScopeRef.current = null;
                 setRefreshStatus({ running: false, progress: null, total: null, error: String(e) });
             }
         }, 3000);
@@ -442,9 +459,11 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         try {
             if (variantId) {
                 await NvdRefreshHandler.triggerBulkRefresh(variantId);
+                activeRefreshScopeRef.current = { variantId };
                 startRefreshPoll(() => NvdRefreshHandler.getBulkRefreshStatus(variantId));
             } else if (projectId) {
                 await NvdRefreshHandler.triggerBulkRefreshForProject(projectId);
+                activeRefreshScopeRef.current = { projectId };
                 startRefreshPoll(() => NvdRefreshHandler.getBulkRefreshStatusForProject(projectId));
             }
         } catch (e) {
@@ -459,9 +478,11 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         try {
             if (variantId) {
                 await NvdRefreshHandler.triggerBulkRefresh(variantId, ids);
+                activeRefreshScopeRef.current = { variantId };
                 startRefreshPoll(() => NvdRefreshHandler.getBulkRefreshStatus(variantId));
             } else if (projectId) {
                 await NvdRefreshHandler.triggerBulkRefreshForProject(projectId, ids);
+                activeRefreshScopeRef.current = { projectId };
                 startRefreshPoll(() => NvdRefreshHandler.getBulkRefreshStatusForProject(projectId));
             }
         } catch (e) {
@@ -1494,8 +1515,11 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                         )}
                     </span>
                 )}
-                {!refreshStatus.running && !refreshStatus.error && (
+                {!refreshStatus.running && !refreshStatus.error && refreshStatus.progress !== 'Cancelled' && (
                     <span>✓ NVD refresh complete</span>
+                )}
+                {!refreshStatus.running && !refreshStatus.error && refreshStatus.progress === 'Cancelled' && (
+                    <span>✗ NVD refresh cancelled</span>
                 )}
                 {refreshStatus.error && (
                     <span>⚠ Refresh error: {refreshStatus.error}</span>
@@ -1505,6 +1529,12 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                         if (refreshPollRef.current) {
                             clearInterval(refreshPollRef.current);
                             refreshPollRef.current = null;
+                        }
+                        const scope = activeRefreshScopeRef.current;
+                        if (scope) {
+                            if (scope.variantId) NvdRefreshHandler.cancelBulkRefresh(scope.variantId).catch(() => {});
+                            else if (scope.projectId) NvdRefreshHandler.cancelBulkRefreshForProject(scope.projectId).catch(() => {});
+                            activeRefreshScopeRef.current = null;
                         }
                         setRefreshStatus(null);
                     }}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -22,6 +22,7 @@ import EPSSProgressHandler from "../handlers/epss_progress";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes, faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo, faBook, faRotate } from '@fortawesome/free-solid-svg-icons';
 import NvdRefreshHandler from "../handlers/nvdRefresh";
+import type { RefreshStatus } from "../handlers/nvdRefresh";
 import RangeSlider from "../components/RangeSlider";
 
 type Props = {
@@ -405,11 +406,11 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         setBannerVisible(false);
     };
 
-    const startRefreshPoll = useCallback((vid: string) => {
+    const startRefreshPoll = useCallback((fetchStatus: () => Promise<RefreshStatus>) => {
         if (refreshPollRef.current) clearInterval(refreshPollRef.current);
         refreshPollRef.current = setInterval(async () => {
             try {
-                const status = await NvdRefreshHandler.getBulkRefreshStatus(vid);
+                const status = await fetchStatus();
                 setRefreshStatus({
                     running: status.status !== 'done' && status.status !== 'error' && status.status !== 'idle',
                     progress: status.progress ?? null,
@@ -430,29 +431,37 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     }, [onRefreshComplete]);
 
     const handleRefreshPendingCVEs = useCallback(async () => {
-        if (!variantId) return;
         setShowRefreshDropdown(false);
         setRefreshStatus({ running: true, progress: null, total: null, error: null });
         try {
-            await NvdRefreshHandler.triggerBulkRefresh(variantId);
-            startRefreshPoll(variantId);
+            if (variantId) {
+                await NvdRefreshHandler.triggerBulkRefresh(variantId);
+                startRefreshPoll(() => NvdRefreshHandler.getBulkRefreshStatus(variantId));
+            } else if (projectId) {
+                await NvdRefreshHandler.triggerBulkRefreshForProject(projectId);
+                startRefreshPoll(() => NvdRefreshHandler.getBulkRefreshStatusForProject(projectId));
+            }
         } catch (e) {
             setRefreshStatus({ running: false, progress: null, total: null, error: String(e) });
         }
-    }, [variantId, startRefreshPoll]);
+    }, [variantId, projectId, startRefreshPoll]);
 
     const handleRefreshFilteredCVEs = useCallback(async () => {
-        if (!variantId) return;
         setShowRefreshDropdown(false);
         const ids = searchFilteredData.map(v => v.id);
         setRefreshStatus({ running: true, progress: null, total: null, error: null });
         try {
-            await NvdRefreshHandler.triggerBulkRefresh(variantId, ids);
-            startRefreshPoll(variantId);
+            if (variantId) {
+                await NvdRefreshHandler.triggerBulkRefresh(variantId, ids);
+                startRefreshPoll(() => NvdRefreshHandler.getBulkRefreshStatus(variantId));
+            } else if (projectId) {
+                await NvdRefreshHandler.triggerBulkRefreshForProject(projectId, ids);
+                startRefreshPoll(() => NvdRefreshHandler.getBulkRefreshStatusForProject(projectId));
+            }
         } catch (e) {
             setRefreshStatus({ running: false, progress: null, total: null, error: String(e) });
         }
-    }, [variantId, searchFilteredData, startRefreshPoll]);
+    }, [variantId, projectId, searchFilteredData, startRefreshPoll]);
 
     const updateSearch = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
         if (event.target.value.length < 2) {
@@ -1356,8 +1365,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 )}
             </div>
 
-            {variantId && (
-                <div ref={refreshDropdownRef} className="ml-1 relative inline-block text-left">
+            <div ref={refreshDropdownRef} className="ml-1 relative inline-block text-left">
                     <button
                         onClick={() => setShowRefreshDropdown(!showRefreshDropdown)}
                         disabled={refreshStatus?.running ?? false}
@@ -1391,7 +1399,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                         </div>
                     )}
                 </div>
-            )}
 
             {/* Package indicator (no dropdown, just display) */}
             {selectedPackages.length > 0 && (

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -396,6 +396,12 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         };
     }, []);
 
+    // Cancel stale poll and reset status when the scope (variant/project) changes
+    useEffect(() => {
+        if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+        setRefreshStatus(null);
+    }, [variantId, projectId]);
+
     const triggerBanner = (message: string, type: 'error' | 'success') => {
         setBannerMessage(message);
         setBannerType(type);

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -37,6 +37,8 @@ type Props = {
     baseVariantId?: string;
     /** 'difference' or 'intersection' when compare mode is active */
     compareOperation?: string;
+    /** Called when a bulk NVD refresh completes with the list of updated CVE IDs */
+    onRefreshComplete?: (changedCves: string[]) => void;
 };
 
 const dt_options: Intl.DateTimeFormatOptions = {
@@ -274,7 +276,7 @@ function PublishedDateFilter({
 const SEVERITY_RANGE_MIN = 0;
 const SEVERITY_RANGE_MAX = 10;
 
-function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln, variantId, projectId, baseVariantId, compareOperation }: Readonly<Props>) {
+function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln, variantId, projectId, baseVariantId, compareOperation, onRefreshComplete }: Readonly<Props>) {
 
     const docUrl = useDocUrl("interactive-mode.html#vulnerability-table");
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);
@@ -416,13 +418,16 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 });
                 if (status.status === 'done' || status.status === 'error' || status.status === 'idle') {
                     if (refreshPollRef.current) clearInterval(refreshPollRef.current);
+                    if (status.status === 'done' && onRefreshComplete) {
+                        onRefreshComplete(status.changed_cves ?? []);
+                    }
                 }
             } catch (e) {
                 if (refreshPollRef.current) clearInterval(refreshPollRef.current);
                 setRefreshStatus({ running: false, progress: null, total: null, error: String(e) });
             }
         }, 3000);
-    }, []);
+    }, [onRefreshComplete]);
 
     const handleRefreshPendingCVEs = useCallback(async () => {
         if (!variantId) return;

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -314,7 +314,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const [showMoreFilters, setShowMoreFilters] = useState(false);
     const [refreshStatus, setRefreshStatus] = useState<{
         running: boolean;
-        progress: number | null;
+        progress: string | null;
         total: number | null;
         error: string | null;
     } | null>(null);

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -409,10 +409,15 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     // correctly targets the previous scope's refresh rather than the new one.
     useEffect(() => {
         return () => {
+            const hadActiveRefresh = refreshPollRef.current !== null;
             if (refreshPollRef.current) clearInterval(refreshPollRef.current);
             if (variantId) NvdRefreshHandler.cancelBulkRefresh(variantId).catch(() => {});
             else if (projectId) NvdRefreshHandler.cancelBulkRefreshForProject(projectId).catch(() => {});
-            setRefreshStatus(null);
+            if (hadActiveRefresh) {
+                setRefreshStatus({ running: false, progress: 'Cancelled', total: null, error: null });
+            } else {
+                setRefreshStatus(null);
+            }
         };
     }, [variantId, projectId]);
 
@@ -1535,8 +1540,10 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                             if (scope.variantId) NvdRefreshHandler.cancelBulkRefresh(scope.variantId).catch(() => {});
                             else if (scope.projectId) NvdRefreshHandler.cancelBulkRefreshForProject(scope.projectId).catch(() => {});
                             activeRefreshScopeRef.current = null;
+                            setRefreshStatus({ running: false, progress: 'Cancelled', total: null, error: null });
+                        } else {
+                            setRefreshStatus(null);
                         }
-                        setRefreshStatus(null);
                     }}
                     className="float-right text-gray-400 hover:text-white ml-4"
                     aria-label="Dismiss"

--- a/frontend/tests/handlers/nvdRefresh.test.ts
+++ b/frontend/tests/handlers/nvdRefresh.test.ts
@@ -1,0 +1,114 @@
+import NvdRefreshHandler from "../../src/handlers/nvdRefresh";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as typeof fetch;
+
+beforeEach(() => {
+    mockFetch.mockReset();
+});
+
+describe("NvdRefreshHandler.triggerBulkRefresh", () => {
+    it("triggerBulkRefresh resolves on success", async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
+        await expect(NvdRefreshHandler.triggerBulkRefresh("variant-uuid")).resolves.toBeUndefined();
+    });
+
+    it("POSTs to the correct URL", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 204,
+        } as Response);
+
+        await NvdRefreshHandler.triggerBulkRefresh("abc");
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/variants/abc/nvd-refresh"),
+            expect.objectContaining({ method: "POST" }),
+        );
+    });
+
+    it("sends cve_ids in the body when provided", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 204,
+        } as Response);
+
+        await NvdRefreshHandler.triggerBulkRefresh("abc", ["CVE-2024-0001"]);
+        const [, opts] = mockFetch.mock.calls[0];
+        expect(JSON.parse(opts.body)).toEqual({ cve_ids: ["CVE-2024-0001"] });
+    });
+    it("throws on non-ok response", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            json: async () => ({ message: "internal error" }),
+        } as Response);
+
+        await expect(NvdRefreshHandler.triggerBulkRefresh("abc")).rejects.toThrow("internal error");
+    });
+});
+
+describe("NvdRefreshHandler.getBulkRefreshStatus", () => {
+    it("GETs the status endpoint", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ status: "running", progress: "5/10", logs: [], total: 10, done_count: 5, error: null }),
+        } as Response);
+
+        const status = await NvdRefreshHandler.getBulkRefreshStatus("abc");
+        expect(status.status).toBe("running");
+        expect(status.total).toBe(10);
+    });
+
+    it("returns error status on non-ok response", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 503,
+        } as Response);
+
+        const status = await NvdRefreshHandler.getBulkRefreshStatus("abc");
+        expect(status.status).toBe("error");
+        expect(status.error).toContain("503");
+    });
+});
+
+describe("NvdRefreshHandler.triggerSingleRefresh", () => {
+    it("returns a Vulnerability object on 200", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                vulnerabilities: [{
+                    id: "CVE-2024-0001",
+                    found_by: [],
+                    datasource: "nvd",
+                    namespace: "nvd",
+                    aliases: [],
+                    related_vulnerabilities: [],
+                    urls: [],
+                    texts: {},
+                    fix: {},
+                    severity: { severity: "high", min_score: 8.1, max_score: 8.1, cvss: [] },
+                    epss: {},
+                    effort: {},
+                    advisories: [],
+                    packages: [],
+                }]
+            }),
+        } as Response);
+
+        const vuln = await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
+        expect(vuln).not.toBeNull();
+        expect(vuln!.id).toBe("CVE-2024-0001");
+    });
+
+    it("returns null on 503", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 503,
+            text: async () => "NVD unavailable",
+        } as Response);
+
+        const result = await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
+        expect(result).toBeNull();
+    });
+});

--- a/frontend/tests/handlers/nvdRefresh.test.ts
+++ b/frontend/tests/handlers/nvdRefresh.test.ts
@@ -8,15 +8,21 @@ beforeEach(() => {
 });
 
 describe("NvdRefreshHandler.triggerBulkRefresh", () => {
-    it("triggerBulkRefresh resolves on success", async () => {
-        mockFetch.mockResolvedValueOnce({ ok: true, status: 204 });
-        await expect(NvdRefreshHandler.triggerBulkRefresh("variant-uuid")).resolves.toBeUndefined();
+    it("triggerBulkRefresh resolves with status on success", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 202,
+            json: async () => ({ status: "started", variant_id: "variant-uuid" }),
+        } as Response);
+        const result = await NvdRefreshHandler.triggerBulkRefresh("variant-uuid");
+        expect(result).toEqual({ status: "started", variant_id: "variant-uuid" });
     });
 
     it("POSTs to the correct URL", async () => {
         mockFetch.mockResolvedValueOnce({
             ok: true,
-            status: 204,
+            status: 202,
+            json: async () => ({ status: "started" }),
         } as Response);
 
         await NvdRefreshHandler.triggerBulkRefresh("abc");
@@ -29,7 +35,8 @@ describe("NvdRefreshHandler.triggerBulkRefresh", () => {
     it("sends cve_ids in the body when provided", async () => {
         mockFetch.mockResolvedValueOnce({
             ok: true,
-            status: 204,
+            status: 202,
+            json: async () => ({ status: "started" }),
         } as Response);
 
         await NvdRefreshHandler.triggerBulkRefresh("abc", ["CVE-2024-0001"]);

--- a/frontend/tests/handlers/nvdRefresh.test.ts
+++ b/frontend/tests/handlers/nvdRefresh.test.ts
@@ -157,3 +157,80 @@ describe("NvdRefreshHandler.triggerSingleRefresh", () => {
         expect(result).toBeNull();
     });
 });
+
+describe("NvdRefreshHandler.triggerBulkRefreshForProject", () => {
+    it("POSTs to the correct project URL", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 202,
+            json: async () => ({ status: "started", project_id: "proj-uuid" }),
+        } as Response);
+
+        await NvdRefreshHandler.triggerBulkRefreshForProject("proj-uuid");
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/projects/proj-uuid/nvd-refresh"),
+            expect.objectContaining({ method: "POST" }),
+        );
+    });
+
+    it("sends cve_ids in body when provided", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 202,
+            json: async () => ({ status: "started" }),
+        } as Response);
+
+        await NvdRefreshHandler.triggerBulkRefreshForProject("proj-uuid", ["CVE-2024-0001"]);
+        const [, opts] = mockFetch.mock.calls[0];
+        expect(JSON.parse(opts.body)).toEqual({ cve_ids: ["CVE-2024-0001"] });
+    });
+
+    it("sends no body when cveIds is omitted", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 202,
+            json: async () => ({ status: "started" }),
+        } as Response);
+
+        await NvdRefreshHandler.triggerBulkRefreshForProject("proj-uuid");
+        const [, opts] = mockFetch.mock.calls[0];
+        expect(opts.body).toBeUndefined();
+    });
+
+    it("throws on non-ok response", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            json: async () => ({ message: "internal error" }),
+        } as Response);
+
+        await expect(NvdRefreshHandler.triggerBulkRefreshForProject("proj-uuid")).rejects.toThrow("internal error");
+    });
+});
+
+describe("NvdRefreshHandler.getBulkRefreshStatusForProject", () => {
+    it("GETs the correct project status URL", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ status: "running", progress: "2/5", total: 5, error: null }),
+        } as Response);
+
+        const status = await NvdRefreshHandler.getBulkRefreshStatusForProject("proj-uuid");
+        expect(status.status).toBe("running");
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/projects/proj-uuid/nvd-refresh/status"),
+            expect.objectContaining({ mode: "cors" }),
+        );
+    });
+
+    it("returns error status on non-ok response", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 503,
+        } as Response);
+
+        const status = await NvdRefreshHandler.getBulkRefreshStatusForProject("proj-uuid");
+        expect(status.status).toBe("error");
+        expect(status.error).toContain("503");
+    });
+});

--- a/frontend/tests/handlers/nvdRefresh.test.ts
+++ b/frontend/tests/handlers/nvdRefresh.test.ts
@@ -76,6 +76,21 @@ describe("NvdRefreshHandler.getBulkRefreshStatus", () => {
         expect(status.status).toBe("error");
         expect(status.error).toContain("503");
     });
+
+    it("includes changed_cves when present in response", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                status: "done",
+                changed_cves: ["CVE-2024-0001", "CVE-2024-0002"],
+                total: 5,
+            }),
+        } as Response);
+
+        const status = await NvdRefreshHandler.getBulkRefreshStatus("abc");
+        expect(status.status).toBe("done");
+        expect(status.changed_cves).toEqual(["CVE-2024-0001", "CVE-2024-0002"]);
+    });
 });
 
 describe("NvdRefreshHandler.triggerBulkRefresh — catch callback", () => {

--- a/frontend/tests/handlers/nvdRefresh.test.ts
+++ b/frontend/tests/handlers/nvdRefresh.test.ts
@@ -78,6 +78,18 @@ describe("NvdRefreshHandler.getBulkRefreshStatus", () => {
     });
 });
 
+describe("NvdRefreshHandler.triggerBulkRefresh — catch callback", () => {
+    it("falls back to 'Unknown error' when response body cannot be parsed as JSON", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            json: async () => { throw new SyntaxError("Unexpected end of JSON input"); },
+        } as unknown as Response);
+
+        await expect(NvdRefreshHandler.triggerBulkRefresh("abc")).rejects.toThrow("Unknown error");
+    });
+});
+
 describe("NvdRefreshHandler.triggerSingleRefresh", () => {
     it("returns a Vulnerability object on 200", async () => {
         mockFetch.mockResolvedValueOnce({
@@ -114,6 +126,17 @@ describe("NvdRefreshHandler.triggerSingleRefresh", () => {
             status: 503,
             text: async () => "NVD unavailable",
         } as Response);
+
+        const result = await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
+        expect(result).toBeNull();
+    });
+
+    it("returns null when response body cannot be parsed as JSON", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => { throw new SyntaxError("Unexpected end of JSON input"); },
+        } as unknown as Response);
 
         const result = await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
         expect(result).toBeNull();

--- a/frontend/tests/handlers/nvdRefresh.test.ts
+++ b/frontend/tests/handlers/nvdRefresh.test.ts
@@ -234,3 +234,29 @@ describe("NvdRefreshHandler.getBulkRefreshStatusForProject", () => {
         expect(status.error).toContain("503");
     });
 });
+
+describe("NvdRefreshHandler.cancelBulkRefresh", () => {
+    it("sends DELETE to the variant refresh URL", async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+
+        await NvdRefreshHandler.cancelBulkRefresh("variant-abc");
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/variants/variant-abc/nvd-refresh"),
+            expect.objectContaining({ method: "DELETE", mode: "cors" }),
+        );
+    });
+});
+
+describe("NvdRefreshHandler.cancelBulkRefreshForProject", () => {
+    it("sends DELETE to the project refresh URL", async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true } as Response);
+
+        await NvdRefreshHandler.cancelBulkRefreshForProject("proj-abc");
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/projects/proj-abc/nvd-refresh"),
+            expect.objectContaining({ method: "DELETE", mode: "cors" }),
+        );
+    });
+});

--- a/frontend/tests/unit_tests/test_assessments_handler.ts
+++ b/frontend/tests/unit_tests/test_assessments_handler.ts
@@ -1,5 +1,8 @@
 
-import { asAssessment, asStringArray } from '../../src/handlers/assessments';
+import fetchMock from 'jest-fetch-mock';
+fetchMock.enableMocks();
+
+import Assessments, { asAssessment, asStringArray } from '../../src/handlers/assessments';
 
 describe('asStringArray', () => {
   test('non array returns empty array', () => {
@@ -105,5 +108,64 @@ describe('asAssessment optional fields', () => {
     expect(assessed.workaround).toBeUndefined();
     expect(assessed.workaround_timestamp).toBeUndefined();
     expect(assessed.last_update).toBeUndefined();
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Assessments.listReview
+// ---------------------------------------------------------------------------
+
+describe('Assessments.listReview', () => {
+  const validAssessment = {
+    id: 'r1',
+    vuln_id: 'CVE-2024-1234',
+    status: 'fixed',
+    timestamp: '2024-06-01T00:00:00',
+    packages: ['pkg@1.0'],
+    responses: [],
+  };
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  test('returns assessments from the review endpoint', async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve({ json: () => Promise.resolve([validAssessment]) } as Response)
+    );
+
+    const result = await Assessments.listReview();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('r1');
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/assessments/review'),
+      expect.objectContaining({ mode: 'cors' })
+    );
+  });
+
+  test('appends variant_id query param when provided', async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+    );
+
+    await Assessments.listReview('var-42');
+
+    const calledUrl: string = (fetchMock.mock.calls[0] as any[])[0];
+    expect(calledUrl).toContain('variant_id=var-42');
+    expect(calledUrl).not.toContain('project_id');
+  });
+
+  test('appends project_id query param when no variantId provided', async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+    );
+
+    await Assessments.listReview(undefined, 'proj-7');
+
+    const calledUrl: string = (fetchMock.mock.calls[0] as any[])[0];
+    expect(calledUrl).toContain('project_id=proj-7');
+    expect(calledUrl).not.toContain('variant_id');
   });
 });

--- a/frontend/tests/unit_tests/test_epss_progress_handler.ts
+++ b/frontend/tests/unit_tests/test_epss_progress_handler.ts
@@ -1,0 +1,137 @@
+import fetchMock from 'jest-fetch-mock';
+fetchMock.enableMocks();
+
+import EPSSProgressHandler from '../../src/handlers/epss_progress';
+import type { EPSSProgress } from '../../src/handlers/epss_progress';
+
+
+describe('EPSSProgressHandler', () => {
+
+    beforeEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    describe('getProgress', () => {
+        test('returns progress data when API responds with complete data', async () => {
+            const mockData = {
+                in_progress: true,
+                phase: 'downloading',
+                current: 50,
+                total: 100,
+                message: 'Fetching EPSS scores...',
+                last_update: '2026-02-05T10:00:00Z',
+                started_at: '2026-02-05T09:00:00Z'
+            };
+
+            fetchMock.mockResponseOnce(JSON.stringify(mockData));
+
+            const progress = await EPSSProgressHandler.getProgress();
+
+            expect(progress).toEqual(mockData);
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.stringContaining('/api/epss/progress'),
+                expect.objectContaining({ mode: 'cors' })
+            );
+        });
+
+        test('returns default values when API responds with partial data', async () => {
+            fetchMock.mockResponseOnce(JSON.stringify({ in_progress: true, phase: 'processing' }));
+
+            const progress = await EPSSProgressHandler.getProgress();
+
+            expect(progress.in_progress).toBe(true);
+            expect(progress.phase).toBe('processing');
+            expect(progress.current).toBe(0);
+            expect(progress.total).toBe(0);
+            expect(progress.message).toBe('');
+            expect(progress.last_update).toBeUndefined();
+            expect(progress.started_at).toBeUndefined();
+        });
+
+        test('returns default values when API responds with null data', async () => {
+            fetchMock.mockResponseOnce(JSON.stringify(null));
+
+            const progress = await EPSSProgressHandler.getProgress();
+
+            expect(progress.in_progress).toBe(false);
+            expect(progress.phase).toBe('idle');
+            expect(progress.current).toBe(0);
+            expect(progress.total).toBe(0);
+            expect(progress.message).toBe('');
+        });
+    });
+
+    describe('getProgressPercentage', () => {
+        test('returns 0 when not in progress and phase is not completed', () => {
+            const progress: EPSSProgress = {
+                in_progress: false,
+                phase: 'idle',
+                current: 0,
+                total: 0,
+                message: ''
+            };
+
+            expect(EPSSProgressHandler.getProgressPercentage(progress)).toBe(0);
+        });
+
+        test('returns 1 when not in progress and phase is completed', () => {
+            const progress: EPSSProgress = {
+                in_progress: false,
+                phase: 'completed',
+                current: 100,
+                total: 100,
+                message: 'Done'
+            };
+
+            expect(EPSSProgressHandler.getProgressPercentage(progress)).toBe(1);
+        });
+
+        test('returns 0 when in progress but total is 0', () => {
+            const progress: EPSSProgress = {
+                in_progress: true,
+                phase: 'starting',
+                current: 0,
+                total: 0,
+                message: 'Starting...'
+            };
+
+            expect(EPSSProgressHandler.getProgressPercentage(progress)).toBe(0);
+        });
+
+        test('returns correct ratio when in progress', () => {
+            const progress: EPSSProgress = {
+                in_progress: true,
+                phase: 'downloading',
+                current: 40,
+                total: 100,
+                message: 'Fetching...'
+            };
+
+            expect(EPSSProgressHandler.getProgressPercentage(progress)).toBe(0.4);
+        });
+
+        test('caps at 1 when current exceeds total', () => {
+            const progress: EPSSProgress = {
+                in_progress: true,
+                phase: 'processing',
+                current: 150,
+                total: 100,
+                message: 'Processing...'
+            };
+
+            expect(EPSSProgressHandler.getProgressPercentage(progress)).toBe(1);
+        });
+
+        test('returns 1 when current equals total and in progress', () => {
+            const progress: EPSSProgress = {
+                in_progress: true,
+                phase: 'finalizing',
+                current: 100,
+                total: 100,
+                message: 'Finalizing...'
+            };
+
+            expect(EPSSProgressHandler.getProgressPercentage(progress)).toBe(1);
+        });
+    });
+});

--- a/frontend/tests/unit_tests/test_project_variant_selector.tsx
+++ b/frontend/tests/unit_tests/test_project_variant_selector.tsx
@@ -519,4 +519,93 @@ describe('ProjectVariantSelector', () => {
             expect(screen.queryByRole('option', { name: 'ProjectAlpha' })).not.toBeInTheDocument();
         });
     });
+
+    test('renders gracefully when Variants.list rejects', async () => {
+        mockVariantsList.mockRejectedValue(new Error('Network error'));
+
+        render(
+            <ProjectVariantSelector onApply={jest.fn()} />
+        );
+        const button = screen.getByRole('button');
+        await act(async () => { fireEvent.click(button); });
+
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+
+        const projectSelect = screen.getAllByRole('combobox')[0];
+        await act(async () => {
+            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
+        });
+
+        await waitFor(() => {
+            // Variants.list rejected, so no variant options beyond the placeholder
+            expect(screen.queryByRole('option', { name: 'default' })).not.toBeInTheDocument();
+        });
+    });
+
+    test('changing project clears the selected variant', async () => {
+        const VARIANTS_PROJ2 = [{ id: 'var-3', name: 'staging', project_id: 'proj-2' }];
+        mockVariantsList
+            .mockResolvedValueOnce(VARIANTS_PROJ1)
+            .mockResolvedValueOnce(VARIANTS_PROJ2);
+
+        render(
+            <ProjectVariantSelector onApply={jest.fn()} />
+        );
+        const button = screen.getByRole('button');
+        await act(async () => { fireEvent.click(button); });
+
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+
+        // Select first project and a variant
+        const projectSelect = screen.getAllByRole('combobox')[0];
+        await act(async () => {
+            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'default' })).toBeInTheDocument();
+        });
+
+        const variantSelect = screen.getAllByRole('combobox')[1];
+        await act(async () => {
+            fireEvent.change(variantSelect, { target: { value: 'var-1' } });
+        });
+
+        // Switch to a different project — variant should be cleared
+        await act(async () => {
+            fireEvent.change(projectSelect, { target: { value: 'proj-2' } });
+        });
+
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'staging' })).toBeInTheDocument();
+        });
+
+        // Variant select should be reset to the placeholder ("All variants")
+        const updatedVariantSelect = screen.getAllByRole('combobox')[1] as HTMLSelectElement;
+        expect(updatedVariantSelect.value).toBe('');
+    });
+
+    test('clicking outside the panel closes it', async () => {
+        render(
+            <ProjectVariantSelector onApply={jest.fn()} />
+        );
+        const button = screen.getByRole('button');
+
+        await act(async () => { fireEvent.click(button); });
+        expect(screen.getByText('Project & Variant')).toBeInTheDocument();
+
+        // Dispatch a mousedown event on an element outside the panel and button
+        const outside = document.createElement('div');
+        document.body.appendChild(outside);
+        await act(async () => {
+            fireEvent.mouseDown(outside);
+        });
+        document.body.removeChild(outside);
+
+        expect(screen.queryByText('Project & Variant')).not.toBeInTheDocument();
+    });
 });

--- a/frontend/tests/unit_tests/test_settings_handlers.ts
+++ b/frontend/tests/unit_tests/test_settings_handlers.ts
@@ -85,6 +85,18 @@ describe('Projects.create', () => {
 
         await expect(Projects.create('Dup')).rejects.toThrow('already exists');
     });
+
+    test('throws generic message when error body is not parseable JSON', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 500,
+                json: () => Promise.reject(new SyntaxError("Unexpected end of JSON input")),
+            } as Response)
+        );
+
+        await expect(Projects.create('X')).rejects.toThrow('Create failed (500)');
+    });
 });
 
 
@@ -122,6 +134,18 @@ describe('Projects.delete', () => {
 
         await expect(Projects.delete('missing')).rejects.toThrow('Not found');
     });
+
+    test('throws generic message when error body is not parseable JSON', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 500,
+                json: () => Promise.reject(new SyntaxError("Unexpected end of JSON input")),
+            } as Response)
+        );
+
+        await expect(Projects.delete('p1')).rejects.toThrow('Delete failed (500)');
+    });
 });
 
 
@@ -151,6 +175,18 @@ describe('Variants.rename', () => {
         fetchMock.mockResponseOnce(JSON.stringify({ error: 'Duplicate' }), { status: 409 });
 
         await expect(Variants.rename('v1', 'Dup')).rejects.toThrow('Duplicate');
+    });
+
+    test('throws generic message when error body is not parseable JSON', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 500,
+                json: () => Promise.reject(new SyntaxError("Unexpected end of JSON input")),
+            } as Response)
+        );
+
+        await expect(Variants.rename('v1', 'X')).rejects.toThrow('Rename failed (500)');
     });
 });
 
@@ -193,6 +229,18 @@ describe('Variants.create', () => {
 
         await expect(Variants.create('p1', 'Dup')).rejects.toThrow('exists');
     });
+
+    test('throws generic message when error body is not parseable JSON', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 500,
+                json: () => Promise.reject(new SyntaxError("Unexpected end of JSON input")),
+            } as Response)
+        );
+
+        await expect(Variants.create('p1', 'X')).rejects.toThrow('Create failed (500)');
+    });
 });
 
 
@@ -218,6 +266,18 @@ describe('Variants.delete', () => {
         fetchMock.mockResponseOnce(JSON.stringify({ error: 'Not found' }), { status: 404 });
 
         await expect(Variants.delete('missing')).rejects.toThrow('Not found');
+    });
+
+    test('throws generic message when error body is not parseable JSON', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 500,
+                json: () => Promise.reject(new SyntaxError("Unexpected end of JSON input")),
+            } as Response)
+        );
+
+        await expect(Variants.delete('v1')).rejects.toThrow('Delete failed (500)');
     });
 });
 

--- a/frontend/tests/unit_tests/test_table_vulnerabilities_refresh.tsx
+++ b/frontend/tests/unit_tests/test_table_vulnerabilities_refresh.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+// @ts-expect-error TS6133
+import React from 'react';
+import TableVulnerabilities from '../../src/pages/TableVulnerabilities';
+import NvdRefreshHandler from '../../src/handlers/nvdRefresh';
+
+jest.mock('../../src/handlers/nvdRefresh', () => ({
+    __esModule: true,
+    default: {
+        triggerBulkRefresh: jest.fn().mockResolvedValue({ status: 'started' }),
+        triggerBulkRefreshForProject: jest.fn().mockResolvedValue({ status: 'started' }),
+        getBulkRefreshStatus: jest.fn().mockResolvedValue({ status: 'idle' }),
+        getBulkRefreshStatusForProject: jest.fn().mockResolvedValue({ status: 'idle' }),
+        triggerSingleRefresh: jest.fn().mockResolvedValue(null),
+    },
+}));
+
+const minimalProps = {
+    vulnerabilities: [],
+    appendAssessment: jest.fn(),
+    appendCVSS: jest.fn().mockReturnValue(null),
+    patchVuln: jest.fn(),
+    projectId: 'test-project-id',
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('TableVulnerabilities — Refresh CVEs button visibility', () => {
+    it('renders the Refresh CVEs button when variantId is not provided', () => {
+        render(<TableVulnerabilities {...minimalProps} />);
+        expect(screen.getByTitle('Refresh CVE data from NVD')).toBeInTheDocument();
+    });
+
+    it('renders the Refresh CVEs button when variantId is an empty string', () => {
+        render(<TableVulnerabilities {...minimalProps} variantId="" />);
+        expect(screen.getByTitle('Refresh CVE data from NVD')).toBeInTheDocument();
+    });
+
+    it('renders the Refresh CVEs button when variantId is set', () => {
+        render(<TableVulnerabilities {...minimalProps} variantId="variant-uuid" />);
+        expect(screen.getByTitle('Refresh CVE data from NVD')).toBeInTheDocument();
+    });
+});
+
+describe('TableVulnerabilities — Refresh CVEs handler branching', () => {
+    it('calls triggerBulkRefreshForProject when no variantId', async () => {
+        render(<TableVulnerabilities {...minimalProps} />);
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+        await waitFor(() => {
+            expect(NvdRefreshHandler.triggerBulkRefreshForProject).toHaveBeenCalledWith('test-project-id');
+            expect(NvdRefreshHandler.triggerBulkRefresh).not.toHaveBeenCalled();
+        });
+    });
+
+    it('calls triggerBulkRefresh when variantId is set', async () => {
+        render(<TableVulnerabilities {...minimalProps} variantId="variant-uuid" />);
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+        await waitFor(() => {
+            expect(NvdRefreshHandler.triggerBulkRefresh).toHaveBeenCalledWith('variant-uuid');
+            expect(NvdRefreshHandler.triggerBulkRefreshForProject).not.toHaveBeenCalled();
+        });
+    });
+
+    it('calls triggerBulkRefreshForProject with filtered ids when no variantId', async () => {
+        render(<TableVulnerabilities {...minimalProps} />);
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('CVEs matching current filters'));
+        await waitFor(() => {
+            expect(NvdRefreshHandler.triggerBulkRefreshForProject).toHaveBeenCalledWith(
+                'test-project-id',
+                expect.any(Array),
+            );
+            expect(NvdRefreshHandler.triggerBulkRefresh).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/frontend/tests/unit_tests/test_table_vulnerabilities_refresh.tsx
+++ b/frontend/tests/unit_tests/test_table_vulnerabilities_refresh.tsx
@@ -13,6 +13,8 @@ jest.mock('../../src/handlers/nvdRefresh', () => ({
         getBulkRefreshStatus: jest.fn().mockResolvedValue({ status: 'idle' }),
         getBulkRefreshStatusForProject: jest.fn().mockResolvedValue({ status: 'idle' }),
         triggerSingleRefresh: jest.fn().mockResolvedValue(null),
+        cancelBulkRefresh: jest.fn().mockResolvedValue(undefined),
+        cancelBulkRefreshForProject: jest.fn().mockResolvedValue(undefined),
     },
 }));
 
@@ -64,6 +66,69 @@ describe('TableVulnerabilities — Refresh poll cancellation on scope change', (
         fireEvent.click(screen.getByText('Pending Assessment CVEs'));
         await waitFor(() => {
             expect(NvdRefreshHandler.triggerBulkRefresh).toHaveBeenCalledWith('variant-b');
+        });
+    });
+
+    it('cancels the backend refresh for the old variant when scope changes', async () => {
+        const { rerender } = render(<TableVulnerabilities {...minimalProps} variantId="variant-a" />);
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+        await waitFor(() => expect(NvdRefreshHandler.triggerBulkRefresh).toHaveBeenCalled());
+
+        rerender(<TableVulnerabilities {...minimalProps} variantId="variant-b" />);
+
+        await waitFor(() => {
+            expect(NvdRefreshHandler.cancelBulkRefresh).toHaveBeenCalledWith('variant-a');
+        });
+        expect(NvdRefreshHandler.cancelBulkRefreshForProject).not.toHaveBeenCalled();
+    });
+
+    it('cancels the backend refresh for the old project when scope changes', async () => {
+        const { rerender } = render(<TableVulnerabilities {...minimalProps} projectId="project-a" />);
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+        await waitFor(() => expect(NvdRefreshHandler.triggerBulkRefreshForProject).toHaveBeenCalled());
+
+        rerender(<TableVulnerabilities {...minimalProps} projectId="project-b" />);
+
+        await waitFor(() => {
+            expect(NvdRefreshHandler.cancelBulkRefreshForProject).toHaveBeenCalledWith('project-a');
+        });
+        expect(NvdRefreshHandler.cancelBulkRefresh).not.toHaveBeenCalled();
+    });
+});
+
+describe('TableVulnerabilities — Cancel backend refresh on dismiss', () => {
+    it('calls cancelBulkRefresh when the dismiss button is clicked during an active variant refresh', async () => {
+        // Keep the refresh running so the dismiss button can cancel it
+        (NvdRefreshHandler.getBulkRefreshStatus as jest.Mock).mockResolvedValue({ status: 'running', progress: '1/5 CPEs' });
+
+        render(<TableVulnerabilities {...minimalProps} variantId="variant-uuid" />);
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+        await waitFor(() => expect(NvdRefreshHandler.triggerBulkRefresh).toHaveBeenCalled());
+
+        const dismissBtn = await screen.findByLabelText('Dismiss');
+        fireEvent.click(dismissBtn);
+
+        await waitFor(() => {
+            expect(NvdRefreshHandler.cancelBulkRefresh).toHaveBeenCalledWith('variant-uuid');
+        });
+    });
+
+    it('calls cancelBulkRefreshForProject when the dismiss button is clicked during an active project refresh', async () => {
+        (NvdRefreshHandler.getBulkRefreshStatusForProject as jest.Mock).mockResolvedValue({ status: 'running', progress: '1/5 CPEs' });
+
+        render(<TableVulnerabilities {...minimalProps} />);
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+        await waitFor(() => expect(NvdRefreshHandler.triggerBulkRefreshForProject).toHaveBeenCalled());
+
+        const dismissBtn = await screen.findByLabelText('Dismiss');
+        fireEvent.click(dismissBtn);
+
+        await waitFor(() => {
+            expect(NvdRefreshHandler.cancelBulkRefreshForProject).toHaveBeenCalledWith('test-project-id');
         });
     });
 });

--- a/frontend/tests/unit_tests/test_table_vulnerabilities_refresh.tsx
+++ b/frontend/tests/unit_tests/test_table_vulnerabilities_refresh.tsx
@@ -48,7 +48,7 @@ describe('TableVulnerabilities — Refresh CVEs button visibility', () => {
 });
 
 describe('TableVulnerabilities — Refresh poll cancellation on scope change', () => {
-    it('clears the poll interval and resets status when variantId changes', async () => {
+    it('clears the poll interval and shows cancelled status when variantId changes', async () => {
         const { rerender } = render(<TableVulnerabilities {...minimalProps} variantId="variant-a" />);
         fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
         fireEvent.click(screen.getByText('Pending Assessment CVEs'));
@@ -57,16 +57,17 @@ describe('TableVulnerabilities — Refresh poll cancellation on scope change', (
         // Simulate switching to a different variant
         rerender(<TableVulnerabilities {...minimalProps} variantId="variant-b" />);
 
-        // Status bar should be gone after scope change
+       // Running spinner should be gone; cancelled message should appear
         await waitFor(() => {
-            expect(screen.queryByText(/Refresh/i, { selector: '.bg-sky-900 *' })).not.toBeInTheDocument();
-        });
-        // New trigger should use the new variantId
-        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
-        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
-        await waitFor(() => {
-            expect(NvdRefreshHandler.triggerBulkRefresh).toHaveBeenCalledWith('variant-b');
-        });
+           expect(screen.queryByText('Refreshing CVEs from NVD…')).not.toBeInTheDocument();
+           expect(screen.getByText('✗ NVD refresh cancelled')).toBeInTheDocument();
+       });
+       // New trigger should use the new variantId
+       fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+       fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+       await waitFor(() => {
+           expect(NvdRefreshHandler.triggerBulkRefresh).toHaveBeenCalledWith('variant-b');
+       });
     });
 
     it('cancels the backend refresh for the old variant when scope changes', async () => {
@@ -113,6 +114,42 @@ describe('TableVulnerabilities — Cancel backend refresh on dismiss', () => {
 
         await waitFor(() => {
             expect(NvdRefreshHandler.cancelBulkRefresh).toHaveBeenCalledWith('variant-uuid');
+        });
+    });
+
+    it('shows cancelled notification when dismiss is clicked during a running refresh', async () => {
+        (NvdRefreshHandler.getBulkRefreshStatus as jest.Mock).mockResolvedValue({ status: 'running', progress: '2/10 CPEs' });
+
+        render(<TableVulnerabilities {...minimalProps} variantId="variant-uuid" />);
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+        await waitFor(() => screen.findByText('Refreshing CVEs from NVD…'));
+
+        const dismissBtn = await screen.findByLabelText('Dismiss');
+        fireEvent.click(dismissBtn);
+
+        await waitFor(() => {
+            expect(screen.getByText('✗ NVD refresh cancelled')).toBeInTheDocument();
+        });
+    });
+
+    it('hides the toast completely when dismiss is clicked on a cancelled status', async () => {
+        (NvdRefreshHandler.getBulkRefreshStatus as jest.Mock).mockResolvedValue({ status: 'running', progress: '2/10 CPEs' });
+
+        render(<TableVulnerabilities {...minimalProps} variantId="variant-uuid" />);
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+        await waitFor(() => screen.findByText('Refreshing CVEs from NVD…'));
+
+        // First dismiss: shows cancelled message
+        const dismissBtn = await screen.findByLabelText('Dismiss');
+        fireEvent.click(dismissBtn);
+        await waitFor(() => expect(screen.getByText('✗ NVD refresh cancelled')).toBeInTheDocument());
+
+        // Second dismiss: hides the toast entirely
+        fireEvent.click(screen.getByLabelText('Dismiss'));
+        await waitFor(() => {
+            expect(screen.queryByText('✗ NVD refresh cancelled')).not.toBeInTheDocument();
         });
     });
 

--- a/frontend/tests/unit_tests/test_table_vulnerabilities_refresh.tsx
+++ b/frontend/tests/unit_tests/test_table_vulnerabilities_refresh.tsx
@@ -45,6 +45,29 @@ describe('TableVulnerabilities — Refresh CVEs button visibility', () => {
     });
 });
 
+describe('TableVulnerabilities — Refresh poll cancellation on scope change', () => {
+    it('clears the poll interval and resets status when variantId changes', async () => {
+        const { rerender } = render(<TableVulnerabilities {...minimalProps} variantId="variant-a" />);
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+        await waitFor(() => expect(NvdRefreshHandler.triggerBulkRefresh).toHaveBeenCalled());
+
+        // Simulate switching to a different variant
+        rerender(<TableVulnerabilities {...minimalProps} variantId="variant-b" />);
+
+        // Status bar should be gone after scope change
+        await waitFor(() => {
+            expect(screen.queryByText(/Refresh/i, { selector: '.bg-sky-900 *' })).not.toBeInTheDocument();
+        });
+        // New trigger should use the new variantId
+        fireEvent.click(screen.getByTitle('Refresh CVE data from NVD'));
+        fireEvent.click(screen.getByText('Pending Assessment CVEs'));
+        await waitFor(() => {
+            expect(NvdRefreshHandler.triggerBulkRefresh).toHaveBeenCalledWith('variant-b');
+        });
+    });
+});
+
 describe('TableVulnerabilities — Refresh CVEs handler branching', () => {
     it('calls triggerBulkRefreshForProject when no variantId', async () => {
         render(<TableVulnerabilities {...minimalProps} />);

--- a/src/controllers/nvd_refresh.py
+++ b/src/controllers/nvd_refresh.py
@@ -44,8 +44,9 @@ def build_cpe_map(
 def apply_nvd_update(vuln_record, details: dict, now: datetime.datetime) -> bool:
     """Compare NVD *details* against *vuln_record* and update in place if different.
 
-    Returns True if any field changed (and update_record was called),
-    False if nothing differed.  Always sets nvd_fetched_at when a change occurs.
+    Returns True if any field changed, False if nothing differed.
+    Always sets nvd_fetched_at regardless of whether any field changed.
+    Sets nvd_data_updated_at only when at least one field changed.
     None values in *details* are treated as "no data" and never overwrite.
     """
     update_kwargs: dict = {}
@@ -65,6 +66,7 @@ def apply_nvd_update(vuln_record, details: dict, now: datetime.datetime) -> bool
             update_kwargs[model_attr] = new_val
 
     if not update_kwargs:
+        vuln_record.update_record(nvd_fetched_at=now, commit=False)
         return False
 
     update_kwargs["nvd_fetched_at"] = now
@@ -207,9 +209,6 @@ def run_nvd_refresh(
             details = NVD_DB.extract_cve_details(cve)
             if apply_nvd_update(rec, details, now):
                 changed_count += 1
-            else:
-                # Stamp fetch time even when content is unchanged
-                rec.update_record(nvd_fetched_at=now, commit=False)
 
         progress["done_count"] = idx
 

--- a/src/controllers/nvd_refresh.py
+++ b/src/controllers/nvd_refresh.py
@@ -1,0 +1,257 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""NVD CVE Refresh controller.
+
+Refreshes existing CVE metadata from NVD without creating new findings.
+Uses CPE batch fetching as primary strategy, per-CVE fallback for stragglers.
+"""
+
+import datetime
+from typing import Optional
+
+
+def build_cpe_map(
+    target_cve_ids: set,
+    findings: list,
+    package_by_id: dict,
+) -> dict:
+    """Build {cpe_name: set(cve_ids)} for the given target CVE IDs.
+
+    *findings* is a list of Finding objects (or mocks with .vulnerability_id
+    and .package_id).  *package_by_id* maps package UUID → Package object
+    (with .cpe list attribute).
+
+    CPEs with wildcard at position [3] (vendor) are excluded — they require
+    virtualMatchString and can't be used for targeted CPE batch lookup.
+    """
+    cpe_to_cves: dict = {}
+    for finding in findings:
+        vuln_id = str(finding.vulnerability_id).upper()
+        if vuln_id not in target_cve_ids:
+            continue
+        pkg = package_by_id.get(finding.package_id)
+        if pkg is None or not pkg.cpe:
+            continue
+        for cpe in pkg.cpe:
+            parts = cpe.split(":")
+            if len(parts) < 5 or parts[3] == "*":
+                continue
+            cpe_to_cves.setdefault(cpe, set()).add(vuln_id)
+    return cpe_to_cves
+
+
+def apply_nvd_update(vuln_record, details: dict, now: datetime.datetime) -> bool:
+    """Compare NVD *details* against *vuln_record* and update in place if different.
+
+    Returns True if any field changed (and update_record was called),
+    False if nothing differed.  Always sets nvd_fetched_at when a change occurs.
+    None values in *details* are treated as "no data" and never overwrite.
+    """
+    update_kwargs: dict = {}
+
+    fields = [
+        ("description", "description"),
+        ("status", "status"),
+        ("attack_vector", "attack_vector"),
+        ("links", "links"),
+        ("weaknesses", "weaknesses"),
+        ("publish_date", "publish_date"),
+        ("nvd_last_modified", "nvd_last_modified"),
+    ]
+    for detail_key, model_attr in fields:
+        new_val = details.get(detail_key)
+        if new_val is not None and new_val != getattr(vuln_record, model_attr):
+            update_kwargs[model_attr] = new_val
+
+    if not update_kwargs:
+        return False
+
+    update_kwargs["nvd_fetched_at"] = now
+    update_kwargs["nvd_data_updated_at"] = now
+    update_kwargs["commit"] = False
+    vuln_record.update_record(**update_kwargs)
+    return True
+
+
+def collect_target_cve_ids(
+    variant_uuid,
+    project_uuid,
+    requested_cve_ids: Optional[list],
+) -> list:
+    """Return the list of CVE IDs to refresh.
+
+    If *requested_cve_ids* is provided, return those directly (explicit list
+    sent by frontend for "refresh matching current filters" mode).
+    Otherwise return all CVEs linked to active findings for the variant/project
+    where the assessment status is 'under_investigation' (Pending Assessment).
+    """
+    if requested_cve_ids is not None:
+        return [cid.upper() for cid in requested_cve_ids if cid]
+
+    from ..extensions import db
+    from ..models.finding import Finding
+    from ..models.observation import Observation
+    from ..models.assessment import Assessment
+    from ..helpers.active_scans import (
+        active_scan_ids_for_variant,
+        active_scan_ids_for_project,
+    )
+
+    if project_uuid:
+        scan_ids = active_scan_ids_for_project(project_uuid)
+    else:
+        scan_ids = active_scan_ids_for_variant(variant_uuid)
+
+    if not scan_ids:
+        return []
+
+    rows = db.session.execute(
+        db.select(Finding.vulnerability_id.distinct())
+        .join(Observation, Observation.finding_id == Finding.id)
+        .join(
+            Assessment,
+            db.and_(
+                Assessment.finding_id == Finding.id,
+                Assessment.variant_id == variant_uuid,
+            ),
+        )
+        .where(Observation.scan_id.in_(scan_ids))
+        .where(Assessment.status == "under_investigation")
+    ).all()
+    return [row[0].upper() for row in rows]
+
+
+def run_nvd_refresh(
+    variant_uuid,
+    project_uuid,
+    requested_cve_ids: Optional[list],
+    progress: dict,
+) -> dict:
+    """Run the full NVD refresh.  Updates *progress* dict in place.
+
+    Returns a summary dict: {"refreshed": int, "changed": int, "failed": int}.
+    Designed to run inside a Flask app_context (background thread).
+    """
+    import os
+    from ..extensions import db
+    from ..models.vulnerability import Vulnerability
+    from ..models.finding import Finding
+    from ..models.package import Package
+    from ..controllers.nvd_db import NVD_DB
+
+    nvd = NVD_DB(nvd_api_key=os.getenv("NVD_API_KEY"))
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    # 1. Collect CVE IDs to refresh
+    progress["logs"].append("Collecting CVEs to refresh…")
+    target_ids = set(collect_target_cve_ids(variant_uuid, project_uuid, requested_cve_ids))
+
+    if not target_ids:
+        progress["status"] = "done"
+        progress["progress"] = "No CVEs to refresh"
+        progress["logs"].append("No CVEs found for the selected scope.")
+        return {"refreshed": 0, "changed": 0, "failed": 0}
+
+    progress["total"] = len(target_ids)
+    progress["logs"].append(f"Found {len(target_ids)} CVE(s) to refresh.")
+
+    # 2. Load findings + packages for CPE map
+    findings = db.session.execute(
+        db.select(Finding)
+        .where(Finding.vulnerability_id.in_(list(target_ids)))
+    ).scalars().all()
+
+    pkg_ids = {f.package_id for f in findings}
+    packages = db.session.execute(
+        db.select(Package).where(Package.id.in_(list(pkg_ids)))
+    ).scalars().all()
+    package_by_id = {p.id: p for p in packages}
+
+    cpe_map = build_cpe_map(target_ids, findings, package_by_id)
+    progress["logs"].append(
+        f"Built CPE map: {len(cpe_map)} unique CPE(s) covering "
+        f"{sum(len(v) for v in cpe_map.values())} CVE references."
+    )
+
+    # 3. CPE batch fetch
+    resolved: set = set()
+    failed: set = set()
+    changed_count = 0
+
+    total_cpes = len(cpe_map)
+    for idx, (cpe_name, _) in enumerate(cpe_map.items(), 1):
+        progress["progress"] = f"{idx}/{total_cpes} CPEs"
+        progress["logs"].append(f"[{idx}/{total_cpes}] Batch query: {cpe_name}…")
+        try:
+            cpe_parts = cpe_name.split(":")
+            has_wildcards = len(cpe_parts) >= 6 and (
+                cpe_parts[2] == "*" or cpe_parts[3] == "*" or cpe_parts[5] == "*"
+            )
+            nvd_vulns = nvd.api_get_cves_by_cpe(
+                cpe_name, results_per_page=100, use_virtual_match=has_wildcards
+            )
+        except Exception as e:
+            progress["logs"].append(f"  ERROR on {cpe_name}: {str(e)[:200]}")
+            continue
+
+        for nvd_vuln in nvd_vulns:
+            cve = nvd_vuln.get("cve", {})
+            cve_id = cve.get("id", "").upper()
+            if cve_id not in target_ids or cve_id in resolved:
+                continue
+            resolved.add(cve_id)
+            rec = Vulnerability.get_by_id(cve_id)
+            if rec is None:
+                continue
+            details = NVD_DB.extract_cve_details(cve)
+            if apply_nvd_update(rec, details, now):
+                changed_count += 1
+            else:
+                # Stamp fetch time even when content is unchanged
+                rec.update_record(nvd_fetched_at=now, commit=False)
+
+        progress["done_count"] = idx
+
+    # 4. Straggler individual pass
+    stragglers = target_ids - resolved
+    if stragglers:
+        progress["logs"].append(
+            f"Straggler pass: {len(stragglers)} CVE(s) not found via CPE batch."
+        )
+    for idx2, cve_id in enumerate(sorted(stragglers), 1):
+        progress["logs"].append(f"  [{idx2}/{len(stragglers)}] Individual fetch: {cve_id}…")
+        try:
+            status, data = nvd.api_get_cve(cve_id)
+            if status == 200 and data.get("vulnerabilities"):
+                cve = data["vulnerabilities"][0]["cve"]
+                details = NVD_DB.extract_cve_details(cve)
+                rec = Vulnerability.get_by_id(cve_id)
+                if rec is not None:
+                    if apply_nvd_update(rec, details, now):
+                        changed_count += 1
+                resolved.add(cve_id)
+            else:
+                # Update nvd_fetched_at only (not nvd_data_updated_at)
+                rec = Vulnerability.get_by_id(cve_id)
+                if rec is not None:
+                    rec.update_record(nvd_fetched_at=now, commit=False)
+                failed.add(cve_id)
+        except Exception as e:
+            progress["logs"].append(f"    ERROR: {str(e)[:200]}")
+            failed.add(cve_id)
+
+    db.session.commit()
+
+    summary = {
+        "refreshed": len(resolved),
+        "changed": changed_count,
+        "failed": len(failed),
+    }
+    progress["status"] = "done"
+    progress["progress"] = (
+        f"Done — {len(resolved)}/{len(target_ids)} refreshed, "
+        f"{changed_count} updated, {len(failed)} failed"
+    )
+    progress["logs"].append(f"✓ Refresh complete. {summary}")
+    return summary

--- a/src/controllers/nvd_refresh.py
+++ b/src/controllers/nvd_refresh.py
@@ -168,7 +168,7 @@ def run_nvd_refresh(
     ).scalars().all()
     package_by_id = {p.id: p for p in packages}
 
-    cpe_map = build_cpe_map(target_ids, findings, package_by_id)
+    cpe_map = build_cpe_map(target_ids, list(findings), package_by_id)
     progress["logs"].append(
         f"Built CPE map: {len(cpe_map)} unique CPE(s) covering "
         f"{sum(len(v) for v in cpe_map.values())} CVE references."

--- a/src/controllers/nvd_refresh.py
+++ b/src/controllers/nvd_refresh.py
@@ -250,15 +250,20 @@ def run_nvd_refresh(
             if cve_id not in target_ids or cve_id in resolved:
                 continue
             resolved.add(cve_id)
-            rec = Vulnerability.get_by_id(cve_id)
-            if rec is None:
-                continue
-            details = NVD_DB.extract_cve_details(cve)
-            vuln_changed = apply_nvd_update(rec, details, now)
-            cvss_changed = update_nvd_cvss_metrics(rec, details)
-            if vuln_changed or cvss_changed:
-                changed_count += 1
-                progress["changed_cves"].append(cve_id)
+            try:
+                rec = Vulnerability.get_by_id(cve_id)
+                if rec is None:
+                    continue
+                details = NVD_DB.extract_cve_details(cve)
+                vuln_changed = apply_nvd_update(rec, details, now)
+                cvss_changed = update_nvd_cvss_metrics(rec, details)
+                if vuln_changed or cvss_changed:
+                    changed_count += 1
+                    progress["changed_cves"].append(cve_id)
+            except Exception as e:
+                progress["logs"].append(f"  ERROR processing {cve_id}: {str(e)[:200]}")
+                resolved.discard(cve_id)
+                failed.add(cve_id)
 
         progress["done_count"] = idx
 

--- a/src/controllers/nvd_refresh.py
+++ b/src/controllers/nvd_refresh.py
@@ -76,6 +76,52 @@ def apply_nvd_update(vuln_record, details: dict, now: datetime.datetime) -> bool
     return True
 
 
+def update_nvd_cvss_metrics(vuln_record, details: dict) -> bool:
+    """Upsert the NVD CVSS score in the ``metrics`` table for *vuln_record*.
+
+    Matches on (vulnerability_id, author='NVD', version=details['cvss_version']).
+    Creates the row if missing; updates score/vector when they differ.
+    Returns True if a change was made, False if nothing differed or no CVSS data.
+    Does NOT commit — caller owns the transaction.
+    """
+    from ..extensions import db
+    from ..models.metrics import Metrics
+
+    base_score = details.get("base_score")
+    cvss_version = details.get("cvss_version")
+    cvss_vector = details.get("cvss_vector")
+
+    if base_score is None or cvss_version is None:
+        return False
+
+    vid = str(vuln_record.id).upper()
+
+    existing = db.session.execute(
+        db.select(Metrics).where(
+            Metrics.vulnerability_id == vid,
+            Metrics.author == "NVD",
+            Metrics.version == cvss_version,
+        )
+    ).scalar_one_or_none()
+
+    if existing is None:
+        db.session.add(Metrics(
+            vulnerability_id=vid,
+            version=cvss_version,
+            score=base_score,
+            vector=cvss_vector,
+            author="NVD",
+        ))
+        return True
+
+    existing_score = float(existing.score) if existing.score is not None else None
+    changed = existing_score != float(base_score) or existing.vector != cvss_vector
+    if changed:
+        existing.score = base_score
+        existing.vector = cvss_vector
+    return changed
+
+
 def collect_target_cve_ids(
     variant_uuid,
     project_uuid,
@@ -156,6 +202,7 @@ def run_nvd_refresh(
         return {"refreshed": 0, "changed": 0, "failed": 0}
 
     progress["total"] = len(target_ids)
+    progress["changed_cves"] = []
     progress["logs"].append(f"Found {len(target_ids)} CVE(s) to refresh.")
 
     # 2. Load findings + packages for CPE map
@@ -207,8 +254,11 @@ def run_nvd_refresh(
             if rec is None:
                 continue
             details = NVD_DB.extract_cve_details(cve)
-            if apply_nvd_update(rec, details, now):
+            vuln_changed = apply_nvd_update(rec, details, now)
+            cvss_changed = update_nvd_cvss_metrics(rec, details)
+            if vuln_changed or cvss_changed:
                 changed_count += 1
+                progress["changed_cves"].append(cve_id)
 
         progress["done_count"] = idx
 
@@ -227,8 +277,11 @@ def run_nvd_refresh(
                 details = NVD_DB.extract_cve_details(cve)
                 rec = Vulnerability.get_by_id(cve_id)
                 if rec is not None:
-                    if apply_nvd_update(rec, details, now):
+                    vuln_changed = apply_nvd_update(rec, details, now)
+                    cvss_changed = update_nvd_cvss_metrics(rec, details)
+                    if vuln_changed or cvss_changed:
                         changed_count += 1
+                        progress["changed_cves"].append(cve_id)
                 resolved.add(cve_id)
             else:
                 # Update nvd_fetched_at only (not nvd_data_updated_at)

--- a/src/controllers/nvd_refresh.py
+++ b/src/controllers/nvd_refresh.py
@@ -232,6 +232,8 @@ def run_nvd_refresh(
 
     total_cpes = len(cpe_map)
     for idx, (cpe_name, _) in enumerate(cpe_map.items(), 1):
+        if progress.get("cancelled"):
+            break
         progress["progress"] = f"{idx}/{total_cpes} CPEs"
         progress["logs"].append(f"[{idx}/{total_cpes}] Batch query: {cpe_name}…")
         try:
@@ -276,6 +278,8 @@ def run_nvd_refresh(
             f"Straggler pass: {len(stragglers)} CVE(s) not found via CPE batch."
         )
     for idx2, cve_id in enumerate(sorted(stragglers), 1):
+        if progress.get("cancelled"):
+            break
         progress["logs"].append(f"  [{idx2}/{len(stragglers)}] Individual fetch: {cve_id}…")
         try:
             status, data = nvd.api_get_cve(cve_id)
@@ -299,6 +303,13 @@ def run_nvd_refresh(
         except Exception as e:
             progress["logs"].append(f"    ERROR: {str(e)[:200]}")
             failed.add(cve_id)
+
+    if progress.get("cancelled"):
+        db.session.rollback()
+        progress["status"] = "cancelled"
+        progress["progress"] = "Cancelled"
+        progress["logs"].append("✗ Refresh cancelled.")
+        return {"refreshed": 0, "changed": 0, "failed": 0}
 
     db.session.commit()
 

--- a/src/controllers/nvd_refresh.py
+++ b/src/controllers/nvd_refresh.py
@@ -154,16 +154,18 @@ def collect_target_cve_ids(
     if not scan_ids:
         return []
 
+    if project_uuid:
+        assessment_join = Assessment.finding_id == Finding.id
+    else:
+        assessment_join = db.and_(
+            Assessment.finding_id == Finding.id,
+            Assessment.variant_id == variant_uuid,
+        )
+
     rows = db.session.execute(
         db.select(Finding.vulnerability_id.distinct())
         .join(Observation, Observation.finding_id == Finding.id)
-        .join(
-            Assessment,
-            db.and_(
-                Assessment.finding_id == Finding.id,
-                Assessment.variant_id == variant_uuid,
-            ),
-        )
+        .join(Assessment, assessment_join)
         .where(Observation.scan_id.in_(scan_ids))
         .where(Assessment.status == "under_investigation")
     ).all()

--- a/src/migrations/versions/j6e7f8a9b0c1_add_nvd_data_updated_at.py
+++ b/src/migrations/versions/j6e7f8a9b0c1_add_nvd_data_updated_at.py
@@ -1,0 +1,23 @@
+"""add nvd_data_updated_at to vulnerabilities
+
+Revision ID: j6e7f8a9b0c1
+Revises: i5d6e7f8a9b0
+Create Date: 2026-05-12 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'j6e7f8a9b0c1'
+down_revision = 'i5d6e7f8a9b0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('vulnerabilities', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('nvd_data_updated_at', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('vulnerabilities', schema=None) as batch_op:
+        batch_op.drop_column('nvd_data_updated_at')

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -47,6 +47,7 @@ class Vulnerability(Base):
     patch_url: Mapped[list | None] = mapped_column(JSON)
     nvd_last_modified: Mapped[str | None] = mapped_column(Text)
     nvd_fetched_at: Mapped[datetime | None]
+    nvd_data_updated_at: Mapped[datetime | None]
 
     # ------------------------------------------------------------------
     # Relationships
@@ -339,6 +340,12 @@ class Vulnerability(Base):
             "advisories": list(self.advisories or []),
             "packages": packages,
             "published": self.published,
+            "nvd_fetched_at": (
+                self.nvd_fetched_at.isoformat() if self.nvd_fetched_at else None
+            ),
+            "nvd_data_updated_at": (
+                self.nvd_data_updated_at.isoformat() if self.nvd_data_updated_at else None
+            ),
         }
 
     @staticmethod
@@ -582,6 +589,7 @@ class Vulnerability(Base):
         patch_url: Optional[list] = None,
         nvd_last_modified: Optional[str] = None,
         nvd_fetched_at: Optional[datetime] = None,
+        nvd_data_updated_at: Optional[datetime] = None,
         commit: bool = True,
     ) -> "Vulnerability":
         """Update DB column fields in place, persist the change and return ``self``.
@@ -617,6 +625,8 @@ class Vulnerability(Base):
             self.nvd_last_modified = nvd_last_modified
         if nvd_fetched_at is not None:
             self.nvd_fetched_at = nvd_fetched_at
+        if nvd_data_updated_at is not None:
+            self.nvd_data_updated_at = nvd_data_updated_at
         if commit:
             db.session.commit()
         return self

--- a/src/routes/_scan_helpers.py
+++ b/src/routes/_scan_helpers.py
@@ -113,7 +113,27 @@ def init_progress(progress_dict: dict, vid_str: str, total: int = 0):
         "logs": [],
         "total": total,
         "done_count": 0,
+        "cancelled": False,
     }
+
+
+def cancel_progress(progress_dict: dict, key: str):
+    """Signal an in-progress scan to stop.
+
+    Sets the ``cancelled`` flag so the worker thread can detect the request
+    and exit cleanly between iterations.  The status field is intentionally
+    left as ``"running"`` here; the worker will update it to ``"cancelled"``
+    once it has actually stopped.  This keeps ``validate_trigger``'s
+    already-running guard accurate — a second POST for the same scope will
+    still get a 409 until the worker acknowledges the cancellation.
+
+    Returns True if a running entry was found, False otherwise.
+    """
+    entry = progress_dict.get(key)
+    if entry is None or entry.get("status") != "running":
+        return False
+    entry["cancelled"] = True
+    return True
 
 
 def set_error(progress_dict: dict, vid_str: str, error: str):

--- a/src/routes/_scan_helpers.py
+++ b/src/routes/_scan_helpers.py
@@ -12,6 +12,7 @@ import uuid as uuid_module
 from flask import jsonify
 
 from ..controllers.variants import VariantController
+from ..controllers.projects import ProjectController
 from ..helpers.active_scans import active_sbom_scan_ids_for_variant, active_package_ids_for_scans
 from ..models.observation import Observation
 from ..models.package import Package
@@ -62,6 +63,33 @@ def validate_trigger(variant_id: str, progress_dict: dict, scan_label: str):
         )
 
     return variant_uuid, variant, None
+
+
+def validate_project_trigger(project_id: str, progress_dict: dict, scan_label: str):
+    """Common validation for project-scoped scan trigger endpoints.
+
+    Parses the project UUID, checks the project exists, and checks that no
+    scan of the same type is already running for that project.
+
+    Returns ``(project_uuid, project, error_response)`` — if
+    *error_response* is not ``None`` the caller should return it immediately.
+    """
+    project_uuid, err = parse_uuid_or_400(project_id, "project id")
+    if err is not None:
+        return None, None, err
+
+    project = ProjectController.get(project_uuid)
+    if project is None:
+        return None, None, (jsonify({"error": "Project not found"}), 404)
+
+    pid_str = str(project_uuid)
+    if pid_str in progress_dict and progress_dict[pid_str].get("status") == "running":
+        return None, None, (
+            jsonify({"error": f"A {scan_label} is already in progress for this project"}),
+            409,
+        )
+
+    return project_uuid, project, None
 
 
 def scan_status_response(variant_id: str, progress_dict: dict):

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -10,7 +10,7 @@ endpoint for polling progress.
 import os
 import threading
 
-from flask import jsonify
+from flask import jsonify, request
 
 from ..models.scan import Scan
 from ..models.finding import Finding
@@ -29,6 +29,7 @@ from ._scan_helpers import (
     resolve_active_packages,
     create_observation_and_assessment,
 )
+from ..controllers.nvd_refresh import run_nvd_refresh
 
 
 def init_app(app):
@@ -667,3 +668,54 @@ def init_app(app):
     def osv_scan_status(variant_id):
         """Check the status of a running OSV scan for the given variant."""
         return scan_status_response(variant_id, _osv_scans_in_progress)
+
+    # ------------------------------------------------------------------
+    # NVD CVE Refresh (bulk, variant-scoped)
+    # ------------------------------------------------------------------
+
+    _nvd_refresh_in_progress: dict = {}
+
+    @app.route('/api/variants/<variant_id>/nvd-refresh', methods=['POST'])
+    def trigger_nvd_refresh(variant_id):
+        """Trigger an NVD metadata refresh for CVEs in the given variant.
+
+        Refreshes existing CVE records only — does not create new findings.
+        Body (optional): {"cve_ids": ["CVE-...", ...]}
+        Omit cve_ids to refresh all Pending Assessment CVEs for the variant.
+        """
+        variant_uuid, variant, err = validate_trigger(
+            variant_id, _nvd_refresh_in_progress, "NVD refresh"
+        )
+        if err is not None:
+            return err
+
+        vid_str = str(variant_uuid)
+        body = request.get_json(silent=True) or {}
+        requested_cve_ids = body.get("cve_ids") or None  # None = default scope
+
+        init_progress(_nvd_refresh_in_progress, vid_str)
+
+        def _run():
+            with app.app_context():
+                try:
+                    run_nvd_refresh(
+                        variant_uuid=variant_uuid,
+                        project_uuid=None,
+                        requested_cve_ids=requested_cve_ids,
+                        progress=_nvd_refresh_in_progress[vid_str],
+                    )
+                except Exception as e:
+                    set_error(_nvd_refresh_in_progress, vid_str, str(e)[:500])
+
+        threading.Thread(
+            target=_run,
+            name=f"nvd-refresh-{vid_str}",
+            daemon=True,
+        ).start()
+
+        return jsonify({"status": "started", "variant_id": vid_str}), 202
+
+    @app.route('/api/variants/<variant_id>/nvd-refresh/status')
+    def nvd_refresh_status(variant_id):
+        """Poll progress of a running NVD refresh for the given variant."""
+        return scan_status_response(variant_id, _nvd_refresh_in_progress)

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -27,6 +27,7 @@ from ._scan_helpers import (
     scan_status_response,
     init_progress,
     set_error,
+    cancel_progress,
     parse_uuid_or_400,
     resolve_active_packages,
     create_observation_and_assessment,
@@ -725,6 +726,17 @@ def init_app(app):
         """Poll progress of a running NVD refresh for the given variant."""
         return scan_status_response(variant_id, _nvd_refresh_in_progress)
 
+    @app.route('/api/variants/<variant_id>/nvd-refresh', methods=['DELETE'])
+    def cancel_nvd_refresh(variant_id):
+        """Request cancellation of a running NVD refresh for the given variant."""
+        variant_uuid, err = parse_uuid_or_400(variant_id, "variant id")
+        if err is not None:
+            return err
+        vid_str = str(variant_uuid)
+        if cancel_progress(_nvd_refresh_in_progress, vid_str):
+            return jsonify({"status": "cancelling", "variant_id": vid_str}), 200
+        return jsonify({"status": "not_running", "variant_id": vid_str}), 200
+
     # ------------------------------------------------------------------
     # NVD CVE Refresh (bulk, project-scoped)
     # ------------------------------------------------------------------
@@ -787,3 +799,14 @@ def init_app(app):
         if info is None:
             return jsonify({"status": "idle"})
         return jsonify(info)
+
+    @app.route('/api/projects/<project_id>/nvd-refresh', methods=['DELETE'])
+    def cancel_project_nvd_refresh(project_id):
+        """Request cancellation of a running NVD refresh for the given project."""
+        project_uuid, err = parse_uuid_or_400(project_id, "project id")
+        if err is not None:
+            return err
+        pid_str = str(project_uuid)
+        if cancel_progress(_nvd_refresh_project_in_progress, pid_str):
+            return jsonify({"status": "cancelling", "project_id": pid_str}), 200
+        return jsonify({"status": "not_running", "project_id": pid_str}), 200

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -692,6 +692,8 @@ def init_app(app):
         vid_str = str(variant_uuid)
         body = request.get_json(silent=True) or {}
         requested_cve_ids = body.get("cve_ids") or None  # None = default scope
+        if requested_cve_ids is not None and not isinstance(requested_cve_ids, list):
+            return jsonify({"error": "'cve_ids' must be a list of CVE ID strings"}), 400
 
         init_progress(_nvd_refresh_in_progress, vid_str)
 

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -23,13 +23,16 @@ from ..views.grype_vulns import GrypeVulns
 
 from ._scan_helpers import (
     validate_trigger,
+    validate_project_trigger,
     scan_status_response,
     init_progress,
     set_error,
+    parse_uuid_or_400,
     resolve_active_packages,
     create_observation_and_assessment,
 )
 from ..controllers.nvd_refresh import run_nvd_refresh
+from ..controllers.projects import ProjectController
 
 
 def init_app(app):
@@ -721,3 +724,66 @@ def init_app(app):
     def nvd_refresh_status(variant_id):
         """Poll progress of a running NVD refresh for the given variant."""
         return scan_status_response(variant_id, _nvd_refresh_in_progress)
+
+    # ------------------------------------------------------------------
+    # NVD CVE Refresh (bulk, project-scoped)
+    # ------------------------------------------------------------------
+
+    _nvd_refresh_project_in_progress: dict = {}
+
+    @app.route('/api/projects/<project_id>/nvd-refresh', methods=['POST'])
+    def trigger_project_nvd_refresh(project_id):
+        """Trigger an NVD metadata refresh for all CVEs in the project.
+
+        Refreshes existing CVE records only — does not create new findings.
+        Body (optional): {"cve_ids": ["CVE-...", ...]}
+        Omit cve_ids to refresh all Pending Assessment CVEs across the project.
+        """
+        project_uuid, project, err = validate_project_trigger(
+            project_id, _nvd_refresh_project_in_progress, "NVD refresh"
+        )
+        if err is not None:
+            return err
+
+        pid_str = str(project_uuid)
+        body = request.get_json(silent=True) or {}
+        requested_cve_ids = body.get("cve_ids") or None
+        if requested_cve_ids is not None and not isinstance(requested_cve_ids, list):
+            return jsonify({"error": "'cve_ids' must be a list of CVE ID strings"}), 400
+
+        init_progress(_nvd_refresh_project_in_progress, pid_str)
+
+        def _run():
+            with app.app_context():
+                try:
+                    run_nvd_refresh(
+                        variant_uuid=None,
+                        project_uuid=project_uuid,
+                        requested_cve_ids=requested_cve_ids,
+                        progress=_nvd_refresh_project_in_progress[pid_str],
+                    )
+                except Exception as e:
+                    set_error(_nvd_refresh_project_in_progress, pid_str, str(e)[:500])
+
+        threading.Thread(
+            target=_run,
+            name=f"nvd-refresh-project-{pid_str}",
+            daemon=True,
+        ).start()
+
+        return jsonify({"status": "started", "project_id": pid_str}), 202
+
+    @app.route('/api/projects/<project_id>/nvd-refresh/status')
+    def project_nvd_refresh_status(project_id):
+        """Poll progress of a running NVD project refresh."""
+        project_uuid, err = parse_uuid_or_400(project_id, "project id")
+        if err is not None:
+            return err
+        project = ProjectController.get(project_uuid)
+        if project is None:
+            return jsonify({"error": "Project not found"}), 404
+        pid_str = str(project_uuid)
+        info = _nvd_refresh_project_in_progress.get(pid_str)
+        if info is None:
+            return jsonify({"status": "idle"})
+        return jsonify(info)

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -22,7 +22,7 @@ from ..models import (
 from ..helpers.datetime_utils import ensure_utc_iso
 from ..extensions import db
 from ..controllers.nvd_db import NVD_DB
-from ..controllers.nvd_refresh import apply_nvd_update
+from ..controllers.nvd_refresh import apply_nvd_update, update_nvd_cvss_metrics
 from ..helpers.verbose import verbose
 from ..helpers.active_scans import (
     active_scan_ids_for_variant,
@@ -670,6 +670,7 @@ def init_app(app):
         details = NVD_DB.extract_cve_details(cve)
         now = datetime.datetime.now(datetime.timezone.utc)
         apply_nvd_update(rec, details, now)
+        update_nvd_cvss_metrics(rec, details)
         db.session.commit()
 
         return jsonify({"vulnerabilities": [rec.to_dict()]}), 200

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
-from flask import request
+from flask import jsonify, request
+import datetime
+import os
 from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload, aliased
 from ..models import (
@@ -19,6 +21,8 @@ from ..models import (
 )
 from ..helpers.datetime_utils import ensure_utc_iso
 from ..extensions import db
+from ..controllers.nvd_db import NVD_DB
+from ..controllers.nvd_refresh import apply_nvd_update
 from ..helpers.verbose import verbose
 from ..helpers.active_scans import (
     active_scan_ids_for_variant,
@@ -645,3 +649,30 @@ def init_app(app):
             response["errors"] = errors
             response["error_count"] = len(errors)
         return response, 200 if results else 400
+
+    @app.route('/api/vulnerabilities/<cve_id>/nvd-refresh', methods=['POST'])
+    def refresh_single_cve(cve_id):
+        cve_id_upper = cve_id.upper()
+        rec = db.session.get(Vulnerability, cve_id_upper)
+        if rec is None:
+            return jsonify({"error": "CVE not found"}), 404
+
+        try:
+            nvd = NVD_DB(nvd_api_key=os.getenv("NVD_API_KEY"))
+            status_code, data = nvd.api_get_cve(cve_id_upper)
+        except Exception as e:
+            return jsonify({"error": f"NVD API unavailable: {e}"}), 503
+
+        if status_code != 200 or not data.get("vulnerabilities"):
+            return jsonify({"error": "NVD API returned no data for this CVE"}), 503
+
+        cve = data["vulnerabilities"][0]["cve"]
+        details = NVD_DB.extract_cve_details(cve)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        changed = apply_nvd_update(rec, details, now)
+        if not changed:
+            # Stamp fetch time even when content is unchanged
+            rec.update_record(nvd_fetched_at=now, commit=False)
+        db.session.commit()
+
+        return jsonify(rec.to_dict()), 200

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -669,10 +669,7 @@ def init_app(app):
         cve = data["vulnerabilities"][0]["cve"]
         details = NVD_DB.extract_cve_details(cve)
         now = datetime.datetime.now(datetime.timezone.utc)
-        changed = apply_nvd_update(rec, details, now)
-        if not changed:
-            # Stamp fetch time even when content is unchanged
-            rec.update_record(nvd_fetched_at=now, commit=False)
+        apply_nvd_update(rec, details, now)
         db.session.commit()
 
-        return jsonify(rec.to_dict()), 200
+        return jsonify({"vulnerabilities": [rec.to_dict()]}), 200

--- a/tests/unit_tests/test_nvd_refresh.py
+++ b/tests/unit_tests/test_nvd_refresh.py
@@ -3,12 +3,12 @@
 
 import datetime
 import uuid
-from unittest.mock import MagicMock, patch, call
-import pytest
+from unittest.mock import MagicMock
 
 from src.controllers.nvd_refresh import (
     build_cpe_map,
     apply_nvd_update,
+    collect_target_cve_ids,
 )
 
 
@@ -146,3 +146,45 @@ def test_apply_nvd_update_handles_none_details_fields_gracefully():
     changed = apply_nvd_update(vuln, details, now)
     assert changed is False
     vuln.update_record.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# build_cpe_map — line 32: continue when vuln_id not in target set
+# ---------------------------------------------------------------------------
+
+def test_build_cpe_map_skips_finding_not_in_target():
+    """Findings whose CVE is not in target_cve_ids are excluded (line 32 continue)."""
+    pkg = MagicMock(id=uuid.uuid4(), cpe=["cpe:2.3:a:vendor:lib:1.0:*:*:*:*:*:*:*"])
+    finding_in = MagicMock(vulnerability_id="CVE-2024-0001", package_id=pkg.id)
+    finding_out = MagicMock(vulnerability_id="CVE-2024-9999", package_id=pkg.id)
+    result = build_cpe_map(
+        {"CVE-2024-0001"},   # only this CVE is targeted
+        [finding_in, finding_out],
+        {pkg.id: pkg},
+    )
+    assert "cpe:2.3:a:vendor:lib:1.0:*:*:*:*:*:*:*" in result
+    assert "CVE-2024-0001" in result["cpe:2.3:a:vendor:lib:1.0:*:*:*:*:*:*:*"]
+    # CVE-2024-9999 was skipped — not in target_cve_ids
+    assert "CVE-2024-9999" not in result["cpe:2.3:a:vendor:lib:1.0:*:*:*:*:*:*:*"]
+
+
+# ---------------------------------------------------------------------------
+# collect_target_cve_ids — explicit list path (no DB needed, lines 89-90)
+# ---------------------------------------------------------------------------
+
+def test_collect_target_cve_ids_explicit_list_uppercases_and_filters():
+    """Explicit list: empty strings are removed, IDs are uppercased."""
+    result = collect_target_cve_ids(None, None, ["cve-2024-0001", "", "cve-2024-0002"])
+    assert result == ["CVE-2024-0001", "CVE-2024-0002"]
+
+
+def test_collect_target_cve_ids_explicit_empty_list():
+    """Explicit empty list returns []."""
+    result = collect_target_cve_ids(None, None, [])
+    assert result == []
+
+
+def test_collect_target_cve_ids_explicit_list_already_uppercase():
+    """Already-uppercased IDs pass through unchanged."""
+    result = collect_target_cve_ids(None, None, ["CVE-2024-1234"])
+    assert result == ["CVE-2024-1234"]

--- a/tests/unit_tests/test_nvd_refresh.py
+++ b/tests/unit_tests/test_nvd_refresh.py
@@ -108,7 +108,10 @@ def test_apply_nvd_update_does_not_set_nvd_data_updated_at_when_nothing_changes(
     }
     changed = apply_nvd_update(vuln, details, now)
     assert changed is False
-    vuln.update_record.assert_not_called()
+    # nvd_fetched_at must always be stamped, nvd_data_updated_at must NOT be set
+    vuln.update_record.assert_called_once_with(nvd_fetched_at=now, commit=False)
+    call_kwargs = vuln.update_record.call_args[1]
+    assert "nvd_data_updated_at" not in call_kwargs
 
 
 def test_apply_nvd_update_always_sets_nvd_fetched_at_on_change():
@@ -131,7 +134,7 @@ def test_apply_nvd_update_always_sets_nvd_fetched_at_on_change():
 
 
 def test_apply_nvd_update_handles_none_details_fields_gracefully():
-    """None values in details do not overwrite existing data."""
+    """None values in details do not overwrite existing data; nvd_fetched_at is still stamped."""
     vuln = _make_vuln(description="keep me")
     now = datetime.datetime.now(datetime.timezone.utc)
     details = {
@@ -145,7 +148,7 @@ def test_apply_nvd_update_handles_none_details_fields_gracefully():
     }
     changed = apply_nvd_update(vuln, details, now)
     assert changed is False
-    vuln.update_record.assert_not_called()
+    vuln.update_record.assert_called_once_with(nvd_fetched_at=now, commit=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_nvd_refresh.py
+++ b/tests/unit_tests/test_nvd_refresh.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import datetime
+import uuid
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+from src.controllers.nvd_refresh import (
+    build_cpe_map,
+    apply_nvd_update,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_cpe_map
+# ---------------------------------------------------------------------------
+
+def test_build_cpe_map_groups_cves_by_cpe():
+    """Multiple CVEs sharing a CPE are all mapped to that CPE."""
+    packages = [
+        MagicMock(id=uuid.uuid4(), cpe=["cpe:2.3:a:vendor:lib:1.0:*:*:*:*:*:*:*"]),
+        MagicMock(id=uuid.uuid4(), cpe=["cpe:2.3:a:vendor:lib:1.0:*:*:*:*:*:*:*"]),
+    ]
+    findings = [
+        MagicMock(vulnerability_id="CVE-2024-0001", package_id=packages[0].id),
+        MagicMock(vulnerability_id="CVE-2024-0002", package_id=packages[1].id),
+    ]
+    result = build_cpe_map(
+        {"CVE-2024-0001", "CVE-2024-0002"},
+        findings,
+        {p.id: p for p in packages},
+    )
+    assert "cpe:2.3:a:vendor:lib:1.0:*:*:*:*:*:*:*" in result
+    assert result["cpe:2.3:a:vendor:lib:1.0:*:*:*:*:*:*:*"] == {"CVE-2024-0001", "CVE-2024-0002"}
+
+
+def test_build_cpe_map_skips_wildcard_vendor():
+    """CPEs with wildcard in the vendor (parts[3]) position are excluded from batch map."""
+    pkg = MagicMock(id=uuid.uuid4(), cpe=["cpe:2.3:a:*:lib:1.0:*:*:*:*:*:*:*"])
+    finding = MagicMock(vulnerability_id="CVE-2024-9999", package_id=pkg.id)
+    result = build_cpe_map(
+        {"CVE-2024-9999"},
+        [finding],
+        {pkg.id: pkg},
+    )
+    assert result == {}
+
+
+def test_build_cpe_map_skips_packages_without_cpe():
+    pkg = MagicMock(id=uuid.uuid4(), cpe=None)
+    finding = MagicMock(vulnerability_id="CVE-2024-1111", package_id=pkg.id)
+    result = build_cpe_map({"CVE-2024-1111"}, [finding], {pkg.id: pkg})
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# apply_nvd_update
+# ---------------------------------------------------------------------------
+
+def _make_vuln(description="old desc", status="medium", links=None,
+               weaknesses=None, publish_date=None, attack_vector="NETWORK",
+               nvd_last_modified="2024-01-01T00:00:00.000"):
+    v = MagicMock()
+    v.description = description
+    v.status = status
+    v.links = links or ["https://nvd.nist.gov/vuln/detail/CVE-2024-0001"]
+    v.weaknesses = weaknesses or ["CWE-79"]
+    v.publish_date = publish_date or datetime.date(2024, 1, 1)
+    v.attack_vector = attack_vector
+    v.nvd_last_modified = nvd_last_modified
+    v.update_record = MagicMock(return_value=v)
+    return v
+
+
+def test_apply_nvd_update_sets_nvd_data_updated_at_when_field_changes():
+    vuln = _make_vuln(description="old")
+    now = datetime.datetime.now(datetime.timezone.utc)
+    details = {
+        "description": "new description",
+        "status": "medium",
+        "links": vuln.links,
+        "weaknesses": vuln.weaknesses,
+        "publish_date": vuln.publish_date,
+        "attack_vector": vuln.attack_vector,
+        "nvd_last_modified": vuln.nvd_last_modified,
+    }
+    changed = apply_nvd_update(vuln, details, now)
+    assert changed is True
+    vuln.update_record.assert_called_once()
+    call_kwargs = vuln.update_record.call_args[1]
+    assert call_kwargs["description"] == "new description"
+    assert call_kwargs["nvd_data_updated_at"] == now
+    assert call_kwargs["nvd_fetched_at"] == now
+
+
+def test_apply_nvd_update_does_not_set_nvd_data_updated_at_when_nothing_changes():
+    vuln = _make_vuln()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    details = {
+        "description": vuln.description,
+        "status": vuln.status,
+        "links": vuln.links,
+        "weaknesses": vuln.weaknesses,
+        "publish_date": vuln.publish_date,
+        "attack_vector": vuln.attack_vector,
+        "nvd_last_modified": vuln.nvd_last_modified,
+    }
+    changed = apply_nvd_update(vuln, details, now)
+    assert changed is False
+    vuln.update_record.assert_not_called()
+
+
+def test_apply_nvd_update_always_sets_nvd_fetched_at_on_change():
+    vuln = _make_vuln(status="low")
+    now = datetime.datetime.now(datetime.timezone.utc)
+    details = {
+        "description": vuln.description,
+        "status": "critical",   # changed
+        "links": vuln.links,
+        "weaknesses": vuln.weaknesses,
+        "publish_date": vuln.publish_date,
+        "attack_vector": vuln.attack_vector,
+        "nvd_last_modified": vuln.nvd_last_modified,
+    }
+    changed = apply_nvd_update(vuln, details, now)
+    assert changed is True
+    kwargs = vuln.update_record.call_args[1]
+    assert kwargs["nvd_fetched_at"] == now
+    assert kwargs["nvd_data_updated_at"] == now
+
+
+def test_apply_nvd_update_handles_none_details_fields_gracefully():
+    """None values in details do not overwrite existing data."""
+    vuln = _make_vuln(description="keep me")
+    now = datetime.datetime.now(datetime.timezone.utc)
+    details = {
+        "description": None,
+        "status": None,
+        "links": None,
+        "weaknesses": None,
+        "publish_date": None,
+        "attack_vector": None,
+        "nvd_last_modified": None,
+    }
+    changed = apply_nvd_update(vuln, details, now)
+    assert changed is False
+    vuln.update_record.assert_not_called()

--- a/tests/unit_tests/test_nvd_refresh.py
+++ b/tests/unit_tests/test_nvd_refresh.py
@@ -9,6 +9,7 @@ from src.controllers.nvd_refresh import (
     build_cpe_map,
     apply_nvd_update,
     collect_target_cve_ids,
+    run_nvd_refresh,
 )
 
 
@@ -191,3 +192,76 @@ def test_collect_target_cve_ids_explicit_list_already_uppercase():
     """Already-uppercased IDs pass through unchanged."""
     result = collect_target_cve_ids(None, None, ["CVE-2024-1234"])
     assert result == ["CVE-2024-1234"]
+
+
+# ---------------------------------------------------------------------------
+# run_nvd_refresh — cancellation
+# ---------------------------------------------------------------------------
+
+def test_run_nvd_refresh_cancels_during_cpe_loop():
+    """If cancelled=True is set before the CPE loop, the function exits early
+    without committing and sets status='cancelled'."""
+    from unittest.mock import patch, MagicMock
+
+    progress = {
+        "status": "running",
+        "progress": "starting",
+        "logs": [],
+        "total": 0,
+        "done_count": 0,
+        "changed_cves": [],
+        "cancelled": True,   # pre-set so the loop breaks on first iteration
+    }
+
+    mock_db = MagicMock()
+    mock_db.select.return_value = MagicMock()
+    mock_db.session.execute.return_value.scalars.return_value.all.return_value = []
+
+    with patch("src.controllers.nvd_db.NVD_DB") as mock_nvd_cls, \
+         patch("src.controllers.nvd_refresh.collect_target_cve_ids", return_value=["CVE-2024-0001"]), \
+         patch("src.controllers.nvd_refresh.build_cpe_map", return_value={"cpe:2.3:a:vendor:lib:1.0": set()}):
+        # Patch the lazy-imported modules by replacing them in the module's import namespace
+        import src.controllers.nvd_refresh as _mod
+        original_db = None
+        import importlib
+        with patch.dict("sys.modules", {}):
+            # Patch via the extensions and models modules that get imported inside the function
+            with patch("src.extensions.db", mock_db), \
+                 patch("src.models.vulnerability.Vulnerability", MagicMock()), \
+                 patch("src.models.finding.Finding", MagicMock()), \
+                 patch("src.models.package.Package", MagicMock()):
+                result = run_nvd_refresh(
+                    variant_uuid="variant-123",
+                    project_uuid=None,
+                    requested_cve_ids=["CVE-2024-0001"],
+                    progress=progress,
+                )
+
+    assert progress["status"] == "cancelled"
+    assert progress["progress"] == "Cancelled"
+    mock_db.session.commit.assert_not_called()
+    mock_db.session.rollback.assert_called_once()
+    assert result == {"refreshed": 0, "changed": 0, "failed": 0}
+
+
+def test_run_nvd_refresh_cancel_does_not_affect_completed_run():
+    """If cancelled=False, the run completes normally and sets status='done'."""
+    from unittest.mock import patch, MagicMock
+
+    progress = {
+        "status": "running",
+        "progress": "starting",
+        "logs": [],
+        "cancelled": False,
+    }
+
+    with patch("src.controllers.nvd_refresh.collect_target_cve_ids", return_value=[]):
+        result = run_nvd_refresh(
+            variant_uuid="variant-123",
+            project_uuid=None,
+            requested_cve_ids=[],
+            progress=progress,
+        )
+
+    assert progress["status"] == "done"
+    assert result == {"refreshed": 0, "changed": 0, "failed": 0}

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -1,0 +1,141 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import time
+import uuid
+from unittest.mock import patch
+import pytest
+
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — follow the same pattern as test_scan_triggers.py
+# ---------------------------------------------------------------------------
+
+def _build_nvd_refresh_db(app):
+    """Populate DB with a variant, a package, and a CVE for refresh tests."""
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("RefreshProject")
+        variant = Variant.create("RefreshVariant", project.id)
+        Scan.create("initial scan", variant.id, scan_type="sbom")
+
+        pkg = Package.find_or_create(
+            "openssl", "1.1.1",
+            cpe=["cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"],
+        )
+        _db.session.commit()
+
+        vuln = Vulnerability.create_record(
+            id="CVE-2024-0001",
+            description="Test CVE for refresh",
+            status="medium",
+        )
+        _db.session.commit()
+
+        Finding.get_or_create(pkg.id, vuln.id)
+        _db.session.commit()
+
+        return {
+            "variant_id": str(variant.id),
+            "cve_id": vuln.id,
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    import os
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        ids = _build_nvd_refresh_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def variant_id(app):
+    return app._test_ids["variant_id"]
+
+
+@pytest.fixture()
+def existing_cve_id(app):
+    return app._test_ids["cve_id"]
+
+
+class TestBulkRefreshEndpoints:
+
+    def test_bulk_refresh_returns_202(self, client, variant_id):
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            resp = client.post(f"/api/variants/{variant_id}/nvd-refresh")
+        assert resp.status_code == 202
+        assert resp.get_json()["status"] == "started"
+
+    def test_bulk_refresh_with_cve_ids_body(self, client, variant_id):
+        with patch("src.routes.scan_triggers.run_nvd_refresh") as mock_refresh:
+            resp = client.post(
+                f"/api/variants/{variant_id}/nvd-refresh",
+                json={"cve_ids": ["CVE-2024-0001", "CVE-2024-0002"]},
+            )
+            assert resp.status_code == 202
+            time.sleep(0.1)  # allow background thread to start
+        # Verify the CVE IDs were forwarded to run_nvd_refresh
+        assert mock_refresh.called
+        kwargs = mock_refresh.call_args[1]
+        assert kwargs.get("requested_cve_ids") == ["CVE-2024-0001", "CVE-2024-0002"]
+
+    def test_bulk_refresh_409_when_already_running(self, client, variant_id):
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            client.post(f"/api/variants/{variant_id}/nvd-refresh")
+            resp = client.post(f"/api/variants/{variant_id}/nvd-refresh")
+        assert resp.status_code == 409
+
+    def test_bulk_refresh_404_unknown_variant(self, client):
+        resp = client.post(f"/api/variants/{uuid.uuid4()}/nvd-refresh")
+        assert resp.status_code == 404
+
+    def test_bulk_refresh_400_invalid_variant_id(self, client):
+        resp = client.post("/api/variants/not-a-uuid/nvd-refresh")
+        assert resp.status_code == 400
+        assert b"Invalid variant id" in resp.data
+
+    def test_status_returns_idle_before_first_refresh(self, client, variant_id):
+        resp = client.get(f"/api/variants/{variant_id}/nvd-refresh/status")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "idle"
+
+    def test_status_returns_progress_while_running(self, client, variant_id):
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            client.post(f"/api/variants/{variant_id}/nvd-refresh")
+        resp = client.get(f"/api/variants/{variant_id}/nvd-refresh/status")
+        data = resp.get_json()
+        assert data["status"] in ("running", "done")
+
+
+class TestBulkRefreshStatus:
+
+    def test_status_400_invalid_variant_id(self, client):
+        resp = client.get("/api/variants/not-a-uuid/nvd-refresh/status")
+        assert resp.status_code == 400
+        assert b"Invalid variant id" in resp.data

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -139,3 +139,50 @@ class TestBulkRefreshStatus:
         resp = client.get("/api/variants/not-a-uuid/nvd-refresh/status")
         assert resp.status_code == 400
         assert b"Invalid variant id" in resp.data
+
+
+class TestSingleCveRefreshEndpoint:
+
+    def test_single_refresh_returns_200_with_vuln_payload(self, client, existing_cve_id):
+        """POST /api/vulnerabilities/<id>/nvd-refresh returns 200 + updated vuln dict."""
+        mock_details = {
+            "description": "updated description",
+            "status": "high",
+            "attack_vector": "NETWORK",
+            "links": ["https://nvd.nist.gov/vuln/detail/CVE-2024-0001"],
+            "weaknesses": ["CWE-79"],
+            "publish_date": None,
+            "nvd_last_modified": "2025-01-01T00:00:00.000",
+            "base_score": 8.1,
+            "cvss_version": "3.1",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+            "cvss_exploitability": 3.9,
+            "cvss_impact": 5.2,
+        }
+        with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.api_get_cve.return_value = (200, {
+                "vulnerabilities": [{"cve": {"id": existing_cve_id}}]
+            })
+            MockNVD.extract_cve_details.return_value = mock_details
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["id"] == existing_cve_id
+        assert "nvd_fetched_at" in data  # timestamp always stamped
+
+    def test_single_refresh_404_unknown_cve(self, client):
+        resp = client.post("/api/vulnerabilities/CVE-9999-FAKE/nvd-refresh")
+        assert resp.status_code == 404
+
+    def test_single_refresh_503_on_empty_nvd_response(self, client, existing_cve_id):
+        """503 when NVD returns 200 but no vulnerability data."""
+        with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.api_get_cve.return_value = (200, {"vulnerabilities": []})
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+        assert resp.status_code == 503
+
+    def test_single_refresh_503_on_nvd_failure(self, client, existing_cve_id):
+        with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.api_get_cve.side_effect = ConnectionError("NVD unavailable")
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+        assert resp.status_code == 503

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -186,3 +186,222 @@ class TestSingleCveRefreshEndpoint:
             MockNVD.return_value.api_get_cve.side_effect = ConnectionError("NVD unavailable")
             resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
         assert resp.status_code == 503
+
+
+class TestCollectTargetCveIds:
+
+    def test_returns_empty_when_no_scans_for_variant(self, app):
+        """A variant that doesn't exist in DB → active_scan_ids returns [] → returns []."""
+        import uuid as _uuid
+        from src.controllers.nvd_refresh import collect_target_cve_ids
+        fake_variant = _uuid.uuid4()
+        with app.app_context():
+            result = collect_target_cve_ids(fake_variant, None, None)
+        assert result == []
+
+    def test_returns_empty_when_no_under_investigation_assessments(self, app, variant_id):
+        """Existing variant with scan but no under_investigation assessments → []."""
+        import uuid as _uuid
+        from src.controllers.nvd_refresh import collect_target_cve_ids
+        with app.app_context():
+            result = collect_target_cve_ids(_uuid.UUID(variant_id), None, None)
+        assert isinstance(result, list)
+        assert result == []
+
+    def test_returns_empty_via_project_uuid_path(self, app):
+        """project_uuid branch: no matching scans → returns []."""
+        import uuid as _uuid
+        from src.controllers.nvd_refresh import collect_target_cve_ids
+        fake_project = _uuid.uuid4()
+        with app.app_context():
+            result = collect_target_cve_ids(None, fake_project, None)
+        assert result == []
+
+
+class TestRunNvdRefresh:
+
+    def test_run_nvd_refresh_empty_target(self, app, variant_id):
+        """run_nvd_refresh with empty requested_cve_ids returns zero counts."""
+        from src.controllers.nvd_refresh import run_nvd_refresh
+        progress = {"status": "running", "logs": [], "done_count": 0}
+        with app.app_context():
+            result = run_nvd_refresh(
+                variant_uuid=variant_id,
+                project_uuid=None,
+                requested_cve_ids=[],
+                progress=progress,
+            )
+        assert result == {"refreshed": 0, "changed": 0, "failed": 0}
+        assert progress["status"] == "done"
+
+    def test_run_nvd_refresh_with_cpe_batch_match(self, app, variant_id, existing_cve_id):
+        """run_nvd_refresh finds CVE via CPE batch and updates the record."""
+        from src.controllers.nvd_refresh import run_nvd_refresh
+        progress = {"status": "running", "logs": [], "done_count": 0}
+
+        mock_nvd_vuln = {
+            "cve": {
+                "id": existing_cve_id,
+                "descriptions": [{"lang": "en", "value": "Updated description"}],
+                "metrics": {},
+                "weaknesses": [],
+                "references": [],
+                "published": "2024-01-01T00:00:00.000",
+                "lastModified": "2025-01-01T00:00:00.000",
+            }
+        }
+
+        with app.app_context():
+            with patch("src.controllers.nvd_db.NVD_DB") as MockNVD:
+                mock_instance = MockNVD.return_value
+                mock_instance.api_get_cves_by_cpe.return_value = [mock_nvd_vuln]
+                MockNVD.extract_cve_details.return_value = {
+                    "description": "Updated description",
+                    "status": "high",
+                    "links": ["https://nvd.nist.gov"],
+                    "weaknesses": [],
+                    "publish_date": None,
+                    "attack_vector": "NETWORK",
+                    "nvd_last_modified": "2025-01-01T00:00:00.000",
+                }
+                result = run_nvd_refresh(
+                    variant_uuid=variant_id,
+                    project_uuid=None,
+                    requested_cve_ids=[existing_cve_id],
+                    progress=progress,
+                )
+
+        assert result["refreshed"] >= 1
+        assert progress["status"] == "done"
+
+    def test_run_nvd_refresh_straggler_path(self, app, variant_id, existing_cve_id):
+        """CVE not found via CPE goes through straggler individual fetch path."""
+        from src.controllers.nvd_refresh import run_nvd_refresh
+        progress = {"status": "running", "logs": [], "done_count": 0}
+
+        with app.app_context():
+            with patch("src.controllers.nvd_db.NVD_DB") as MockNVD:
+                mock_instance = MockNVD.return_value
+                mock_instance.api_get_cves_by_cpe.return_value = []
+                mock_instance.api_get_cve.return_value = (200, {
+                    "vulnerabilities": [{"cve": {
+                        "id": existing_cve_id,
+                        "descriptions": [{"lang": "en", "value": "Via straggler"}],
+                        "metrics": {},
+                        "weaknesses": [],
+                        "references": [],
+                        "published": "2024-01-01T00:00:00.000",
+                        "lastModified": "2025-01-01T00:00:00.000",
+                    }}]
+                })
+                MockNVD.extract_cve_details.return_value = {
+                    "description": "Via straggler",
+                    "status": "medium",
+                    "links": [],
+                    "weaknesses": [],
+                    "publish_date": None,
+                    "attack_vector": "NETWORK",
+                    "nvd_last_modified": "2025-01-01T00:00:00.000",
+                }
+                result = run_nvd_refresh(
+                    variant_uuid=variant_id,
+                    project_uuid=None,
+                    requested_cve_ids=[existing_cve_id],
+                    progress=progress,
+                )
+
+        assert progress["status"] == "done"
+        assert isinstance(result["refreshed"], int)
+
+    def test_run_nvd_refresh_straggler_nvd_failure(self, app, variant_id, existing_cve_id):
+        """Straggler fetch returning non-200 goes to failed set."""
+        from src.controllers.nvd_refresh import run_nvd_refresh
+        progress = {"status": "running", "logs": [], "done_count": 0}
+
+        with app.app_context():
+            with patch("src.controllers.nvd_db.NVD_DB") as MockNVD:
+                mock_instance = MockNVD.return_value
+                mock_instance.api_get_cves_by_cpe.return_value = []
+                mock_instance.api_get_cve.return_value = (503, {})
+                result = run_nvd_refresh(
+                    variant_uuid=variant_id,
+                    project_uuid=None,
+                    requested_cve_ids=[existing_cve_id],
+                    progress=progress,
+                )
+
+        assert progress["status"] == "done"
+        assert result["failed"] >= 1
+
+    def test_run_nvd_refresh_cpe_exception_handling(self, app, variant_id, existing_cve_id):
+        """CPE batch exception is caught and logged; straggler handles the CVE."""
+        from src.controllers.nvd_refresh import run_nvd_refresh
+        progress = {"status": "running", "logs": [], "done_count": 0}
+
+        with app.app_context():
+            with patch("src.controllers.nvd_db.NVD_DB") as MockNVD:
+                mock_instance = MockNVD.return_value
+                mock_instance.api_get_cves_by_cpe.side_effect = ConnectionError("NVD unreachable")
+                mock_instance.api_get_cve.return_value = (503, {})
+                result = run_nvd_refresh(
+                    variant_uuid=variant_id,
+                    project_uuid=None,
+                    requested_cve_ids=[existing_cve_id],
+                    progress=progress,
+                )
+
+        assert progress["status"] == "done"
+        assert result["failed"] >= 0
+
+    def test_run_nvd_refresh_straggler_exception_handling(self, app, variant_id, existing_cve_id):
+        """Straggler fetch exception is caught and CVE is counted as failed."""
+        from src.controllers.nvd_refresh import run_nvd_refresh
+        progress = {"status": "running", "logs": [], "done_count": 0}
+
+        with app.app_context():
+            with patch("src.controllers.nvd_db.NVD_DB") as MockNVD:
+                mock_instance = MockNVD.return_value
+                mock_instance.api_get_cves_by_cpe.return_value = []
+                mock_instance.api_get_cve.side_effect = ConnectionError("timeout")
+                result = run_nvd_refresh(
+                    variant_uuid=variant_id,
+                    project_uuid=None,
+                    requested_cve_ids=[existing_cve_id],
+                    progress=progress,
+                )
+
+        assert progress["status"] == "done"
+        assert result["failed"] >= 1
+
+    def test_run_nvd_refresh_cpe_match_no_db_record(self, app, variant_id):
+        """CVE resolved via CPE but not found in local DB is skipped gracefully."""
+        from src.controllers.nvd_refresh import run_nvd_refresh
+        progress = {"status": "running", "logs": [], "done_count": 0}
+        missing_cve = "CVE-9999-0001"
+
+        mock_nvd_vuln = {"cve": {"id": missing_cve}}
+
+        with app.app_context():
+            with patch("src.controllers.nvd_db.NVD_DB") as MockNVD:
+                mock_instance = MockNVD.return_value
+                mock_instance.api_get_cves_by_cpe.return_value = [mock_nvd_vuln]
+                MockNVD.extract_cve_details.return_value = {
+                    "description": "no record",
+                    "status": "low",
+                    "links": [],
+                    "weaknesses": [],
+                    "publish_date": None,
+                    "attack_vector": None,
+                    "nvd_last_modified": None,
+                }
+                # Use a CVE that doesn't exist in the DB (no Finding → empty cpe_map)
+                # but pass it as explicit ID so target_ids is non-empty
+                result = run_nvd_refresh(
+                    variant_uuid=variant_id,
+                    project_uuid=None,
+                    requested_cve_ids=[missing_cve],
+                    progress=progress,
+                )
+
+        assert progress["status"] == "done"
+        assert isinstance(result, dict)

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -167,8 +167,9 @@ class TestSingleCveRefreshEndpoint:
             resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert data["id"] == existing_cve_id
-        assert "nvd_fetched_at" in data  # timestamp always stamped
+        assert "vulnerabilities" in data
+        assert data["vulnerabilities"][0]["id"] == existing_cve_id
+        assert "nvd_fetched_at" in data["vulnerabilities"][0]  # timestamp always stamped
 
     def test_single_refresh_404_unknown_cve(self, client):
         resp = client.post("/api/vulnerabilities/CVE-9999-FAKE/nvd-refresh")

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -120,6 +120,16 @@ class TestBulkRefreshEndpoints:
         assert resp.status_code == 400
         assert b"Invalid variant id" in resp.data
 
+    def test_bulk_refresh_400_when_cve_ids_is_string(self, client, variant_id):
+        """Sending cve_ids as a bare string (not a list) returns 400 before starting."""
+        resp = client.post(
+            f"/api/variants/{variant_id}/nvd-refresh",
+            json={"cve_ids": "CVE-2024-0001"},
+        )
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "cve_ids" in data.get("error", "").lower()
+
     def test_status_returns_idle_before_first_refresh(self, client, variant_id):
         resp = client.get(f"/api/variants/{variant_id}/nvd-refresh/status")
         assert resp.status_code == 200
@@ -449,6 +459,58 @@ class TestRunNvdRefresh:
 
         assert progress["status"] == "done"
         assert isinstance(result, dict)
+
+    def test_run_nvd_refresh_cpe_inner_exception_isolates_cve(self, app, variant_id, existing_cve_id):
+        """A DB exception inside the CPE batch inner loop marks that CVE failed without
+        aborting the overall refresh — the progress status must still reach 'done'."""
+        from src.controllers.nvd_refresh import run_nvd_refresh
+        progress = {"status": "running", "logs": [], "done_count": 0}
+
+        mock_nvd_vuln = {
+            "cve": {
+                "id": existing_cve_id,
+                "descriptions": [{"lang": "en", "value": "Updated"}],
+                "metrics": {},
+                "weaknesses": [],
+                "references": [],
+                "published": "2024-01-01T00:00:00.000",
+                "lastModified": "2025-01-01T00:00:00.000",
+            }
+        }
+
+        with app.app_context():
+            with patch("src.controllers.nvd_db.NVD_DB") as MockNVD:
+                mock_instance = MockNVD.return_value
+                mock_instance.api_get_cves_by_cpe.return_value = [mock_nvd_vuln]
+                MockNVD.extract_cve_details.return_value = {
+                    "description": "Updated",
+                    "status": "high",
+                    "links": [],
+                    "weaknesses": [],
+                    "publish_date": None,
+                    "attack_vector": "NETWORK",
+                    "nvd_last_modified": "2025-01-01T00:00:00.000",
+                    "base_score": 9.0,
+                    "cvss_version": "3.1",
+                    "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                }
+                with patch(
+                    "src.controllers.nvd_refresh.update_nvd_cvss_metrics",
+                    side_effect=RuntimeError("simulated DB error"),
+                ):
+                    result = run_nvd_refresh(
+                        variant_uuid=variant_id,
+                        project_uuid=None,
+                        requested_cve_ids=[existing_cve_id],
+                        progress=progress,
+                    )
+
+        # Refresh must complete normally; the erroring CVE must be in failed
+        assert progress["status"] == "done"
+        assert result["failed"] >= 1
+        assert result["refreshed"] == 0
+        # Error must be logged
+        assert any("ERROR" in log for log in progress["logs"])
 
 
 class TestUpdateNvdCvssMetrics:

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -724,3 +724,79 @@ class TestProjectBulkRefreshEndpoints:
         import uuid
         resp = client.get(f"/api/projects/{uuid.uuid4()}/nvd-refresh/status")
         assert resp.status_code == 404
+
+
+class TestCancelVariantNvdRefresh:
+
+    def test_cancel_returns_200_when_running(self, client, variant_id):
+        """DELETE /nvd-refresh returns 200 and cancelling when a refresh is in progress."""
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            client.post(f"/api/variants/{variant_id}/nvd-refresh")
+        resp = client.delete(f"/api/variants/{variant_id}/nvd-refresh")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "cancelling"
+
+    def test_cancel_returns_not_running_when_idle(self, client, variant_id):
+        """DELETE /nvd-refresh returns not_running when no refresh is active."""
+        resp = client.delete(f"/api/variants/{variant_id}/nvd-refresh")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "not_running"
+
+    def test_cancel_sets_cancelled_flag(self, client, variant_id):
+        """DELETE sets cancelled=True in the progress dict so the worker stops."""
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            client.post(f"/api/variants/{variant_id}/nvd-refresh")
+        client.delete(f"/api/variants/{variant_id}/nvd-refresh")
+        # After cancel, the status endpoint should report status still as running
+        # (the flag is set but the worker thread has not necessarily stopped yet)
+        status_resp = client.get(f"/api/variants/{variant_id}/nvd-refresh/status")
+        data = status_resp.get_json()
+        assert data.get("cancelled") is True
+
+    def test_cancel_400_invalid_variant_id(self, client):
+        resp = client.delete("/api/variants/not-a-uuid/nvd-refresh")
+        assert resp.status_code == 400
+
+    def test_cancel_allows_new_refresh_after_worker_stops(self, client, variant_id):
+        """Once the worker finishes (status != 'running'), a new POST is accepted."""
+        # Run a refresh that completes quickly
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            client.post(f"/api/variants/{variant_id}/nvd-refresh")
+        # Cancel it
+        client.delete(f"/api/variants/{variant_id}/nvd-refresh")
+        # Simulate worker having finished by patching the progress dict state
+        with patch("src.routes.scan_triggers.run_nvd_refresh") as mock_run:
+            # We need the dict to show non-running status; easiest via a second run
+            # after the first completes naturally (patched mock returns immediately)
+            time.sleep(0.1)  # wait for thread to finish
+            resp = client.post(f"/api/variants/{variant_id}/nvd-refresh")
+        # 202 if the previous run already finished, 409 if still running — either is valid
+        assert resp.status_code in (202, 409)
+
+
+class TestCancelProjectNvdRefresh:
+
+    def test_cancel_project_returns_200_when_running(self, client, project_id):
+        """DELETE /projects/<id>/nvd-refresh returns 200 and cancelling when active."""
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            client.post(f"/api/projects/{project_id}/nvd-refresh")
+        resp = client.delete(f"/api/projects/{project_id}/nvd-refresh")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "cancelling"
+
+    def test_cancel_project_returns_not_running_when_idle(self, client, project_id):
+        resp = client.delete(f"/api/projects/{project_id}/nvd-refresh")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "not_running"
+
+    def test_cancel_project_sets_cancelled_flag(self, client, project_id):
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            client.post(f"/api/projects/{project_id}/nvd-refresh")
+        client.delete(f"/api/projects/{project_id}/nvd-refresh")
+        status_resp = client.get(f"/api/projects/{project_id}/nvd-refresh/status")
+        data = status_resp.get_json()
+        assert data.get("cancelled") is True
+
+    def test_cancel_project_400_invalid_project_id(self, client):
+        resp = client.delete("/api/projects/not-a-uuid/nvd-refresh")
+        assert resp.status_code == 400

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -29,7 +29,7 @@ def _build_nvd_refresh_db(app):
 
         project = Project.create("RefreshProject")
         variant = Variant.create("RefreshVariant", project.id)
-        Scan.create("initial scan", variant.id, scan_type="sbom")
+        scan = Scan.create("initial scan", variant.id, scan_type="sbom")
 
         pkg = Package.find_or_create(
             "openssl", "1.1.1",
@@ -49,6 +49,8 @@ def _build_nvd_refresh_db(app):
 
         return {
             "variant_id": str(variant.id),
+            "project_id": str(project.id),
+            "scan_id": str(scan.id),
             "cve_id": vuln.id,
         }
 
@@ -77,6 +79,16 @@ def client(app):
 @pytest.fixture()
 def variant_id(app):
     return app._test_ids["variant_id"]
+
+
+@pytest.fixture()
+def project_id(app):
+    return app._test_ids["project_id"]
+
+
+@pytest.fixture()
+def scan_id(app):
+    return app._test_ids["scan_id"]
 
 
 @pytest.fixture()
@@ -606,3 +618,38 @@ class TestUpdateNvdCvssMetrics:
             changed = update_nvd_cvss_metrics(vuln, {"cvss_version": "3.1"})
             assert changed is False
 
+
+
+class TestCollectTargetCveIdsProjectScope:
+    """Direct DB test for collect_target_cve_ids in project mode."""
+
+    def test_returns_under_investigation_cves_across_all_variants(self, app, variant_id, scan_id):
+        """CVEs under_investigation in any variant are returned when project_uuid is given."""
+        import uuid
+        from src.controllers.nvd_refresh import collect_target_cve_ids
+        from src.models.assessment import Assessment
+        from src.models.observation import Observation
+        from src.models.finding import Finding
+        from src.extensions import db
+
+        with app.app_context():
+            project_id = app._test_ids["project_id"]
+            finding = db.session.execute(db.select(Finding)).scalars().first()
+            v_uuid = uuid.UUID(variant_id)
+            s_uuid = uuid.UUID(scan_id)
+
+            # Wire finding → scan via Observation (required by the join in collect_target_cve_ids)
+            Observation.create(finding_id=finding.id, scan_id=s_uuid, commit=True)
+
+            # Create an assessment under_investigation for the variant
+            Assessment.create(
+                status="under_investigation",
+                simplified_status="Pending Assessment",
+                finding_id=finding.id,
+                variant_id=v_uuid,
+                origin="test",
+                commit=True,
+            )
+
+            result = collect_target_cve_ids(None, uuid.UUID(project_id), None)
+            assert "CVE-2024-0001" in result

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -374,6 +374,49 @@ class TestRunNvdRefresh:
         assert progress["status"] == "done"
         assert result["failed"] >= 1
 
+    def test_run_nvd_refresh_changed_cves_tracked(self, app, variant_id, existing_cve_id):
+        """changed_cves list in progress is populated when a CVE is updated."""
+        from src.controllers.nvd_refresh import run_nvd_refresh
+        progress = {"status": "running", "logs": [], "done_count": 0}
+
+        with app.app_context():
+            with patch("src.controllers.nvd_db.NVD_DB") as MockNVD:
+                mock_instance = MockNVD.return_value
+                mock_instance.api_get_cves_by_cpe.return_value = []
+                mock_instance.api_get_cve.return_value = (200, {
+                    "vulnerabilities": [{"cve": {
+                        "id": existing_cve_id,
+                        "descriptions": [{"lang": "en", "value": "New description from NVD"}],
+                        "metrics": {},
+                        "weaknesses": [],
+                        "references": [],
+                        "published": "2024-01-01T00:00:00.000",
+                        "lastModified": "2025-06-01T00:00:00.000",
+                    }}]
+                })
+                MockNVD.extract_cve_details.return_value = {
+                    "description": "New description from NVD",
+                    "status": "high",
+                    "links": ["https://nvd.nist.gov"],
+                    "weaknesses": ["CWE-200"],
+                    "publish_date": None,
+                    "attack_vector": "NETWORK",
+                    "nvd_last_modified": "2025-06-01T00:00:00.000",
+                    "base_score": 8.5,
+                    "cvss_version": "3.1",
+                    "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+                }
+                result = run_nvd_refresh(
+                    variant_uuid=variant_id,
+                    project_uuid=None,
+                    requested_cve_ids=[existing_cve_id],
+                    progress=progress,
+                )
+
+        assert result["changed"] >= 1
+        assert "changed_cves" in progress
+        assert existing_cve_id in progress["changed_cves"]
+
     def test_run_nvd_refresh_cpe_match_no_db_record(self, app, variant_id):
         """CVE resolved via CPE but not found in local DB is skipped gracefully."""
         from src.controllers.nvd_refresh import run_nvd_refresh
@@ -406,3 +449,98 @@ class TestRunNvdRefresh:
 
         assert progress["status"] == "done"
         assert isinstance(result, dict)
+
+
+class TestUpdateNvdCvssMetrics:
+
+    def test_creates_new_metrics_row_when_absent(self, app, existing_cve_id):
+        """Creates a Metrics row with author='NVD' when none exists."""
+        from src.controllers.nvd_refresh import update_nvd_cvss_metrics
+        from src.models.metrics import Metrics
+        from src.models.vulnerability import Vulnerability
+
+        with app.app_context():
+            vuln = Vulnerability.get_by_id(existing_cve_id)
+            details = {
+                "base_score": 7.5,
+                "cvss_version": "3.1",
+                "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            }
+            changed = update_nvd_cvss_metrics(vuln, details)
+            _db.session.commit()
+
+            assert changed is True
+            rows = Metrics.get_by_vulnerability(existing_cve_id)
+            nvd_rows = [r for r in rows if r.author == "NVD"]
+            assert len(nvd_rows) == 1
+            assert float(nvd_rows[0].score) == 7.5
+            assert nvd_rows[0].version == "3.1"
+
+    def test_updates_existing_row_when_score_differs(self, app, existing_cve_id):
+        """Updates score and vector on an existing NVD Metrics row."""
+        from src.controllers.nvd_refresh import update_nvd_cvss_metrics
+        from src.models.metrics import Metrics
+        from src.models.vulnerability import Vulnerability
+
+        with app.app_context():
+            # Seed an existing NVD row with a stale score
+            old = Metrics(
+                vulnerability_id=existing_cve_id,
+                version="3.1",
+                score=5.0,
+                vector="CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                author="NVD",
+            )
+            _db.session.add(old)
+            _db.session.commit()
+
+            vuln = Vulnerability.get_by_id(existing_cve_id)
+            details = {
+                "base_score": 9.8,
+                "cvss_version": "3.1",
+                "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            }
+            changed = update_nvd_cvss_metrics(vuln, details)
+            _db.session.commit()
+
+            assert changed is True
+            updated = _db.session.get(Metrics, old.id)
+            assert float(updated.score) == 9.8
+            assert updated.vector == "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+
+    def test_returns_false_when_score_unchanged(self, app, existing_cve_id):
+        """No change when existing NVD row already has the same score and vector."""
+        from src.controllers.nvd_refresh import update_nvd_cvss_metrics
+        from src.models.metrics import Metrics
+        from src.models.vulnerability import Vulnerability
+
+        with app.app_context():
+            existing = Metrics(
+                vulnerability_id=existing_cve_id,
+                version="3.1",
+                score=7.5,
+                vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                author="NVD",
+            )
+            _db.session.add(existing)
+            _db.session.commit()
+
+            vuln = Vulnerability.get_by_id(existing_cve_id)
+            details = {
+                "base_score": 7.5,
+                "cvss_version": "3.1",
+                "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            }
+            changed = update_nvd_cvss_metrics(vuln, details)
+            assert changed is False
+
+    def test_returns_false_when_no_base_score_in_details(self, app, existing_cve_id):
+        """Returns False and does nothing when details has no base_score."""
+        from src.controllers.nvd_refresh import update_nvd_cvss_metrics
+        from src.models.vulnerability import Vulnerability
+
+        with app.app_context():
+            vuln = Vulnerability.get_by_id(existing_cve_id)
+            changed = update_nvd_cvss_metrics(vuln, {"cvss_version": "3.1"})
+            assert changed is False
+

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -653,3 +653,74 @@ class TestCollectTargetCveIdsProjectScope:
 
             result = collect_target_cve_ids(None, uuid.UUID(project_id), None)
             assert "CVE-2024-0001" in result
+
+
+class TestProjectBulkRefreshEndpoints:
+
+    def test_project_bulk_refresh_returns_202(self, client, project_id):
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            resp = client.post(f"/api/projects/{project_id}/nvd-refresh")
+        assert resp.status_code == 202
+        data = resp.get_json()
+        assert data["status"] == "started"
+        assert data["project_id"] == project_id
+
+    def test_project_bulk_refresh_with_cve_ids_body(self, client, project_id):
+        with patch("src.routes.scan_triggers.run_nvd_refresh") as mock_refresh:
+            resp = client.post(
+                f"/api/projects/{project_id}/nvd-refresh",
+                json={"cve_ids": ["CVE-2024-0001", "CVE-2024-0002"]},
+            )
+            assert resp.status_code == 202
+            time.sleep(0.1)
+        assert mock_refresh.called
+        kwargs = mock_refresh.call_args[1]
+        assert kwargs.get("requested_cve_ids") == ["CVE-2024-0001", "CVE-2024-0002"]
+        assert kwargs.get("project_uuid") is not None
+        assert kwargs.get("variant_uuid") is None
+
+    def test_project_bulk_refresh_409_when_already_running(self, client, project_id):
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            client.post(f"/api/projects/{project_id}/nvd-refresh")
+            resp = client.post(f"/api/projects/{project_id}/nvd-refresh")
+        assert resp.status_code == 409
+
+    def test_project_bulk_refresh_404_unknown_project(self, client):
+        import uuid
+        resp = client.post(f"/api/projects/{uuid.uuid4()}/nvd-refresh")
+        assert resp.status_code == 404
+
+    def test_project_bulk_refresh_400_invalid_project_id(self, client):
+        resp = client.post("/api/projects/not-a-uuid/nvd-refresh")
+        assert resp.status_code == 400
+        assert b"Invalid project id" in resp.data
+
+    def test_project_bulk_refresh_400_when_cve_ids_is_string(self, client, project_id):
+        resp = client.post(
+            f"/api/projects/{project_id}/nvd-refresh",
+            json={"cve_ids": "CVE-2024-0001"},
+        )
+        assert resp.status_code == 400
+        assert "cve_ids" in resp.get_json().get("error", "").lower()
+
+    def test_project_status_returns_idle_before_first_refresh(self, client, project_id):
+        resp = client.get(f"/api/projects/{project_id}/nvd-refresh/status")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "idle"
+
+    def test_project_status_returns_progress_while_running(self, client, project_id):
+        with patch("src.routes.scan_triggers.run_nvd_refresh"):
+            client.post(f"/api/projects/{project_id}/nvd-refresh")
+        resp = client.get(f"/api/projects/{project_id}/nvd-refresh/status")
+        data = resp.get_json()
+        assert data["status"] in ("running", "done")
+
+    def test_project_status_400_invalid_project_id(self, client):
+        resp = client.get("/api/projects/not-a-uuid/nvd-refresh/status")
+        assert resp.status_code == 400
+        assert b"Invalid project id" in resp.data
+
+    def test_project_status_404_unknown_project(self, client):
+        import uuid
+        resp = client.get(f"/api/projects/{uuid.uuid4()}/nvd-refresh/status")
+        assert resp.status_code == 404


### PR DESCRIPTION
### Changes proposed in this pull request:

This PR introduces batch and single CVE info refresh. The majority of the refresh is achieved by calling the CPE API, which returns multiple CVEs in one go, and updating the matching CVEs. The refresh of the remaining non-matching CVEs by the CPE API call will be updated by a single CVE API call for each.
### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change
The following files contain the stale (made-up) NVD info:
[test-nvd-refresh-stale.grype.json](https://github.com/user-attachments/files/27808607/test-nvd-refresh-stale.grype.json)
[test-nvd-refresh-stale.spdx.json](https://github.com/user-attachments/files/27808608/test-nvd-refresh-stale.spdx.json)

Run the following command with the files above: 
```bash
    ./vulnscout --dev \
   --add-spdx example/spdx2/test-nvd-refresh-stale.spdx.json \
   --add-grype example/spdx2/test-nvd-refresh-stale.grype.json \
   --serve
```

<img width="772" height="623" alt="image" src="https://github.com/user-attachments/assets/a43f6513-9095-48b5-90f6-8cdea2457b3b" />

The batch refresh button is available next to the filter for any variant and all variants as well:
<img width="333" height="326" alt="image" src="https://github.com/user-attachments/assets/3135981b-00ef-421d-a615-4c3c12dc6d77" />
<img width="339" height="175" alt="image" src="https://github.com/user-attachments/assets/2807a295-a04c-439e-b529-e19b7b2766f1" />

Run the following command in a different terminal to add a second variant if needed: 
```bash
 ./vulnscout --variant arm64 \
    --add-spdx example/spdx2/test-nvd-refresh-stale.spdx.json \
    --add-grype example/spdx2/test-nvd-refresh-stale.grype.json
```


Two options are available for the batch refresh:
<img width="393" height="230" alt="image" src="https://github.com/user-attachments/assets/f55657bb-85a8-40cf-91ce-e1d7cafedaf0" />

A toast shows up when the refresh runs:
<img width="1275" height="172" alt="image" src="https://github.com/user-attachments/assets/b484f251-0b2b-4c72-9575-ccef29f8a08f" />

When any CVE is updated by the refresh, a different toast at the bottom right corner shows up:
<img width="440" height="595" alt="image" src="https://github.com/user-attachments/assets/41739aa8-7ddf-4f8a-a4ef-bb9a9fe454b9" />



### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [x] Added necessary reviewers


