### PR TITLE
Revert "fix(cmd_scans): use click.echo instead of echo_via_pager"

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,4 @@
 cyclonedx-python-lib==11.7.0
-click>=8.0,<8.4  # pinned until https://github.com/pallets/click/issues/3449 is fixed
 flake8==7.0.0
 Flask==3.0.3
 Flask-SQLAlchemy==3.1.1


### PR DESCRIPTION
This reverts commit 81c6060e532f6abcba25aca6c11d91e7e9e1ae32 (#335).

[Click 8.4.1](https://github.com/pallets/click/releases/tag/8.4.1) fixed the issue.