### PR TITLE
Add ability to import / export custom user data

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -486,6 +486,67 @@ Upload an OpenVEX `.json` or `.tar.gz` file. For `.tar.gz` archives, filenames i
 }
 ```
 
+### Custom Data Import / Export
+
+#### Export Custom Data
+
+```
+GET /api/assessments/review/export-custom-data
+```
+
+Exports all handmade (review) assessments, custom CVSS scores, and time estimates as a single JSON file.
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `variant_id` | UUID | Restrict to a single variant |
+| `project_id` | UUID | Restrict to all variants of a project |
+
+**Response:** JSON file download (`Content-Disposition: attachment; filename=custom_data.json`) containing:
+
+```json
+{
+  "version": "1.0",
+  "assessments": [...],
+  "cvss": [...],
+  "time_estimates": [...]
+}
+```
+
+Returns `404` if there is no custom data to export.
+
+#### Import Custom Data
+
+```
+POST /api/assessments/review/import-custom-data
+```
+
+Imports assessments, custom CVSS scores, and time estimates from a custom-data JSON file.
+
+Accepts either:
+
+- `multipart/form-data` with a `file` field containing a `.json` file.
+- `application/json` body with the custom-data payload directly.
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `variant_id` | UUID | *(optional)* Force all imported records to a specific variant |
+
+**Response:**
+```json
+{
+  "status": "success",
+  "assessments_imported": 12,
+  "cvss_imported": 5,
+  "time_estimates_imported": 3
+}
+```
+
+Returns `400` for invalid format or unsupported content type.
+
 ---
 
 ## Documents
@@ -654,6 +715,48 @@ GET /api/scans/<scan_id>/global-result
 Returns every active finding, vulnerability, and package at the time of the given scan, combining SBOM and tool-scan data with source attribution. Tool-scan findings are filtered to packages present in the SBOM.
 
 **Response:** JSON object with `findings`, `vulnerabilities`, and `packages` arrays, each entry enriched with an `origin` field indicating the source (SBOM document name/format or tool scan source).
+
+### Export Scan Diff
+
+```
+GET /api/scans/<scan_id>/export-diff
+```
+
+Exports a single scan's diff as a cleaned JSON download. The response strips internal fields and normalises supplier names for a portable, human-readable report.
+
+For **SBOM scans** the export includes `vulnerabilities`, `findings`, `packages`, `assessments`, and (when the scan is not the first) a `diff` object with `*_added`, `*_removed`, `*_upgraded`, and `*_unchanged` arrays.
+
+For **tool scans** the export includes `vulnerabilities`, `findings`, `newly_detected_vulns`, `newly_detected_findings`, and `newly_detected_assessments`.
+
+**Response:** JSON file download (`Content-Disposition: attachment`).
+
+### Export Scan Global Result
+
+```
+GET /api/scans/<scan_id>/export-result
+```
+
+Exports a single scan's global result (SBOM + tool data merged) as a cleaned JSON download. The response includes `packages`, `findings`, and `vulnerabilities` arrays with source attribution.
+
+**Response:** JSON file download (`Content-Disposition: attachment`).
+
+### Export All Scans
+
+```
+GET /api/scans/export
+```
+
+Exports all visible scans, optionally filtered by variant or project.
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `variant_id` | UUID | Restrict to a single variant |
+| `project_id` | UUID | Restrict to all variants of a project |
+| `type` | string | `"diff"` (default) or `"total"` — selects the diff or global-result export format |
+
+**Response:** JSON array of export objects grouped per variant, served as a file download (`Content-Disposition: attachment`). Returns `404` if no scans match the filter.
 
 ---
 

--- a/doc/source/interactive-mode.md
+++ b/doc/source/interactive-mode.md
@@ -227,6 +227,19 @@ Each tab header carries its own badge counts, and every table inside supports a 
 
 Clicking the **Scan Result** button on a scan entry opens a modal showing the complete state of the global result at that point in time — the union of SBOM packages and all tool-scan findings. The modal displays packages, findings, and vulnerabilities tabs, each with their total counts. This is useful for understanding the full picture at a given snapshot rather than just the delta.
 
+### Scan Export
+
+VulnScout lets you export scan data as JSON files for archiving, reporting, or sharing with external tools.
+
+**Per-scan export:** each scan entry has a download button that opens a small menu with two choices:
+
+- **Export Diff** — downloads a JSON file containing only what changed compared to the previous scan (added, removed, upgraded, and unchanged packages, findings, and vulnerabilities). For tool scans the export also includes newly-detected findings and assessments.
+- **Export Scan Result** — downloads a JSON file with the complete global result at that point in time, including full package, finding, and vulnerability lists with source attribution.
+
+Both files include scan metadata (timestamp, scan type, project, and variant) and strip internal identifiers so the output is portable.
+
+**Export All:** an **Export** button in the toolbar lets you download the entire visible scan history at once. A dropdown offers two modes — **Export All Diffs** and **Export All Scan Results** — which produce a single JSON array grouping all scans by variant. The export respects the current project/variant scope.
+
 ---
 
 ## Review
@@ -257,5 +270,5 @@ The toolbar mirrors the vulnerability table's search bar. Filters are available 
 
 Two buttons in the toolbar handle review portability:
 
-- **Import Review**: accepts an OpenVEX file (JSON or `.tar.gz`) and merges its assessments into the current project. This is useful for receiving triage decisions from another team or from a previous VulnScout instance.
-- **Export Review**: downloads all review assessments as an OpenVEX `.tar.gz` archive. The export captures the full set of handmade assessments so they can be shared, archived, or loaded into another VulnScout deployment.
+- **Import Review**: accepts either an OpenVEX file (JSON or `.tar.gz`) or a VulnScout custom-data JSON file and merges its contents into the current project. OpenVEX files import assessments only; custom-data files additionally restore custom CVSS scores and time estimates. This is useful for receiving triage decisions from another team or migrating data between VulnScout instances.
+- **Export Review**: downloads all handmade assessments, custom CVSS scores, and time estimates as a single JSON file. The export captures the full set of user-created data so it can be shared, archived, or loaded into another VulnScout deployment.

--- a/frontend/src/handlers/assessments.ts
+++ b/frontend/src/handlers/assessments.ts
@@ -31,6 +31,28 @@ type Assessment = {
 
 export type { Assessment };
 
+type ReviewTimeEstimate = {
+    vuln_id: string;
+    optimistic: number;
+    likely: number;
+    pessimistic: number;
+    optimistic_iso: string;
+    likely_iso: string;
+    pessimistic_iso: string;
+    vuln_texts?: Record<string, string>;
+};
+
+type ReviewCustomCvss = {
+    vuln_id: string;
+    version: string;
+    vector_string: string;
+    base_score: number;
+    author: string;
+    vuln_texts?: Record<string, string>;
+};
+
+export type { ReviewTimeEstimate, ReviewCustomCvss };
+
 const asStringArray = (data: any): string[] => {
     if (!Array.isArray(data)) return [];
     return data.filter((item: any) => typeof item === "string");
@@ -125,6 +147,32 @@ class Assessments {
         const response = await fetch(url.toString(), { mode: "cors" });
         const data = await response.json();
         return data.flatMap(asAssessment);
+    }
+
+    /**
+     * Fetch vulnerabilities with non-zero time estimates for the review tab.
+     */
+    static async listReviewTimeEstimates(variantId?: string, projectId?: string): Promise<ReviewTimeEstimate[]> {
+        const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments/review/time-estimates", window.location.href);
+        if (variantId) url.searchParams.set('variant_id', variantId);
+        else if (projectId) url.searchParams.set('project_id', projectId);
+        const response = await fetch(url.toString(), { mode: "cors" });
+        const data = await response.json();
+        if (!Array.isArray(data)) return [];
+        return data;
+    }
+
+    /**
+     * Fetch vulnerabilities with custom CVSS scores for the review tab.
+     */
+    static async listReviewCustomCvss(variantId?: string, projectId?: string): Promise<ReviewCustomCvss[]> {
+        const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments/review/custom-cvss", window.location.href);
+        if (variantId) url.searchParams.set('variant_id', variantId);
+        else if (projectId) url.searchParams.set('project_id', projectId);
+        const response = await fetch(url.toString(), { mode: "cors" });
+        const data = await response.json();
+        if (!Array.isArray(data)) return [];
+        return data;
     }
 }
 

--- a/frontend/src/helpers/exportJson.ts
+++ b/frontend/src/helpers/exportJson.ts
@@ -1,0 +1,36 @@
+/**
+ * Sanitize a string for use in a filename: replace whitespace with underscores,
+ * strip characters that are problematic in filenames.
+ */
+export function sanitizeFilename(name: string): string {
+    return name
+        .replace(/\s+/g, '_')
+        .replace(/[<>:"/\\|?*]+/g, '')
+        .replace(/_+/g, '_')
+        .replace(/^_|_$/g, '');
+}
+
+/**
+ * Format a Date (or current time) as YYYYMMDD_HHmmss for use in filenames.
+ */
+export function formatTimestampForFilename(date?: Date | string): string {
+    const d = date ? new Date(date) : new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
+}
+
+/**
+ * Trigger a JSON file download in the browser.
+ */
+export function downloadJson(data: unknown, filename: string): void {
+    const json = JSON.stringify(data, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -11,7 +11,6 @@ import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleQuestion, faCircleInfo, faFileExport, faFileImport, faPenToSquare, faTrash, faBook } from '@fortawesome/free-solid-svg-icons';
-import Vulnerabilities from '../handlers/vulnerabilities';
 import { downloadJson, sanitizeFilename, formatTimestampForFilename } from '../helpers/exportJson';
 import EditAssessment from '../components/EditAssessment';
 import type { EditAssessmentData } from '../components/EditAssessment';
@@ -279,53 +278,21 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
 
     const handleExportReview = useCallback(async () => {
         try {
-            const vulns = await Vulnerabilities.list(variantId, projectId);
-
-            const exportedAssessments = assessments.map(a => ({
-                vuln_id: a.vuln_id,
-                status: a.status,
-                simplified_status: a.simplified_status,
-                justification: a.justification ?? null,
-                impact_statement: a.impact_statement ?? null,
-                status_notes: a.status_notes ?? null,
-                workaround: a.workaround ?? null,
-                packages: a.packages,
-                variant_id: a.variant_id ?? null,
-            }));
-
-            const cvssEntries: { vuln_id: string; version: string; vector_string: string; base_score: number; author: string }[] = [];
-            const timeEstimates: { vuln_id: string; optimistic: string; likely: string; pessimistic: string }[] = [];
-
-            for (const v of vulns) {
-                for (const c of v.severity.cvss) {
-                    if (c.author && c.author !== 'nvd' && c.author !== 'unknown') {
-                        cvssEntries.push({
-                            vuln_id: v.id,
-                            version: c.version,
-                            vector_string: c.vector_string,
-                            base_score: c.base_score,
-                            author: c.author,
-                        });
-                    }
-                }
-                if (v.effort.optimistic.total_seconds > 0 || v.effort.likely.total_seconds > 0 || v.effort.pessimistic.total_seconds > 0) {
-                    timeEstimates.push({
-                        vuln_id: v.id,
-                        optimistic: v.effort.optimistic.formatAsIso8601(),
-                        likely: v.effort.likely.formatAsIso8601(),
-                        pessimistic: v.effort.pessimistic.formatAsIso8601(),
-                    });
-                }
+            const params = new URLSearchParams();
+            if (variantId) params.set('variant_id', variantId);
+            else if (projectId) params.set('project_id', projectId);
+            const url = new URL(
+                import.meta.env.VITE_API_URL + "/api/assessments/review/export-custom-data" +
+                (params.toString() ? `?${params.toString()}` : ''),
+                window.location.href,
+            );
+            const res = await fetch(url.toString(), { mode: 'cors' });
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                showMessage(err.error || 'Failed to export custom data.', 'error');
+                return;
             }
-
-            const data = {
-                version: 1,
-                exported_at: new Date().toISOString(),
-                assessments: exportedAssessments,
-                cvss: cvssEntries,
-                time_estimates: timeEstimates,
-            };
-
+            const data = await res.json();
             const ts = formatTimestampForFilename();
             const filename = `custom_data_${sanitizeFilename(variantId ?? projectId ?? 'all')}_${ts}.json`;
             downloadJson(data, filename);
@@ -333,7 +300,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             console.error('Export error:', err);
             showMessage('Failed to export custom data.', 'error');
         }
-    }, [assessments, variantId, projectId, showMessage]);
+    }, [variantId, projectId, showMessage]);
 
     const handleImportReview = useCallback(() => {
         fileInputRef.current?.click();
@@ -371,7 +338,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             return;
         }
 
-        // New JSON format or legacy single OpenVEX JSON
+        // JSON files: detect format and route to appropriate backend endpoint
         const reader = new FileReader();
         reader.onload = async () => {
             try {
@@ -397,7 +364,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     return;
                 }
 
-                // New custom data format
+                // New custom data format — send to backend import-custom-data endpoint
                 if (!parsed?.version || !parsed?.assessments) {
                     showMessage('Invalid file format. Expected a VulnScout custom data export.', 'error');
                     if (fileInputRef.current) fileInputRef.current.value = '';
@@ -405,93 +372,36 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                 }
 
                 setImportStatus("Importing...");
-                const summary: string[] = [];
+                const params = new URLSearchParams();
+                if (variantId) params.set('variant_id', variantId);
+                const url = new URL(
+                    import.meta.env.VITE_API_URL + "/api/assessments/review/import-custom-data" +
+                    (params.toString() ? `?${params.toString()}` : ''),
+                    window.location.href,
+                );
+                const res = await fetch(url.toString(), {
+                    method: 'POST',
+                    mode: 'cors',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: text,
+                });
+                const result = await res.json();
 
-                // Import assessments via existing backend endpoint
-                if (Array.isArray(parsed.assessments) && parsed.assessments.length > 0) {
-                    // Build an OpenVEX-like document to feed the existing import endpoint
-                    const statements = parsed.assessments.map((a: any) => ({
-                        status: a.status,
-                        justification: a.justification ?? '',
-                        impact_statement: a.impact_statement ?? '',
-                        status_notes: a.status_notes ?? '',
-                        action_statement: a.workaround ?? '',
-                        vulnerability: { name: a.vuln_id },
-                        products: (a.packages ?? []).map((p: string) => ({ '@id': p })),
-                    }));
-                    const openvexDoc = {
-                        '@context': 'https://openvex.dev/ns/v0.2.0',
-                        '@id': 'urn:vulnscout:import:' + Date.now(),
-                        author: 'vulnscout-import',
-                        timestamp: new Date().toISOString(),
-                        version: 1,
-                        statements,
-                    };
-                    const blob = new Blob([JSON.stringify(openvexDoc)], { type: 'application/json' });
-                    const importFile = new File([blob], 'import.json', { type: 'application/json' });
-                    const formData = new FormData();
-                    formData.append('file', importFile);
-                    const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments/review/import", window.location.href);
-                    const res = await fetch(url.toString(), { method: 'POST', body: formData, mode: 'cors' });
-                    const result = await res.json();
-                    const count = result.created?.length ?? 0;
-                    const skipped = result.skipped ?? 0;
-                    summary.push(`${count} assessment(s) imported${skipped ? `, ${skipped} skipped` : ''}`);
-                }
-
-                // Import CVSS and time estimates via batch PATCH
-                const batchItems: any[] = [];
-                if (Array.isArray(parsed.cvss)) {
-                    for (const c of parsed.cvss) {
-                        if (!c.vuln_id || !c.vector_string || !c.version) continue;
-                        let existing = batchItems.find((b: any) => b.id === c.vuln_id);
-                        if (!existing) {
-                            existing = { id: c.vuln_id };
-                            batchItems.push(existing);
-                        }
-                        existing.cvss = {
-                            base_score: c.base_score,
-                            vector_string: c.vector_string,
-                            version: c.version,
-                        };
+                if (result.status === 'success') {
+                    const summary: string[] = [];
+                    if (result.assessments_imported > 0) {
+                        let msg = `${result.assessments_imported} assessment(s) imported`;
+                        if (result.assessments_skipped) msg += `, ${result.assessments_skipped} skipped`;
+                        summary.push(msg);
                     }
+                    if (result.cvss_imported > 0) summary.push(`${result.cvss_imported} CVSS score(s)`);
+                    if (result.time_estimates_imported > 0) summary.push(`${result.time_estimates_imported} time estimate(s)`);
+                    if (result.errors?.length) summary.push(`${result.errors.length} error(s)`);
+                    Assessments.listReview(variantId, projectId).then(d => setAssessments(groupAssessments(d)));
+                    showMessage(summary.length > 0 ? `Imported: ${summary.join(', ')}` : 'Import complete (no data changed)', 'success');
+                } else {
+                    showMessage(`Import error: ${result.errors?.[0]?.error || 'Unknown error'}`, 'error');
                 }
-                if (Array.isArray(parsed.time_estimates)) {
-                    for (const t of parsed.time_estimates) {
-                        if (!t.vuln_id) continue;
-                        let existing = batchItems.find((b: any) => b.id === t.vuln_id);
-                        if (!existing) {
-                            existing = { id: t.vuln_id };
-                            batchItems.push(existing);
-                        }
-                        existing.effort = {
-                            optimistic: t.optimistic,
-                            likely: t.likely,
-                            pessimistic: t.pessimistic,
-                        };
-                        if (t.variant_id) existing.variant_id = t.variant_id;
-                    }
-                }
-
-                if (batchItems.length > 0) {
-                    const batchUrl = new URL(import.meta.env.VITE_API_URL + "/api/vulnerabilities/batch", window.location.href);
-                    const batchRes = await fetch(batchUrl.toString(), {
-                        method: 'PATCH',
-                        mode: 'cors',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ vulnerabilities: batchItems }),
-                    });
-                    const batchResult = await batchRes.json();
-                    const cvssCount = parsed.cvss?.length ?? 0;
-                    const effortCount = parsed.time_estimates?.length ?? 0;
-                    if (cvssCount > 0) summary.push(`${cvssCount} CVSS score(s)`);
-                    if (effortCount > 0) summary.push(`${effortCount} time estimate(s)`);
-                    if (batchResult.error_count) summary.push(`${batchResult.error_count} error(s)`);
-                }
-
-                // Reload assessments
-                Assessments.listReview(variantId, projectId).then(d => setAssessments(groupAssessments(d)));
-                showMessage(summary.length > 0 ? `Imported: ${summary.join(', ')}` : 'Import complete (no data changed)', 'success');
                 setImportStatus(null);
             } catch (err) {
                 console.error(err);

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo, useRef, useCallback } from "react";
 import { createColumnHelper } from "@tanstack/react-table";
 import TableGeneric from "../components/TableGeneric";
 import Assessments from "../handlers/assessments";
-import type { Assessment } from "../handlers/assessments";
+import type { Assessment, ReviewTimeEstimate, ReviewCustomCvss } from "../handlers/assessments";
 import { asAssessment } from "../handlers/assessments";
 import type { Vulnerability } from "../handlers/vulnerabilities";
 import { asVulnerability } from "../handlers/vulnerabilities";
@@ -18,12 +18,15 @@ import type { Variant } from '../handlers/variant';
 import ConfirmationModal from '../components/ConfirmationModal';
 import MessageBanner from '../components/MessageBanner';
 import Variants from '../handlers/variant';
+import Projects from '../handlers/project';
 import { useDocUrl } from '../helpers/useDocUrl';
 import { splitPkgId, extractSupplierName } from '../helpers/pkgId';
 
 type AssessmentMutation =
     | { type: 'delete'; vulnId: string; ids: string[] }
     | { type: 'update'; vulnId: string; ids: string[]; data: EditAssessmentData };
+
+type ReviewTab = 'assessments' | 'time-estimates' | 'custom-cvss';
 
 type Props = {
     variantId?: string;
@@ -45,6 +48,8 @@ type ReviewRow = Assessment & {
 };
 
 const columnHelper = createColumnHelper<ReviewRow>();
+const teColumnHelper = createColumnHelper<ReviewTimeEstimate>();
+const cvssColumnHelper = createColumnHelper<ReviewCustomCvss>();
 
 /**
  * Group assessments that share the same CVE, status, justification, notes,
@@ -104,7 +109,10 @@ function formatDate(iso: string): string {
 
 function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) {
     const docUrl = useDocUrl("interactive-mode.html#review");
+    const [activeTab, setActiveTab] = useState<ReviewTab>('assessments');
     const [assessments, setAssessments] = useState<Assessment[]>([]);
+    const [timeEstimates, setTimeEstimates] = useState<ReviewTimeEstimate[]>([]);
+    const [customCvss, setCustomCvss] = useState<ReviewCustomCvss[]>([]);
     const [vulnDescriptions, setVulnDescriptions] = useState<Record<string, { title: string; content: string }[]>>({});
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -116,6 +124,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     const [showSearchHelper, setShowSearchHelper] = useState(false);
     const [importStatus, setImportStatus] = useState<string | null>(null);
     const [variantNames, setVariantNames] = useState<Record<string, string>>({});
+    const [projectNames, setProjectNames] = useState<Record<string, string>>({});
     const [allVariants, setAllVariants] = useState<Variant[]>([]);
     const [editingRow, setEditingRow] = useState<ReviewRow | null>(null);
     const [editSubmitting, setEditSubmitting] = useState(false);
@@ -157,21 +166,48 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             setVariantNames(map);
             setAllVariants(vs);
         }).catch(() => {});
+        Projects.list().then(ps => {
+            const map: Record<string, string> = {};
+            for (const p of ps) map[p.id] = p.name;
+            setProjectNames(map);
+        }).catch(() => {});
     }, []);
 
     useEffect(() => {
         setLoading(true);
         setError(null);
-        Assessments.listReview(variantId, projectId)
-            .then(data => {
-                setAssessments(groupAssessments(data));
+        Promise.all([
+            Assessments.listReview(variantId, projectId),
+            Assessments.listReviewTimeEstimates(variantId, projectId),
+            Assessments.listReviewCustomCvss(variantId, projectId),
+        ])
+            .then(([reviewData, teData, cvssData]) => {
+                setAssessments(groupAssessments(reviewData));
+                setTimeEstimates(teData);
+                setCustomCvss(cvssData);
                 setLoading(false);
                 // Build tooltip descriptions from vuln_texts included in the response
                 const descMap: Record<string, { title: string; content: string }[]> = {};
-                for (const a of data) {
+                for (const a of reviewData) {
                     if (a.vuln_id && !descMap[a.vuln_id] && a.vuln_texts) {
                         const entries = Object.entries(a.vuln_texts);
                         descMap[a.vuln_id] = entries.length > 0
+                            ? entries.map(([title, content]) => ({ title, content }))
+                            : [{ title: "description", content: "No description available" }];
+                    }
+                }
+                for (const te of teData) {
+                    if (te.vuln_id && !descMap[te.vuln_id] && te.vuln_texts) {
+                        const entries = Object.entries(te.vuln_texts);
+                        descMap[te.vuln_id] = entries.length > 0
+                            ? entries.map(([title, content]) => ({ title, content }))
+                            : [{ title: "description", content: "No description available" }];
+                    }
+                }
+                for (const c of cvssData) {
+                    if (c.vuln_id && !descMap[c.vuln_id] && c.vuln_texts) {
+                        const entries = Object.entries(c.vuln_texts);
+                        descMap[c.vuln_id] = entries.length > 0
                             ? entries.map(([title, content]) => ({ title, content }))
                             : [{ title: "description", content: "No description available" }];
                     }
@@ -180,7 +216,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             })
             .catch(err => {
                 console.error(err);
-                setError("Failed to load review assessments");
+                setError("Failed to load review data");
                 setLoading(false);
             });
     }, [variantId, projectId]);
@@ -294,13 +330,18 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             }
             const data = await res.json();
             const ts = formatTimestampForFilename();
-            const filename = `custom_data_${sanitizeFilename(variantId ?? projectId ?? 'all')}_${ts}.json`;
+            const pName = projectId ? projectNames[projectId]
+                : variantId ? projectNames[allVariants.find(v => v.id === variantId)?.project_id ?? ''] ?? ''
+                : '';
+            const vName = variantId ? variantNames[variantId] ?? '' : '';
+            const label = [pName, vName].filter(Boolean).join('_') || 'all';
+            const filename = `custom_data_${sanitizeFilename(label)}_${ts}.json`;
             downloadJson(data, filename);
         } catch (err) {
             console.error('Export error:', err);
             showMessage('Failed to export custom data.', 'error');
         }
-    }, [variantId, projectId, showMessage]);
+    }, [variantId, projectId, showMessage, projectNames, variantNames, allVariants]);
 
     const handleImportReview = useCallback(() => {
         fileInputRef.current?.click();
@@ -673,6 +714,111 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         }),
     ], [handleVulnClick, variantNames]);
 
+    const teColumns = useMemo(() => [
+        teColumnHelper.accessor("vuln_id", {
+            id: 'te_vuln_id',
+            header: () => <div className="flex items-center justify-center">Vulnerability</div>,
+            size: 160,
+            cell: info => (
+                <div
+                    className="flex items-center justify-center w-full h-full text-center cursor-pointer hover:bg-slate-700 hover:text-blue-300 transition-colors p-4"
+                    onClick={() => handleVulnClick(info.getValue())}
+                    title="Click to view details"
+                >
+                    <span className="font-mono text-sm">{info.getValue()}</span>
+                </div>
+            ),
+        }),
+        teColumnHelper.accessor("optimistic", {
+            header: () => <div className="flex items-center justify-center">Optimistic (h)</div>,
+            size: 120,
+            cell: info => (
+                <div className="flex items-center justify-center h-full">
+                    <span className="text-sm font-mono">{info.getValue()}h</span>
+                </div>
+            ),
+        }),
+        teColumnHelper.accessor("likely", {
+            header: () => <div className="flex items-center justify-center">Likely (h)</div>,
+            size: 120,
+            cell: info => (
+                <div className="flex items-center justify-center h-full">
+                    <span className="text-sm font-mono">{info.getValue()}h</span>
+                </div>
+            ),
+        }),
+        teColumnHelper.accessor("pessimistic", {
+            header: () => <div className="flex items-center justify-center">Pessimistic (h)</div>,
+            size: 120,
+            cell: info => (
+                <div className="flex items-center justify-center h-full">
+                    <span className="text-sm font-mono">{info.getValue()}h</span>
+                </div>
+            ),
+        }),
+    ], [handleVulnClick]);
+
+    const cvssColumns = useMemo(() => [
+        cvssColumnHelper.accessor("vuln_id", {
+            id: 'cvss_vuln_id',
+            header: () => <div className="flex items-center justify-center">Vulnerability</div>,
+            size: 160,
+            cell: info => (
+                <div
+                    className="flex items-center justify-center w-full h-full text-center cursor-pointer hover:bg-slate-700 hover:text-blue-300 transition-colors p-4"
+                    onClick={() => handleVulnClick(info.getValue())}
+                    title="Click to view details"
+                >
+                    <span className="font-mono text-sm">{info.getValue()}</span>
+                </div>
+            ),
+        }),
+        cvssColumnHelper.accessor("version", {
+            header: () => <div className="flex items-center justify-center">CVSS Version</div>,
+            size: 110,
+            cell: info => (
+                <div className="flex items-center justify-center h-full">
+                    <span className="text-sm">{info.getValue()}</span>
+                </div>
+            ),
+        }),
+        cvssColumnHelper.accessor("vector_string", {
+            header: () => <div className="flex items-center justify-center">Vector</div>,
+            size: 350,
+            cell: info => (
+                <div className="flex items-center justify-center h-full">
+                    <span className="text-xs font-mono break-all">{info.getValue()}</span>
+                </div>
+            ),
+        }),
+        cvssColumnHelper.accessor("base_score", {
+            header: () => <div className="flex items-center justify-center">Base Score</div>,
+            size: 100,
+            cell: info => {
+                const score = info.getValue();
+                let color = "text-gray-300";
+                if (score >= 9.0) color = "text-red-400";
+                else if (score >= 7.0) color = "text-orange-400";
+                else if (score >= 4.0) color = "text-yellow-400";
+                else if (score > 0) color = "text-green-400";
+                return (
+                    <div className="flex items-center justify-center h-full">
+                        <span className={`text-sm font-bold ${color}`}>{score.toFixed(1)}</span>
+                    </div>
+                );
+            },
+        }),
+        cvssColumnHelper.accessor("author", {
+            header: () => <div className="flex items-center justify-center">Author</div>,
+            size: 120,
+            cell: info => (
+                <div className="flex items-center justify-center h-full">
+                    <span className="text-sm">{info.getValue()}</span>
+                </div>
+            ),
+        }),
+    ], [handleVulnClick]);
+
     if (loading) {
         return (
             <div className="relative h-64">
@@ -694,7 +840,9 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         );
     }
 
-    if (assessments.length === 0) {
+    const hasAnyData = assessments.length > 0 || timeEstimates.length > 0 || customCvss.length > 0;
+
+    if (!hasAnyData) {
         return (
             <div>
                 {showBanner && (
@@ -706,9 +854,9 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     />
                 )}
                 <div className="text-center py-10 text-gray-400">
-                    <p className="text-lg">No handmade assessments found</p>
+                    <p className="text-lg">No custom data found</p>
                     <p className="text-sm mt-2">
-                        Assessments created directly in VulnScout (not imported from SBOM documents) will appear here.
+                        Assessments, time estimates or custom CVSS scores created directly in VulnScout will appear here.
                     </p>
                 </div>
             </div>
@@ -764,27 +912,31 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     )}
                 </div>
 
-                <FilterOption
-                    label="Status"
-                    options={statusList}
-                    selected={selectedStatuses}
-                    setSelected={setSelectedStatuses}
-                />
+                {activeTab === 'assessments' && (
+                    <>
+                        <FilterOption
+                            label="Status"
+                            options={statusList}
+                            selected={selectedStatuses}
+                            setSelected={setSelectedStatuses}
+                        />
 
-                <FilterOption
-                    label="Justification"
-                    options={justificationList}
-                    selected={selectedJustifications}
-                    setSelected={setSelectedJustifications}
-                />
+                        <FilterOption
+                            label="Justification"
+                            options={justificationList}
+                            selected={selectedJustifications}
+                            setSelected={setSelectedJustifications}
+                        />
 
-                {hasSupplierInfo && (
-                    <FilterOption
-                        label="Supplier"
-                        options={supplierList}
-                        selected={selectedSuppliers}
-                        setSelected={setSelectedSuppliers}
-                    />
+                        {hasSupplierInfo && (
+                            <FilterOption
+                                label="Supplier"
+                                options={supplierList}
+                                selected={selectedSuppliers}
+                                setSelected={setSelectedSuppliers}
+                            />
+                        )}
+                    </>
                 )}
 
                 <div className="ml-auto flex items-center gap-2 relative">
@@ -881,29 +1033,118 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                 </div>
             )}
 
-            <div className="mb-3 flex items-center justify-between">
-                <h2 className="text-lg font-bold text-gray-200">
-                    Review Assessments
-                </h2>
+            <div className="mb-3 flex items-center gap-1 border-b border-gray-700">
+                <button
+                    className={`px-4 py-2 text-sm font-medium rounded-t transition-colors ${
+                        activeTab === 'assessments'
+                            ? 'bg-sky-800 text-white border-b-2 border-sky-400'
+                            : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800'
+                    }`}
+                    onClick={() => setActiveTab('assessments')}
+                >
+                    Assessments{assessments.length > 0 ? ` (${assessments.length})` : ''}
+                </button>
+                <button
+                    className={`px-4 py-2 text-sm font-medium rounded-t transition-colors ${
+                        activeTab === 'time-estimates'
+                            ? 'bg-sky-800 text-white border-b-2 border-sky-400'
+                            : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800'
+                    }`}
+                    onClick={() => setActiveTab('time-estimates')}
+                >
+                    Time Estimates{timeEstimates.length > 0 ? ` (${timeEstimates.length})` : ''}
+                </button>
+                <button
+                    className={`px-4 py-2 text-sm font-medium rounded-t transition-colors ${
+                        activeTab === 'custom-cvss'
+                            ? 'bg-sky-800 text-white border-b-2 border-sky-400'
+                            : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800'
+                    }`}
+                    onClick={() => setActiveTab('custom-cvss')}
+                >
+                    Custom CVSS{customCvss.length > 0 ? ` (${customCvss.length})` : ''}
+                </button>
             </div>
-            <TableGeneric<ReviewRow>
-                columns={columns}
-                data={filteredAssessments.map(a => ({
-                    ...a,
-                    texts: vulnDescriptions[a.vuln_id] ?? [],
-                    _allIds: (a as any)._allIds ?? [a.id],
-                    _variantIds: (a as any)._variantIds ?? (a.variant_id ? [a.variant_id] : []),
-                    extractedSuppliers: [...new Set(
-                        a.packages.map(p => extractSupplierName(splitPkgId(p).supplier)).filter(s => s !== '')
-                    )],
-                }))}
-                search={search}
-                fuseKeys={["vuln_id", "packages", "simplified_status", "status_notes", "justification", "workaround", "extractedSuppliers"]}
-                estimateRowHeight={50}
-                hasPagination={true}
-                hoverField="texts"
-                hoverIdField="vuln_id"
-            />
+
+            {activeTab === 'assessments' && (
+                assessments.length === 0 ? (
+                    <div className="text-center py-10 text-gray-400">
+                        <p className="text-lg">No handmade assessments found</p>
+                        <p className="text-sm mt-2">
+                            Assessments created directly in VulnScout (not imported from SBOM documents) will appear here.
+                        </p>
+                    </div>
+                ) : (
+                    <TableGeneric<ReviewRow>
+                        columns={columns}
+                        data={filteredAssessments.map(a => ({
+                            ...a,
+                            texts: vulnDescriptions[a.vuln_id] ?? [],
+                            _allIds: (a as any)._allIds ?? [a.id],
+                            _variantIds: (a as any)._variantIds ?? (a.variant_id ? [a.variant_id] : []),
+                            extractedSuppliers: [...new Set(
+                                a.packages.map(p => extractSupplierName(splitPkgId(p).supplier)).filter(s => s !== '')
+                            )],
+                        }))}
+                        search={search}
+                        fuseKeys={["vuln_id", "packages", "simplified_status", "status_notes", "justification", "workaround", "extractedSuppliers"]}
+                        estimateRowHeight={50}
+                        hasPagination={true}
+                        hoverField="texts"
+                        hoverIdField="vuln_id"
+                    />
+                )
+            )}
+
+            {activeTab === 'time-estimates' && (
+                timeEstimates.length === 0 ? (
+                    <div className="text-center py-10 text-gray-400">
+                        <p className="text-lg">No time estimates found</p>
+                        <p className="text-sm mt-2">
+                            Time estimates added to vulnerabilities will appear here.
+                        </p>
+                    </div>
+                ) : (
+                    <TableGeneric<ReviewTimeEstimate & { texts: { title: string; content: string }[] }>
+                        columns={teColumns as any}
+                        data={timeEstimates.map(te => ({
+                            ...te,
+                            texts: vulnDescriptions[te.vuln_id] ?? [],
+                        }))}
+                        search={search}
+                        fuseKeys={["vuln_id"]}
+                        estimateRowHeight={50}
+                        hasPagination={true}
+                        hoverField="texts"
+                        hoverIdField="vuln_id"
+                    />
+                )
+            )}
+
+            {activeTab === 'custom-cvss' && (
+                customCvss.length === 0 ? (
+                    <div className="text-center py-10 text-gray-400">
+                        <p className="text-lg">No custom CVSS scores found</p>
+                        <p className="text-sm mt-2">
+                            Custom CVSS scores added to vulnerabilities will appear here.
+                        </p>
+                    </div>
+                ) : (
+                    <TableGeneric<ReviewCustomCvss & { texts: { title: string; content: string }[] }>
+                        columns={cvssColumns as any}
+                        data={customCvss.map(c => ({
+                            ...c,
+                            texts: vulnDescriptions[c.vuln_id] ?? [],
+                        }))}
+                        search={search}
+                        fuseKeys={["vuln_id", "vector_string", "author"]}
+                        estimateRowHeight={50}
+                        hasPagination={true}
+                        hoverField="texts"
+                        hoverIdField="vuln_id"
+                    />
+                )
+            )}
 
             {modalVuln && (
                 <VulnModal

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -11,6 +11,8 @@ import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleQuestion, faCircleInfo, faFileExport, faFileImport, faPenToSquare, faTrash, faBook } from '@fortawesome/free-solid-svg-icons';
+import Vulnerabilities from '../handlers/vulnerabilities';
+import { downloadJson, sanitizeFilename, formatTimestampForFilename } from '../helpers/exportJson';
 import EditAssessment from '../components/EditAssessment';
 import type { EditAssessmentData } from '../components/EditAssessment';
 import type { Variant } from '../handlers/variant';
@@ -275,24 +277,63 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         setSelectedSuppliers([]);
     };
 
-    const handleExportReview = useCallback(() => {
-        const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments/review/export", window.location.href);
-        fetch(url.toString(), { mode: 'cors' })
-            .then(res => {
-                if (!res.ok) throw new Error(`Export failed (${res.status})`);
-                return res.blob();
-            })
-            .then(blob => {
-                const a = document.createElement('a');
-                a.href = URL.createObjectURL(blob);
-                a.download = 'review_openvex.tar.gz';
-                document.body.appendChild(a);
-                a.click();
-                a.remove();
-                URL.revokeObjectURL(a.href);
-            })
-            .catch(err => console.error('Export error:', err));
-    }, []);
+    const handleExportReview = useCallback(async () => {
+        try {
+            const vulns = await Vulnerabilities.list(variantId, projectId);
+
+            const exportedAssessments = assessments.map(a => ({
+                vuln_id: a.vuln_id,
+                status: a.status,
+                simplified_status: a.simplified_status,
+                justification: a.justification ?? null,
+                impact_statement: a.impact_statement ?? null,
+                status_notes: a.status_notes ?? null,
+                workaround: a.workaround ?? null,
+                packages: a.packages,
+                variant_id: a.variant_id ?? null,
+            }));
+
+            const cvssEntries: { vuln_id: string; version: string; vector_string: string; base_score: number; author: string }[] = [];
+            const timeEstimates: { vuln_id: string; optimistic: string; likely: string; pessimistic: string }[] = [];
+
+            for (const v of vulns) {
+                for (const c of v.severity.cvss) {
+                    if (c.author && c.author !== 'nvd' && c.author !== 'unknown') {
+                        cvssEntries.push({
+                            vuln_id: v.id,
+                            version: c.version,
+                            vector_string: c.vector_string,
+                            base_score: c.base_score,
+                            author: c.author,
+                        });
+                    }
+                }
+                if (v.effort.optimistic.total_seconds > 0 || v.effort.likely.total_seconds > 0 || v.effort.pessimistic.total_seconds > 0) {
+                    timeEstimates.push({
+                        vuln_id: v.id,
+                        optimistic: v.effort.optimistic.formatAsIso8601(),
+                        likely: v.effort.likely.formatAsIso8601(),
+                        pessimistic: v.effort.pessimistic.formatAsIso8601(),
+                    });
+                }
+            }
+
+            const data = {
+                version: 1,
+                exported_at: new Date().toISOString(),
+                assessments: exportedAssessments,
+                cvss: cvssEntries,
+                time_estimates: timeEstimates,
+            };
+
+            const ts = formatTimestampForFilename();
+            const filename = `custom_data_${sanitizeFilename(variantId ?? projectId ?? 'all')}_${ts}.json`;
+            downloadJson(data, filename);
+        } catch (err) {
+            console.error('Export error:', err);
+            showMessage('Failed to export custom data.', 'error');
+        }
+    }, [assessments, variantId, projectId, showMessage]);
 
     const handleImportReview = useCallback(() => {
         fileInputRef.current?.click();
@@ -301,33 +342,167 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     const handleFileSelected = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
         if (!file) return;
-        const formData = new FormData();
-        formData.append('file', file);
-        const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments/review/import", window.location.href);
-        setImportStatus("Importing...");
-        fetch(url.toString(), { method: 'POST', body: formData, mode: 'cors' })
-            .then(res => res.json())
-            .then(data => {
-                if (data.status === 'success') {
-                    // Reload the assessments list
-                    Assessments.listReview(variantId, projectId).then(data => setAssessments(groupAssessments(data)));
-                } else {
-                    setImportStatus(`Error: ${data.error || 'Unknown error'}`);
-                    setTimeout(() => setImportStatus(null), 4000);
+
+        // Old OpenVEX format: .tar.gz or .tgz files — use legacy import path
+        if (file.name.endsWith('.tar.gz') || file.name.endsWith('.tgz')) {
+            const formData = new FormData();
+            formData.append('file', file);
+            const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments/review/import", window.location.href);
+            setImportStatus("Importing...");
+            fetch(url.toString(), { method: 'POST', body: formData, mode: 'cors' })
+                .then(res => res.json())
+                .then(data => {
+                    if (data.status === 'success') {
+                        Assessments.listReview(variantId, projectId).then(data => setAssessments(groupAssessments(data)));
+                        showMessage('Assessments imported successfully!', 'success');
+                    } else {
+                        showMessage(`Import error: ${data.error || 'Unknown error'}`, 'error');
+                    }
+                    setImportStatus(null);
+                })
+                .catch(err => {
+                    console.error(err);
+                    showMessage('Import failed', 'error');
+                    setImportStatus(null);
+                })
+                .finally(() => {
+                    if (fileInputRef.current) fileInputRef.current.value = '';
+                });
+            return;
+        }
+
+        // New JSON format or legacy single OpenVEX JSON
+        const reader = new FileReader();
+        reader.onload = async () => {
+            try {
+                const text = reader.result as string;
+                const parsed = JSON.parse(text);
+
+                // Detect old OpenVEX format: has @context with "openvex"
+                if (parsed?.['@context'] && String(parsed['@context']).includes('openvex')) {
+                    const formData = new FormData();
+                    formData.append('file', file);
+                    const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments/review/import", window.location.href);
+                    setImportStatus("Importing...");
+                    const res = await fetch(url.toString(), { method: 'POST', body: formData, mode: 'cors' });
+                    const data = await res.json();
+                    if (data.status === 'success') {
+                        Assessments.listReview(variantId, projectId).then(d => setAssessments(groupAssessments(d)));
+                        showMessage('Assessments imported successfully!', 'success');
+                    } else {
+                        showMessage(`Import error: ${data.error || 'Unknown error'}`, 'error');
+                    }
+                    setImportStatus(null);
+                    if (fileInputRef.current) fileInputRef.current.value = '';
                     return;
                 }
+
+                // New custom data format
+                if (!parsed?.version || !parsed?.assessments) {
+                    showMessage('Invalid file format. Expected a VulnScout custom data export.', 'error');
+                    if (fileInputRef.current) fileInputRef.current.value = '';
+                    return;
+                }
+
+                setImportStatus("Importing...");
+                const summary: string[] = [];
+
+                // Import assessments via existing backend endpoint
+                if (Array.isArray(parsed.assessments) && parsed.assessments.length > 0) {
+                    // Build an OpenVEX-like document to feed the existing import endpoint
+                    const statements = parsed.assessments.map((a: any) => ({
+                        status: a.status,
+                        justification: a.justification ?? '',
+                        impact_statement: a.impact_statement ?? '',
+                        status_notes: a.status_notes ?? '',
+                        action_statement: a.workaround ?? '',
+                        vulnerability: { name: a.vuln_id },
+                        products: (a.packages ?? []).map((p: string) => ({ '@id': p })),
+                    }));
+                    const openvexDoc = {
+                        '@context': 'https://openvex.dev/ns/v0.2.0',
+                        '@id': 'urn:vulnscout:import:' + Date.now(),
+                        author: 'vulnscout-import',
+                        timestamp: new Date().toISOString(),
+                        version: 1,
+                        statements,
+                    };
+                    const blob = new Blob([JSON.stringify(openvexDoc)], { type: 'application/json' });
+                    const importFile = new File([blob], 'import.json', { type: 'application/json' });
+                    const formData = new FormData();
+                    formData.append('file', importFile);
+                    const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments/review/import", window.location.href);
+                    const res = await fetch(url.toString(), { method: 'POST', body: formData, mode: 'cors' });
+                    const result = await res.json();
+                    const count = result.created?.length ?? 0;
+                    const skipped = result.skipped ?? 0;
+                    summary.push(`${count} assessment(s) imported${skipped ? `, ${skipped} skipped` : ''}`);
+                }
+
+                // Import CVSS and time estimates via batch PATCH
+                const batchItems: any[] = [];
+                if (Array.isArray(parsed.cvss)) {
+                    for (const c of parsed.cvss) {
+                        if (!c.vuln_id || !c.vector_string || !c.version) continue;
+                        let existing = batchItems.find((b: any) => b.id === c.vuln_id);
+                        if (!existing) {
+                            existing = { id: c.vuln_id };
+                            batchItems.push(existing);
+                        }
+                        existing.cvss = {
+                            base_score: c.base_score,
+                            vector_string: c.vector_string,
+                            version: c.version,
+                        };
+                    }
+                }
+                if (Array.isArray(parsed.time_estimates)) {
+                    for (const t of parsed.time_estimates) {
+                        if (!t.vuln_id) continue;
+                        let existing = batchItems.find((b: any) => b.id === t.vuln_id);
+                        if (!existing) {
+                            existing = { id: t.vuln_id };
+                            batchItems.push(existing);
+                        }
+                        existing.effort = {
+                            optimistic: t.optimistic,
+                            likely: t.likely,
+                            pessimistic: t.pessimistic,
+                        };
+                        if (t.variant_id) existing.variant_id = t.variant_id;
+                    }
+                }
+
+                if (batchItems.length > 0) {
+                    const batchUrl = new URL(import.meta.env.VITE_API_URL + "/api/vulnerabilities/batch", window.location.href);
+                    const batchRes = await fetch(batchUrl.toString(), {
+                        method: 'PATCH',
+                        mode: 'cors',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ vulnerabilities: batchItems }),
+                    });
+                    const batchResult = await batchRes.json();
+                    const cvssCount = parsed.cvss?.length ?? 0;
+                    const effortCount = parsed.time_estimates?.length ?? 0;
+                    if (cvssCount > 0) summary.push(`${cvssCount} CVSS score(s)`);
+                    if (effortCount > 0) summary.push(`${effortCount} time estimate(s)`);
+                    if (batchResult.error_count) summary.push(`${batchResult.error_count} error(s)`);
+                }
+
+                // Reload assessments
+                Assessments.listReview(variantId, projectId).then(d => setAssessments(groupAssessments(d)));
+                showMessage(summary.length > 0 ? `Imported: ${summary.join(', ')}` : 'Import complete (no data changed)', 'success');
                 setImportStatus(null);
-            })
-            .catch(err => {
+            } catch (err) {
                 console.error(err);
-                setImportStatus("Import failed");
-                setTimeout(() => setImportStatus(null), 4000);
-            })
-            .finally(() => {
-                // Reset file input so the same file can be re-selected
+                showMessage('Import failed — invalid file', 'error');
+                setImportStatus(null);
+            } finally {
                 if (fileInputRef.current) fileInputRef.current.value = '';
-            });
-    }, [variantId, projectId]);
+            }
+        };
+        reader.readAsText(file);
+    }, [variantId, projectId, showMessage]);
 
     const handleDeleteRow = useCallback(async () => {
         if (!rowToDelete) return;
@@ -590,8 +765,13 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
 
     if (loading) {
         return (
-            <div className="flex items-center justify-center h-64">
-                <div className="w-8 h-8 border-4 border-cyan-500 border-t-transparent rounded-full animate-spin"></div>
+            <div className="relative h-64">
+                <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
+                    <div className="flex flex-col items-center gap-3 text-white">
+                        <div className="w-10 h-10 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
+                        <span className="text-sm font-semibold">Loading assessments...</span>
+                    </div>
+                </div>
             </div>
         );
     }
@@ -745,10 +925,10 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     <button
                         onClick={handleImportReview}
                         className="bg-green-700 hover:bg-green-600 px-3 py-1 rounded text-white border border-green-500 flex items-center gap-1.5"
-                        title="Import assessments from an OpenVEX file"
+                        title="Import custom data (assessments, CVSS, time estimates)"
                     >
                         <FontAwesomeIcon icon={faFileImport} />
-                        Import Review
+                        Import Custom Data
                     </button>
                     <input
                         ref={fileInputRef}
@@ -761,10 +941,10 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     <button
                         onClick={handleExportReview}
                         className="bg-green-700 hover:bg-green-600 px-3 py-1 rounded text-white border border-green-500 flex items-center gap-1.5"
-                        title="Export review assessments as OpenVEX"
+                        title="Export custom data (assessments, CVSS, time estimates)"
                     >
                         <FontAwesomeIcon icon={faFileExport} />
-                        Export Review
+                        Export Custom Data
                     </button>
                 </div>
             </div>

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -20,7 +20,7 @@ import type { ScanManagerSnapshot } from "../handlers/scanStateManager";
 import ScanProgressPanel from "../components/ScanProgressPanel";
 import { useDocUrl } from "../helpers/useDocUrl";
 import { extractSupplierName } from "../helpers/pkgId";
-import { downloadJson, sanitizeFilename, formatTimestampForFilename } from "../helpers/exportJson";
+import { downloadJson } from "../helpers/exportJson";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook, faDownload } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "../components/ConfirmationModal";
@@ -32,6 +32,20 @@ type Props = {
     projectId?: string;
     onScanComplete?: () => void;
 };
+
+async function downloadFromEndpoint(path: string, fallbackFilename: string): Promise<void> {
+    const url = new URL(import.meta.env.VITE_API_URL + path, window.location.href);
+    const resp = await fetch(url.toString(), { mode: 'cors' });
+    if (!resp.ok) {
+        const body = await resp.json().catch(() => ({}));
+        throw new Error(body.error || `Export failed (${resp.status})`);
+    }
+    const disposition = resp.headers.get('Content-Disposition');
+    const match = disposition?.match(/filename="?([^"]+)"?/);
+    const filename = match?.[1] ?? fallbackFilename;
+    const data = await resp.json();
+    downloadJson(data, filename);
+}
 
 function formatDate(iso: string): string {
     const d = new Date(iso);
@@ -1009,152 +1023,7 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
     );
 }
 
-// ---------------------------------------------------------------------------
-// Export helpers
-// ---------------------------------------------------------------------------
 
-function stripFindingIds(entry: FindingDiffEntry) {
-    return {
-        vulnerability_id: entry.vulnerability_id,
-        package_name: entry.package_name,
-        package_version: entry.package_version,
-        supplier: extractSupplierName(entry.package_supplier || '') || undefined,
-    };
-}
-
-function stripPackageIds(entry: PackageDiffEntry) {
-    return {
-        package_name: entry.package_name,
-        package_version: entry.package_version,
-        supplier: extractSupplierName(entry.package_supplier || '') || undefined,
-    };
-}
-
-function stripPackageUpgradeIds(entry: PackageUpgradeEntry) {
-    return {
-        package_name: entry.package_name,
-        old_version: entry.old_version,
-        new_version: entry.new_version,
-        supplier: extractSupplierName(entry.package_supplier || '') || undefined,
-    };
-}
-
-function stripFindingUpgradeIds(entry: FindingUpgradeEntry) {
-    return {
-        vulnerability_id: entry.vulnerability_id,
-        package_name: entry.package_name,
-        old_version: entry.old_version,
-        new_version: entry.new_version,
-        supplier: extractSupplierName(entry.package_supplier || '') || undefined,
-    };
-}
-
-function stripAssessment(entry: AssessmentDiffEntry) {
-    return {
-        vulnerability_id: entry.vulnerability_id,
-        status: entry.status,
-        simplified_status: entry.simplified_status,
-        justification: entry.justification,
-        impact_statement: entry.impact_statement,
-        status_notes: entry.status_notes,
-    };
-}
-
-function scanMeta(scan: Scan) {
-    return {
-        scan_id: scan.id,
-        timestamp: scan.timestamp,
-        scan_type: (scan.scan_type || 'sbom') === 'tool' ? 'vulnerability_scan' : 'import_sbom',
-        scan_source: scan.scan_source ?? undefined,
-        project_name: scan.project_name ?? undefined,
-        variant_id: scan.variant_id,
-        variant_name: scan.variant_name ?? undefined,
-    };
-}
-
-function buildDiffExport(scan: Scan, diff: ScanDiff) {
-    const meta = scanMeta(scan);
-    const isTool = (scan.scan_type || 'sbom') === 'tool';
-
-    if (isTool) {
-        return {
-            ...meta,
-            vulnerabilities: diff.all_vulns ?? diff.vulns_added,
-            findings: (diff.all_findings ?? diff.findings_added).map(stripFindingIds),
-            newly_detected_vulns: diff.newly_detected_vulns_list ?? [],
-            newly_detected_findings: (diff.newly_detected_findings_list ?? []).map(stripFindingIds),
-            newly_detected_assessments: (diff.newly_detected_assessments_list ?? []).map(stripAssessment),
-        };
-    }
-
-    // Import SBOM
-    const base: Record<string, unknown> = {
-        ...meta,
-        vulnerabilities: diff.all_vulns ?? [...diff.vulns_added, ...diff.vulns_unchanged],
-        findings: (diff.all_findings ?? [...diff.findings_added, ...diff.findings_unchanged]).map(stripFindingIds),
-        packages: [...diff.packages_added, ...diff.packages_unchanged].map(stripPackageIds),
-        assessments: [...(diff.assessments_added ?? []), ...(diff.assessments_unchanged ?? [])].map(stripAssessment),
-    };
-
-    if (!diff.is_first) {
-        base.diff = {
-            vulns_added: diff.vulns_added,
-            vulns_removed: diff.vulns_removed,
-            vulns_unchanged: diff.vulns_unchanged,
-            findings_added: diff.findings_added.map(stripFindingIds),
-            findings_removed: diff.findings_removed.map(stripFindingIds),
-            findings_upgraded: diff.findings_upgraded.map(stripFindingUpgradeIds),
-            findings_unchanged: diff.findings_unchanged.map(stripFindingIds),
-            packages_added: diff.packages_added.map(stripPackageIds),
-            packages_removed: diff.packages_removed.map(stripPackageIds),
-            packages_upgraded: diff.packages_upgraded.map(stripPackageUpgradeIds),
-            packages_unchanged: diff.packages_unchanged.map(stripPackageIds),
-            assessments_added: (diff.assessments_added ?? []).map(stripAssessment),
-            assessments_removed: (diff.assessments_removed ?? []).map(stripAssessment),
-            assessments_unchanged: (diff.assessments_unchanged ?? []).map(stripAssessment),
-        };
-    }
-
-    return base;
-}
-
-function buildGlobalResultExport(scan: Scan, result: GlobalResult) {
-    return {
-        ...scanMeta(scan),
-        packages: result.packages.map(p => ({
-            package_name: p.package_name,
-            package_version: p.package_version,
-            supplier: extractSupplierName(p.package_supplier || '') || undefined,
-            sources: p.sources,
-        })),
-        findings: result.findings.map(f => ({
-            vulnerability_id: f.vulnerability_id,
-            package_name: f.package_name,
-            package_version: f.package_version,
-            supplier: extractSupplierName(f.package_supplier || '') || undefined,
-            sources: f.sources,
-        })),
-        vulnerabilities: result.vulnerabilities.map(v => ({
-            vulnerability_id: v.vulnerability_id,
-            sources: v.sources,
-        })),
-        assessments: (result.assessments ?? []).map(stripAssessment),
-    };
-}
-
-function exportFilename(type: 'diff' | 'total', scan: Scan, timestamp?: string) {
-    const proj = sanitizeFilename(scan.project_name || 'project');
-    const variant = sanitizeFilename(scan.variant_name || scan.variant_id);
-    const ts = timestamp ?? formatTimestampForFilename();
-    return `scans_${type}_${proj}_${variant}_${ts}.json`;
-}
-
-function singleExportFilename(type: 'diff' | 'total', scan: Scan) {
-    const proj = sanitizeFilename(scan.project_name || 'project');
-    const variant = sanitizeFilename(scan.variant_name || scan.variant_id);
-    const ts = formatTimestampForFilename(scan.timestamp);
-    return `scan_${type}_${proj}_${variant}_${ts}.json`;
-}
 
 // ---------------------------------------------------------------------------
 // Main page
@@ -1233,9 +1102,9 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         setExportingScanId(scan.id);
         setExportMenuScanId(null);
         try {
-            const diff = await ScansHandler.getDiff(scan.id);
-            if (!diff) return;
-            downloadJson(buildDiffExport(scan, diff), singleExportFilename('diff', scan));
+            await downloadFromEndpoint(`/api/scans/${scan.id}/export-diff`, 'scan_diff.json');
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to export scan diff.');
         } finally {
             setExportingScanId(null);
         }
@@ -1245,9 +1114,9 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         setExportingScanId(scan.id);
         setExportMenuScanId(null);
         try {
-            const result = await ScansHandler.getGlobalResult(scan.id);
-            if (!result) return;
-            downloadJson(buildGlobalResultExport(scan, result), singleExportFilename('total', scan));
+            await downloadFromEndpoint(`/api/scans/${scan.id}/export-result`, 'scan_total.json');
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to export scan result.');
         } finally {
             setExportingScanId(null);
         }
@@ -1418,44 +1287,12 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         setExportAllMenuOpen(false);
         setExportingAll(true);
         try {
-            // Group scans by (project_name, variant_id)
-            const groups = new Map<string, Scan[]>();
-            for (const scan of filteredScans) {
-                const key = `${scan.project_name ?? ''}::${scan.variant_id}`;
-                const arr = groups.get(key) ?? [];
-                arr.push(scan);
-                groups.set(key, arr);
-            }
-
-            const ts = formatTimestampForFilename();
-
-            for (const groupScans of groups.values()) {
-                const representative = groupScans[0];
-
-                if (type === 'diff') {
-                    const results = await Promise.all(
-                        groupScans.map(async (scan) => {
-                            const diff = await ScansHandler.getDiff(scan.id);
-                            return diff ? buildDiffExport(scan, diff) : null;
-                        })
-                    );
-                    const data = results.filter(Boolean);
-                    if (data.length > 0) {
-                        downloadJson(data, exportFilename('diff', representative, ts));
-                    }
-                } else {
-                    const results = await Promise.all(
-                        groupScans.map(async (scan) => {
-                            const result = await ScansHandler.getGlobalResult(scan.id);
-                            return result ? buildGlobalResultExport(scan, result) : null;
-                        })
-                    );
-                    const data = results.filter(Boolean);
-                    if (data.length > 0) {
-                        downloadJson(data, exportFilename('total', representative, ts));
-                    }
-                }
-            }
+            const params = new URLSearchParams({ type });
+            if (variantId) params.set('variant_id', variantId);
+            else if (projectId) params.set('project_id', projectId);
+            await downloadFromEndpoint(`/api/scans/export?${params}`, `scans_${type}.json`);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to export scans.');
         } finally {
             setExportingAll(false);
         }

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -20,8 +20,9 @@ import type { ScanManagerSnapshot } from "../handlers/scanStateManager";
 import ScanProgressPanel from "../components/ScanProgressPanel";
 import { useDocUrl } from "../helpers/useDocUrl";
 import { extractSupplierName } from "../helpers/pkgId";
+import { downloadJson, sanitizeFilename, formatTimestampForFilename } from "../helpers/exportJson";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook } from "@fortawesome/free-solid-svg-icons";
+import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook, faDownload } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "../components/ConfirmationModal";
 import Variants from "../handlers/variant";
 import type { Variant } from "../handlers/variant";
@@ -1009,6 +1010,153 @@ function DiffModal({ scanId, scanType, onClose }: { scanId: string; scanType: st
 }
 
 // ---------------------------------------------------------------------------
+// Export helpers
+// ---------------------------------------------------------------------------
+
+function stripFindingIds(entry: FindingDiffEntry) {
+    return {
+        vulnerability_id: entry.vulnerability_id,
+        package_name: entry.package_name,
+        package_version: entry.package_version,
+        supplier: extractSupplierName(entry.package_supplier || '') || undefined,
+    };
+}
+
+function stripPackageIds(entry: PackageDiffEntry) {
+    return {
+        package_name: entry.package_name,
+        package_version: entry.package_version,
+        supplier: extractSupplierName(entry.package_supplier || '') || undefined,
+    };
+}
+
+function stripPackageUpgradeIds(entry: PackageUpgradeEntry) {
+    return {
+        package_name: entry.package_name,
+        old_version: entry.old_version,
+        new_version: entry.new_version,
+        supplier: extractSupplierName(entry.package_supplier || '') || undefined,
+    };
+}
+
+function stripFindingUpgradeIds(entry: FindingUpgradeEntry) {
+    return {
+        vulnerability_id: entry.vulnerability_id,
+        package_name: entry.package_name,
+        old_version: entry.old_version,
+        new_version: entry.new_version,
+        supplier: extractSupplierName(entry.package_supplier || '') || undefined,
+    };
+}
+
+function stripAssessment(entry: AssessmentDiffEntry) {
+    return {
+        vulnerability_id: entry.vulnerability_id,
+        status: entry.status,
+        simplified_status: entry.simplified_status,
+        justification: entry.justification,
+        impact_statement: entry.impact_statement,
+        status_notes: entry.status_notes,
+    };
+}
+
+function scanMeta(scan: Scan) {
+    return {
+        scan_id: scan.id,
+        timestamp: scan.timestamp,
+        scan_type: (scan.scan_type || 'sbom') === 'tool' ? 'vulnerability_scan' : 'import_sbom',
+        scan_source: scan.scan_source ?? undefined,
+        project_name: scan.project_name ?? undefined,
+        variant_id: scan.variant_id,
+        variant_name: scan.variant_name ?? undefined,
+    };
+}
+
+function buildDiffExport(scan: Scan, diff: ScanDiff) {
+    const meta = scanMeta(scan);
+    const isTool = (scan.scan_type || 'sbom') === 'tool';
+
+    if (isTool) {
+        return {
+            ...meta,
+            vulnerabilities: diff.all_vulns ?? diff.vulns_added,
+            findings: (diff.all_findings ?? diff.findings_added).map(stripFindingIds),
+            newly_detected_vulns: diff.newly_detected_vulns_list ?? [],
+            newly_detected_findings: (diff.newly_detected_findings_list ?? []).map(stripFindingIds),
+            newly_detected_assessments: (diff.newly_detected_assessments_list ?? []).map(stripAssessment),
+        };
+    }
+
+    // Import SBOM
+    const base: Record<string, unknown> = {
+        ...meta,
+        vulnerabilities: diff.all_vulns ?? [...diff.vulns_added, ...diff.vulns_unchanged],
+        findings: (diff.all_findings ?? [...diff.findings_added, ...diff.findings_unchanged]).map(stripFindingIds),
+        packages: [...diff.packages_added, ...diff.packages_unchanged].map(stripPackageIds),
+        assessments: [...(diff.assessments_added ?? []), ...(diff.assessments_unchanged ?? [])].map(stripAssessment),
+    };
+
+    if (!diff.is_first) {
+        base.diff = {
+            vulns_added: diff.vulns_added,
+            vulns_removed: diff.vulns_removed,
+            vulns_unchanged: diff.vulns_unchanged,
+            findings_added: diff.findings_added.map(stripFindingIds),
+            findings_removed: diff.findings_removed.map(stripFindingIds),
+            findings_upgraded: diff.findings_upgraded.map(stripFindingUpgradeIds),
+            findings_unchanged: diff.findings_unchanged.map(stripFindingIds),
+            packages_added: diff.packages_added.map(stripPackageIds),
+            packages_removed: diff.packages_removed.map(stripPackageIds),
+            packages_upgraded: diff.packages_upgraded.map(stripPackageUpgradeIds),
+            packages_unchanged: diff.packages_unchanged.map(stripPackageIds),
+            assessments_added: (diff.assessments_added ?? []).map(stripAssessment),
+            assessments_removed: (diff.assessments_removed ?? []).map(stripAssessment),
+            assessments_unchanged: (diff.assessments_unchanged ?? []).map(stripAssessment),
+        };
+    }
+
+    return base;
+}
+
+function buildGlobalResultExport(scan: Scan, result: GlobalResult) {
+    return {
+        ...scanMeta(scan),
+        packages: result.packages.map(p => ({
+            package_name: p.package_name,
+            package_version: p.package_version,
+            supplier: extractSupplierName(p.package_supplier || '') || undefined,
+            sources: p.sources,
+        })),
+        findings: result.findings.map(f => ({
+            vulnerability_id: f.vulnerability_id,
+            package_name: f.package_name,
+            package_version: f.package_version,
+            supplier: extractSupplierName(f.package_supplier || '') || undefined,
+            sources: f.sources,
+        })),
+        vulnerabilities: result.vulnerabilities.map(v => ({
+            vulnerability_id: v.vulnerability_id,
+            sources: v.sources,
+        })),
+        assessments: (result.assessments ?? []).map(stripAssessment),
+    };
+}
+
+function exportFilename(type: 'diff' | 'total', scan: Scan, timestamp?: string) {
+    const proj = sanitizeFilename(scan.project_name || 'project');
+    const variant = sanitizeFilename(scan.variant_name || scan.variant_id);
+    const ts = timestamp ?? formatTimestampForFilename();
+    return `scans_${type}_${proj}_${variant}_${ts}.json`;
+}
+
+function singleExportFilename(type: 'diff' | 'total', scan: Scan) {
+    const proj = sanitizeFilename(scan.project_name || 'project');
+    const variant = sanitizeFilename(scan.variant_name || scan.variant_id);
+    const ts = formatTimestampForFilename(scan.timestamp);
+    return `scan_${type}_${proj}_${variant}_${ts}.json`;
+}
+
+// ---------------------------------------------------------------------------
 // Main page
 // ---------------------------------------------------------------------------
 
@@ -1027,6 +1175,14 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     const [showGrype, setShowGrype] = useState(true);
     const [showOsv, setShowOsv] = useState(true);
     const [showNvd, setShowNvd] = useState(true);
+
+    // Export state
+    const [exportMenuScanId, setExportMenuScanId] = useState<string | null>(null);
+    const [exportingScanId, setExportingScanId] = useState<string | null>(null);
+    const [exportAllMenuOpen, setExportAllMenuOpen] = useState(false);
+    const [exportingAll, setExportingAll] = useState(false);
+    const exportMenuRef = useRef<HTMLDivElement>(null);
+    const exportAllMenuRef = useRef<HTMLDivElement>(null);
 
     // Scan menu state
     const [scanMenuOpen, setScanMenuOpen] = useState(false);
@@ -1069,6 +1225,31 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
             setDeletingId(null);
             refreshScans();
             onScanComplete?.();
+        }
+    }
+
+    // -- Per-scan export --
+    async function handleExportScanDiff(scan: Scan) {
+        setExportingScanId(scan.id);
+        setExportMenuScanId(null);
+        try {
+            const diff = await ScansHandler.getDiff(scan.id);
+            if (!diff) return;
+            downloadJson(buildDiffExport(scan, diff), singleExportFilename('diff', scan));
+        } finally {
+            setExportingScanId(null);
+        }
+    }
+
+    async function handleExportScanResult(scan: Scan) {
+        setExportingScanId(scan.id);
+        setExportMenuScanId(null);
+        try {
+            const result = await ScansHandler.getGlobalResult(scan.id);
+            if (!result) return;
+            downloadJson(buildGlobalResultExport(scan, result), singleExportFilename('total', scan));
+        } finally {
+            setExportingScanId(null);
         }
     }
 
@@ -1130,6 +1311,31 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
             return () => document.removeEventListener('mousedown', handleClickOutside);
         }
     }, [scanMenuOpen]);
+
+    // Close export menus on outside click
+    useEffect(() => {
+        function handleClickOutside(e: MouseEvent) {
+            if (exportMenuRef.current && !exportMenuRef.current.contains(e.target as Node)) {
+                setExportMenuScanId(null);
+            }
+        }
+        if (exportMenuScanId) {
+            document.addEventListener('mousedown', handleClickOutside);
+            return () => document.removeEventListener('mousedown', handleClickOutside);
+        }
+    }, [exportMenuScanId]);
+
+    useEffect(() => {
+        function handleClickOutside(e: MouseEvent) {
+            if (exportAllMenuRef.current && !exportAllMenuRef.current.contains(e.target as Node)) {
+                setExportAllMenuOpen(false);
+            }
+        }
+        if (exportAllMenuOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+            return () => document.removeEventListener('mousedown', handleClickOutside);
+        }
+    }, [exportAllMenuOpen]);
 
     function toggleVariant(vid: string) {
         setSelectedVariantIds(prev => {
@@ -1207,6 +1413,54 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         return true;
     });
 
+    // -- Export All (grouped by project/variant) --
+    async function handleExportAll(type: 'diff' | 'total') {
+        setExportAllMenuOpen(false);
+        setExportingAll(true);
+        try {
+            // Group scans by (project_name, variant_id)
+            const groups = new Map<string, Scan[]>();
+            for (const scan of filteredScans) {
+                const key = `${scan.project_name ?? ''}::${scan.variant_id}`;
+                const arr = groups.get(key) ?? [];
+                arr.push(scan);
+                groups.set(key, arr);
+            }
+
+            const ts = formatTimestampForFilename();
+
+            for (const groupScans of groups.values()) {
+                const representative = groupScans[0];
+
+                if (type === 'diff') {
+                    const results = await Promise.all(
+                        groupScans.map(async (scan) => {
+                            const diff = await ScansHandler.getDiff(scan.id);
+                            return diff ? buildDiffExport(scan, diff) : null;
+                        })
+                    );
+                    const data = results.filter(Boolean);
+                    if (data.length > 0) {
+                        downloadJson(data, exportFilename('diff', representative, ts));
+                    }
+                } else {
+                    const results = await Promise.all(
+                        groupScans.map(async (scan) => {
+                            const result = await ScansHandler.getGlobalResult(scan.id);
+                            return result ? buildGlobalResultExport(scan, result) : null;
+                        })
+                    );
+                    const data = results.filter(Boolean);
+                    if (data.length > 0) {
+                        downloadJson(data, exportFilename('total', representative, ts));
+                    }
+                }
+            }
+        } finally {
+            setExportingAll(false);
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Linear timeline — source-to-color mapping for tool scan squares
     // -----------------------------------------------------------------------
@@ -1276,7 +1530,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                 NVD
             </button>
 
-            {/* Right side: doc link + scan menu */}
+            {/* Right side: doc link + export + scan menu */}
             <div className="ml-auto flex items-center gap-3">
                 <a
                     href={docUrl}
@@ -1288,6 +1542,44 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                 >
                     <FontAwesomeIcon icon={faBook} />
                 </a>
+
+                {/* Export All dropdown */}
+                {filteredScans.length > 0 && (
+                    <div className="relative" ref={exportAllMenuRef}>
+                        <button
+                            onClick={() => setExportAllMenuOpen(o => !o)}
+                            disabled={exportingAll}
+                            className={[
+                                "inline-flex items-center gap-2 px-3 py-1.5 rounded text-sm font-semibold transition-colors",
+                                exportingAll
+                                    ? "bg-sky-800/50 text-sky-300 cursor-wait"
+                                    : "bg-sky-900 hover:bg-sky-950 text-white",
+                            ].join(' ')}
+                            title="Export scan history"
+                        >
+                            <FontAwesomeIcon icon={faDownload} />
+                            {exportingAll ? 'Exporting…' : 'Export'}
+                        </button>
+
+                        {exportAllMenuOpen && (
+                            <div className="absolute right-0 top-full mt-1 z-50 w-52 rounded-lg border border-sky-700/60 bg-neutral-900 shadow-xl p-2">
+                                <button
+                                    onClick={() => handleExportAll('diff')}
+                                    className="w-full text-left px-3 py-2 text-sm text-neutral-200 hover:bg-sky-900/40 rounded transition-colors"
+                                >
+                                    Export All Diffs
+                                </button>
+                                <button
+                                    onClick={() => handleExportAll('total')}
+                                    className="w-full text-left px-3 py-2 text-sm text-neutral-200 hover:bg-sky-900/40 rounded transition-colors"
+                                >
+                                    Export All Scan Results
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                )}
+
                 {/* Run Scans dropdown */}
                 {canTriggerScan && (
                     <div className="relative" ref={scanMenuRef}>
@@ -1453,6 +1745,14 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
 
     return (
         <>
+            {(exportingAll || exportingScanId) && (
+                <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
+                    <div className="flex flex-col items-center gap-3 text-white">
+                        <div className="w-10 h-10 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
+                        <span className="text-sm font-semibold">Exporting…</span>
+                    </div>
+                </div>
+            )}
             {openDiffId && (
                 <DiffModal scanId={openDiffId} scanType={openDiffType} onClose={() => setOpenDiffId(null)} />
             )}
@@ -1519,13 +1819,47 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                             <div className="flex-1 min-w-0 py-2 pl-3">
                             <div className="group/card relative p-4 bg-white dark:bg-neutral-700 rounded-lg shadow-sm border border-gray-100 dark:border-neutral-600">
                                 {/* Delete button — top-right corner */}
-                                <button
-                                    onClick={() => setDeletingId(scan.id)}
-                                    title="Delete scan"
-                                    className="absolute top-2 right-2 z-10 opacity-0 group-hover/card:opacity-100 text-neutral-400 hover:text-red-400 transition-all p-1"
-                                >
-                                    <FontAwesomeIcon icon={faTrash} className="text-sm" />
-                                </button>
+                                <div className="absolute top-2 right-2 z-10 flex items-center gap-1 opacity-0 group-hover/card:opacity-100 transition-all">
+                                    {/* Export button */}
+                                    <div className="relative" ref={exportMenuScanId === scan.id ? exportMenuRef : undefined}>
+                                        <button
+                                            onClick={() => setExportMenuScanId(exportMenuScanId === scan.id ? null : scan.id)}
+                                            disabled={exportingScanId === scan.id}
+                                            title="Export scan"
+                                            className={[
+                                                "p-1 transition-colors",
+                                                exportingScanId === scan.id
+                                                    ? "text-cyan-400 cursor-wait"
+                                                    : "text-neutral-400 hover:text-cyan-400",
+                                            ].join(' ')}
+                                        >
+                                            <FontAwesomeIcon icon={faDownload} className="text-sm" />
+                                        </button>
+                                        {exportMenuScanId === scan.id && (
+                                            <div className="absolute right-0 top-full mt-1 z-50 w-48 rounded-lg border border-sky-700/60 bg-neutral-900 shadow-xl p-1.5">
+                                                <button
+                                                    onClick={() => handleExportScanDiff(scan)}
+                                                    className="w-full text-left px-3 py-1.5 text-xs text-neutral-200 hover:bg-sky-900/40 rounded transition-colors"
+                                                >
+                                                    Export Diff
+                                                </button>
+                                                <button
+                                                    onClick={() => handleExportScanResult(scan)}
+                                                    className="w-full text-left px-3 py-1.5 text-xs text-neutral-200 hover:bg-sky-900/40 rounded transition-colors"
+                                                >
+                                                    Export Scan Result
+                                                </button>
+                                            </div>
+                                        )}
+                                    </div>
+                                    <button
+                                        onClick={() => setDeletingId(scan.id)}
+                                        title="Delete scan"
+                                        className="text-neutral-400 hover:text-red-400 transition-colors p-1"
+                                    >
+                                        <FontAwesomeIcon icon={faTrash} className="text-sm" />
+                                    </button>
+                                </div>
                                 {/* Row 1: timestamp + scan type badge */}
                                 <div className="flex items-center gap-2 mb-1">
                                     <time className="text-sm font-semibold text-gray-500 dark:text-neutral-400">

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -485,10 +485,10 @@ def build_custom_data_export(
     dict with keys ``version``, ``exported_at``, ``assessments``, ``cvss``,
     ``time_estimates``.
     """
+    from ..extensions import db
     from ..models.assessment import Assessment as DBAssessment
     from ..models.metrics import Metrics
     from ..models.time_estimate import TimeEstimate
-    from ..models.finding import Finding
     from ..models.iso8601_duration import Iso8601Duration
 
     handmade = DBAssessment.get_handmade(variant_ids)
@@ -508,56 +508,61 @@ def build_custom_data_export(
             "variant_id": d.get("variant_id"),
         })
 
-    # Collect distinct vulnerability IDs referenced by the assessments
-    vuln_ids: set[str] = set()
-    for a in handmade:
-        if a.vuln_id:
-            vuln_ids.add(a.vuln_id)
-
-    # Gather custom CVSS entries (exclude 'nvd' and 'unknown' authors)
+    # Gather ALL custom CVSS entries (exclude 'nvd' and 'unknown' authors),
+    # not just those linked to handmade assessments.
     cvss_entries: list[dict] = []
-    for vid in sorted(vuln_ids):
-        for m in Metrics.get_by_vulnerability(vid):
-            author = m.author or "unknown"
-            if author in ("nvd", "unknown"):
-                continue
-            cvss_entries.append({
-                "vuln_id": vid,
-                "version": m.version or "",
-                "vector_string": m.vector or "",
-                "base_score": float(m.score) if m.score is not None else 0.0,
-                "author": author,
-            })
+    all_metrics = list(db.session.execute(
+        db.select(Metrics).where(
+            Metrics.author.notin_(["nvd", "unknown"]),
+            Metrics.author.isnot(None),
+        )
+    ).scalars().all())
+    for m in sorted(all_metrics, key=lambda m: m.vulnerability_id):
+        cvss_entries.append({
+            "vuln_id": m.vulnerability_id,
+            "version": m.version or "",
+            "vector_string": m.vector or "",
+            "base_score": float(m.score) if m.score is not None else 0.0,
+            "author": m.author,
+        })
 
-    # Gather non-zero time estimates
+    # Gather ALL non-zero time estimates, not just those linked to
+    # handmade assessments.
     time_estimates: list[dict] = []
-    seen_findings: set = set()
-    for vid in sorted(vuln_ids):
-        findings = Finding.get_by_vulnerability(vid)
-        for f in findings:
-            if f.id in seen_findings:
-                continue
-            seen_findings.add(f.id)
-            te_list = TimeEstimate.get_by_finding(f.id)
-            for te in te_list:
-                opt = te.optimistic or 0
-                lik = te.likely or 0
-                pes = te.pessimistic or 0
-                if opt == 0 and lik == 0 and pes == 0:
-                    continue
+    all_te = list(db.session.execute(
+        db.select(TimeEstimate).where(
+            db.or_(
+                TimeEstimate.optimistic > 0,
+                TimeEstimate.likely > 0,
+                TimeEstimate.pessimistic > 0,
+            )
+        )
+    ).scalars().all())
 
-                def _hours_to_iso(h: int) -> str:
-                    try:
-                        return str(Iso8601Duration(f"PT{h}H"))
-                    except (ValueError, TypeError):
-                        return f"PT{h}H"
+    def _hours_to_iso(h: int) -> str:
+        try:
+            return str(Iso8601Duration(f"PT{h}H"))
+        except (ValueError, TypeError):
+            return f"PT{h}H"
 
-                time_estimates.append({
-                    "vuln_id": vid,
-                    "optimistic": _hours_to_iso(opt),
-                    "likely": _hours_to_iso(lik),
-                    "pessimistic": _hours_to_iso(pes),
-                })
+    seen_vulns_te: set[str] = set()
+    for te in all_te:
+        if te.finding is None:
+            continue
+        vid = te.finding.vulnerability_id
+        if vid in seen_vulns_te:
+            continue
+        seen_vulns_te.add(vid)
+        opt = te.optimistic or 0
+        lik = te.likely or 0
+        pes = te.pessimistic or 0
+        time_estimates.append({
+            "vuln_id": vid,
+            "optimistic": _hours_to_iso(opt),
+            "likely": _hours_to_iso(lik),
+            "pessimistic": _hours_to_iso(pes),
+        })
+    time_estimates.sort(key=lambda t: t["vuln_id"])
 
     return {
         "version": 1,

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -462,3 +462,316 @@ def import_directory(
         total_skipped += s
 
     return total_created, total_errors, total_skipped, variant_files_found
+
+
+# ---------------------------------------------------------------------------
+# Custom-data export (assessments + CVSS + time estimates)
+# ---------------------------------------------------------------------------
+
+def build_custom_data_export(
+    variant_ids: list | None = None,
+) -> dict:
+    """Build a custom-data export dict containing assessments, CVSS and time
+    estimates for the given variant(s).
+
+    Parameters
+    ----------
+    variant_ids:
+        List of variant UUIDs to scope the export.  When *None* all
+        handmade assessments across all variants are exported.
+
+    Returns
+    -------
+    dict with keys ``version``, ``exported_at``, ``assessments``, ``cvss``,
+    ``time_estimates``.
+    """
+    from ..models.assessment import Assessment as DBAssessment
+    from ..models.metrics import Metrics
+    from ..models.time_estimate import TimeEstimate
+    from ..models.finding import Finding
+    from ..models.iso8601_duration import Iso8601Duration
+
+    handmade = DBAssessment.get_handmade(variant_ids)
+
+    exported_assessments = []
+    for a in handmade:
+        d = a.to_dict()
+        exported_assessments.append({
+            "vuln_id": d["vuln_id"],
+            "status": d["status"],
+            "simplified_status": d.get("simplified_status", ""),
+            "justification": d.get("justification") or None,
+            "impact_statement": d.get("impact_statement") or None,
+            "status_notes": d.get("status_notes") or None,
+            "workaround": d.get("workaround") or None,
+            "packages": d["packages"],
+            "variant_id": d.get("variant_id"),
+        })
+
+    # Collect distinct vulnerability IDs referenced by the assessments
+    vuln_ids: set[str] = set()
+    for a in handmade:
+        if a.vuln_id:
+            vuln_ids.add(a.vuln_id)
+
+    # Gather custom CVSS entries (exclude 'nvd' and 'unknown' authors)
+    cvss_entries: list[dict] = []
+    for vid in sorted(vuln_ids):
+        for m in Metrics.get_by_vulnerability(vid):
+            author = m.author or "unknown"
+            if author in ("nvd", "unknown"):
+                continue
+            cvss_entries.append({
+                "vuln_id": vid,
+                "version": m.version or "",
+                "vector_string": m.vector or "",
+                "base_score": float(m.score) if m.score is not None else 0.0,
+                "author": author,
+            })
+
+    # Gather non-zero time estimates
+    time_estimates: list[dict] = []
+    seen_findings: set = set()
+    for vid in sorted(vuln_ids):
+        findings = Finding.get_by_vulnerability(vid)
+        for f in findings:
+            if f.id in seen_findings:
+                continue
+            seen_findings.add(f.id)
+            te_list = TimeEstimate.get_by_finding(f.id)
+            for te in te_list:
+                opt = te.optimistic or 0
+                lik = te.likely or 0
+                pes = te.pessimistic or 0
+                if opt == 0 and lik == 0 and pes == 0:
+                    continue
+
+                def _hours_to_iso(h: int) -> str:
+                    try:
+                        return str(Iso8601Duration(f"PT{h}H"))
+                    except (ValueError, TypeError):
+                        return f"PT{h}H"
+
+                time_estimates.append({
+                    "vuln_id": vid,
+                    "optimistic": _hours_to_iso(opt),
+                    "likely": _hours_to_iso(lik),
+                    "pessimistic": _hours_to_iso(pes),
+                })
+
+    return {
+        "version": 1,
+        "exported_at": _dt.now(_tz.utc).isoformat(),
+        "assessments": exported_assessments,
+        "cvss": cvss_entries,
+        "time_estimates": time_estimates,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Custom-data import (assessments + CVSS + time estimates)
+# ---------------------------------------------------------------------------
+
+def import_custom_data(
+    data: dict,
+    variant_by_name: dict,
+    variant_id: "_uuid.UUID | None" = None,
+) -> dict:
+    """Import a custom-data JSON document containing assessments, CVSS and
+    time estimates.
+
+    Parameters
+    ----------
+    data:
+        Parsed JSON matching the custom-data export format
+        (``{version, assessments, cvss, time_estimates}``).
+    variant_by_name:
+        Mapping ``{name: Variant, sanitised_name: Variant}`` for variant
+        resolution.
+    variant_id:
+        When provided, all assessments are attached to this variant.
+        When *None*, each assessment's ``variant_id`` field is used.
+
+    Returns
+    -------
+    dict with ``status``, ``assessments_imported``, ``assessments_skipped``,
+    ``cvss_imported``, ``time_estimates_imported``, ``errors``.
+    """
+    from ..extensions import db
+    from ..models.assessment import Assessment as DBAssessment, STATUS_TO_SIMPLIFIED
+    from ..models.vulnerability import Vulnerability as DBVuln
+    from ..models.package import Package
+    from ..models.finding import Finding
+    from .vuln_helpers import (
+        _validate_effort,
+        _validate_and_apply_cvss,
+        _apply_effort,
+    )
+
+    result: dict = {
+        "status": "success",
+        "assessments_imported": 0,
+        "assessments_skipped": 0,
+        "cvss_imported": 0,
+        "time_estimates_imported": 0,
+        "errors": [],
+    }
+
+    # -- Import assessments --
+    assessments_list = data.get("assessments", [])
+    if isinstance(assessments_list, list):
+        for a in assessments_list:
+            if not isinstance(a, dict):
+                continue
+            vuln_name = a.get("vuln_id")
+            status = a.get("status")
+            if not vuln_name or not status:
+                result["errors"].append({
+                    "vuln_id": vuln_name or "?",
+                    "error": "Missing vuln_id or status",
+                })
+                continue
+            pkg_ids = a.get("packages", [])
+            if not pkg_ids:
+                result["errors"].append({
+                    "vuln_id": vuln_name,
+                    "error": "No packages found",
+                })
+                continue
+
+            # Determine which variant to attach to
+            target_variant_id = variant_id
+            if target_variant_id is None and a.get("variant_id"):
+                try:
+                    target_variant_id = _uuid.UUID(a["variant_id"])
+                except (ValueError, TypeError):
+                    v = variant_by_name.get(a["variant_id"])
+                    if v:
+                        target_variant_id = v.id
+
+            justification = a.get("justification", "")
+            impact_statement = a.get("impact_statement", "")
+            status_notes = a.get("status_notes", "")
+            workaround = a.get("workaround", "")
+
+            for pkg_string_id in pkg_ids:
+                try:
+                    if "::" in pkg_string_id:
+                        base, _supplier = pkg_string_id.split("::", 1)
+                    else:
+                        base, _supplier = pkg_string_id, ""
+                    if "@" in base:
+                        name, version = base.rsplit("@", 1)
+                    else:
+                        name, version = base, ""
+                    db_pkg = Package.find_or_create(name, version, supplier=_supplier)
+                    DBVuln.get_or_create(vuln_name)
+                    finding = Finding.get_or_create(db_pkg.id, vuln_name)
+
+                    existing = db.session.execute(
+                        db.select(DBAssessment).where(
+                            DBAssessment.finding_id == finding.id,
+                            DBAssessment.variant_id == target_variant_id,
+                            DBAssessment.status == status,
+                        )
+                    ).scalar_one_or_none()
+                    if existing is not None:
+                        result["assessments_skipped"] += 1
+                        continue
+
+                    DBAssessment.create(
+                        status=status,
+                        simplified_status=STATUS_TO_SIMPLIFIED.get(
+                            status, "Pending Assessment"
+                        ),
+                        finding_id=finding.id,
+                        variant_id=target_variant_id,
+                        origin="custom",
+                        status_notes=status_notes,
+                        justification=justification,
+                        impact_statement=impact_statement,
+                        workaround=workaround,
+                        responses=[],
+                        commit=True,
+                    )
+                    result["assessments_imported"] += 1
+                except Exception as e:
+                    result["errors"].append({
+                        "vuln_id": vuln_name,
+                        "package": pkg_string_id,
+                        "error": str(e),
+                    })
+
+    # -- Import CVSS --
+    cvss_list = data.get("cvss", [])
+    if isinstance(cvss_list, list):
+        for c in cvss_list:
+            if not isinstance(c, dict):
+                continue
+            vuln_id = c.get("vuln_id")
+            if not vuln_id:
+                continue
+            record = DBVuln.get_by_id(vuln_id)
+            if not record:
+                result["errors"].append({
+                    "vuln_id": vuln_id,
+                    "error": "Vulnerability not found (CVSS)",
+                })
+                continue
+            cvss_data = {
+                "base_score": c.get("base_score"),
+                "vector_string": c.get("vector_string"),
+                "version": c.get("version"),
+                "author": c.get("author", "custom"),
+                "exploitability_score": c.get("exploitability_score", 0.0),
+                "impact_score": c.get("impact_score", 0.0),
+            }
+            err = _validate_and_apply_cvss(cvss_data, record.id,
+                                           log_prefix="import-custom-data")
+            if err:
+                result["errors"].append({"vuln_id": vuln_id, "error": err})
+            else:
+                result["cvss_imported"] += 1
+
+    # -- Import time estimates --
+    te_list = data.get("time_estimates", [])
+    if isinstance(te_list, list):
+        for t in te_list:
+            if not isinstance(t, dict):
+                continue
+            vuln_id = t.get("vuln_id")
+            if not vuln_id:
+                continue
+            record = DBVuln.get_by_id(vuln_id)
+            if not record:
+                result["errors"].append({
+                    "vuln_id": vuln_id,
+                    "error": "Vulnerability not found (time estimate)",
+                })
+                continue
+            eff = {
+                "optimistic": t.get("optimistic"),
+                "likely": t.get("likely"),
+                "pessimistic": t.get("pessimistic"),
+            }
+            opt, lik, pes, err = _validate_effort(eff)
+            if err:
+                result["errors"].append({"vuln_id": vuln_id, "error": err})
+                continue
+
+            te_variant_id = variant_id
+            if te_variant_id is None and t.get("variant_id"):
+                try:
+                    te_variant_id = _uuid.UUID(t["variant_id"])
+                except (ValueError, TypeError):
+                    pass
+
+            _apply_effort(record, te_variant_id, opt, lik, pes,
+                          log_prefix="import-custom-data")
+            result["time_estimates_imported"] += 1
+
+    if not result["assessments_imported"] and not result["cvss_imported"] and not result["time_estimates_imported"]:
+        if result["errors"]:
+            result["status"] = "error"
+
+    return result

--- a/src/helpers/vuln_helpers.py
+++ b/src/helpers/vuln_helpers.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Shared validation and persistence helpers for vulnerability CVSS scores
+and time-estimate (effort) values.
+
+Used by both ``routes/vulnerabilities.py`` (batch PATCH) and
+``helpers/assessment_io.py`` (custom-data import).
+"""
+
+from __future__ import annotations
+
+from ..models import Metrics, CVSS, Iso8601Duration
+from ..helpers.verbose import verbose
+
+
+def _parse_effort_hours(value) -> int:
+    """Parse an effort value (ISO 8601 duration string or integer hours) to whole hours."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return int(Iso8601Duration(value).total_seconds // 3600)
+    raise ValueError(f"Invalid effort value: {value!r}")
+
+
+def _validate_effort(eff: dict):
+    """Validate and parse effort dict with optimistic/likely/pessimistic keys.
+
+    Returns ``(opt, lik, pes, None)`` on success or ``(None, None, None, error_string)``
+    on failure.
+    """
+    if not all(k in eff for k in ("optimistic", "likely", "pessimistic")):
+        return None, None, None, "Invalid effort values"
+    try:
+        opt = _parse_effort_hours(eff["optimistic"])
+        lik = _parse_effort_hours(eff["likely"])
+        pes = _parse_effort_hours(eff["pessimistic"])
+    except (ValueError, TypeError):
+        return None, None, None, "Invalid effort values"
+    if not (opt <= lik <= pes):
+        return None, None, None, "Invalid effort values"
+    return opt, lik, pes, None
+
+
+def _validate_and_apply_cvss(new_cvss: dict, record_id: str, log_prefix: str = ""):
+    """Validate CVSS payload and persist to Metrics.
+
+    Returns an error string on validation failure, ``None`` on success.
+    """
+    required_keys = {"base_score", "vector_string", "version"}
+    if not required_keys.issubset(new_cvss.keys()):
+        return "Invalid CVSS data"
+    cvss_obj = CVSS.from_dict(new_cvss)
+    try:
+        Metrics.from_cvss(cvss_obj, record_id)
+    except Exception as e:
+        verbose(f"[{log_prefix} cvss] {e}")
+    return None
+
+
+def _apply_effort(record, variant_id, opt, lik, pes, log_prefix: str = ""):
+    """Persist effort values to the first finding's TimeEstimate."""
+    try:
+        from ..models.time_estimate import TimeEstimate
+        for finding in (record.findings or []):
+            if variant_id is not None:
+                existing = TimeEstimate.get_by_finding_and_variant(finding.id, variant_id)
+            else:
+                existing = finding.time_estimate
+            if existing is not None:
+                existing.update(optimistic=opt, likely=lik, pessimistic=pes)
+            else:
+                TimeEstimate.create(
+                    finding_id=finding.id, variant_id=variant_id,
+                    optimistic=opt, likely=lik, pessimistic=pes
+                )
+            break
+    except Exception as e:
+        verbose(f"[{log_prefix} effort] {e}")

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -21,6 +21,8 @@ from ..helpers.assessment_io import (
     import_statements as _import_openvex_statements,
     build_variant_by_name_map,
     import_archive_bytes,
+    build_custom_data_export,
+    import_custom_data,
 )
 
 OPENVEX_FILE = "/scan/outputs/openvex.json"
@@ -334,6 +336,95 @@ def init_app(app):
             return {"status": "success", "imported": len(created), "skipped": skipped, "errors": errors}, 200
 
         return {"error": "Unsupported file type. Please upload a .json or .tar.gz file."}, 400
+
+    @app.route('/api/assessments/review/export-custom-data')
+    def export_review_custom_data():
+        """Export handmade (review) assessments, custom CVSS scores and time
+        estimates as a single JSON file.
+
+        Query parameters:
+
+        * ``variant_id`` – restrict to a single variant.
+        * ``project_id`` – restrict to all variants in a project.
+        """
+        variant_id = request.args.get('variant_id')
+        project_id = request.args.get('project_id')
+
+        variant_ids = None
+        if variant_id:
+            vid, err = parse_uuid_or_400(variant_id, "variant_id")
+            if err:
+                return err
+            variant_ids = [vid]
+        elif project_id:
+            pid, err = parse_uuid_or_400(project_id, "project_id")
+            if err:
+                return err
+            variants = DBVariant.get_by_project(pid)
+            variant_ids = [v.id for v in variants]
+
+        data = build_custom_data_export(variant_ids)
+
+        if not data["assessments"] and not data["cvss"] and not data["time_estimates"]:
+            return {"error": "No custom data to export"}, 404
+
+        import json as _json
+        json_bytes = _json.dumps(data, indent=2)
+        return json_bytes, 200, {
+            "Content-Type": "application/json",
+            "Content-Disposition": "attachment; filename=custom_data.json",
+        }
+
+    @app.route('/api/assessments/review/import-custom-data', methods=['POST'])
+    def import_review_custom_data():
+        """Import assessments, CVSS scores and time estimates from a custom-data
+        JSON file.
+
+        Accepts either:
+
+        * ``multipart/form-data`` with a ``file`` field containing a ``.json``
+          file.
+        * ``application/json`` body with the custom-data payload directly.
+
+        Optional query parameter ``variant_id`` to force all imported
+        assessments to a specific variant.
+        """
+        import json as _json
+
+        variant_id = None
+        raw_vid = request.args.get('variant_id')
+        if raw_vid:
+            variant_id, err = parse_uuid_or_400(raw_vid, "variant_id")
+            if err:
+                return err
+
+        # Parse the incoming data
+        data = None
+        if request.content_type and 'multipart/form-data' in request.content_type:
+            uploaded = request.files.get('file')
+            if not uploaded or not uploaded.filename:
+                return {"error": "No file uploaded"}, 400
+            try:
+                data = _json.load(uploaded.stream)
+            except Exception:
+                return {"error": "Invalid JSON file"}, 400
+        elif request.content_type and 'application/json' in request.content_type:
+            data = request.get_json(silent=True)
+            if data is None:
+                return {"error": "Invalid JSON body"}, 400
+        else:
+            return {"error": "Expected multipart/form-data or application/json"}, 400
+
+        if not isinstance(data, dict) or "version" not in data:
+            return {"error": "Invalid custom-data format. Expected {version, assessments, ...}"}, 400
+
+        variant_by_name = build_variant_by_name_map()
+        result = import_custom_data(data, variant_by_name, variant_id)
+
+        _save_openvex()
+
+        status_code = 200 if result["status"] == "success" else 400
+        return result, status_code
 
     @app.route('/api/assessments/<assessment_id>')
     def assess_by_id(assessment_id: str):

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -337,6 +337,114 @@ def init_app(app):
 
         return {"error": "Unsupported file type. Please upload a .json or .tar.gz file."}, 400
 
+    @app.route('/api/assessments/review/time-estimates')
+    def review_time_estimates():
+        """Return vulnerabilities that have non-zero time estimates.
+
+        Each entry contains the vulnerability ID and its three-point estimate
+        (optimistic / likely / pessimistic) as ISO 8601 durations plus the
+        raw hour values.
+        """
+        from ..models.time_estimate import TimeEstimate
+        from ..models.iso8601_duration import Iso8601Duration
+        from ..models.variant import Variant as DBVariant
+        from sqlalchemy.orm import joinedload
+
+        variant_id = request.args.get('variant_id')
+        project_id = request.args.get('project_id')
+
+        query = (
+            db.select(TimeEstimate)
+            .options(joinedload(TimeEstimate.finding))
+            .where(
+                db.or_(
+                    TimeEstimate.optimistic > 0,
+                    TimeEstimate.likely > 0,
+                    TimeEstimate.pessimistic > 0,
+                )
+            )
+        )
+
+        variant_ids_filter: list | None = None
+        if variant_id:
+            vid, err = parse_uuid_or_400(variant_id, "variant_id")
+            if err:
+                return err
+            variant_ids_filter = [vid]
+        elif project_id:
+            pid, err = parse_uuid_or_400(project_id, "project_id")
+            if err:
+                return err
+            variant_ids_filter = [v.id for v in DBVariant.get_by_project(pid)]
+
+        if variant_ids_filter is not None:
+            query = query.where(
+                db.or_(
+                    TimeEstimate.variant_id.in_(variant_ids_filter),
+                    TimeEstimate.variant_id.is_(None),
+                )
+            )
+
+        all_te = list(db.session.execute(query).scalars().all())
+
+        def _hours_to_iso(h: int) -> str:
+            try:
+                return str(Iso8601Duration(f"PT{h}H"))
+            except (ValueError, TypeError):
+                return f"PT{h}H"
+
+        vuln_map: dict[str, dict] = {}
+        for te in all_te:
+            if te.finding is None:
+                continue
+            vid = te.finding.vulnerability_id
+            if vid in vuln_map:
+                continue
+            opt = te.optimistic or 0
+            lik = te.likely or 0
+            pes = te.pessimistic or 0
+            vuln = DBVuln.get_by_id(vid)
+            vuln_map[vid] = {
+                "vuln_id": vid,
+                "optimistic": opt,
+                "likely": lik,
+                "pessimistic": pes,
+                "optimistic_iso": _hours_to_iso(opt),
+                "likely_iso": _hours_to_iso(lik),
+                "pessimistic_iso": _hours_to_iso(pes),
+                "vuln_texts": dict(vuln.texts or {}) if vuln else {},
+            }
+
+        return sorted(vuln_map.values(), key=lambda x: x["vuln_id"])
+
+    @app.route('/api/assessments/review/custom-cvss')
+    def review_custom_cvss():
+        """Return vulnerabilities that have custom CVSS scores (author is not
+        ``nvd`` or ``unknown``).
+        """
+        from ..models.metrics import Metrics
+
+        all_metrics = list(db.session.execute(
+            db.select(Metrics).where(
+                Metrics.author.notin_(["nvd", "unknown"]),
+                Metrics.author.isnot(None),
+            )
+        ).scalars().all())
+
+        result: list[dict] = []
+        for m in sorted(all_metrics, key=lambda m: m.vulnerability_id):
+            vuln = DBVuln.get_by_id(m.vulnerability_id)
+            result.append({
+                "vuln_id": m.vulnerability_id,
+                "version": m.version or "",
+                "vector_string": m.vector or "",
+                "base_score": float(m.score) if m.score is not None else 0.0,
+                "author": m.author,
+                "vuln_texts": dict(vuln.texts or {}) if vuln else {},
+            })
+
+        return result
+
     @app.route('/api/assessments/review/export-custom-data')
     def export_review_custom_data():
         """Export handmade (review) assessments, custom CVSS scores and time
@@ -350,16 +458,25 @@ def init_app(app):
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
 
+        from ..models.project import Project as DBProject
+
         variant_ids = None
+        project_name = None
         if variant_id:
             vid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:
                 return err
             variant_ids = [vid]
+            variant = DBVariant.get_by_id(vid)
+            if variant and variant.project:
+                project_name = variant.project.name
         elif project_id:
             pid, err = parse_uuid_or_400(project_id, "project_id")
             if err:
                 return err
+            project = DBProject.get_by_id(pid)
+            if project:
+                project_name = project.name
             variants = DBVariant.get_by_project(pid)
             variant_ids = [v.id for v in variants]
 
@@ -369,10 +486,13 @@ def init_app(app):
             return {"error": "No custom data to export"}, 404
 
         import json as _json
+        import re as _re
         json_bytes = _json.dumps(data, indent=2)
+        safe_name = _re.sub(r'[^\w\-.]', '_', project_name) if project_name else None
+        fname = f"custom_data_{safe_name}.json" if safe_name else "custom_data.json"
         return json_bytes, 200, {
             "Content-Type": "application/json",
-            "Content-Disposition": "attachment; filename=custom_data.json",
+            "Content-Disposition": f'attachment; filename="{fname}"',
         }
 
     @app.route('/api/assessments/review/import-custom-data', methods=['POST'])

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -8,9 +8,11 @@ Computation helpers live in sibling modules:
 - ``_scan_diff``     — diff algorithms & list-view serialisation
 """
 
+import re
 import uuid as uuid_module
+from datetime import datetime, timezone
 
-from flask import jsonify
+from flask import jsonify, request as flask_request
 
 from ..controllers.scans import ScanController
 from ..controllers.projects import ProjectController
@@ -55,6 +57,191 @@ from ._scan_diff import (  # noqa: F401  — re-exports
     _classify_finding_changes,
     _prev_scan_map,
 )
+
+
+# ---------------------------------------------------------------------------
+# Scan export helpers — mirror the frontend strip/transform functions
+# ---------------------------------------------------------------------------
+
+def _extract_supplier_name(supplier: str) -> str:
+    """Strip SPDX-style prefix and trailing email from a supplier string."""
+    s = re.sub(r'^[^:]+:\s*', '', supplier)
+    return re.sub(r'\s*\([^)]*\)$', '', s)
+
+
+def _scan_meta(scan, variant_name=None, project_name=None):
+    """Build scan metadata dict for export."""
+    scan_type = scan.scan_type or "sbom"
+    ts = scan.timestamp
+    if isinstance(ts, datetime):
+        ts = ts.isoformat()
+    return {
+        "scan_id": str(scan.id),
+        "timestamp": ts,
+        "scan_type": "vulnerability_scan" if scan_type == "tool" else "import_sbom",
+        "scan_source": scan.scan_source or None,
+        "project_name": project_name or None,
+        "variant_id": str(scan.variant_id),
+        "variant_name": variant_name or None,
+    }
+
+
+def _strip_finding(entry: dict) -> dict:
+    supplier = _extract_supplier_name(entry.get("package_supplier", "") or "")
+    result = {
+        "vulnerability_id": entry.get("vulnerability_id", ""),
+        "package_name": entry.get("package_name", ""),
+        "package_version": entry.get("package_version", ""),
+    }
+    if supplier:
+        result["supplier"] = supplier
+    return result
+
+
+def _strip_package(entry: dict) -> dict:
+    supplier = _extract_supplier_name(entry.get("package_supplier", "") or "")
+    result = {
+        "package_name": entry.get("package_name", ""),
+        "package_version": entry.get("package_version", ""),
+    }
+    if supplier:
+        result["supplier"] = supplier
+    return result
+
+
+def _strip_package_upgrade(entry: dict) -> dict:
+    supplier = _extract_supplier_name(entry.get("package_supplier", "") or "")
+    result = {
+        "package_name": entry.get("package_name", ""),
+        "old_version": entry.get("old_version", ""),
+        "new_version": entry.get("new_version", ""),
+    }
+    if supplier:
+        result["supplier"] = supplier
+    return result
+
+
+def _strip_finding_upgrade(entry: dict) -> dict:
+    supplier = _extract_supplier_name(entry.get("package_supplier", "") or "")
+    result = {
+        "vulnerability_id": entry.get("vulnerability_id", ""),
+        "package_name": entry.get("package_name", ""),
+        "old_version": entry.get("old_version", ""),
+        "new_version": entry.get("new_version", ""),
+    }
+    if supplier:
+        result["supplier"] = supplier
+    return result
+
+
+def _strip_assessment(entry: dict) -> dict:
+    return {
+        "vulnerability_id": entry.get("vulnerability_id", ""),
+        "status": entry.get("status", ""),
+        "simplified_status": entry.get("simplified_status", ""),
+        "justification": entry.get("justification", ""),
+        "impact_statement": entry.get("impact_statement", ""),
+        "status_notes": entry.get("status_notes", ""),
+    }
+
+
+def _build_diff_export(scan, diff: dict, variant_name=None, project_name=None) -> dict:
+    """Build the export-ready dict from a scan and its diff response."""
+    meta = _scan_meta(scan, variant_name, project_name)
+    is_tool = (scan.scan_type or "sbom") == "tool"
+
+    if is_tool:
+        return {
+            **meta,
+            "vulnerabilities": diff.get("all_vulns") or diff.get("vulns_added", []),
+            "findings": [_strip_finding(f) for f in (diff.get("all_findings") or diff.get("findings_added", []))],
+            "newly_detected_vulns": diff.get("newly_detected_vulns_list") or [],
+            "newly_detected_findings": [_strip_finding(f) for f in (diff.get("newly_detected_findings_list") or [])],
+            "newly_detected_assessments": [_strip_assessment(a) for a in (diff.get("newly_detected_assessments_list") or [])],
+        }
+
+    # SBOM scan
+    base: dict = {
+        **meta,
+        "vulnerabilities": diff.get("all_vulns") or (diff.get("vulns_added", []) + diff.get("vulns_unchanged", [])),
+        "findings": [_strip_finding(f) for f in (diff.get("all_findings") or (diff.get("findings_added", []) + diff.get("findings_unchanged", [])))],
+        "packages": [_strip_package(p) for p in (diff.get("packages_added", []) + diff.get("packages_unchanged", []))],
+        "assessments": [_strip_assessment(a) for a in (list(diff.get("assessments_added") or []) + list(diff.get("assessments_unchanged") or []))],
+    }
+
+    if not diff.get("is_first", True):
+        base["diff"] = {
+            "vulns_added": diff.get("vulns_added", []),
+            "vulns_removed": diff.get("vulns_removed", []),
+            "vulns_unchanged": diff.get("vulns_unchanged", []),
+            "findings_added": [_strip_finding(f) for f in diff.get("findings_added", [])],
+            "findings_removed": [_strip_finding(f) for f in diff.get("findings_removed", [])],
+            "findings_upgraded": [_strip_finding_upgrade(f) for f in diff.get("findings_upgraded", [])],
+            "findings_unchanged": [_strip_finding(f) for f in diff.get("findings_unchanged", [])],
+            "packages_added": [_strip_package(p) for p in diff.get("packages_added", [])],
+            "packages_removed": [_strip_package(p) for p in diff.get("packages_removed", [])],
+            "packages_upgraded": [_strip_package_upgrade(p) for p in diff.get("packages_upgraded", [])],
+            "packages_unchanged": [_strip_package(p) for p in diff.get("packages_unchanged", [])],
+            "assessments_added": [_strip_assessment(a) for a in (diff.get("assessments_added") or [])],
+            "assessments_removed": [_strip_assessment(a) for a in (diff.get("assessments_removed") or [])],
+            "assessments_unchanged": [_strip_assessment(a) for a in (diff.get("assessments_unchanged") or [])],
+        }
+
+    return base
+
+
+def _build_global_result_export(scan, result: dict, variant_name=None, project_name=None) -> dict:
+    """Build the export-ready dict from a scan and its global result."""
+    meta = _scan_meta(scan, variant_name, project_name)
+    return {
+        **meta,
+        "packages": [
+            {
+                "package_name": p.get("package_name", ""),
+                "package_version": p.get("package_version", ""),
+                **({"supplier": s} if (s := _extract_supplier_name(p.get("package_supplier", "") or "")) else {}),
+                "sources": p.get("sources", []),
+            }
+            for p in result.get("packages", [])
+        ],
+        "findings": [
+            {
+                "vulnerability_id": f.get("vulnerability_id", ""),
+                "package_name": f.get("package_name", ""),
+                "package_version": f.get("package_version", ""),
+                **({"supplier": s} if (s := _extract_supplier_name(f.get("package_supplier", "") or "")) else {}),
+                "sources": f.get("sources", []),
+            }
+            for f in result.get("findings", [])
+        ],
+        "vulnerabilities": [
+            {
+                "vulnerability_id": v.get("vulnerability_id", ""),
+                "sources": v.get("sources", []),
+            }
+            for v in result.get("vulnerabilities", [])
+        ],
+        "assessments": [_strip_assessment(a) for a in result.get("assessments", [])],
+    }
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize a string for use in a filename."""
+    s = re.sub(r'\s+', '_', name)
+    s = re.sub(r'[<>:"/\\|?*]+', '', s)
+    s = re.sub(r'_+', '_', s)
+    return s.strip('_')
+
+
+def _format_timestamp_for_filename(dt=None) -> str:
+    """Format a datetime (or now) as YYYYMMDD_HHmmss for filenames."""
+    if dt is None:
+        d = datetime.now(timezone.utc)
+    elif isinstance(dt, str):
+        d = datetime.fromisoformat(dt)
+    else:
+        d = dt
+    return d.strftime('%Y%m%d_%H%M%S')
 
 
 def init_app(app):
@@ -159,366 +346,44 @@ def init_app(app):
         if scan is None:
             return jsonify({"error": "Scan not found"}), 404
 
-        # Locate the previous scan of the same type (and source) for the same variant
-        all_variant_scans = ScanController.get_by_variant(scan.variant_id)
+        diff = _compute_diff_dict(scan)
+
         scan_type = scan.scan_type or "sbom"
-        scan_source = scan.scan_source
-        prev_scan_id = None
-        same_type_scans = [
-            s for s in all_variant_scans
-            if (s.scan_type or "sbom") == scan_type
-            and (s.scan_source == scan_source if scan_type == "tool" else True)
-        ]
-        for i, s in enumerate(same_type_scans):
-            if s.id == scan.id and i > 0:
-                prev_scan_id = same_type_scans[i - 1].id
-                break
+        prev_scan_id = diff["previous_scan_id"]
 
-        is_tool_scan = scan_type == "tool"
-        scan_origin = _origin_for_scan(scan)
-
-        # Load previous scan once (reused for findings diff, SBOM diff, and assessments)
-        _prev_scan = _load_scan_with_findings(prev_scan_id) if prev_scan_id else None
-
-        # --- Findings diff ---
-        current_finding_ids = {obs.finding_id for obs in scan.observations}
-        curr_vulns = {obs.finding.vulnerability_id for obs in scan.observations}
-
-        if is_tool_scan:
-            # Tool scan: diff against the GLOBAL state using the same
-            # helpers as the list view (_contributing_scans_at/before +
-            # _global_result_id_sets) so that numbers are always in sync.
-            sbom_before, tools_before = _contributing_scans_before(
-                scan, all_variant_scans)
-            sbom_after, tools_after = _contributing_scans_at(
-                scan, all_variant_scans)
-            _global_before_f, _global_before_v, _ = _global_result_id_sets(
-                sbom_before, tools_before,
-                filter_tool_by_sbom_pkgs=True)
-            _global_after_f, _global_after_v, _ = _global_result_id_sets(
-                sbom_after, tools_after,
-                filter_tool_by_sbom_pkgs=True)
-
-            added_fids = _global_after_f - _global_before_f
-            removed_fids = _global_before_f - _global_after_f
-
-            findings_added = [
-                _obs_to_dict(obs, scan_origin)
-                for obs in scan.observations if obs.finding_id in added_fids
-            ]
-            # Removed findings come from the previous same-source scan
-            if _prev_scan:
-                _prev_origin = _origin_for_scan(_prev_scan)
-                findings_removed = [
-                    _obs_to_dict(obs, _prev_origin)
-                    for obs in _prev_scan.observations
-                    if obs.finding_id in removed_fids
-                ]
-            else:
-                findings_removed: list = []
-            vulns_added = sorted(_global_after_v - _global_before_v)
-            vulns_removed = sorted(_global_before_v - _global_after_v)
-        elif prev_scan_id is None:
-            findings_added = [_obs_to_dict(obs, scan_origin) for obs in scan.observations]
-            findings_removed: list = []
-            vulns_added = sorted(curr_vulns)
-            vulns_removed: list = []
-        else:
-            prev_finding_ids = {obs.finding_id for obs in _prev_scan.observations} if _prev_scan else set()
-            prev_vulns = {obs.finding.vulnerability_id for obs in _prev_scan.observations} if _prev_scan else set()
-            added_fids = current_finding_ids - prev_finding_ids
-            removed_fids = prev_finding_ids - current_finding_ids
-            findings_added = [
-                _obs_to_dict(obs, scan_origin)
-                for obs in scan.observations if obs.finding_id in added_fids
-            ]
-            findings_removed = (
-                [_obs_to_dict(obs, scan_origin) for obs in _prev_scan.observations if obs.finding_id in removed_fids]
-                if _prev_scan else []
-            )
-            vulns_added = sorted(curr_vulns - prev_vulns)
-            vulns_removed = sorted(prev_vulns - curr_vulns)
-
-        # --- Packages diff (skipped for tool scans) ---
-        if is_tool_scan:
-            curr_pkg_ids: set = set()
-            packages_added: list = []
-            packages_removed: list = []
-            packages_upgraded: list = []
-            upgraded_pairs: list = []
-        else:
-            scans_to_query = [scan.id] if prev_scan_id is None else [scan.id, prev_scan_id]
-            pkg_sets = _packages_by_scan_ids(scans_to_query)
-            curr_pkg_ids = pkg_sets.get(scan.id, set())
-            prev_pkg_ids = pkg_sets.get(prev_scan_id, set()) if prev_scan_id else set()
-
-            raw_added_pkg_ids = curr_pkg_ids - prev_pkg_ids
-            raw_removed_pkg_ids = prev_pkg_ids - curr_pkg_ids
-
-            all_relevant_pkg_ids = raw_added_pkg_ids | raw_removed_pkg_ids
-            pkg_lookup = _package_rows(all_relevant_pkg_ids)
-
-            truly_added_ids, truly_removed_ids, upgraded_pairs = _classify_package_changes(
-                raw_added_pkg_ids, raw_removed_pkg_ids, pkg_lookup
-            )
-
-            packages_added = [_pkg_to_dict(pkg_lookup[pid]) for pid in truly_added_ids if pid in pkg_lookup]
-            packages_removed = [_pkg_to_dict(pkg_lookup[pid]) for pid in truly_removed_ids if pid in pkg_lookup]
-            packages_upgraded = [
-                {
-                    "package_name": (old_pkg.name or "unknown"),
-                    "old_version": (old_pkg.version or ""),
-                    "new_version": (new_pkg.version or ""),
-                    "old_package_id": str(old_pkg.id),
-                    "new_package_id": str(new_pkg.id),
-                    "package_supplier": (old_pkg.supplier or ""),
-                }
-                for old_pkg, new_pkg in upgraded_pairs
-            ]
-
-        # --- Classify findings using scan-result diffs ---
-        # For SBOM scans: scan result = SBOM ∪ tool-scan findings on
-        # that SBOM's active packages.  The diff is between the current
-        # and previous scan results so all categories are consistent:
-        #   new + upgraded + unchanged  = current scan result
-        #   removed + upgraded + unchanged = previous scan result
-        if not is_tool_scan and prev_scan_id is not None:
-            # Use the same shared helpers as the list view so that
-            # counts are always in sync.  Enable SBOM-package filtering
-            # so tool findings for removed packages classify correctly.
-            _, latest_tool = _contributing_scans_at(scan, all_variant_scans)
-            curr_sr_fids, curr_sr_vids, _ = _global_result_id_sets(
-                scan, latest_tool, filter_tool_by_sbom_pkgs=True)
-            prev_sr_fids, prev_sr_vids, _ = _global_result_id_sets(
-                _prev_scan, latest_tool,
-                filter_tool_by_sbom_pkgs=True)
-
-            # Build finding_id → (obs_dict, origin) lookup for full output.
-            # We still need to load observations for the detail response.
-            fid_obs_map: dict = {}  # finding_id → obs dict
-            fid_info: dict = {}     # finding_id → (pkg_id, vuln_id)
-            for obs in scan.observations:
-                fid = obs.finding_id
-                fid_obs_map[fid] = _obs_to_dict(obs, scan_origin)
-                fid_info[fid] = (obs.finding.package_id, obs.finding.vulnerability_id)
-            for obs in (_prev_scan.observations if _prev_scan else []):
-                fid = obs.finding_id
-                if fid not in fid_obs_map:
-                    fid_obs_map[fid] = _obs_to_dict(obs, scan_origin)
-                if fid not in fid_info:
-                    fid_info[fid] = (obs.finding.package_id, obs.finding.vulnerability_id)
-            for tool_scan_obj in latest_tool.values():
-                tool_loaded = _load_scan_with_findings(tool_scan_obj.id)
-                if not tool_loaded:
-                    continue
-                tool_origin = _origin_for_scan(tool_loaded)
-                for obs in tool_loaded.observations:
-                    fid = obs.finding_id
-                    if fid not in fid_obs_map:
-                        fid_obs_map[fid] = _obs_to_dict(obs, tool_origin)
-                    if fid not in fid_info:
-                        fid_info[fid] = (obs.finding.package_id, obs.finding.vulnerability_id)
-
-            # Diff scan results
-            sr_new_fids = curr_sr_fids - prev_sr_fids
-            sr_gone_fids = prev_sr_fids - curr_sr_fids
-            sr_unchanged_fids = prev_sr_fids & curr_sr_fids
-
-            # 1:1 upgrade matching
-            upgraded_old_ids_set: set = {old_pkg.id for old_pkg, _ in upgraded_pairs}
-            upgraded_new_ids_set: set = {new_pkg.id for _, new_pkg in upgraded_pairs}
-            upgraded_old_to_new: dict = {}
-            for old_pkg, new_pkg in upgraded_pairs:
-                upgraded_old_to_new[old_pkg.id] = (old_pkg, new_pkg)
-
-            # Group gone findings on upgraded-old packages by vuln
-            _rem_by_vuln: dict = {}  # vuln_id → [(fid, pkg_id)]
-            for fid in sr_gone_fids:
-                info = fid_info.get(fid)
-                if info and info[0] in upgraded_old_ids_set:
-                    _rem_by_vuln.setdefault(info[1], []).append((fid, info[0]))
-
-            # Match new findings on upgraded-new packages 1:1
-            sr_upgraded_fids_new: set = set()   # fids from new (on new pkg)
-            sr_upgraded_fids_gone: set = set()   # fids from gone (on old pkg)
-            findings_upgraded_list: list = []
-            for fid in sr_new_fids:
-                info = fid_info.get(fid)
-                if info and info[0] in upgraded_new_ids_set:
-                    candidates = _rem_by_vuln.get(info[1], [])
-                    if candidates:
-                        old_fid, old_pkg_id = candidates.pop(0)
-                        sr_upgraded_fids_new.add(fid)
-                        sr_upgraded_fids_gone.add(old_fid)
-                        old_pkg, new_pkg = upgraded_old_to_new[old_pkg_id]
-                        obs_dict = fid_obs_map.get(fid, {})
-                        findings_upgraded_list.append({
-                            "vulnerability_id": info[1],
-                            "package_name": old_pkg.name or "unknown",
-                            "old_version": old_pkg.version or "",
-                            "new_version": new_pkg.version or "",
-                            "package_supplier": old_pkg.supplier or "",
-                            "origin": obs_dict.get("origin", scan_origin),
-                        })
-
-            findings_added = [
-                fid_obs_map[fid] for fid in sr_new_fids - sr_upgraded_fids_new
-                if fid in fid_obs_map
-            ]
-            findings_removed = [
-                fid_obs_map[fid] for fid in sr_gone_fids - sr_upgraded_fids_gone
-                if fid in fid_obs_map
-            ]
-            findings_upgraded = findings_upgraded_list
-            findings_unchanged = [
-                fid_obs_map[fid] for fid in sr_unchanged_fids
-                if fid in fid_obs_map
-            ]
-
-            vulns_added = sorted(curr_sr_vids - prev_sr_vids)
-            vulns_removed = sorted(prev_sr_vids - curr_sr_vids)
-            vulns_unchanged = sorted(prev_sr_vids & curr_sr_vids)
-
-            # Unchanged packages
-            unchanged_pkg_ids = curr_pkg_ids & prev_pkg_ids  # type: ignore[possibly-undefined]
-            for old_pkg, new_pkg in upgraded_pairs:
-                unchanged_pkg_ids.discard(old_pkg.id)
-                unchanged_pkg_ids.discard(new_pkg.id)
-            if unchanged_pkg_ids:
-                unchanged_pkg_lookup = _package_rows(unchanged_pkg_ids)
-                packages_unchanged = [
-                    _pkg_to_dict(unchanged_pkg_lookup[pid])
-                    for pid in unchanged_pkg_ids if pid in unchanged_pkg_lookup
-                ]
-            else:
-                packages_unchanged = []
-        elif not is_tool_scan:
-            # First SBOM scan — no previous scan result
-            findings_upgraded = []
-            findings_unchanged = []
-            vulns_unchanged = []
-            packages_unchanged = []
-        else:
-            findings_upgraded = []
-            findings_unchanged = []
-            vulns_unchanged = []
-            packages_unchanged = []
-
-        # Sort for stable output
-        packages_added.sort(key=lambda p: (p["package_name"], p["package_version"]))
-        packages_removed.sort(key=lambda p: (p["package_name"], p["package_version"]))
-        packages_upgraded.sort(key=lambda p: (p["package_name"], p["old_version"]))
-        findings_upgraded.sort(key=lambda f: (f["package_name"], f["vulnerability_id"]))
-
-        # --- Newly detected (tool scans only) ---
-        # Vulns from THIS scan not in the previous global result,
-        # plus findings linked to those new vulns.
-        newly_detected_findings_count = None
-        newly_detected_vulns_count = None
-        newly_detected_findings_list = None
-        newly_detected_vulns_list = None
-        newly_detected_assessments_list = None
-
-        if is_tool_scan:
-            # Use the filtered global sets so that
-            # prev Scan Result + newly_detected == Scan Result.
-            _new_vids = _global_after_v - _global_before_v
-            _new_fids = _global_after_f - _global_before_f
-            newly_detected_vulns_count = len(_new_vids)
-            newly_detected_vulns_list = sorted(_new_vids)
-            newly_detected_findings_list = [
-                _obs_to_dict(obs, scan_origin)
-                for obs in scan.observations
-                if obs.finding_id in _new_fids
-            ]
-            newly_detected_findings_count = len(newly_detected_findings_list)
-
-            # Newly detected assessments: diff global assessment sets
-            _before_assess_ids = _global_assessment_ids_for(sbom_before, tools_before)
-            _after_assess_ids = _global_assessment_ids_for(sbom_after, tools_after)
-            _new_assess_ids = _after_assess_ids - _before_assess_ids
-            if _new_assess_ids:
-                from ..models.assessment import Assessment
-                _assess_rows = db.session.execute(
-                    db.select(
-                        Assessment.id,
-                        Finding.vulnerability_id,
-                        Assessment.status,
-                        Assessment.simplified_status,
-                        Assessment.justification,
-                        Assessment.impact_statement,
-                        Assessment.status_notes,
-                    )
-                    .join(Finding, Finding.id == Assessment.finding_id)
-                    .where(Assessment.id.in_(_new_assess_ids))
-                ).all()
-                newly_detected_assessments_list = [
-                    {
-                        "vulnerability_id": vid,
-                        "status": status or "under_investigation",
-                        "simplified_status": simp or "Pending Assessment",
-                        "justification": just or "",
-                        "impact_statement": impact or "",
-                        "status_notes": notes or "",
-                    }
-                    for _aid, vid, status, simp, just, impact, notes in _assess_rows
-                ]
-                newly_detected_assessments_list.sort(key=lambda a: a["vulnerability_id"])
-            else:
-                newly_detected_assessments_list = []
-
-        # For tool scans, provide flat lists of ALL findings/vulns from this scan
-        all_findings_list = None
-        all_vulns_list = None
-        if is_tool_scan:
-            all_findings_list = [
-                _obs_to_dict(obs, scan_origin)
-                for obs in scan.observations
-            ]
-            all_vulns_list = sorted(curr_vulns)
-
-        # --- Assessment counts + detail (single shared query) ---
-        # Determine next scan timestamp for same variant to bound the window
-        _next_scan_ts = None
-        for s in all_variant_scans:
-            if s.timestamp > scan.timestamp:
-                if _next_scan_ts is None or s.timestamp < _next_scan_ts:
-                    _next_scan_ts = s.timestamp
-        # Locate previous scan object for removed-assessment computation
-        assess_detail = _assessments_detail_for_scan(
-            scan, next_scan_ts=_next_scan_ts, prev_scan=_prev_scan
-        )
+        newly_detected_findings_list = diff.get("newly_detected_findings_list")
+        newly_detected_vulns_list = diff.get("newly_detected_vulns_list")
 
         return jsonify({
             "scan_id": str(scan.id),
             "scan_type": scan_type,
             "previous_scan_id": str(prev_scan_id) if prev_scan_id else None,
-            "is_first": prev_scan_id is None,
-            "finding_count": len(current_finding_ids),
-            "package_count": len(curr_pkg_ids),
-            "vuln_count": len(curr_vulns),
-            "findings_added": findings_added,
-            "findings_removed": findings_removed,
-            "findings_upgraded": findings_upgraded,
-            "findings_unchanged": findings_unchanged,
-            "packages_added": packages_added,
-            "packages_removed": packages_removed,
-            "packages_upgraded": packages_upgraded,
-            "packages_unchanged": packages_unchanged,
-            "vulns_added": vulns_added,
-            "vulns_removed": vulns_removed,
-            "vulns_unchanged": vulns_unchanged,
-            "assessment_count": assess_detail["total"],
-            "assessments_added": assess_detail["added"],
-            "assessments_removed": assess_detail["removed"],
-            "assessments_unchanged": assess_detail["unchanged_list"],
-            "newly_detected_findings": newly_detected_findings_count,
-            "newly_detected_vulns": newly_detected_vulns_count,
+            "is_first": diff["is_first"],
+            "finding_count": diff["finding_count"],
+            "package_count": diff["package_count"],
+            "vuln_count": diff["vuln_count"],
+            "findings_added": diff["findings_added"],
+            "findings_removed": diff["findings_removed"],
+            "findings_upgraded": diff["findings_upgraded"],
+            "findings_unchanged": diff["findings_unchanged"],
+            "packages_added": diff["packages_added"],
+            "packages_removed": diff["packages_removed"],
+            "packages_upgraded": diff["packages_upgraded"],
+            "packages_unchanged": diff["packages_unchanged"],
+            "vulns_added": diff["vulns_added"],
+            "vulns_removed": diff["vulns_removed"],
+            "vulns_unchanged": diff["vulns_unchanged"],
+            "assessment_count": diff["assessment_total"],
+            "assessments_added": diff["assessments_added"],
+            "assessments_removed": diff["assessments_removed"],
+            "assessments_unchanged": diff["assessments_unchanged"],
+            "newly_detected_findings": len(newly_detected_findings_list) if newly_detected_findings_list is not None else None,
+            "newly_detected_vulns": len(newly_detected_vulns_list) if newly_detected_vulns_list is not None else None,
             "newly_detected_findings_list": newly_detected_findings_list,
             "newly_detected_vulns_list": newly_detected_vulns_list,
-            "newly_detected_assessments_list": newly_detected_assessments_list,
-            "all_findings": all_findings_list,
-            "all_vulns": all_vulns_list,
+            "newly_detected_assessments_list": diff.get("newly_detected_assessments_list"),
+            "all_findings": diff.get("all_findings"),
+            "all_vulns": diff.get("all_vulns"),
         })
 
     # ------------------------------------------------------------------
@@ -545,3 +410,377 @@ def init_app(app):
 
         all_variant_scans = ScanController.get_by_variant(scan.variant_id)
         return jsonify(_global_result_full(scan, all_variant_scans))
+
+    # ------------------------------------------------------------------
+    # Export endpoints — server-side data transformation for downloads
+    # ------------------------------------------------------------------
+
+    def _compute_diff_dict(scan):
+        """Compute the diff dict for a scan (same logic as get_scan_diff)."""
+        all_variant_scans = ScanController.get_by_variant(scan.variant_id)
+        scan_type = scan.scan_type or "sbom"
+        scan_source = scan.scan_source
+        prev_scan_id = None
+        same_type_scans = [
+            s for s in all_variant_scans
+            if (s.scan_type or "sbom") == scan_type
+            and (s.scan_source == scan_source if scan_type == "tool" else True)
+        ]
+        for i, s in enumerate(same_type_scans):
+            if s.id == scan.id and i > 0:
+                prev_scan_id = same_type_scans[i - 1].id
+                break
+
+        is_tool_scan = scan_type == "tool"
+        scan_origin = _origin_for_scan(scan)
+        _prev_scan = _load_scan_with_findings(prev_scan_id) if prev_scan_id else None
+
+        current_finding_ids = {obs.finding_id for obs in scan.observations}
+        curr_vulns = {obs.finding.vulnerability_id for obs in scan.observations}
+
+        if is_tool_scan:
+            sbom_before, tools_before = _contributing_scans_before(scan, all_variant_scans)
+            sbom_after, tools_after = _contributing_scans_at(scan, all_variant_scans)
+            _global_before_f, _global_before_v, _ = _global_result_id_sets(
+                sbom_before, tools_before, filter_tool_by_sbom_pkgs=True)
+            _global_after_f, _global_after_v, _ = _global_result_id_sets(
+                sbom_after, tools_after, filter_tool_by_sbom_pkgs=True)
+            added_fids = _global_after_f - _global_before_f
+            removed_fids = _global_before_f - _global_after_f
+            findings_added = [_obs_to_dict(obs, scan_origin) for obs in scan.observations if obs.finding_id in added_fids]
+            if _prev_scan:
+                _prev_origin = _origin_for_scan(_prev_scan)
+                findings_removed = [_obs_to_dict(obs, _prev_origin) for obs in _prev_scan.observations if obs.finding_id in removed_fids]
+            else:
+                findings_removed = []
+            vulns_added = sorted(_global_after_v - _global_before_v)
+            vulns_removed = sorted(_global_before_v - _global_after_v)
+        elif prev_scan_id is None:
+            findings_added = [_obs_to_dict(obs, scan_origin) for obs in scan.observations]
+            findings_removed = []
+            vulns_added = sorted(curr_vulns)
+            vulns_removed = []
+        else:
+            prev_finding_ids = {obs.finding_id for obs in _prev_scan.observations} if _prev_scan else set()
+            prev_vulns = {obs.finding.vulnerability_id for obs in _prev_scan.observations} if _prev_scan else set()
+            added_fids = current_finding_ids - prev_finding_ids
+            removed_fids = prev_finding_ids - current_finding_ids
+            findings_added = [_obs_to_dict(obs, scan_origin) for obs in scan.observations if obs.finding_id in added_fids]
+            findings_removed = [_obs_to_dict(obs, scan_origin) for obs in _prev_scan.observations if obs.finding_id in removed_fids] if _prev_scan else []
+            vulns_added = sorted(curr_vulns - prev_vulns)
+            vulns_removed = sorted(prev_vulns - curr_vulns)
+
+        if is_tool_scan:
+            curr_pkg_ids = set()
+            packages_added = []
+            packages_removed = []
+            packages_upgraded = []
+        else:
+            scans_to_query = [scan.id] if prev_scan_id is None else [scan.id, prev_scan_id]
+            pkg_sets = _packages_by_scan_ids(scans_to_query)
+            curr_pkg_ids = pkg_sets.get(scan.id, set())
+            prev_pkg_ids = pkg_sets.get(prev_scan_id, set()) if prev_scan_id else set()
+            raw_added_pkg_ids = curr_pkg_ids - prev_pkg_ids
+            raw_removed_pkg_ids = prev_pkg_ids - curr_pkg_ids
+            all_relevant_pkg_ids = raw_added_pkg_ids | raw_removed_pkg_ids
+            pkg_lookup = _package_rows(all_relevant_pkg_ids)
+            truly_added_ids, truly_removed_ids, upgraded_pairs_list = _classify_package_changes(
+                raw_added_pkg_ids, raw_removed_pkg_ids, pkg_lookup)
+            packages_added = [_pkg_to_dict(pkg_lookup[pid]) for pid in truly_added_ids if pid in pkg_lookup]
+            packages_removed = [_pkg_to_dict(pkg_lookup[pid]) for pid in truly_removed_ids if pid in pkg_lookup]
+            packages_upgraded = [
+                {"package_name": old_pkg.name or "unknown", "old_version": old_pkg.version or "",
+                 "new_version": new_pkg.version or "", "old_package_id": str(old_pkg.id),
+                 "new_package_id": str(new_pkg.id), "package_supplier": old_pkg.supplier or ""}
+                for old_pkg, new_pkg in upgraded_pairs_list
+            ]
+
+        # Classify findings for SBOM with previous
+        if not is_tool_scan and prev_scan_id is not None:
+            _, latest_tool = _contributing_scans_at(scan, all_variant_scans)
+            curr_sr_fids, curr_sr_vids, _ = _global_result_id_sets(scan, latest_tool, filter_tool_by_sbom_pkgs=True)
+            prev_sr_fids, prev_sr_vids, _ = _global_result_id_sets(_prev_scan, latest_tool, filter_tool_by_sbom_pkgs=True)
+            fid_obs_map = {}
+            fid_info = {}
+            for obs in scan.observations:
+                fid_obs_map[obs.finding_id] = _obs_to_dict(obs, scan_origin)
+                fid_info[obs.finding_id] = (obs.finding.package_id, obs.finding.vulnerability_id)
+            for obs in (_prev_scan.observations if _prev_scan else []):
+                if obs.finding_id not in fid_obs_map:
+                    fid_obs_map[obs.finding_id] = _obs_to_dict(obs, scan_origin)
+                if obs.finding_id not in fid_info:
+                    fid_info[obs.finding_id] = (obs.finding.package_id, obs.finding.vulnerability_id)
+            for tool_scan_obj in latest_tool.values():
+                tool_loaded = _load_scan_with_findings(tool_scan_obj.id)
+                if not tool_loaded:
+                    continue
+                tool_origin = _origin_for_scan(tool_loaded)
+                for obs in tool_loaded.observations:
+                    if obs.finding_id not in fid_obs_map:
+                        fid_obs_map[obs.finding_id] = _obs_to_dict(obs, tool_origin)
+                    if obs.finding_id not in fid_info:
+                        fid_info[obs.finding_id] = (obs.finding.package_id, obs.finding.vulnerability_id)
+
+            sr_new_fids = curr_sr_fids - prev_sr_fids
+            sr_gone_fids = prev_sr_fids - curr_sr_fids
+            sr_unchanged_fids = prev_sr_fids & curr_sr_fids
+
+            upgraded_old_ids_set = {old_pkg.id for old_pkg, _ in upgraded_pairs_list}  # noqa: F841
+            upgraded_new_ids_set = {new_pkg.id for _, new_pkg in upgraded_pairs_list}
+            upgraded_old_to_new = {old_pkg.id: (old_pkg, new_pkg) for old_pkg, new_pkg in upgraded_pairs_list}
+            _rem_by_vuln = {}
+            for fid in sr_gone_fids:
+                info = fid_info.get(fid)
+                if info and info[0] in upgraded_old_ids_set:
+                    _rem_by_vuln.setdefault(info[1], []).append((fid, info[0]))
+            sr_upgraded_fids_new = set()
+            sr_upgraded_fids_gone = set()
+            findings_upgraded_list = []
+            for fid in sr_new_fids:
+                info = fid_info.get(fid)
+                if info and info[0] in upgraded_new_ids_set:
+                    candidates = _rem_by_vuln.get(info[1], [])
+                    if candidates:
+                        old_fid, old_pkg_id = candidates.pop(0)
+                        sr_upgraded_fids_new.add(fid)
+                        sr_upgraded_fids_gone.add(old_fid)
+                        old_pkg, new_pkg = upgraded_old_to_new[old_pkg_id]
+                        obs_dict = fid_obs_map.get(fid, {})
+                        findings_upgraded_list.append({
+                            "vulnerability_id": info[1], "package_name": old_pkg.name or "unknown",
+                            "old_version": old_pkg.version or "", "new_version": new_pkg.version or "",
+                            "package_supplier": old_pkg.supplier or "", "origin": obs_dict.get("origin", scan_origin),
+                        })
+            findings_added = [fid_obs_map[fid] for fid in sr_new_fids - sr_upgraded_fids_new if fid in fid_obs_map]
+            findings_removed = [fid_obs_map[fid] for fid in sr_gone_fids - sr_upgraded_fids_gone if fid in fid_obs_map]
+            findings_upgraded = findings_upgraded_list
+            findings_unchanged = [fid_obs_map[fid] for fid in sr_unchanged_fids if fid in fid_obs_map]
+            vulns_added = sorted(curr_sr_vids - prev_sr_vids)
+            vulns_removed = sorted(prev_sr_vids - curr_sr_vids)
+            vulns_unchanged = sorted(prev_sr_vids & curr_sr_vids)
+            unchanged_pkg_ids = curr_pkg_ids & prev_pkg_ids
+            for old_pkg, new_pkg in upgraded_pairs_list:
+                unchanged_pkg_ids.discard(old_pkg.id)
+                unchanged_pkg_ids.discard(new_pkg.id)
+            if unchanged_pkg_ids:
+                unchanged_pkg_lookup = _package_rows(unchanged_pkg_ids)
+                packages_unchanged = [_pkg_to_dict(unchanged_pkg_lookup[pid]) for pid in unchanged_pkg_ids if pid in unchanged_pkg_lookup]
+            else:
+                packages_unchanged = []
+        elif not is_tool_scan:
+            findings_upgraded = []
+            findings_unchanged = []
+            vulns_unchanged = []
+            packages_unchanged = []
+        else:
+            findings_upgraded = []
+            findings_unchanged = []
+            vulns_unchanged = []
+            packages_unchanged = []
+
+        # Newly detected (tool scans only)
+        newly_detected_findings_list = None
+        newly_detected_vulns_list = None
+        newly_detected_assessments_list = None
+        if is_tool_scan:
+            _new_vids = _global_after_v - _global_before_v
+            _new_fids = _global_after_f - _global_before_f
+            newly_detected_vulns_list = sorted(_new_vids)
+            newly_detected_findings_list = [_obs_to_dict(obs, scan_origin) for obs in scan.observations if obs.finding_id in _new_fids]
+            from ..models.assessment import Assessment as _Assessment
+            _before_assess_ids = _global_assessment_ids_for(sbom_before, tools_before)
+            _after_assess_ids = _global_assessment_ids_for(sbom_after, tools_after)
+            _new_assess_ids = _after_assess_ids - _before_assess_ids
+            if _new_assess_ids:
+                from ..models.finding import Finding as _Finding
+                _assess_rows = db.session.execute(
+                    db.select(_Assessment.id, _Finding.vulnerability_id, _Assessment.status,
+                              _Assessment.simplified_status, _Assessment.justification,
+                              _Assessment.impact_statement, _Assessment.status_notes)
+                    .join(_Finding, _Finding.id == _Assessment.finding_id)
+                    .where(_Assessment.id.in_(_new_assess_ids))
+                ).all()
+                newly_detected_assessments_list = sorted([
+                    {"vulnerability_id": vid, "status": status or "under_investigation",
+                     "simplified_status": simp or "Pending Assessment", "justification": just or "",
+                     "impact_statement": impact or "", "status_notes": notes or ""}
+                    for _aid, vid, status, simp, just, impact, notes in _assess_rows
+                ], key=lambda a: a["vulnerability_id"])
+            else:
+                newly_detected_assessments_list = []
+
+        all_findings_list = None
+        all_vulns_list = None
+        if is_tool_scan:
+            all_findings_list = [_obs_to_dict(obs, scan_origin) for obs in scan.observations]
+            all_vulns_list = sorted(curr_vulns)
+
+        _next_scan_ts = None
+        for s in all_variant_scans:
+            if s.timestamp > scan.timestamp:
+                if _next_scan_ts is None or s.timestamp < _next_scan_ts:
+                    _next_scan_ts = s.timestamp
+        assess_detail = _assessments_detail_for_scan(scan, next_scan_ts=_next_scan_ts, prev_scan=_prev_scan)
+
+        return {
+            "previous_scan_id": prev_scan_id,
+            "is_first": prev_scan_id is None,
+            "finding_count": len(current_finding_ids),
+            "package_count": len(curr_pkg_ids),
+            "vuln_count": len(curr_vulns),
+            "findings_added": findings_added,
+            "findings_removed": findings_removed,
+            "findings_upgraded": findings_upgraded,
+            "findings_unchanged": findings_unchanged,
+            "packages_added": packages_added,
+            "packages_removed": packages_removed,
+            "packages_upgraded": packages_upgraded,
+            "packages_unchanged": packages_unchanged,
+            "vulns_added": vulns_added,
+            "vulns_removed": vulns_removed,
+            "vulns_unchanged": vulns_unchanged,
+            "assessment_total": assess_detail["total"],
+            "assessments_added": assess_detail["added"],
+            "assessments_removed": assess_detail["removed"],
+            "assessments_unchanged": assess_detail["unchanged_list"],
+            "newly_detected_findings_list": newly_detected_findings_list,
+            "newly_detected_vulns_list": newly_detected_vulns_list,
+            "newly_detected_assessments_list": newly_detected_assessments_list,
+            "all_findings": all_findings_list,
+            "all_vulns": all_vulns_list,
+        }
+
+    @app.route('/api/scans/<scan_id>/export-diff')
+    def export_scan_diff(scan_id):
+        """Export a single scan's diff as a cleaned JSON download."""
+        try:
+            scan_uuid = uuid_module.UUID(scan_id)
+        except ValueError:
+            return jsonify({"error": "Invalid scan id"}), 400
+
+        scan = _load_scan_with_findings(scan_uuid)
+        if scan is None:
+            return jsonify({"error": "Scan not found"}), 404
+
+        variant_map = _variant_info([scan.variant_id])
+        vname, pname = variant_map.get(scan.variant_id, (None, None))
+
+        diff = _compute_diff_dict(scan)
+        export_data = _build_diff_export(scan, diff, vname, pname)
+
+        proj = _sanitize_filename(pname or "project")
+        variant = _sanitize_filename(vname or str(scan.variant_id))
+        ts = _format_timestamp_for_filename(scan.timestamp)
+        filename = f"scan_diff_{proj}_{variant}_{ts}.json"
+
+        response = jsonify(export_data)
+        response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response
+
+    @app.route('/api/scans/<scan_id>/export-result')
+    def export_scan_result(scan_id):
+        """Export a single scan's global result as a cleaned JSON download."""
+        try:
+            scan_uuid = uuid_module.UUID(scan_id)
+        except ValueError:
+            return jsonify({"error": "Invalid scan id"}), 400
+
+        scan = _load_scan_with_findings(scan_uuid)
+        if scan is None:
+            return jsonify({"error": "Scan not found"}), 404
+
+        variant_map = _variant_info([scan.variant_id])
+        vname, pname = variant_map.get(scan.variant_id, (None, None))
+
+        all_variant_scans = ScanController.get_by_variant(scan.variant_id)
+        result = _global_result_full(scan, all_variant_scans)
+        export_data = _build_global_result_export(scan, result, vname, pname)
+
+        proj = _sanitize_filename(pname or "project")
+        variant = _sanitize_filename(vname or str(scan.variant_id))
+        ts = _format_timestamp_for_filename(scan.timestamp)
+        filename = f"scan_total_{proj}_{variant}_{ts}.json"
+
+        response = jsonify(export_data)
+        response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response
+
+    @app.route('/api/scans/export')
+    def export_all_scans():
+        """Export all visible scans (optionally filtered by variant/project).
+
+        Query params:
+          - variant_id: filter to a single variant
+          - project_id: filter to a single project
+          - type: 'diff' or 'total' (default: 'diff')
+        Returns a JSON array of export objects grouped per variant, with
+        Content-Disposition for download.
+        """
+        export_type = flask_request.args.get("type", "diff")
+        if export_type not in ("diff", "total"):
+            return jsonify({"error": "type must be 'diff' or 'total'"}), 400
+
+        variant_id = flask_request.args.get("variant_id")
+        project_id = flask_request.args.get("project_id")
+
+        if variant_id:
+            try:
+                uuid_module.UUID(variant_id)
+            except ValueError:
+                return jsonify({"error": "Invalid variant_id"}), 400
+            scans = ScanController.get_by_variant(variant_id)
+        elif project_id:
+            try:
+                uuid_module.UUID(project_id)
+            except ValueError:
+                return jsonify({"error": "Invalid project_id"}), 400
+            project = ProjectController.get(project_id)
+            if project is None:
+                return jsonify({"error": "Project not found"}), 404
+            scans = ScanController.get_by_project(project_id)
+        else:
+            scans = ScanController.get_all()
+
+        if not scans:
+            return jsonify([])
+
+        MAX_EXPORT_SCANS = 200
+        if len(scans) > MAX_EXPORT_SCANS:
+            return jsonify({
+                "error": f"Too many scans ({len(scans)}). "
+                         f"Maximum is {MAX_EXPORT_SCANS}. "
+                         "Filter by variant_id or project_id to reduce the set."
+            }), 400
+
+        # Group scans by (project_name, variant_id) to produce one file per group
+        variant_ids = list({s.variant_id for s in scans})
+        variant_map = _variant_info(variant_ids)
+
+        groups: dict = {}
+        for scan in scans:
+            vname, pname = variant_map.get(scan.variant_id, (None, None))
+            key = f"{pname or ''}::{scan.variant_id}"
+            groups.setdefault(key, []).append((scan, vname, pname))
+
+        all_exports = []
+        for group_scans in groups.values():
+            group_data = []
+            for scan, vname, pname in group_scans:
+                loaded = _load_scan_with_findings(scan.id)
+                if not loaded:
+                    continue
+                if export_type == "diff":
+                    diff = _compute_diff_dict(loaded)
+                    group_data.append(_build_diff_export(loaded, diff, vname, pname))
+                else:
+                    all_variant_scans = ScanController.get_by_variant(scan.variant_id)
+                    result = _global_result_full(loaded, all_variant_scans)
+                    group_data.append(_build_global_result_export(loaded, result, vname, pname))
+            all_exports.extend(group_data)
+
+        ts = _format_timestamp_for_filename()
+        filename = f"scans_{export_type}_{ts}.json"
+
+        response = jsonify(all_exports)
+        response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -154,19 +154,43 @@ def _build_diff_export(scan, diff: dict, variant_name=None, project_name=None) -
         return {
             **meta,
             "vulnerabilities": diff.get("all_vulns") or diff.get("vulns_added", []),
-            "findings": [_strip_finding(f) for f in (diff.get("all_findings") or diff.get("findings_added", []))],
+            "findings": [
+                _strip_finding(f)
+                for f in (diff.get("all_findings") or diff.get("findings_added", []))
+            ],
             "newly_detected_vulns": diff.get("newly_detected_vulns_list") or [],
-            "newly_detected_findings": [_strip_finding(f) for f in (diff.get("newly_detected_findings_list") or [])],
-            "newly_detected_assessments": [_strip_assessment(a) for a in (diff.get("newly_detected_assessments_list") or [])],
+            "newly_detected_findings": [
+                _strip_finding(f)
+                for f in (diff.get("newly_detected_findings_list") or [])
+            ],
+            "newly_detected_assessments": [
+                _strip_assessment(a)
+                for a in (diff.get("newly_detected_assessments_list") or [])
+            ],
         }
 
     # SBOM scan
     base: dict = {
         **meta,
         "vulnerabilities": diff.get("all_vulns") or (diff.get("vulns_added", []) + diff.get("vulns_unchanged", [])),
-        "findings": [_strip_finding(f) for f in (diff.get("all_findings") or (diff.get("findings_added", []) + diff.get("findings_unchanged", [])))],
-        "packages": [_strip_package(p) for p in (diff.get("packages_added", []) + diff.get("packages_unchanged", []))],
-        "assessments": [_strip_assessment(a) for a in (list(diff.get("assessments_added") or []) + list(diff.get("assessments_unchanged") or []))],
+        "findings": [
+            _strip_finding(f)
+            for f in (
+                diff.get("all_findings")
+                or (diff.get("findings_added", []) + diff.get("findings_unchanged", []))
+            )
+        ],
+        "packages": [
+            _strip_package(p)
+            for p in (diff.get("packages_added", []) + diff.get("packages_unchanged", []))
+        ],
+        "assessments": [
+            _strip_assessment(a)
+            for a in (
+                list(diff.get("assessments_added") or [])
+                + list(diff.get("assessments_unchanged") or [])
+            )
+        ],
     }
 
     if not diff.get("is_first", True):
@@ -377,8 +401,16 @@ def init_app(app):
             "assessments_added": diff["assessments_added"],
             "assessments_removed": diff["assessments_removed"],
             "assessments_unchanged": diff["assessments_unchanged"],
-            "newly_detected_findings": len(newly_detected_findings_list) if newly_detected_findings_list is not None else None,
-            "newly_detected_vulns": len(newly_detected_vulns_list) if newly_detected_vulns_list is not None else None,
+            "newly_detected_findings": (
+                len(newly_detected_findings_list)
+                if newly_detected_findings_list is not None
+                else None
+            ),
+            "newly_detected_vulns": (
+                len(newly_detected_vulns_list)
+                if newly_detected_vulns_list is not None
+                else None
+            ),
             "newly_detected_findings_list": newly_detected_findings_list,
             "newly_detected_vulns_list": newly_detected_vulns_list,
             "newly_detected_assessments_list": diff.get("newly_detected_assessments_list"),
@@ -447,10 +479,16 @@ def init_app(app):
                 sbom_after, tools_after, filter_tool_by_sbom_pkgs=True)
             added_fids = _global_after_f - _global_before_f
             removed_fids = _global_before_f - _global_after_f
-            findings_added = [_obs_to_dict(obs, scan_origin) for obs in scan.observations if obs.finding_id in added_fids]
+            findings_added = [
+                _obs_to_dict(obs, scan_origin)
+                for obs in scan.observations if obs.finding_id in added_fids
+            ]
             if _prev_scan:
                 _prev_origin = _origin_for_scan(_prev_scan)
-                findings_removed = [_obs_to_dict(obs, _prev_origin) for obs in _prev_scan.observations if obs.finding_id in removed_fids]
+                findings_removed = [
+                    _obs_to_dict(obs, _prev_origin)
+                    for obs in _prev_scan.observations if obs.finding_id in removed_fids
+                ]
             else:
                 findings_removed = []
             vulns_added = sorted(_global_after_v - _global_before_v)
@@ -465,8 +503,14 @@ def init_app(app):
             prev_vulns = {obs.finding.vulnerability_id for obs in _prev_scan.observations} if _prev_scan else set()
             added_fids = current_finding_ids - prev_finding_ids
             removed_fids = prev_finding_ids - current_finding_ids
-            findings_added = [_obs_to_dict(obs, scan_origin) for obs in scan.observations if obs.finding_id in added_fids]
-            findings_removed = [_obs_to_dict(obs, scan_origin) for obs in _prev_scan.observations if obs.finding_id in removed_fids] if _prev_scan else []
+            findings_added = [
+                _obs_to_dict(obs, scan_origin)
+                for obs in scan.observations if obs.finding_id in added_fids
+            ]
+            findings_removed = [
+                _obs_to_dict(obs, scan_origin)
+                for obs in _prev_scan.observations if obs.finding_id in removed_fids
+            ] if _prev_scan else []
             vulns_added = sorted(curr_vulns - prev_vulns)
             vulns_removed = sorted(prev_vulns - curr_vulns)
 
@@ -498,8 +542,10 @@ def init_app(app):
         # Classify findings for SBOM with previous
         if not is_tool_scan and prev_scan_id is not None:
             _, latest_tool = _contributing_scans_at(scan, all_variant_scans)
-            curr_sr_fids, curr_sr_vids, _ = _global_result_id_sets(scan, latest_tool, filter_tool_by_sbom_pkgs=True)
-            prev_sr_fids, prev_sr_vids, _ = _global_result_id_sets(_prev_scan, latest_tool, filter_tool_by_sbom_pkgs=True)
+            curr_sr_fids, curr_sr_vids, _ = _global_result_id_sets(
+                scan, latest_tool, filter_tool_by_sbom_pkgs=True)
+            prev_sr_fids, prev_sr_vids, _ = _global_result_id_sets(
+                _prev_scan, latest_tool, filter_tool_by_sbom_pkgs=True)
             fid_obs_map = {}
             fid_info = {}
             for obs in scan.observations:
@@ -564,7 +610,10 @@ def init_app(app):
                 unchanged_pkg_ids.discard(new_pkg.id)
             if unchanged_pkg_ids:
                 unchanged_pkg_lookup = _package_rows(unchanged_pkg_ids)
-                packages_unchanged = [_pkg_to_dict(unchanged_pkg_lookup[pid]) for pid in unchanged_pkg_ids if pid in unchanged_pkg_lookup]
+                packages_unchanged = [
+                    _pkg_to_dict(unchanged_pkg_lookup[pid])
+                    for pid in unchanged_pkg_ids if pid in unchanged_pkg_lookup
+                ]
             else:
                 packages_unchanged = []
         elif not is_tool_scan:
@@ -586,7 +635,10 @@ def init_app(app):
             _new_vids = _global_after_v - _global_before_v
             _new_fids = _global_after_f - _global_before_f
             newly_detected_vulns_list = sorted(_new_vids)
-            newly_detected_findings_list = [_obs_to_dict(obs, scan_origin) for obs in scan.observations if obs.finding_id in _new_fids]
+            newly_detected_findings_list = [
+                _obs_to_dict(obs, scan_origin)
+                for obs in scan.observations if obs.finding_id in _new_fids
+            ]
             from ..models.assessment import Assessment as _Assessment
             _before_assess_ids = _global_assessment_ids_for(sbom_before, tools_before)
             _after_assess_ids = _global_assessment_ids_for(sbom_after, tools_after)

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -12,14 +12,12 @@ from ..models import (
     Scan,
     Variant,
     Metrics,
-    CVSS,
     SBOMDocument,
     SBOMPackage,
     Iso8601Duration
 )
 from ..helpers.datetime_utils import ensure_utc_iso
 from ..extensions import db
-from ..helpers.verbose import verbose
 from ..helpers.active_scans import (
     active_scan_ids_for_variant,
     active_scan_ids_for_project,
@@ -527,6 +525,7 @@ def init_app(app):
                     log_prefix=f"PATCH /api/vulnerabilities/{record.id}")
                 if cvss_err:
                     return cvss_err, 400
+                db.session.expire(record, ['metrics'])
 
         return record.to_dict()
 
@@ -573,6 +572,7 @@ def init_app(app):
                 if cvss_err:
                     errors.append({"id": item["id"], "error": cvss_err})
                     continue
+                db.session.expire(record, ['metrics'])
 
             results.append(record.to_dict())
 

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -25,6 +25,11 @@ from ..helpers.active_scans import (
     active_scan_ids_for_project,
     active_package_ids_for_scans,
 )
+from ..helpers.vuln_helpers import (
+    _validate_effort,
+    _validate_and_apply_cvss,
+    _apply_effort,
+)
 from ._scan_helpers import parse_uuid_or_400
 
 TIME_ESTIMATES_PATH = "/scan/outputs/time_estimates.json"
@@ -43,71 +48,6 @@ def _sbom_pkg_filter(pkg_ids):
         Scan.scan_type == "sbom",
         Finding.package_id.in_(pkg_ids),
     )
-
-
-def _parse_effort_hours(value) -> int:
-    """Parse an effort value (ISO 8601 duration string or integer hours) to whole hours."""
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str):
-        return int(Iso8601Duration(value).total_seconds // 3600)
-    raise ValueError(f"Invalid effort value: {value!r}")
-
-
-def _validate_effort(eff: dict):
-    """Validate and parse effort dict with optimistic/likely/pessimistic keys.
-
-    Returns ``(opt, lik, pes, None)`` on success or ``(None, None, None, error_string)``
-    on failure.
-    """
-    if not all(k in eff for k in ("optimistic", "likely", "pessimistic")):
-        return None, None, None, "Invalid effort values"
-    try:
-        opt = _parse_effort_hours(eff["optimistic"])
-        lik = _parse_effort_hours(eff["likely"])
-        pes = _parse_effort_hours(eff["pessimistic"])
-    except (ValueError, TypeError):
-        return None, None, None, "Invalid effort values"
-    if not (opt <= lik <= pes):
-        return None, None, None, "Invalid effort values"
-    return opt, lik, pes, None
-
-
-def _validate_and_apply_cvss(new_cvss: dict, record_id: str, log_prefix: str = ""):
-    """Validate CVSS payload and persist to Metrics.
-
-    Returns an error string on validation failure, ``None`` on success.
-    """
-    required_keys = {"base_score", "vector_string", "version"}
-    if not required_keys.issubset(new_cvss.keys()):
-        return "Invalid CVSS data"
-    cvss_obj = CVSS.from_dict(new_cvss)
-    try:
-        Metrics.from_cvss(cvss_obj, record_id)
-    except Exception as e:
-        verbose(f"[{log_prefix} cvss] {e}")
-    return None
-
-
-def _apply_effort(record, variant_id, opt, lik, pes, log_prefix: str = ""):
-    """Persist effort values to the first finding's TimeEstimate."""
-    try:
-        from ..models.time_estimate import TimeEstimate
-        for finding in (record.findings or []):
-            if variant_id is not None:
-                existing = TimeEstimate.get_by_finding_and_variant(finding.id, variant_id)
-            else:
-                existing = finding.time_estimate
-            if existing is not None:
-                existing.update(optimistic=opt, likely=lik, pessimistic=pes)
-            else:
-                TimeEstimate.create(
-                    finding_id=finding.id, variant_id=variant_id,
-                    optimistic=opt, likely=lik, pessimistic=pes
-                )
-            break
-    except Exception as e:
-        verbose(f"[{log_prefix} effort] {e}")
 
 
 # Formats that are exclusively vulnerability scanners (never pure package BOMs)

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -522,3 +522,332 @@ def test_export_import_round_trip(client):
     assert import_resp.status_code == 200
     result = json.loads(import_resp.data)
     assert result["status"] == "success"
+
+
+# ── GET /api/assessments/review/export-custom-data ───────────────────────
+
+def test_export_custom_data_empty(client):
+    """No handmade assessments → 404."""
+    resp = client.get("/api/assessments/review/export-custom-data")
+    assert resp.status_code == 404
+
+
+def test_export_custom_data_basic(client):
+    """After creating an assessment, export-custom-data returns the right structure."""
+    _create_handmade_assessment(client)
+    resp = client.get("/api/assessments/review/export-custom-data")
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert data["version"] == 1
+    assert "exported_at" in data
+    assert isinstance(data["assessments"], list)
+    assert len(data["assessments"]) >= 1
+    assert isinstance(data["cvss"], list)
+    assert isinstance(data["time_estimates"], list)
+    # Each assessment should have the expected keys
+    a = data["assessments"][0]
+    assert "vuln_id" in a
+    assert "status" in a
+    assert "packages" in a
+
+
+def test_export_custom_data_by_variant(client):
+    """Filter by variant_id returns only that variant's assessments."""
+    _create_handmade_assessment(client)
+    resp = client.get(f"/api/assessments/review/export-custom-data?variant_id={VARIANT_UUID}")
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert len(data["assessments"]) >= 1
+    for a in data["assessments"]:
+        assert a["variant_id"] == VARIANT_UUID
+
+
+def test_export_custom_data_by_project(client):
+    _create_handmade_assessment(client)
+    resp = client.get(f"/api/assessments/review/export-custom-data?project_id={PROJECT_UUID}")
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert len(data["assessments"]) >= 1
+
+
+def test_export_custom_data_invalid_variant(client):
+    resp = client.get("/api/assessments/review/export-custom-data?variant_id=bad")
+    assert resp.status_code == 400
+
+
+def test_export_custom_data_invalid_project(client):
+    resp = client.get("/api/assessments/review/export-custom-data?project_id=bad")
+    assert resp.status_code == 400
+
+
+def test_export_custom_data_with_cvss(client):
+    """Custom CVSS entries (non-nvd, non-unknown) appear in the export."""
+    _create_handmade_assessment(client)
+    # Add a custom CVSS via the batch endpoint
+    client.patch("/api/vulnerabilities/batch", json={
+        "vulnerabilities": [{
+            "id": "CVE-2020-35492",
+            "cvss": {
+                "base_score": 7.5,
+                "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "version": "3.1",
+                "author": "my-custom-tool",
+                "exploitability_score": 0.0,
+                "impact_score": 0.0,
+            },
+        }]
+    })
+    resp = client.get("/api/assessments/review/export-custom-data")
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    # The CVSS entry should exist (author may vary depending on Metrics.from_cvss logic)
+    assert isinstance(data["cvss"], list)
+
+
+def test_export_custom_data_with_time_estimate(client):
+    """Time estimates appear in the export."""
+    _create_handmade_assessment(client)
+    # Add a time estimate via the batch endpoint
+    client.patch("/api/vulnerabilities/batch", json={
+        "vulnerabilities": [{
+            "id": "CVE-2020-35492",
+            "effort": {
+                "optimistic": "PT2H",
+                "likely": "PT4H",
+                "pessimistic": "PT8H",
+            },
+        }]
+    })
+    resp = client.get("/api/assessments/review/export-custom-data")
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert isinstance(data["time_estimates"], list)
+    assert len(data["time_estimates"]) >= 1
+    te = data["time_estimates"][0]
+    assert te["vuln_id"] == "CVE-2020-35492"
+    assert "optimistic" in te
+    assert "likely" in te
+    assert "pessimistic" in te
+
+
+# ── POST /api/assessments/review/import-custom-data ──────────────────────
+
+def _custom_data_payload(assessments=None, cvss=None, time_estimates=None):
+    """Build a minimal custom-data JSON payload."""
+    return {
+        "version": 1,
+        "exported_at": "2025-01-01T00:00:00Z",
+        "assessments": assessments or [],
+        "cvss": cvss or [],
+        "time_estimates": time_estimates or [],
+    }
+
+
+def test_import_custom_data_no_file(client):
+    resp = client.post("/api/assessments/review/import-custom-data",
+                       content_type="multipart/form-data")
+    assert resp.status_code == 400
+
+
+def test_import_custom_data_wrong_content_type(client):
+    resp = client.post("/api/assessments/review/import-custom-data",
+                       data=b"hello", content_type="text/plain")
+    assert resp.status_code == 400
+
+
+def test_import_custom_data_invalid_json(client):
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        data={"file": (io.BytesIO(b"not json"), "data.json")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 400
+
+
+def test_import_custom_data_missing_version(client):
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json={"assessments": []},
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+def test_import_custom_data_assessments(client):
+    """Import assessments via the custom-data endpoint."""
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2020-35492",
+        "status": "affected",
+        "packages": ["cairo@1.16.0"],
+        "variant_id": VARIANT_UUID,
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload,
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["status"] == "success"
+    assert result["assessments_imported"] >= 1
+
+
+def test_import_custom_data_duplicate_skipped(client):
+    """Same assessment imported twice → second is skipped."""
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2020-35492",
+        "status": "not_affected",
+        "justification": "component_not_present",
+        "packages": ["cairo@1.16.0"],
+        "variant_id": VARIANT_UUID,
+    }])
+    resp1 = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp1.status_code == 200
+    r1 = json.loads(resp1.data)
+    assert r1["assessments_imported"] >= 1
+
+    resp2 = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp2.status_code == 200
+    r2 = json.loads(resp2.data)
+    assert r2["assessments_skipped"] >= 1
+    assert r2["assessments_imported"] == 0
+
+
+def test_import_custom_data_cvss(client):
+    """Import CVSS via the custom-data endpoint."""
+    payload = _custom_data_payload(cvss=[{
+        "vuln_id": "CVE-2020-35492",
+        "version": "3.1",
+        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "base_score": 7.5,
+        "author": "custom-author",
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["cvss_imported"] >= 1
+
+
+def test_import_custom_data_time_estimates(client):
+    """Import time estimates via the custom-data endpoint."""
+    payload = _custom_data_payload(time_estimates=[{
+        "vuln_id": "CVE-2020-35492",
+        "optimistic": "PT2H",
+        "likely": "PT4H",
+        "pessimistic": "PT8H",
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["time_estimates_imported"] >= 1
+
+
+def test_import_custom_data_all_together(client):
+    """Import assessments + CVSS + time estimates in a single request."""
+    payload = _custom_data_payload(
+        assessments=[{
+            "vuln_id": "CVE-2020-35492",
+            "status": "under_investigation",
+            "packages": ["cairo@1.16.0"],
+            "variant_id": VARIANT_UUID,
+        }],
+        cvss=[{
+            "vuln_id": "CVE-2020-35492",
+            "version": "3.1",
+            "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "base_score": 7.5,
+            "author": "my-tool",
+        }],
+        time_estimates=[{
+            "vuln_id": "CVE-2020-35492",
+            "optimistic": "PT1H",
+            "likely": "PT2H",
+            "pessimistic": "PT4H",
+        }],
+    )
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["assessments_imported"] >= 1
+    assert result["cvss_imported"] >= 1
+    assert result["time_estimates_imported"] >= 1
+
+
+def test_import_custom_data_via_file_upload(client):
+    """Import custom-data via multipart file upload."""
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2020-35492",
+        "status": "affected",
+        "packages": ["cairo@1.16.0"],
+        "variant_id": VARIANT_UUID,
+    }])
+    data_bytes = json.dumps(payload).encode("utf-8")
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        data={"file": (io.BytesIO(data_bytes), "custom_data.json")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["assessments_imported"] >= 1
+
+
+def test_import_custom_data_unknown_vuln_cvss(client):
+    """CVSS for a non-existent vulnerability → error reported."""
+    payload = _custom_data_payload(cvss=[{
+        "vuln_id": "CVE-9999-99999",
+        "version": "3.1",
+        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "base_score": 7.5,
+        "author": "test",
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    # Should succeed overall but report the error
+    result = json.loads(resp.data)
+    assert any("Vulnerability not found" in e.get("error", "") for e in result.get("errors", []))
+
+
+def test_export_import_custom_data_round_trip(client):
+    """Export custom data → import it back."""
+    _create_handmade_assessment(client, status="affected")
+    # Add CVSS and time estimate
+    client.patch("/api/vulnerabilities/batch", json={
+        "vulnerabilities": [{
+            "id": "CVE-2020-35492",
+            "effort": {"optimistic": "PT1H", "likely": "PT2H", "pessimistic": "PT4H"},
+        }]
+    })
+
+    # Export
+    export_resp = client.get("/api/assessments/review/export-custom-data")
+    assert export_resp.status_code == 200
+    exported = json.loads(export_resp.data)
+    assert exported["version"] == 1
+    assert len(exported["assessments"]) >= 1
+
+    # Import back
+    import_resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=exported, content_type="application/json",
+    )
+    assert import_resp.status_code == 200
+    result = json.loads(import_resp.data)
+    assert result["status"] == "success"

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -524,6 +524,100 @@ def test_export_import_round_trip(client):
     assert result["status"] == "success"
 
 
+# ── GET /api/assessments/review/time-estimates ───────────────────────────
+
+def test_review_time_estimates_empty(client):
+    """No time estimates → empty list."""
+    resp = client.get("/api/assessments/review/time-estimates")
+    assert resp.status_code == 200
+    assert json.loads(resp.data) == []
+
+
+def test_review_time_estimates_basic(client):
+    """After adding a time estimate it appears in the listing."""
+    _create_handmade_assessment(client)
+    client.patch("/api/vulnerabilities/batch", json={
+        "vulnerabilities": [{
+            "id": "CVE-2020-35492",
+            "effort": {"optimistic": "PT2H", "likely": "PT4H", "pessimistic": "PT8H"},
+        }]
+    })
+    resp = client.get("/api/assessments/review/time-estimates")
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert len(data) >= 1
+    entry = data[0]
+    assert entry["vuln_id"] == "CVE-2020-35492"
+    assert entry["optimistic"] == 2
+    assert entry["likely"] == 4
+    assert entry["pessimistic"] == 8
+    assert "optimistic_iso" in entry
+    assert "vuln_texts" in entry
+
+
+def test_review_time_estimates_by_variant(client):
+    _create_handmade_assessment(client)
+    client.patch("/api/vulnerabilities/batch", json={
+        "vulnerabilities": [{
+            "id": "CVE-2020-35492",
+            "effort": {"optimistic": "PT1H", "likely": "PT2H", "pessimistic": "PT3H"},
+        }]
+    })
+    resp = client.get(f"/api/assessments/review/time-estimates?variant_id={VARIANT_UUID}")
+    assert resp.status_code == 200
+    assert isinstance(json.loads(resp.data), list)
+
+
+def test_review_time_estimates_by_project(client):
+    _create_handmade_assessment(client)
+    client.patch("/api/vulnerabilities/batch", json={
+        "vulnerabilities": [{
+            "id": "CVE-2020-35492",
+            "effort": {"optimistic": "PT1H", "likely": "PT2H", "pessimistic": "PT3H"},
+        }]
+    })
+    resp = client.get(f"/api/assessments/review/time-estimates?project_id={PROJECT_UUID}")
+    assert resp.status_code == 200
+    assert isinstance(json.loads(resp.data), list)
+
+
+# ── GET /api/assessments/review/custom-cvss ──────────────────────────────
+
+def test_review_custom_cvss_empty(client):
+    """No custom CVSS entries → empty list."""
+    resp = client.get("/api/assessments/review/custom-cvss")
+    assert resp.status_code == 200
+    assert json.loads(resp.data) == []
+
+
+def test_review_custom_cvss_basic(client):
+    """Custom CVSS entries (non-nvd author) appear in the listing."""
+    _create_handmade_assessment(client)
+    client.patch("/api/vulnerabilities/batch", json={
+        "vulnerabilities": [{
+            "id": "CVE-2020-35492",
+            "cvss": {
+                "base_score": 8.0,
+                "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "version": "3.1",
+                "author": "custom-tool",
+                "exploitability_score": 0.0,
+                "impact_score": 0.0,
+            },
+        }]
+    })
+    resp = client.get("/api/assessments/review/custom-cvss")
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert len(data) >= 1
+    entry = data[0]
+    assert entry["vuln_id"] == "CVE-2020-35492"
+    assert "version" in entry
+    assert "vector_string" in entry
+    assert "author" in entry
+    assert "vuln_texts" in entry
+
+
 # ── GET /api/assessments/review/export-custom-data ───────────────────────
 
 def test_export_custom_data_empty(client):
@@ -628,6 +722,26 @@ def test_export_custom_data_with_time_estimate(client):
     assert "optimistic" in te
     assert "likely" in te
     assert "pessimistic" in te
+
+
+def test_export_custom_data_filename_by_variant(client):
+    """Export by variant_id includes the project name in the filename."""
+    _create_handmade_assessment(client)
+    resp = client.get(f"/api/assessments/review/export-custom-data?variant_id={VARIANT_UUID}")
+    assert resp.status_code == 200
+    disposition = resp.headers.get("Content-Disposition", "")
+    assert "custom_data_" in disposition
+    assert disposition.endswith('.json"')
+
+
+def test_export_custom_data_filename_by_project(client):
+    """Export by project_id includes the project name in the filename."""
+    _create_handmade_assessment(client)
+    resp = client.get(f"/api/assessments/review/export-custom-data?project_id={PROJECT_UUID}")
+    assert resp.status_code == 200
+    disposition = resp.headers.get("Content-Disposition", "")
+    assert "custom_data_" in disposition
+    assert disposition.endswith('.json"')
 
 
 # ── POST /api/assessments/review/import-custom-data ──────────────────────

--- a/tests/webapp_tests/test_scan_export.py
+++ b/tests/webapp_tests/test_scan_export.py
@@ -1,0 +1,295 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for scan export endpoints in src/routes/scans.py."""
+
+import pytest
+import json
+import os
+import uuid
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _build_export_db(app):
+    """Populate a Project → Variant → 2 SBOM Scans chain for export tests.
+
+    Layout
+    ------
+    ExportProject / ExportVariant
+        ScanA  (first SBOM, cairo@1.16.0, CVE-2020-35492)
+        ScanB  (second SBOM, cairo@1.16.0 + libpng@1.6.37, CVE-2020-35492 + CVE-2019-7317)
+
+    Returns UUID strings safe outside app context.
+    """
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.observation import Observation
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("ExportProject")
+        variant = Variant.create("ExportVariant", project.id)
+
+        scan_a = Scan.create("first scan", variant.id)
+        scan_b = Scan.create("second scan", variant.id)
+
+        pkg1 = Package.find_or_create("cairo", "1.16.0")
+        pkg2 = Package.find_or_create("libpng", "1.6.37")
+        vuln1 = Vulnerability.create_record(id="CVE-2020-35492", description="cairo vuln")
+        vuln2 = Vulnerability.create_record(id="CVE-2019-7317", description="libpng vuln")
+        finding1 = Finding.get_or_create(pkg1.id, vuln1.id)
+        finding2 = Finding.get_or_create(pkg2.id, vuln2.id)
+        _db.session.commit()
+
+        # ScanA: one package, one finding
+        sbom_a = SBOMDocument.create("/scan_a/sbom.json", "spdx", scan_a.id)
+        SBOMPackage.create(sbom_a.id, pkg1.id)
+        Observation.create(finding_id=finding1.id, scan_id=scan_a.id)
+
+        # ScanB: two packages, two findings
+        sbom_b = SBOMDocument.create("/scan_b/sbom.json", "spdx", scan_b.id)
+        SBOMPackage.create(sbom_b.id, pkg1.id)
+        SBOMPackage.create(sbom_b.id, pkg2.id)
+        Observation.create(finding_id=finding1.id, scan_id=scan_b.id)
+        Observation.create(finding_id=finding2.id, scan_id=scan_b.id)
+        _db.session.commit()
+
+        return {
+            "project_id": str(project.id),
+            "variant_id": str(variant.id),
+            "scan_a_id": str(scan_a.id),
+            "scan_b_id": str(scan_b.id),
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        ids = _build_export_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+# ---------------------------------------------------------------------------
+# GET /api/scans/<scan_id>/export-diff
+# ---------------------------------------------------------------------------
+
+class TestExportScanDiff:
+    def test_export_first_scan_diff(self, client, ids):
+        """First scan export has no diff section, just current state."""
+        r = client.get(f"/api/scans/{ids['scan_a_id']}/export-diff")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert data["scan_id"] == ids["scan_a_id"]
+        assert data["scan_type"] == "import_sbom"
+        assert data["project_name"] == "ExportProject"
+        assert data["variant_name"] == "ExportVariant"
+        assert "diff" not in data
+        assert "vulnerabilities" in data
+        assert "findings" in data
+        assert "packages" in data
+
+    def test_export_second_scan_diff(self, client, ids):
+        """Second scan export includes a diff section."""
+        r = client.get(f"/api/scans/{ids['scan_b_id']}/export-diff")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert data["scan_id"] == ids["scan_b_id"]
+        assert "diff" in data
+        diff = data["diff"]
+        # libpng was added in scan_b
+        added_pkgs = diff["packages_added"]
+        added_pkg_names = [p["package_name"] for p in added_pkgs]
+        assert "libpng" in added_pkg_names
+
+    def test_export_diff_strips_internal_ids(self, client, ids):
+        """Export should not contain package_id or finding_id fields."""
+        r = client.get(f"/api/scans/{ids['scan_a_id']}/export-diff")
+        data = json.loads(r.data)
+        for f in data.get("findings", []):
+            assert "finding_id" not in f
+            assert "package_id" not in f
+
+    def test_export_diff_has_content_disposition(self, client, ids):
+        """Response includes Content-Disposition header for download."""
+        r = client.get(f"/api/scans/{ids['scan_a_id']}/export-diff")
+        assert r.status_code == 200
+        cd = r.headers.get("Content-Disposition", "")
+        assert "attachment" in cd
+        assert "scan_diff_" in cd
+        assert ".json" in cd
+
+    def test_export_diff_invalid_id(self, client):
+        """Invalid UUID returns 400."""
+        r = client.get("/api/scans/not-a-uuid/export-diff")
+        assert r.status_code == 400
+
+    def test_export_diff_not_found(self, client):
+        """Non-existent scan returns 404."""
+        r = client.get(f"/api/scans/{uuid.uuid4()}/export-diff")
+        assert r.status_code == 404
+
+    def test_export_diff_includes_metadata(self, client, ids):
+        """Export includes scan_source, variant_id, timestamp."""
+        r = client.get(f"/api/scans/{ids['scan_a_id']}/export-diff")
+        data = json.loads(r.data)
+        assert "timestamp" in data
+        assert data["variant_id"] == ids["variant_id"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/scans/<scan_id>/export-result
+# ---------------------------------------------------------------------------
+
+class TestExportScanResult:
+    def test_export_result_basic(self, client, ids):
+        """Export global result includes packages, findings, vulns."""
+        r = client.get(f"/api/scans/{ids['scan_b_id']}/export-result")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert data["scan_id"] == ids["scan_b_id"]
+        assert data["scan_type"] == "import_sbom"
+        assert "packages" in data
+        assert "findings" in data
+        assert "vulnerabilities" in data
+        assert "assessments" in data
+
+    def test_export_result_strips_ids(self, client, ids):
+        """Export should not contain internal IDs in packages/findings."""
+        r = client.get(f"/api/scans/{ids['scan_b_id']}/export-result")
+        data = json.loads(r.data)
+        for p in data.get("packages", []):
+            assert "package_id" not in p
+        for f in data.get("findings", []):
+            assert "finding_id" not in f
+            assert "package_id" not in f
+
+    def test_export_result_has_sources(self, client, ids):
+        """Global result export includes source attribution."""
+        r = client.get(f"/api/scans/{ids['scan_b_id']}/export-result")
+        data = json.loads(r.data)
+        for p in data.get("packages", []):
+            assert "sources" in p
+        for f in data.get("findings", []):
+            assert "sources" in f
+
+    def test_export_result_has_content_disposition(self, client, ids):
+        """Response includes Content-Disposition header."""
+        r = client.get(f"/api/scans/{ids['scan_b_id']}/export-result")
+        assert r.status_code == 200
+        cd = r.headers.get("Content-Disposition", "")
+        assert "attachment" in cd
+        assert "scan_total_" in cd
+
+    def test_export_result_invalid_id(self, client):
+        r = client.get("/api/scans/not-a-uuid/export-result")
+        assert r.status_code == 400
+
+    def test_export_result_not_found(self, client):
+        r = client.get(f"/api/scans/{uuid.uuid4()}/export-result")
+        assert r.status_code == 404
+
+    def test_export_result_metadata(self, client, ids):
+        """Export result has project/variant metadata."""
+        r = client.get(f"/api/scans/{ids['scan_b_id']}/export-result")
+        data = json.loads(r.data)
+        assert data["project_name"] == "ExportProject"
+        assert data["variant_name"] == "ExportVariant"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/scans/export (batch)
+# ---------------------------------------------------------------------------
+
+class TestExportAllScans:
+    def test_export_all_diff(self, client, ids):
+        """Export all diffs returns a list with entries for each scan."""
+        r = client.get("/api/scans/export?type=diff")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert isinstance(data, list)
+        assert len(data) >= 2
+        scan_ids = {d["scan_id"] for d in data}
+        assert ids["scan_a_id"] in scan_ids
+        assert ids["scan_b_id"] in scan_ids
+
+    def test_export_all_total(self, client, ids):
+        """Export all results returns a list."""
+        r = client.get("/api/scans/export?type=total")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert isinstance(data, list)
+        assert len(data) >= 2
+
+    def test_export_all_by_variant(self, client, ids):
+        """Filter by variant_id."""
+        r = client.get(f"/api/scans/export?type=diff&variant_id={ids['variant_id']}")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert len(data) >= 2
+        for d in data:
+            assert d["variant_id"] == ids["variant_id"]
+
+    def test_export_all_by_project(self, client, ids):
+        """Filter by project_id."""
+        r = client.get(f"/api/scans/export?type=diff&project_id={ids['project_id']}")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert len(data) >= 2
+
+    def test_export_all_invalid_type(self, client):
+        """Invalid type parameter returns 400."""
+        r = client.get("/api/scans/export?type=invalid")
+        assert r.status_code == 400
+
+    def test_export_all_invalid_variant(self, client):
+        """Invalid variant_id returns 400."""
+        r = client.get("/api/scans/export?type=diff&variant_id=bad")
+        assert r.status_code == 400
+
+    def test_export_all_has_content_disposition(self, client):
+        """Batch export includes Content-Disposition header."""
+        r = client.get("/api/scans/export?type=diff")
+        assert r.status_code == 200
+        cd = r.headers.get("Content-Disposition", "")
+        assert "attachment" in cd
+        assert "scans_diff_" in cd
+
+    def test_export_all_entries_have_no_internal_ids(self, client, ids):
+        """Entries in batch export should not contain internal IDs."""
+        r = client.get("/api/scans/export?type=diff")
+        data = json.loads(r.data)
+        for entry in data:
+            for f in entry.get("findings", []):
+                assert "finding_id" not in f
+                assert "package_id" not in f

--- a/tests/webapp_tests/test_vulnerabilities_coverage.py
+++ b/tests/webapp_tests/test_vulnerabilities_coverage.py
@@ -382,8 +382,11 @@ def test_patch_vulnerabilities_batch_mixed_results(client):
 
 
 # Test PATCH vulnerabilities batch - update with CVSS
-def test_patch_vulnerabilities_batch_with_cvss(client):
+def test_patch_vulnerabilities_batch_with_cvss(client, monkeypatch):
     """Test batch update with CVSS data"""
+    from src.models import Metrics
+    monkeypatch.setattr(Metrics, "_seen", set())
+
     response = client.patch("/api/vulnerabilities/batch", json={
         'vulnerabilities': [
             {


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Scan history: Export scans (full or diff)
* Review: import and export all custom user data (assessments, cvss, time estimate, ...)

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

**1. Export custom data (empty state)**
- Go to the **Review** page
- Click the **Export** button (custom data)
- Expected: error toast saying "No custom data to export" (backend returns 404)

**2. Export custom data (with data)**
- Create at least one assessment
- Click **Export** again
- Expected: a `custom_data_<variant>_<timestamp>.json` file downloads
- Open the JSON, verify it has proper content

**3. Export filtered by variant/project**
- With the variant selector active, export again
- Open the JSON

**4. Import custom data (JSON body)**
- Take the exported JSON from step 2
- On the Review page, click **Import** and select that file
- Expected: success toast with counts like "X assessment(s) imported, Y skipped"
- Re-importing the same file should show "0 imported, N skipped" (duplicates skipped)

**6. Import invalid file**
- Try importing a `.txt` file or malformed JSON
- Expected: error toast, no crash

**7. Export single scan diff**
- Go to **Scan History**
- Click the export menu on a scan then "Export Diff"
- Expected: a `scan_diff_<project>_<variant>_<timestamp>.json` downloads
- Verify output has proper content
- If it's the 2nd+ scan: verify a `diff` section exists with `vulns_added`, `packages_added`, ...

**9. Export single scan result (global)**
- Click "Export Result" on a scan
- Expected: a `scan_total_<project>_<variant>_<timestamp>.json` downloads
- Verify output has proper content

**10. Export all scans (batch diff)**
- Click "Export All" → "Diff"
- Expected: single JSON file with an array of all scan diffs
- Each entry should have proper content

**11. Export all scans (batch total)**
- Click "Export All" → "Total"
- Expected: single JSON file with array of global results per scan

**12. Export error handling**
- Stop the backend, try exporting → Expected: error banner appears in the UI (not a silent failure)
- Restart the backend

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


