### PR TITLE
Rework scan page UI

### DIFF
--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -22,7 +22,7 @@ import { useDocUrl } from "../helpers/useDocUrl";
 import { extractSupplierName } from "../helpers/pkgId";
 import { downloadJson } from "../helpers/exportJson";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook, faDownload } from "@fortawesome/free-solid-svg-icons";
+import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faMagnifyingGlass, faCube, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook, faDownload } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "../components/ConfirmationModal";
 import Variants from "../handlers/variant";
 import type { Variant } from "../handlers/variant";
@@ -1758,245 +1758,141 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                     }
                                 </p>
 
-                                {/* Row 2: badges + details button */}
-                                {(scan.scan_type || 'sbom') === 'tool' && (
-                                <>
-                                {/* Update Vulnerabilities row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Update Vulnerabilities:</span>
-                                    {scan.is_first ? (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
-                                            </span>
-                                            {scan.newly_detected_vulns != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_vulns > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {scan.newly_detected_vulns.toLocaleString()} new vulnerabilities discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    ) : (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
-                                            </span>
-                                            {scan.newly_detected_vulns != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_vulns > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {scan.newly_detected_vulns.toLocaleString()} new vulnerabilities discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    )}
-                                </div>
-                                {/* Update Findings row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Update Findings:</span>
-                                    {scan.is_first ? (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.finding_count ?? 0).toLocaleString()} findings detected
-                                            </span>
-                                            {scan.newly_detected_findings != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_findings > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {scan.newly_detected_findings.toLocaleString()} new findings discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    ) : (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.finding_count ?? 0).toLocaleString()} findings detected
-                                            </span>
-                                            {scan.newly_detected_findings != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_findings > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {scan.newly_detected_findings.toLocaleString()} new findings discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    )}
-
-                                </div>
-                                {/* Update Assessments row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Update Assessments:</span>
-                                    {scan.is_first ? (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.assessment_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.assessment_count ?? 0).toLocaleString()} assessments detected
-                                            </span>
-                                            {scan.newly_detected_assessments != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.newly_detected_assessments ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.newly_detected_assessments ?? 0).toLocaleString()} new assessments discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    ) : (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.assessment_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.assessment_count ?? 0).toLocaleString()} assessments detected
-                                            </span>
-                                            {scan.newly_detected_assessments != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.newly_detected_assessments ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.newly_detected_assessments ?? 0).toLocaleString()} new assessments discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    )}
-                                    {/* Details button */}
-                                    <button
-                                        onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
-                                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
-                                    >
-                                        Details
-                                    </button>
-                                </div>
-                                </>
-                                )}
-                                {(scan.scan_type || 'sbom') !== 'tool' && (
-                                <>
-                                {/* Vulnerabilities row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Vulnerabilities:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
-                                    </span>
-                                    {!scan.is_first && (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.vulns_added ?? 0).toLocaleString()} new vulnerabilities
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.vulns_removed ?? 0).toLocaleString()} vulnerabilities removed
-                                            </span>
-                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
-                                                {(scan.vulns_unchanged ?? 0).toLocaleString()} vulnerabilities unchanged
-                                            </span>
-                                        </>
-                                    )}
-                                </div>
-                                {/* Findings row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Findings:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.finding_count ?? 0).toLocaleString()} findings detected
-                                    </span>
-                                    {!scan.is_first && (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.findings_added ?? 0).toLocaleString()} new findings
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.findings_removed ?? 0).toLocaleString()} findings removed
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.findings_upgraded ?? 0).toLocaleString()} findings upgraded
-                                            </span>
-                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
-                                                {(scan.findings_unchanged ?? 0).toLocaleString()} findings unchanged
-                                            </span>
-                                        </>
-                                    )}
-                                </div>
-                                {/* Packages row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Packages:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.package_count ?? 0).toLocaleString()} packages detected
-                                    </span>
-                                    {!scan.is_first && (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.packages_added ?? 0).toLocaleString()} new packages
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.packages_removed ?? 0).toLocaleString()} packages removed
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.packages_upgraded ?? 0).toLocaleString()} packages upgraded
-                                            </span>
-                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
-                                                {(scan.packages_unchanged ?? 0).toLocaleString()} packages unchanged
-                                            </span>
-                                        </>
-                                    )}
-                                </div>
-                                {/* Assessments row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Assessments:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.assessment_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.assessment_count ?? 0).toLocaleString()} assessments detected
-                                    </span>
-                                    {!scan.is_first && (scan.assessment_count ?? 0) > 0 && (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.assessments_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.assessments_added ?? 0).toLocaleString()} new assessments
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.assessments_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.assessments_removed ?? 0).toLocaleString()} assessments removed
-                                            </span>
-                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
-                                                {(scan.assessments_unchanged ?? 0).toLocaleString()} assessments unchanged
-                                            </span>
-                                        </>
-                                    )}
-                                    {/* Details button */}
-                                    <button
-                                        onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
-                                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
-                                    >
-                                        Details
-                                    </button>
-                                </div>
-
-                                {/* Scan Result row — uses global counts when tool scans exist, else SBOM-only */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1 mt-2 pt-2 border-t border-neutral-300 dark:border-neutral-600">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Scan Result:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${((scan.global_package_count ?? scan.package_count ?? 0)) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.global_package_count ?? scan.package_count ?? 0).toLocaleString()} packages
-                                    </span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${((scan.global_finding_count ?? scan.finding_count ?? 0)) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.global_finding_count ?? scan.finding_count ?? 0).toLocaleString()} findings
-                                    </span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${((scan.global_vuln_count ?? scan.vuln_count ?? 0)) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.global_vuln_count ?? scan.vuln_count ?? 0).toLocaleString()} vulnerabilities
-                                    </span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_assessment_count ?? scan.assessment_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.global_assessment_count ?? scan.assessment_count ?? 0).toLocaleString()} assessments
-                                    </span>
-                                    <button
-                                        onClick={() => setOpenGlobalId(scan.id)}
-                                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
-                                    >
-                                        Details
-                                    </button>
-                                </div>
-                                </>
-                                )}
-
-                                {/* Scan Result (tool scans only) — SBOM ∪ all sources */}
-                                {(scan.scan_type || 'sbom') === 'tool' && scan.global_finding_count != null && (
-                                    <div className="flex items-center gap-2 flex-wrap mb-1 mt-2 pt-2 border-t border-neutral-300 dark:border-neutral-600">
-                                        <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Scan Result:</span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_package_count ?? 0).toLocaleString()} packages
+                                {/* Section A: Current result */}
+                                <div className="mb-3">
+                                    <p className="text-sm font-bold text-gray-800 dark:text-neutral-100 mb-2">Current result</p>
+                                    <div className="flex items-baseline gap-6 flex-wrap">
+                                        <span>
+                                            <span className="text-2xl font-bold text-cyan-400">
+                                                {(scan.global_package_count ?? scan.package_count ?? 0).toLocaleString()}
+                                            </span>{' '}
+                                            <span className="text-sm text-neutral-400">packages</span>
                                         </span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_finding_count ?? 0).toLocaleString()} findings
+                                        <span>
+                                            <span className="text-2xl font-bold text-cyan-400">
+                                                {(scan.global_vuln_count ?? scan.vuln_count ?? 0).toLocaleString()}
+                                            </span>{' '}
+                                            <span className="text-sm text-neutral-400">unique vulnerabilities</span>
                                         </span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_vuln_count ?? 0).toLocaleString()} vulnerabilities
+                                        <span>
+                                            <span className="text-2xl font-bold text-cyan-400">
+                                                {(scan.global_finding_count ?? scan.finding_count ?? 0).toLocaleString()}
+                                            </span>{' '}
+                                            <span className="text-sm text-neutral-400">vulnerability matches</span>
                                         </span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_assessment_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_assessment_count ?? 0).toLocaleString()} assessments
-                                        </span>
-                                        <button
-                                            onClick={() => setOpenGlobalId(scan.id)}
-                                            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
-                                        >
-                                            Details
-                                        </button>
                                     </div>
-                                )}
+                                    <div className="flex items-center justify-between mt-2">
+                                        <span className="text-xs text-neutral-400 italic">
+                                            {(scan.vulns_added === null && scan.findings_added === null) &&
+                                                'A vulnerability match is one vulnerability affecting one package.'}
+                                        </span>
+                                        <div className="flex items-center gap-2">
+                                            {(scan.vulns_added === null && scan.findings_added === null) && (
+                                                <button
+                                                    onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
+                                                    className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
+                                                >
+                                                    Details
+                                                </button>
+                                            )}
+                                            {scan.global_finding_count != null && (
+                                                <button
+                                                    onClick={() => setOpenGlobalId(scan.id)}
+                                                    className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
+                                                >
+                                                    View all
+                                                </button>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {/* Section B: Changes since previous scan */}
+                                {(scan.vulns_added !== null || scan.findings_added !== null) && (() => {
+                                    const vulnsAdded = scan.vulns_added ?? 0;
+                                    const vulnsRemoved = scan.vulns_removed ?? 0;
+                                    const vulnsUnchanged = scan.vulns_unchanged ?? 0;
+                                    const findingsAdded = scan.findings_added ?? 0;
+                                    const findingsRemoved = scan.findings_removed ?? 0;
+                                    const findingsUpgraded = scan.findings_upgraded ?? 0;
+                                    const findingsUnchanged = scan.findings_unchanged ?? 0;
+                                    const pkgsAdded = scan.packages_added ?? 0;
+                                    const pkgsRemoved = scan.packages_removed ?? 0;
+                                    const pkgsUpgraded = scan.packages_upgraded ?? 0;
+                                    const pkgsUnchanged = scan.packages_unchanged ?? 0;
+                                    const stillPresent = isTool ? 'previously known' : 'still present';
+                                    const noChanges =
+                                        vulnsAdded === 0 && vulnsRemoved === 0 &&
+                                        findingsAdded === 0 && findingsRemoved === 0 && findingsUpgraded === 0 &&
+                                        (isTool || (pkgsAdded === 0 && pkgsRemoved === 0 && pkgsUpgraded === 0));
+                                    const dot = <span className="text-neutral-500 mx-1" aria-hidden="true">·</span>;
+                                    return (
+                                        <div>
+                                            <p className="text-sm font-bold text-gray-800 dark:text-neutral-100 mb-2">Changes since previous scan</p>
+                                            <div className="space-y-1 text-sm">
+                                                {!noChanges && (
+                                                    <>
+                                                        {/* Unique vulnerabilities row */}
+                                                        <div className="flex items-center flex-wrap gap-x-1 gap-y-0.5">
+                                                            <FontAwesomeIcon icon={faShieldHalved} className="text-neutral-500 w-4 flex-shrink-0" aria-hidden="true" />
+                                                            <span className="text-neutral-400">Unique vulnerabilities:</span>
+                                                            <span className={vulnsAdded > 0 ? 'text-green-400' : 'text-neutral-400'}>
+                                                                {vulnsAdded.toLocaleString()} new
+                                                            </span>
+                                                            {dot}
+                                                            <span className={vulnsRemoved > 0 ? 'text-red-400' : 'text-neutral-400'}>
+                                                                {vulnsRemoved.toLocaleString()} no longer present
+                                                            </span>
+                                                            {vulnsUnchanged > 0 && <>{dot}<span className="text-neutral-400">{vulnsUnchanged.toLocaleString()} {stillPresent}</span></>}
+                                                        </div>
+                                                        {/* Vulnerability matches row */}
+                                                        <div className="flex items-center flex-wrap gap-x-1 gap-y-0.5">
+                                                            <FontAwesomeIcon icon={faMagnifyingGlass} className="text-neutral-500 w-4 flex-shrink-0" aria-hidden="true" />
+                                                            <span className="text-neutral-400">Vulnerability matches:</span>
+                                                            <span className={findingsAdded > 0 ? 'text-green-400' : 'text-neutral-400'}>
+                                                                {findingsAdded.toLocaleString()} new
+                                                            </span>
+                                                            {dot}
+                                                            <span className={findingsRemoved > 0 ? 'text-red-400' : 'text-neutral-400'}>
+                                                                {findingsRemoved.toLocaleString()} no longer present
+                                                            </span>
+                                                            {findingsUpgraded > 0 && <>{dot}<span className="text-yellow-400">{findingsUpgraded.toLocaleString()} updated</span></>}
+                                                            {findingsUnchanged > 0 && <>{dot}<span className="text-neutral-400">{findingsUnchanged.toLocaleString()} {stillPresent}</span></>}
+                                                        </div>
+                                                        {/* Packages row — SBOM scans only */}
+                                                        {!isTool && (
+                                                            <div className="flex items-center flex-wrap gap-x-1 gap-y-0.5">
+                                                                <FontAwesomeIcon icon={faCube} className="text-neutral-500 w-4 flex-shrink-0" aria-hidden="true" />
+                                                                <span className="text-neutral-400">Packages:</span>
+                                                                <span className={pkgsAdded > 0 ? 'text-green-400' : 'text-neutral-400'}>
+                                                                    {pkgsAdded.toLocaleString()} added
+                                                                </span>
+                                                                {dot}
+                                                                <span className={pkgsRemoved > 0 ? 'text-red-400' : 'text-neutral-400'}>
+                                                                    {pkgsRemoved.toLocaleString()} removed
+                                                                </span>
+                                                                {pkgsUpgraded > 0 && <>{dot}<span className="text-yellow-400">{pkgsUpgraded.toLocaleString()} updated</span></>}
+                                                                {pkgsUnchanged > 0 && <>{dot}<span className="text-neutral-400">{pkgsUnchanged.toLocaleString()} unchanged</span></>}
+                                                            </div>
+                                                        )}
+                                                    </>
+                                                )}
+                                            </div>
+                                            <div className="flex items-center justify-between mt-2">
+                                                {noChanges
+                                                    ? <p className="text-sm text-neutral-400 italic">No changes detected</p>
+                                                    : <span />
+                                                }
+                                                <button
+                                                    onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
+                                                    className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
+                                                >
+                                                    Details
+                                                </button>
+                                            </div>
+                                        </div>
+                                    );
+                                })()}
 
                                 {/* Description row */}
                                 {editingDescId === scan.id ? (

--- a/frontend/tests/unit_tests/test_scan_history_card.tsx
+++ b/frontend/tests/unit_tests/test_scan_history_card.tsx
@@ -1,0 +1,334 @@
+/// <reference types="jest" />
+import fetchMock from 'jest-fetch-mock';
+fetchMock.enableMocks();
+
+import { render, screen, waitFor } from '@testing-library/react';
+import "@testing-library/jest-dom";
+// @ts-expect-error TS6133
+import React from 'react';
+
+import type { Scan } from '../../src/handlers/scans';
+import ScanHistory from '../../src/pages/ScanHistory';
+
+// Stable snapshot reference for useSyncExternalStore compatibility
+const EMPTY_SCAN_SNAPSHOT: never[] = Object.freeze([]) as never[];
+
+// Mock all scan state stores — return idle/empty by default
+jest.mock('../../src/handlers/grypeScanState', () => ({
+    subscribe: jest.fn((cb: () => void) => { void cb; return () => {}; }),
+    getSnapshot: jest.fn(() => EMPTY_SCAN_SNAPSHOT),
+    setOnDone: jest.fn(),
+    triggerScan: jest.fn(),
+    dismiss: jest.fn(),
+}));
+jest.mock('../../src/handlers/nvdScanState', () => ({
+    subscribe: jest.fn((cb: () => void) => { void cb; return () => {}; }),
+    getSnapshot: jest.fn(() => EMPTY_SCAN_SNAPSHOT),
+    setOnDone: jest.fn(),
+    triggerScan: jest.fn(),
+    dismiss: jest.fn(),
+}));
+jest.mock('../../src/handlers/osvScanState', () => ({
+    subscribe: jest.fn((cb: () => void) => { void cb; return () => {}; }),
+    getSnapshot: jest.fn(() => EMPTY_SCAN_SNAPSHOT),
+    setOnDone: jest.fn(),
+    triggerScan: jest.fn(),
+    dismiss: jest.fn(),
+}));
+jest.mock('../../src/handlers/variant', () => ({
+    __esModule: true,
+    default: {
+        listAll: jest.fn().mockResolvedValue([]),
+        list: jest.fn().mockResolvedValue([]),
+    },
+}));
+
+beforeEach(() => {
+    fetchMock.resetMocks();
+});
+
+// --- Shared mock scan factory ---
+
+const baseScan: Scan = {
+    id: 'scan-1',
+    description: null,
+    scan_type: 'sbom',
+    scan_source: null,
+    timestamp: '2026-04-21T13:29:00.000Z',
+    variant_id: 'v1',
+    variant_name: 'default',
+    project_name: 'default',
+    finding_count: 15441,
+    package_count: 261,
+    vuln_count: 15333,
+    is_first: false,
+    findings_added: 4439,
+    findings_removed: 1357,
+    findings_upgraded: 0,
+    findings_unchanged: 10936,
+    packages_added: 232,
+    packages_removed: 21,
+    packages_upgraded: 16,
+    packages_unchanged: 13,
+    vulns_added: 4053,
+    vulns_removed: 30,
+    vulns_unchanged: 11293,
+    assessment_count: null,
+    assessments_added: null,
+    assessments_removed: null,
+    assessments_unchanged: null,
+    newly_detected_findings: null,
+    newly_detected_vulns: null,
+    newly_detected_assessments: null,
+    branch_finding_count: null,
+    branch_vuln_count: null,
+    branch_package_count: null,
+    global_finding_count: 15441,
+    global_vuln_count: 15333,
+    global_package_count: 261,
+    global_assessment_count: null,
+    formats: ['SPDX'],
+};
+
+function renderWithScan(scan: Scan) {
+    fetchMock.mockResponseOnce(JSON.stringify([scan]));
+    return render(<ScanHistory variantId="v1" />);
+}
+
+describe('ScanHistory card — Current result section', () => {
+
+    test('shows "Current result" heading', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+    });
+
+    test('displays package count with "packages" label', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => {
+            expect(screen.getByText('261')).toBeInTheDocument();
+            expect(screen.getByText('packages')).toBeInTheDocument();
+        });
+    });
+
+    test('uses "unique vulnerabilities" label (not "vulnerabilities")', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('unique vulnerabilities')).toBeInTheDocument());
+    });
+
+    test('uses "vulnerability matches" label (not "findings")', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('vulnerability matches')).toBeInTheDocument());
+    });
+
+    test('shows "View all" button when global_finding_count is set', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+    });
+
+    test('hides "View all" button when global_finding_count is null', async () => {
+        renderWithScan({ ...baseScan, global_finding_count: null, global_vuln_count: null, global_package_count: null });
+        // Wait for the card to render before asserting absence
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+        expect(screen.queryByText('View all')).not.toBeInTheDocument();
+    });
+
+    test('shows "Details" button in Section A when Section B is hidden (first scan)', async () => {
+        const firstScan: Scan = {
+            ...baseScan,
+            is_first: true,
+            vulns_added: null,
+            findings_added: null,
+            vulns_removed: null,
+            vulns_unchanged: null,
+            findings_removed: null,
+            findings_upgraded: null,
+            findings_unchanged: null,
+            packages_added: null,
+            packages_removed: null,
+            packages_upgraded: null,
+            packages_unchanged: null,
+        };
+        renderWithScan(firstScan);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+        expect(screen.getByText('Details')).toBeInTheDocument();
+        expect(screen.queryByText('Changes since previous scan')).not.toBeInTheDocument();
+    });
+
+});
+
+describe('ScanHistory card — Changes since previous scan section', () => {
+
+    test('shows "Changes since previous scan" heading when deltas are present', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+    });
+
+    test('hides "Changes since previous scan" section when deltas are null (first SBOM scan)', async () => {
+        const firstScan: Scan = {
+            ...baseScan,
+            is_first: true,
+            vulns_added: null,
+            vulns_removed: null,
+            vulns_unchanged: null,
+            findings_added: null,
+            findings_removed: null,
+            findings_upgraded: null,
+            findings_unchanged: null,
+            packages_added: null,
+            packages_removed: null,
+            packages_upgraded: null,
+            packages_unchanged: null,
+        };
+        renderWithScan(firstScan);
+        // Wait for the card to render before asserting absence
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+        expect(screen.queryByText('Changes since previous scan')).not.toBeInTheDocument();
+    });
+
+    test('uses "no longer present" label (not "removed")', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getAllByText(/no longer present/).length).toBeGreaterThan(0));
+    });
+
+    test('uses "still present" label for SBOM scans (not "unchanged")', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getAllByText(/still present/).length).toBeGreaterThan(0));
+    });
+
+    test('uses "previously known" label for tool scans', async () => {
+        const toolScan: Scan = {
+            ...baseScan,
+            scan_type: 'tool',
+            scan_source: 'grype',
+            vulns_added: 10,
+            vulns_removed: 0,
+            vulns_unchanged: 5,
+            findings_added: 10,
+            findings_removed: 0,
+            findings_upgraded: 0,
+            findings_unchanged: 5,
+            packages_added: null,
+            packages_removed: null,
+            packages_upgraded: null,
+            packages_unchanged: null,
+        };
+        renderWithScan(toolScan);
+        await waitFor(() => expect(screen.getAllByText(/previously known/).length).toBeGreaterThan(0));
+    });
+
+    test('shows "No changes detected" when all deltas are zero', async () => {
+        const noChangesScan: Scan = {
+            ...baseScan,
+            vulns_added: 0,
+            vulns_removed: 0,
+            vulns_unchanged: 0,
+            findings_added: 0,
+            findings_removed: 0,
+            findings_upgraded: 0,
+            findings_unchanged: 0,
+            packages_added: 0,
+            packages_removed: 0,
+            packages_upgraded: 0,
+            packages_unchanged: 0,
+        };
+        renderWithScan(noChangesScan);
+        await waitFor(() => expect(screen.getByText('No changes detected')).toBeInTheDocument());
+    });
+
+    test('shows Packages row for SBOM scans', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Packages:')).toBeInTheDocument());
+    });
+
+    test('hides Packages row for tool scans', async () => {
+        const toolScan: Scan = { ...baseScan, scan_type: 'tool', scan_source: 'grype' };
+        renderWithScan(toolScan);
+        // Wait for the card to render before asserting absence
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        expect(screen.queryByText('Packages:')).not.toBeInTheDocument();
+    });
+
+    test('shows "Changes since previous scan" for first tool scan when deltas are non-null', async () => {
+        const firstToolScan: Scan = {
+            ...baseScan,
+            scan_type: 'tool',
+            scan_source: 'grype',
+            is_first: true,
+            vulns_added: 10,
+            vulns_removed: 0,
+            vulns_unchanged: 0,
+            findings_added: 10,
+            findings_removed: 0,
+            findings_upgraded: 0,
+            findings_unchanged: 0,
+            packages_added: null,
+            packages_removed: null,
+            packages_upgraded: null,
+            packages_unchanged: null,
+        };
+        renderWithScan(firstToolScan);
+        await waitFor(() =>
+            expect(screen.getByText('Changes since previous scan')).toBeInTheDocument()
+        );
+    });
+
+    test('shows "No changes detected" for tool scan with all-zero deltas (packages excluded)', async () => {
+        const noChangesToolScan: Scan = {
+            ...baseScan,
+            scan_type: 'tool',
+            scan_source: 'osv',
+            vulns_added: 0,
+            vulns_removed: 0,
+            vulns_unchanged: 0,
+            findings_added: 0,
+            findings_removed: 0,
+            findings_upgraded: 0,
+            findings_unchanged: 0,
+            // packages_* are null for tool scans — must not block "No changes detected"
+            packages_added: null,
+            packages_removed: null,
+            packages_upgraded: null,
+            packages_unchanged: null,
+        };
+        renderWithScan(noChangesToolScan);
+        await waitFor(() => expect(screen.getByText('No changes detected')).toBeInTheDocument());
+    });
+
+    test('shows "Details" button to open diff modal', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Details')).toBeInTheDocument());
+    });
+
+});
+
+describe('ScanHistory card — First scan footnote', () => {
+
+    test('shows footnote when Section B is hidden', async () => {
+        const firstScan: Scan = {
+            ...baseScan,
+            vulns_added: null,
+            findings_added: null,
+            packages_added: null,
+            vulns_removed: null,
+            vulns_unchanged: null,
+            findings_removed: null,
+            findings_upgraded: null,
+            findings_unchanged: null,
+            packages_removed: null,
+            packages_upgraded: null,
+            packages_unchanged: null,
+        };
+        renderWithScan(firstScan);
+        await waitFor(() =>
+            expect(screen.getByText(/A vulnerability match is one vulnerability affecting one package/)).toBeInTheDocument()
+        );
+    });
+
+    test('hides footnote when Section B is visible', async () => {
+        renderWithScan(baseScan);
+        // Wait for the card to render before asserting absence
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        expect(screen.queryByText(/A vulnerability match is one vulnerability affecting one package/)).not.toBeInTheDocument();
+    });
+
+});

--- a/frontend/tests/unit_tests/test_scan_history_card.tsx
+++ b/frontend/tests/unit_tests/test_scan_history_card.tsx
@@ -2,13 +2,15 @@
 import fetchMock from 'jest-fetch-mock';
 fetchMock.enableMocks();
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import "@testing-library/jest-dom";
 // @ts-expect-error TS6133
 import React from 'react';
 
-import type { Scan } from '../../src/handlers/scans';
+import type { Scan, ScanDiff, GlobalResult } from '../../src/handlers/scans';
 import ScanHistory from '../../src/pages/ScanHistory';
+import Variants from '../../src/handlers/variant';
+import * as grypeScanState from '../../src/handlers/grypeScanState';
 
 // Stable snapshot reference for useSyncExternalStore compatibility
 const EMPTY_SCAN_SNAPSHOT: never[] = Object.freeze([]) as never[];
@@ -45,6 +47,7 @@ jest.mock('../../src/handlers/variant', () => ({
 
 beforeEach(() => {
     fetchMock.resetMocks();
+    (grypeScanState.getSnapshot as jest.Mock).mockReturnValue(EMPTY_SCAN_SNAPSHOT);
 });
 
 // --- Shared mock scan factory ---
@@ -94,6 +97,127 @@ function renderWithScan(scan: Scan) {
     fetchMock.mockResponseOnce(JSON.stringify([scan]));
     return render(<ScanHistory variantId="v1" />);
 }
+
+function renderWithScans(scans: Scan[]) {
+    fetchMock.mockResponseOnce(JSON.stringify(scans));
+    return render(<ScanHistory variantId="v1" />);
+}
+
+// ---------------------------------------------------------------------------
+// Mock data for DiffModal and GlobalResultModal
+// ---------------------------------------------------------------------------
+
+const mockScanDiff: ScanDiff = {
+    scan_id: 'scan-1',
+    scan_type: 'sbom',
+    previous_scan_id: 'prev-scan',
+    is_first: false,
+    finding_count: 2,
+    package_count: 3,
+    vuln_count: 2,
+    findings_added: [
+        { finding_id: 'f1', package_name: 'openssl', package_version: '3.2.1', package_id: 'p1', vulnerability_id: 'CVE-2024-0727' }
+    ],
+    findings_removed: [],
+    findings_upgraded: [],
+    findings_unchanged: [
+        { finding_id: 'f2', package_name: 'curl', package_version: '8.9.0', package_id: 'p2', vulnerability_id: 'CVE-2023-2650' }
+    ],
+    packages_added: [
+        { package_id: 'p3', package_name: 'zlib', package_version: '1.3.1' }
+    ],
+    packages_removed: [],
+    packages_upgraded: [],
+    packages_unchanged: [
+        { package_id: 'p2', package_name: 'curl', package_version: '8.9.0' }
+    ],
+    vulns_added: ['CVE-2024-0727'],
+    vulns_removed: [],
+    vulns_unchanged: ['CVE-2023-2650'],
+    assessment_count: 1,
+    assessments_added: [],
+    assessments_removed: [],
+    assessments_unchanged: [
+        {
+            vulnerability_id: 'CVE-2023-2650',
+            status: 'not_affected',
+            simplified_status: 'Not Affected',
+            justification: 'vulnerable_code_not_present',
+            impact_statement: 'Not impacted',
+            status_notes: '',
+        }
+    ],
+    newly_detected_findings: null,
+    newly_detected_vulns: null,
+    newly_detected_findings_list: null,
+    newly_detected_vulns_list: null,
+    newly_detected_assessments_list: null,
+    all_findings: null,
+    all_vulns: null,
+};
+
+const mockFirstScanDiff: ScanDiff = {
+    ...mockScanDiff,
+    previous_scan_id: null,
+    is_first: true,
+    packages_added: [
+        { package_id: 'p1', package_name: 'openssl', package_version: '3.0.0' },
+        { package_id: 'p2', package_name: 'curl', package_version: '8.7.0' },
+    ],
+    findings_added: [
+        { finding_id: 'f1', package_name: 'openssl', package_version: '3.0.0', package_id: 'p1', vulnerability_id: 'CVE-2023-0286' }
+    ],
+    assessments_added: [],
+    assessments_unchanged: [],
+};
+
+const mockToolScanDiff: ScanDiff = {
+    ...mockScanDiff,
+    scan_id: 'tool-scan-1',
+    scan_type: 'tool',
+    packages_added: [],
+    packages_removed: [],
+    packages_upgraded: [],
+    packages_unchanged: [],
+    newly_detected_findings: 1,
+    newly_detected_vulns: 1,
+    newly_detected_findings_list: [
+        { finding_id: 'nf1', package_name: 'nginx', package_version: '1.25.3', package_id: 'np1', vulnerability_id: 'CVE-2024-9999' }
+    ],
+    newly_detected_vulns_list: ['CVE-2024-9999'],
+    newly_detected_assessments_list: [],
+};
+
+const mockGlobalResult: GlobalResult = {
+    scan_id: 'scan-1',
+    scan_type: 'sbom',
+    packages: [
+        { package_id: 'p1', package_name: 'openssl', package_version: '3.2.1', sources: ['sbom', 'grype'] }
+    ],
+    findings: [
+        { finding_id: 'f1', package_name: 'openssl', package_version: '3.2.1', package_id: 'p1', vulnerability_id: 'CVE-2024-0727', sources: ['grype'] }
+    ],
+    vulnerabilities: [
+        { vulnerability_id: 'CVE-2024-0727', sources: ['grype'] }
+    ],
+    assessments: [
+        { vulnerability_id: 'CVE-2024-0727', status: 'under_investigation', simplified_status: 'In Triage', justification: '', impact_statement: '', status_notes: '' }
+    ],
+    package_count: 1,
+    finding_count: 1,
+    vuln_count: 1,
+    assessment_count: 1,
+};
+
+// Large dataset constants for filter-input coverage (> 10 entries required to show the input)
+const LARGE_PACKAGES_ADDED = Array.from({ length: 11 }, (_, i) => ({
+    package_id: `lg-p${i}`, package_name: `pkg-large-${i}`, package_version: `1.0.${i}`,
+}));
+const LARGE_PACKAGES_UPGRADED = Array.from({ length: 11 }, (_, i) => ({
+    package_name: `pkg-large-${i}`, old_version: `1.0.${i}`, new_version: `2.0.${i}`,
+    old_package_id: `lg-p${i}-old`, new_package_id: `lg-p${i}-new`,
+}));
+const LARGE_VULNS_ADDED = Array.from({ length: 11 }, (_, i) => `CVE-2024-${String(i).padStart(4, '0')}`);
 
 describe('ScanHistory card — Current result section', () => {
 
@@ -329,6 +453,994 @@ describe('ScanHistory card — First scan footnote', () => {
         // Wait for the card to render before asserting absence
         await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
         expect(screen.queryByText(/A vulnerability match is one vulnerability affecting one package/)).not.toBeInTheDocument();
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Page states
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory page — loading/empty/error states', () => {
+
+    test('shows "No scans found." when the API returns an empty list', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('No scans found.')).toBeInTheDocument());
+    });
+
+    test('shows error message when the scan list fetch throws', async () => {
+        fetchMock.mockRejectOnce(new Error('Network failure'));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Failed to load scan history.')).toBeInTheDocument());
+    });
+
+    test('renders "Scan History" heading for any non-empty scan list', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Scan History')).toBeInTheDocument());
+    });
+
+    test('renders without variantId using project-level URL (covers else branch)', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        render(<ScanHistory projectId="proj-1" />);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Scan type badges
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory card — scan type badges', () => {
+
+    test('shows "Grype Scan" badge for grype tool scans', async () => {
+        renderWithScan({ ...baseScan, scan_type: 'tool', scan_source: 'grype' });
+        await waitFor(() => expect(screen.getByText('Grype Scan')).toBeInTheDocument());
+    });
+
+    test('shows "NVD CPE Scan" badge for nvd tool scans', async () => {
+        renderWithScan({ ...baseScan, scan_type: 'tool', scan_source: 'nvd' });
+        await waitFor(() => expect(screen.getByText('NVD CPE Scan')).toBeInTheDocument());
+    });
+
+    test('shows "OSV Scan" badge for osv tool scans', async () => {
+        renderWithScan({ ...baseScan, scan_type: 'tool', scan_source: 'osv' });
+        await waitFor(() => expect(screen.getByText('OSV Scan')).toBeInTheDocument());
+    });
+
+    test('shows "Import SBOM" and format badges for SBOM scans', async () => {
+        renderWithScan({ ...baseScan, scan_type: 'sbom', formats: ['SPDX', 'CycloneDX'] });
+        await waitFor(() => {
+            expect(screen.getByText('Import SBOM')).toBeInTheDocument();
+            expect(screen.getByText('SPDX')).toBeInTheDocument();
+            expect(screen.getByText('CycloneDX')).toBeInTheDocument();
+        });
+    });
+
+    test('shows project name and variant name when project_name is set', async () => {
+        renderWithScan({ ...baseScan, project_name: 'MyProject', variant_name: 'prod' });
+        await waitFor(() => {
+            expect(screen.getByText('MyProject')).toBeInTheDocument();
+            expect(screen.getByText('prod')).toBeInTheDocument();
+        });
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Filter controls
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory page — filter controls', () => {
+
+    test('"Hide empty scans" toggle filters out no-change scans', async () => {
+        const noChangesScan: Scan = {
+            ...baseScan,
+            id: 'scan-2',
+            is_first: false,
+            vulns_added: 0, vulns_removed: 0,
+            findings_added: 0, findings_removed: 0, findings_upgraded: 0,
+            packages_added: 0, packages_removed: 0, packages_upgraded: 0,
+        };
+        renderWithScans([baseScan, noChangesScan]);
+        await waitFor(() => expect(screen.getAllByText('Current result')).toHaveLength(2));
+
+        fireEvent.click(screen.getByText('Hide empty scans'));
+
+        await waitFor(() => expect(screen.getAllByText('Current result')).toHaveLength(1));
+    });
+
+    test('Grype toggle hides grype tool scans', async () => {
+        const grypeScan: Scan = { ...baseScan, id: 'scan-2', scan_type: 'tool', scan_source: 'grype', vulns_added: 2, findings_added: 2 };
+        renderWithScans([baseScan, grypeScan]);
+        await waitFor(() => expect(screen.getAllByText('Current result')).toHaveLength(2));
+
+        fireEvent.click(screen.getByText('Grype'));
+
+        await waitFor(() => expect(screen.getAllByText('Current result')).toHaveLength(1));
+    });
+
+    test('OSV toggle hides osv tool scans', async () => {
+        const osvScan: Scan = { ...baseScan, id: 'scan-2', scan_type: 'tool', scan_source: 'osv', vulns_added: 1, findings_added: 1 };
+        renderWithScans([baseScan, osvScan]);
+        await waitFor(() => expect(screen.getAllByText('Current result')).toHaveLength(2));
+
+        fireEvent.click(screen.getByText('OSV'));
+
+        await waitFor(() => expect(screen.getAllByText('Current result')).toHaveLength(1));
+    });
+
+    test('NVD toggle hides nvd tool scans', async () => {
+        const nvdScan: Scan = { ...baseScan, id: 'scan-2', scan_type: 'tool', scan_source: 'nvd', vulns_added: 1, findings_added: 1 };
+        renderWithScans([baseScan, nvdScan]);
+        await waitFor(() => expect(screen.getAllByText('Current result')).toHaveLength(2));
+
+        fireEvent.click(screen.getByText('NVD'));
+
+        await waitFor(() => expect(screen.getAllByText('Current result')).toHaveLength(1));
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// DiffModal interactions
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory — DiffModal interactions', () => {
+
+    test('clicking Details in Section B opens DiffModal', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByText('Details'));
+
+        await waitFor(() => expect(screen.getByText('Scan diff details')).toBeInTheDocument());
+    });
+
+    test('DiffModal loads and shows packages tab by default for SBOM scans', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+
+        // PackageDiffTable heading format: "Added packages (1)"
+        await waitFor(() => expect(screen.getByText('Added packages (1)')).toBeInTheDocument());
+    });
+
+    test('DiffModal shows findings when Findings tab is clicked', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Scan diff details')).toBeInTheDocument());
+
+        // Tabs only render after the diff data loads
+        const findingsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Findings'));
+            if (!tab) throw new Error('Findings tab not found');
+            return tab;
+        });
+        fireEvent.click(findingsTab);
+
+        await waitFor(() => expect(screen.getByText('Added findings (1)')).toBeInTheDocument());
+    });
+
+    test('DiffModal shows vulnerabilities when Vulnerabilities tab is clicked', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Scan diff details')).toBeInTheDocument());
+
+        const vulnsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Vulnerabilities'));
+            if (!tab) throw new Error('Vulnerabilities tab not found');
+            return tab;
+        });
+        fireEvent.click(vulnsTab);
+
+        await waitFor(() => expect(screen.getByText('New vulnerabilities (1)')).toBeInTheDocument());
+    });
+
+    test('DiffModal shows assessments when Assessments tab is clicked', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Scan diff details')).toBeInTheDocument());
+
+        const assessmentsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Assessments'));
+            if (!tab) throw new Error('Assessments tab not found');
+            return tab;
+        });
+        fireEvent.click(assessmentsTab);
+
+        await waitFor(() => expect(screen.getByText('Unchanged assessments (1)')).toBeInTheDocument());
+    });
+
+    test('DiffModal closes when Close button is clicked', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Scan diff details')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByText('Close'));
+
+        await waitFor(() => expect(screen.queryByText('Scan diff details')).not.toBeInTheDocument());
+    });
+
+    test('DiffModal shows first-scan message for is_first=true diffs', async () => {
+        const firstScan: Scan = {
+            ...baseScan,
+            is_first: true,
+            vulns_added: null,
+            findings_added: null,
+            vulns_removed: null,
+            vulns_unchanged: null,
+            findings_removed: null,
+            findings_upgraded: null,
+            findings_unchanged: null,
+            packages_added: null,
+            packages_removed: null,
+            packages_upgraded: null,
+            packages_unchanged: null,
+        };
+        fetchMock.mockResponseOnce(JSON.stringify([firstScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockFirstScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+
+        // Section A has "Details" for first scan
+        fireEvent.click(screen.getByText('Details'));
+
+        await waitFor(() => expect(screen.getByText(/This is the first scan/)).toBeInTheDocument());
+    });
+
+    test('DiffModal for tool scan shows "Tool scan diff details" title', async () => {
+        const toolScan: Scan = {
+            ...baseScan,
+            id: 'tool-scan-1',
+            scan_type: 'tool',
+            scan_source: 'grype',
+            newly_detected_findings: 1,
+            newly_detected_vulns: 1,
+        };
+        fetchMock.mockResponseOnce(JSON.stringify([toolScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockToolScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByText('Details'));
+
+        await waitFor(() => expect(screen.getByText('Tool scan diff details')).toBeInTheDocument());
+    });
+
+    test('DiffModal for tool scan shows "New Discovered" tab with newly detected content', async () => {
+        const toolScan: Scan = {
+            ...baseScan,
+            id: 'tool-scan-1',
+            scan_type: 'tool',
+            scan_source: 'grype',
+            newly_detected_findings: 1,
+            newly_detected_vulns: 1,
+        };
+        fetchMock.mockResponseOnce(JSON.stringify([toolScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockToolScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Tool scan diff details')).toBeInTheDocument());
+
+        const newDiscoveredTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('New Discovered'));
+            if (!tab) throw new Error('New Discovered tab not found');
+            return tab;
+        });
+        fireEvent.click(newDiscoveredTab);
+
+        await waitFor(() => expect(screen.getByText('New findings discovered (1)')).toBeInTheDocument());
+    });
+
+    test('DiffModal shows error when getDiff returns null', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce('', { status: 500 }); // getDiff returns null
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByText('Details'));
+
+        await waitFor(() => expect(screen.getByText('Failed to load diff details.')).toBeInTheDocument());
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// GlobalResultModal interactions
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory — GlobalResultModal interactions', () => {
+
+    test('clicking "View all" button opens GlobalResultModal', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockGlobalResult));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByText('View all'));
+
+        await waitFor(() => expect(screen.getByText('Scan Result — Active Items')).toBeInTheDocument());
+    });
+
+    test('GlobalResultModal shows packages tab by default with package names', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockGlobalResult));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('View all'));
+
+        await waitFor(() => expect(screen.getByText('openssl')).toBeInTheDocument());
+    });
+
+    test('GlobalResultModal shows findings when Findings tab is clicked', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockGlobalResult));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('View all'));
+        await waitFor(() => expect(screen.getByText('Scan Result — Active Items')).toBeInTheDocument());
+
+        // Tabs only render after data loads
+        const findingsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Findings'));
+            if (!tab) throw new Error('Findings tab not found');
+            return tab;
+        });
+        fireEvent.click(findingsTab);
+
+        await waitFor(() => expect(screen.getByText('CVE-2024-0727')).toBeInTheDocument());
+    });
+
+    test('GlobalResultModal shows vulnerabilities when Vulnerabilities tab is clicked', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockGlobalResult));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('View all'));
+        await waitFor(() => expect(screen.getByText('Scan Result — Active Items')).toBeInTheDocument());
+
+        const vulnsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Vulnerabilities'));
+            if (!tab) throw new Error('Vulnerabilities tab not found');
+            return tab;
+        });
+        fireEvent.click(vulnsTab);
+
+        // Vulnerabilities table shows vuln IDs
+        await waitFor(() => expect(screen.getAllByText('CVE-2024-0727').length).toBeGreaterThan(0));
+    });
+
+    test('GlobalResultModal closes when Close button is clicked', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockGlobalResult));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('View all'));
+        await waitFor(() => expect(screen.getByText('Scan Result — Active Items')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByText('Close'));
+
+        await waitFor(() => expect(screen.queryByText('Scan Result — Active Items')).not.toBeInTheDocument());
+    });
+
+    test('GlobalResultModal shows error when getGlobalResult returns null', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce('', { status: 500 });
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByText('View all'));
+
+        await waitFor(() => expect(screen.getByText('Failed to load scan result.')).toBeInTheDocument());
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Description editing
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory card — description editing', () => {
+
+    test('clicking pencil icon reveals description edit input', async () => {
+        renderWithScan({ ...baseScan, description: 'Initial description' });
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByTitle('Edit description'));
+
+        await waitFor(() => expect(screen.getByPlaceholderText('Add a description…')).toBeInTheDocument());
+        expect(screen.getByTitle('Save')).toBeInTheDocument();
+        expect(screen.getByTitle('Cancel')).toBeInTheDocument();
+    });
+
+    test('clicking Cancel exits edit mode without saving', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+        fireEvent.click(screen.getByTitle('Edit description'));
+        await waitFor(() => expect(screen.getByPlaceholderText('Add a description…')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByTitle('Cancel'));
+
+        await waitFor(() => expect(screen.queryByPlaceholderText('Add a description…')).not.toBeInTheDocument());
+    });
+
+    test('saving a description updates the scan card and exits edit mode', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+        fireEvent.click(screen.getByTitle('Edit description'));
+        await waitFor(() => expect(screen.getByPlaceholderText('Add a description…')).toBeInTheDocument());
+
+        fireEvent.change(screen.getByPlaceholderText('Add a description…'), { target: { value: 'New desc' } });
+        fetchMock.mockResponseOnce('{}', { status: 200 });
+        fireEvent.click(screen.getByTitle('Save'));
+
+        await waitFor(() => expect(screen.queryByPlaceholderText('Add a description…')).not.toBeInTheDocument());
+    });
+
+    test('pressing Escape key cancels the description edit', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+        fireEvent.click(screen.getByTitle('Edit description'));
+        await waitFor(() => expect(screen.getByPlaceholderText('Add a description…')).toBeInTheDocument());
+
+        fireEvent.keyDown(screen.getByPlaceholderText('Add a description…'), { key: 'Escape' });
+
+        await waitFor(() => expect(screen.queryByPlaceholderText('Add a description…')).not.toBeInTheDocument());
+    });
+
+    test('pressing Enter key triggers description save', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+        fireEvent.click(screen.getByTitle('Edit description'));
+        await waitFor(() => expect(screen.getByPlaceholderText('Add a description…')).toBeInTheDocument());
+
+        fetchMock.mockResponseOnce('{}', { status: 200 });
+        fireEvent.keyDown(screen.getByPlaceholderText('Add a description…'), { key: 'Enter' });
+
+        await waitFor(() => expect(screen.queryByPlaceholderText('Add a description…')).not.toBeInTheDocument());
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Delete confirmation modal
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory card — delete scan', () => {
+
+    test('clicking trash icon opens the Delete Scan confirmation modal', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByTitle('Delete scan'));
+
+        await waitFor(() => expect(screen.getByText('Delete Scan')).toBeInTheDocument());
+        expect(screen.getByText(/Are you sure you want to delete this scan/)).toBeInTheDocument();
+    });
+
+    test('clicking Cancel in the delete modal dismisses it', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+        fireEvent.click(screen.getByTitle('Delete scan'));
+        await waitFor(() => expect(screen.getByText('Delete Scan')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByText('Cancel'));
+
+        await waitFor(() => expect(screen.queryByText('Delete Scan')).not.toBeInTheDocument());
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Section B delta row edge cases
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory card — Section B delta display details', () => {
+
+    test('shows "updated" label for findings_upgraded > 0', async () => {
+        renderWithScan({ ...baseScan, findings_upgraded: 3 });
+        await waitFor(() => expect(screen.getByText(/3 updated/)).toBeInTheDocument());
+    });
+
+    test('shows "updated" label for packages_upgraded > 0', async () => {
+        renderWithScan({ ...baseScan, packages_upgraded: 2 });
+        await waitFor(() => expect(screen.getByText(/2 updated/)).toBeInTheDocument());
+    });
+
+    test('shows "unchanged" label for packages_unchanged > 0', async () => {
+        renderWithScan({ ...baseScan, packages_unchanged: 10 });
+        await waitFor(() => expect(screen.getByText(/10 unchanged/)).toBeInTheDocument());
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// DiffModal — keyboard, overlay, and filter interactions
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory — DiffModal advanced interactions', () => {
+
+    test('pressing Escape closes the DiffModal', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Scan diff details')).toBeInTheDocument());
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+
+        await waitFor(() => expect(screen.queryByText('Scan diff details')).not.toBeInTheDocument());
+    });
+
+    test('typing in Assessments tab filter narrows results', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Scan diff details')).toBeInTheDocument());
+
+        const assessmentsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Assessments'));
+            if (!tab) throw new Error('Assessments tab not found');
+            return tab;
+        });
+        fireEvent.click(assessmentsTab);
+        await waitFor(() => expect(screen.getByText('Unchanged assessments (1)')).toBeInTheDocument());
+
+        // AssessmentDiffTable always has a filter textbox; use index [2] for "Unchanged" (has 1 entry)
+        const filterInputs = screen.getAllByRole('textbox');
+        fireEvent.change(filterInputs[2], { target: { value: 'CVE-2023-2650' } });
+        await waitFor(() => expect(screen.getByText('CVE-2023-2650')).toBeInTheDocument());
+    });
+
+    test('typing in Findings tab filter updates displayed results', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Scan diff details')).toBeInTheDocument());
+
+        const findingsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Findings'));
+            if (!tab) throw new Error('Findings tab not found');
+            return tab;
+        });
+        fireEvent.click(findingsTab);
+        await waitFor(() => expect(screen.getByText('Added findings (1)')).toBeInTheDocument());
+
+        // FindingDiffTable always has a filter textbox
+        const filterInputs = screen.getAllByRole('textbox');
+        fireEvent.change(filterInputs[0], { target: { value: 'openssl' } });
+        // openssl is still shown after filter
+        await waitFor(() => expect(screen.getByText('openssl')).toBeInTheDocument());
+    });
+
+    test('DiffModal shows FindingUpgradeDiffTable for scans with findings_upgraded', async () => {
+        const upgradedFindingsDiff: ScanDiff = {
+            ...mockScanDiff,
+            findings_upgraded: [
+                {
+                    vulnerability_id: 'CVE-2024-1234',
+                    package_name: 'libxml2',
+                    old_version: '2.9.14',
+                    new_version: '2.12.0',
+                }
+            ],
+        };
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(upgradedFindingsDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Scan diff details')).toBeInTheDocument());
+
+        const findingsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Findings'));
+            if (!tab) throw new Error('Findings tab not found');
+            return tab;
+        });
+        fireEvent.click(findingsTab);
+
+        await waitFor(() => expect(screen.getByText('Findings on upgraded packages (1)')).toBeInTheDocument());
+        expect(screen.getByText('libxml2')).toBeInTheDocument();
+    });
+
+    test('DiffModal GlobalResultModal Escape key closes it', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockGlobalResult));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('View all'));
+        await waitFor(() => expect(screen.getByText('Scan Result — Active Items')).toBeInTheDocument());
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+
+        await waitFor(() => expect(screen.queryByText('Scan Result — Active Items')).not.toBeInTheDocument());
+    });
+
+    test('DiffModal Packages tab shows PackageUpgradeDiffTable for upgraded packages', async () => {
+        const upgradedPkgDiff: ScanDiff = {
+            ...mockScanDiff,
+            packages_upgraded: [
+                { package_name: 'openssl', old_version: '3.0.0', new_version: '3.2.1', old_package_id: 'p1-old', new_package_id: 'p1-new' }
+            ],
+        };
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(upgradedPkgDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+
+        // Packages tab is default for SBOM — wait for upgraded packages section to appear
+        await waitFor(() => expect(screen.getByText('Upgraded packages (1)')).toBeInTheDocument());
+        expect(screen.getByText('3.0.0')).toBeInTheDocument();
+        expect(screen.getByText('3.2.1')).toBeInTheDocument();
+    });
+
+    test('typing in FindingUpgradeDiffTable filter narrows results', async () => {
+        const upgradedFindingsDiff: ScanDiff = {
+            ...mockScanDiff,
+            findings_upgraded: [
+                { vulnerability_id: 'CVE-2024-1234', package_name: 'libxml2', old_version: '2.9.14', new_version: '2.12.0' }
+            ],
+        };
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(upgradedFindingsDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Scan diff details')).toBeInTheDocument());
+
+        const findingsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Findings'));
+            if (!tab) throw new Error('Findings tab not found');
+            return tab;
+        });
+        fireEvent.click(findingsTab);
+        await waitFor(() => expect(screen.getByText('Findings on upgraded packages (1)')).toBeInTheDocument());
+
+        // FindingUpgradeDiffTable always has a filter textbox; index [2] = upgrade table
+        // (after Added findings [0], Removed findings [1], FindingUpgradeDiffTable [2], Unchanged [3])
+        const filterInputs = screen.getAllByRole('textbox');
+        fireEvent.change(filterInputs[2], { target: { value: 'libxml2' } });
+        await waitFor(() => expect(screen.getByText('libxml2')).toBeInTheDocument());
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Delete scan confirmation
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory card — delete scan confirmation', () => {
+
+    test('clicking "Yes, delete" calls deleteScan and refreshes', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+        fireEvent.click(screen.getByTitle('Delete scan'));
+        await waitFor(() => expect(screen.getByText('Delete Scan')).toBeInTheDocument());
+
+        // Mock the deleteScan API response, then the re-fetch
+        fetchMock.mockResponseOnce(JSON.stringify({ orphaned_findings_removed: 2 }), { status: 200 });
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        fireEvent.click(screen.getByText('Yes, delete'));
+
+        await waitFor(() => expect(screen.queryByText('Delete Scan')).not.toBeInTheDocument());
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Run Scans menu
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory — Run Scans menu', () => {
+
+    test('clicking Run Scans opens the scan menu', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Run Scans')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByText('Run Scans'));
+
+        await waitFor(() => expect(screen.getByText('Scan types')).toBeInTheDocument());
+        // Scan menu has "NVD CPE" (different from filter bar's "NVD")
+        expect(screen.getByText('NVD CPE')).toBeInTheDocument();
+        expect(screen.getByText('OSV', { selector: 'span' })).toBeInTheDocument();
+    });
+
+    test('toggling a scan type checkbox deselects it', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Run Scans')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Run Scans'));
+        await waitFor(() => expect(screen.getByText('Scan types')).toBeInTheDocument());
+
+        // All scan type checkboxes start checked
+        const checkboxes = screen.getAllByRole('checkbox');
+        const grypeCb = checkboxes[0]; // first scan type = grype
+        expect(grypeCb).toBeChecked();
+        fireEvent.click(grypeCb);
+        expect(grypeCb).not.toBeChecked();
+    });
+
+    test('"Run N scans" button is disabled when no scan types selected', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Run Scans')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Run Scans'));
+        await waitFor(() => expect(screen.getByText('Scan types')).toBeInTheDocument());
+
+        // Deselect all scan types (first 3 checkboxes = grype, nvd, osv)
+        const checkboxes = screen.getAllByRole('checkbox');
+        for (const cb of checkboxes.slice(0, 3)) {
+            if ((cb as HTMLInputElement).checked) fireEvent.click(cb);
+        }
+
+        const runBtn = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Run') && b !== screen.getByText('Run Scans'));
+        expect(runBtn).toBeDisabled();
+    });
+
+    test('shows "No variants found" when variants list is empty', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Run Scans')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Run Scans'));
+        await waitFor(() => expect(screen.getByText('No variants found')).toBeInTheDocument());
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// GlobalResultModal — filter and Assessments tab
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory — GlobalResultModal extra coverage', () => {
+
+    test('GlobalResultModal filter narrows packages', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockGlobalResult));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('View all'));
+        await waitFor(() => expect(screen.getByText('openssl')).toBeInTheDocument());
+
+        // GlobalResultModal has a filter textbox in the tab bar
+        const filterInputs = screen.getAllByRole('textbox');
+        fireEvent.change(filterInputs[0], { target: { value: 'openssl' } });
+
+        await waitFor(() => expect(screen.getByText('openssl')).toBeInTheDocument());
+    });
+
+    test('GlobalResultModal shows Assessments tab', async () => {
+        const resultWithAssessment: GlobalResult = {
+            ...mockGlobalResult,
+            assessments: [
+                {
+                    vulnerability_id: 'CVE-2024-0727',
+                    status: 'not_affected',
+                    simplified_status: 'Not Affected',
+                    justification: 'vulnerable_code_not_present',
+                    impact_statement: 'Code path not reachable',
+                    status_notes: '',
+                }
+            ],
+            assessment_count: 1,
+        };
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(resultWithAssessment));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('View all'));
+        await waitFor(() => expect(screen.getByText('Scan Result — Active Items')).toBeInTheDocument());
+
+        const assessmentsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Assessments'));
+            if (!tab) throw new Error('Assessments tab not found');
+            return tab;
+        });
+        fireEvent.click(assessmentsTab);
+
+        await waitFor(() => expect(screen.getAllByText('CVE-2024-0727').length).toBeGreaterThan(0));
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Additional coverage: catch handlers, tab navigation, large datasets, menus
+// ---------------------------------------------------------------------------
+
+describe('ScanHistory — additional coverage', () => {
+
+    test('DiffModal shows error when getDiff fetch rejects', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockRejectOnce(new Error('network error'));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Current result')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Failed to load diff details.')).toBeInTheDocument());
+    });
+
+    test('GlobalResultModal shows error when fetch rejects', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockRejectOnce(new Error('network error'));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('View all'));
+        await waitFor(() => expect(screen.getByText('Failed to load scan result.')).toBeInTheDocument());
+    });
+
+    test('GlobalResultModal Packages tab onClick is covered by navigating back', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockGlobalResult));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('View all')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('View all'));
+        const findingsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Findings'));
+            if (!tab) throw new Error('Findings tab not found');
+            return tab;
+        });
+        fireEvent.click(findingsTab);
+        // Navigate back to Packages tab (covers line 489 onClick)
+        const packagesTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Packages'));
+            if (!tab) throw new Error('Packages tab not found');
+            return tab;
+        });
+        fireEvent.click(packagesTab);
+        await waitFor(() => expect(screen.getByText('openssl')).toBeInTheDocument());
+    });
+
+    test('DiffModal Packages tab onClick is covered by navigating back', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(mockScanDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        const findingsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Findings'));
+            if (!tab) throw new Error('Findings tab not found');
+            return tab;
+        });
+        fireEvent.click(findingsTab);
+        // Navigate back to Packages tab (covers line 694 onClick)
+        const packagesTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Packages'));
+            if (!tab) throw new Error('Packages tab not found');
+            return tab;
+        });
+        fireEvent.click(packagesTab);
+        await waitFor(() => expect(screen.getByText('Added packages (1)')).toBeInTheDocument());
+    });
+
+    test('PackageDiffTable filter input appears and filter fn is covered with > 10 entries', async () => {
+        const largeDiff: ScanDiff = { ...mockScanDiff, packages_added: LARGE_PACKAGES_ADDED };
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(largeDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        // Packages tab is default for SBOM; wait for the large table to render
+        await waitFor(() => expect(screen.getByText('Added packages (11)')).toBeInTheDocument());
+        // Filter input is shown when entries > 10
+        const filterInputs = screen.getAllByRole('textbox');
+        expect(filterInputs.length).toBeGreaterThan(0);
+        fireEvent.change(filterInputs[0], { target: { value: 'pkg-large-0' } });
+        await waitFor(() => expect(screen.getByText('pkg-large-0')).toBeInTheDocument());
+    });
+
+    test('PackageUpgradeDiffTable filter input appears and filter fn is covered with > 10 entries', async () => {
+        const largeDiff: ScanDiff = { ...mockScanDiff, packages_upgraded: LARGE_PACKAGES_UPGRADED };
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(largeDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        await waitFor(() => expect(screen.getByText('Upgraded packages (11)')).toBeInTheDocument());
+        const filterInputs = screen.getAllByRole('textbox');
+        expect(filterInputs.length).toBeGreaterThan(0);
+        fireEvent.change(filterInputs[0], { target: { value: 'pkg-large-0' } });
+        await waitFor(() => expect(screen.getByText('pkg-large-0')).toBeInTheDocument());
+    });
+
+    test('VulnDiffList filter input appears and filter fn is covered with > 10 vulns', async () => {
+        const largeDiff: ScanDiff = { ...mockScanDiff, vulns_added: LARGE_VULNS_ADDED };
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        fetchMock.mockResponseOnce(JSON.stringify(largeDiff));
+        render(<ScanHistory variantId="v1" />);
+        await waitFor(() => expect(screen.getByText('Changes since previous scan')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Details'));
+        const vulnsTab = await waitFor(() => {
+            const tab = screen.getAllByRole('button').find(b => b.textContent?.startsWith('Vulnerabilities'));
+            if (!tab) throw new Error('Vulnerabilities tab not found');
+            return tab;
+        });
+        fireEvent.click(vulnsTab);
+        await waitFor(() => expect(screen.getByText('New vulnerabilities (11)')).toBeInTheDocument());
+        const filterInputs = screen.getAllByRole('textbox');
+        expect(filterInputs.length).toBeGreaterThan(0);
+        fireEvent.change(filterInputs[0], { target: { value: 'CVE-2024-0000' } });
+        await waitFor(() => expect(screen.getByText('CVE-2024-0000')).toBeInTheDocument());
+    });
+
+    test('scan menu closes on outside click (handleClickOutside)', async () => {
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Run Scans')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Run Scans'));
+        await waitFor(() => expect(screen.getByText('Scan types')).toBeInTheDocument());
+        fireEvent.mouseDown(document.body);
+        await waitFor(() => expect(screen.queryByText('Scan types')).not.toBeInTheDocument());
+    });
+
+    test('variant checkbox toggles and Run button triggers handleRunSelectedScans', async () => {
+        (Variants.listAll as jest.Mock).mockResolvedValueOnce([
+            { id: 'v1', name: 'Prod', project_id: 'proj-1' },
+        ]);
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Run Scans')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Run Scans'));
+        await waitFor(() => expect(screen.getByText('Prod')).toBeInTheDocument());
+
+        // checkboxes: [0]=grype [1]=nvd [2]=osv [3]=variant
+        const checkboxes = screen.getAllByRole('checkbox');
+        const variantCb = checkboxes[3];
+        expect(variantCb).toBeChecked();
+        fireEvent.click(variantCb); // toggleVariant — unchecks
+        expect(variantCb).not.toBeChecked();
+        fireEvent.click(variantCb); // toggleVariant — re-checks
+        expect(variantCb).toBeChecked();
+
+        // Click Run button (handleRunSelectedScans)
+        const runBtn = screen.getAllByRole('button').find(b => /Run \d+ scans? on/.test(b.textContent || ''));
+        expect(runBtn).toBeDefined();
+        expect(runBtn).not.toBeDisabled();
+        fireEvent.click(runBtn!);
+        await waitFor(() => expect(screen.queryByText('Scan types')).not.toBeInTheDocument());
+    });
+
+    test('Select all and Select none with two variants', async () => {
+        (Variants.list as jest.Mock).mockResolvedValueOnce([
+            { id: 'v1', name: 'Variant A', project_id: 'proj-1' },
+            { id: 'v2', name: 'Variant B', project_id: 'proj-1' },
+        ]);
+        fetchMock.mockResponseOnce(JSON.stringify([baseScan]));
+        render(<ScanHistory projectId="proj-1" />);
+        await waitFor(() => expect(screen.getByText('Run Scans')).toBeInTheDocument());
+        fireEvent.click(screen.getByText('Run Scans'));
+        await waitFor(() => expect(screen.getByText('Variant A')).toBeInTheDocument());
+        expect(screen.getByText('Variant B')).toBeInTheDocument();
+
+        // Select none then Select all (covers those onClick lambdas)
+        const selectNoneBtn = await waitFor(() => screen.getByText('Select none'));
+        fireEvent.click(selectNoneBtn);
+        const selectAllBtn = screen.getByText('Select all');
+        fireEvent.click(selectAllBtn);
+    });
+
+    test('scan progress panels render with running grype entries', async () => {
+        const runningEntries = [{ variantId: 'v1', variantName: 'default', status: 'running', error: null, progress: '50%', logs: [], total: 100, doneCount: 50 }];
+        (grypeScanState.getSnapshot as jest.Mock).mockReturnValue(runningEntries);
+        renderWithScan(baseScan);
+        await waitFor(() => expect(screen.getByText('Grype Scan – default in progress')).toBeInTheDocument());
     });
 
 });

--- a/frontend/tests/unit_tests/test_scan_progress_panel.tsx
+++ b/frontend/tests/unit_tests/test_scan_progress_panel.tsx
@@ -1,0 +1,111 @@
+/// <reference types="jest" />
+import fetchMock from 'jest-fetch-mock';
+fetchMock.enableMocks();
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import "@testing-library/jest-dom";
+import type { ScanEntryState } from '../../src/handlers/scanStateManager';
+import { faBug } from '@fortawesome/free-solid-svg-icons';
+import ScanProgressPanel from '../../src/components/ScanProgressPanel';
+
+const colors = {
+    border: 'border-purple-700/60',
+    headerBg: 'bg-purple-900/40',
+    iconText: 'text-purple-400',
+    titleText: 'text-purple-200',
+    subtitleText: 'text-purple-300/80',
+    bar: 'bg-purple-500',
+};
+
+function makeEntry(overrides: Partial<ScanEntryState> = {}): ScanEntryState {
+    return {
+        variantId: 'v1',
+        variantName: 'MyVariant',
+        status: 'running',
+        error: null,
+        progress: null,
+        logs: [],
+        total: 0,
+        doneCount: 0,
+        ...overrides,
+    };
+}
+
+describe('ScanProgressPanel', () => {
+
+    test('renders label and variant name with "in progress" status', () => {
+        render(<ScanProgressPanel entry={makeEntry()} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByText('Grype Scan – MyVariant in progress')).toBeInTheDocument();
+    });
+
+    test('shows "queued" status text for queued entry', () => {
+        render(<ScanProgressPanel entry={makeEntry({ status: 'queued' })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByText('Grype Scan – MyVariant queued')).toBeInTheDocument();
+    });
+
+    test('shows "failed" status text for error entry', () => {
+        render(<ScanProgressPanel entry={makeEntry({ status: 'error', logs: ['some error'] })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByText('Grype Scan – MyVariant failed')).toBeInTheDocument();
+    });
+
+    test('shows "complete" status text for done entry', () => {
+        render(<ScanProgressPanel entry={makeEntry({ status: 'done' })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByText('Grype Scan – MyVariant complete')).toBeInTheDocument();
+    });
+
+    test('shows progress string when set', () => {
+        render(<ScanProgressPanel entry={makeEntry({ progress: 'Processing 50 of 100' })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByText('Processing 50 of 100')).toBeInTheDocument();
+    });
+
+    test('shows percentage when total > 0', () => {
+        render(<ScanProgressPanel entry={makeEntry({ total: 100, doneCount: 75 })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByText(/75%/)).toBeInTheDocument();
+    });
+
+    test('does not show dismiss button while running', () => {
+        render(<ScanProgressPanel entry={makeEntry({ status: 'running' })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.queryByTitle('Close')).not.toBeInTheDocument();
+    });
+
+    test('does not show dismiss button while queued', () => {
+        render(<ScanProgressPanel entry={makeEntry({ status: 'queued' })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.queryByTitle('Close')).not.toBeInTheDocument();
+    });
+
+    test('shows dismiss button when done', () => {
+        render(<ScanProgressPanel entry={makeEntry({ status: 'done' })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByTitle('Close')).toBeInTheDocument();
+    });
+
+    test('calls onDismiss when dismiss button is clicked', () => {
+        const onDismiss = jest.fn();
+        render(<ScanProgressPanel entry={makeEntry({ status: 'done' })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={onDismiss} />);
+        fireEvent.click(screen.getByTitle('Close'));
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    test('shows dismiss button for error entry', () => {
+        render(<ScanProgressPanel entry={makeEntry({ status: 'error', logs: ['err'] })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByTitle('Close')).toBeInTheDocument();
+    });
+
+    test('renders log lines', () => {
+        render(<ScanProgressPanel entry={makeEntry({ logs: ['line 1', '✓ done', '[2024] ERROR bad'] })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByText('line 1')).toBeInTheDocument();
+        expect(screen.getByText('✓ done')).toBeInTheDocument();
+        expect(screen.getByText('[2024] ERROR bad')).toBeInTheDocument();
+    });
+
+    test('shows "Waiting for first results…" when running with no logs', () => {
+        render(<ScanProgressPanel entry={makeEntry({ status: 'running', logs: [] })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByText('Waiting for first results…')).toBeInTheDocument();
+    });
+
+    test('shows progress with percentage when progress string and total are set', () => {
+        render(<ScanProgressPanel entry={makeEntry({ progress: 'CVE batch 3/10', total: 10, doneCount: 3 })} label="Grype Scan" icon={faBug} colors={colors} onDismiss={jest.fn()} />);
+        expect(screen.getByText(/CVE batch 3\/10/)).toBeInTheDocument();
+        expect(screen.getByText(/30%/)).toBeInTheDocument();
+    });
+
+});

--- a/frontend/tests/unit_tests/test_scans_handler.ts
+++ b/frontend/tests/unit_tests/test_scans_handler.ts
@@ -1,0 +1,418 @@
+/// <reference types="jest" />
+import fetchMock from 'jest-fetch-mock';
+fetchMock.enableMocks();
+
+import ScansHandler from '../../src/handlers/scans';
+
+beforeEach(() => {
+    fetchMock.resetMocks();
+});
+
+const VALID_SCAN = {
+    id: 'scan-1',
+    description: null,
+    scan_type: 'sbom',
+    scan_source: null,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    variant_id: 'v1',
+    variant_name: 'default',
+    project_name: null,
+    finding_count: 10,
+    package_count: 5,
+    vuln_count: 8,
+    is_first: false,
+    findings_added: null,
+    findings_removed: null,
+    findings_upgraded: null,
+    packages_added: null,
+    packages_removed: null,
+    packages_upgraded: null,
+    vulns_added: null,
+    vulns_removed: null,
+    vulns_unchanged: null,
+    findings_unchanged: null,
+    packages_unchanged: null,
+    assessment_count: null,
+    assessments_added: null,
+    assessments_removed: null,
+    assessments_unchanged: null,
+    newly_detected_findings: null,
+    newly_detected_vulns: null,
+    newly_detected_assessments: null,
+    branch_finding_count: null,
+    branch_vuln_count: null,
+    branch_package_count: null,
+    global_finding_count: null,
+    global_vuln_count: null,
+    global_package_count: null,
+    global_assessment_count: null,
+    formats: ['SPDX'],
+};
+
+// ---------------------------------------------------------------------------
+// ScansHandler.list
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.list', () => {
+    test('uses variant URL when variantId is provided', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([VALID_SCAN]));
+        const scans = await ScansHandler.list('v1');
+        expect(scans.length).toBe(1);
+        expect(scans[0].id).toBe('scan-1');
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/variants/v1/scans'),
+            expect.objectContaining({ mode: 'cors' })
+        );
+    });
+
+    test('uses project URL when only projectId is given', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([VALID_SCAN]));
+        const scans = await ScansHandler.list(undefined, 'proj-1');
+        expect(scans.length).toBe(1);
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/projects/proj-1/scans'),
+            expect.objectContaining({ mode: 'cors' })
+        );
+    });
+
+    test('uses generic /api/scans URL when no IDs provided', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        await ScansHandler.list();
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/scans'),
+            expect.objectContaining({ mode: 'cors' })
+        );
+    });
+
+    test('returns empty array on non-ok HTTP response', async () => {
+        fetchMock.mockResponseOnce('', { status: 500 });
+        const scans = await ScansHandler.list('v1');
+        expect(scans).toEqual([]);
+    });
+
+    test('returns empty array when response is not an array', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ items: [] }));
+        const scans = await ScansHandler.list('v1');
+        expect(scans).toEqual([]);
+    });
+
+    test('filters out items missing required string/number fields', async () => {
+        const data = [
+            { ...VALID_SCAN, id: 123 },                // id not string
+            { ...VALID_SCAN, timestamp: null },         // timestamp not string
+            { ...VALID_SCAN, variant_id: undefined },   // variant_id missing
+            { ...VALID_SCAN, finding_count: 'ten' },    // finding_count not number
+            VALID_SCAN,                                  // valid
+        ];
+        fetchMock.mockResponseOnce(JSON.stringify(data));
+        const scans = await ScansHandler.list('v1');
+        expect(scans.length).toBe(1);
+        expect(scans[0].id).toBe('scan-1');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ScansHandler.getDiff
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.getDiff', () => {
+    test('returns diff data when API responds with valid scan_id', async () => {
+        const mockDiff = { scan_id: 'scan-1', scan_type: 'sbom', is_first: false };
+        fetchMock.mockResponseOnce(JSON.stringify(mockDiff));
+        const diff = await ScansHandler.getDiff('scan-1');
+        expect(diff).not.toBeNull();
+        expect(diff?.scan_id).toBe('scan-1');
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/scans/scan-1/diff'),
+            expect.objectContaining({ mode: 'cors' })
+        );
+    });
+
+    test('returns null on non-ok HTTP response', async () => {
+        fetchMock.mockResponseOnce('', { status: 404 });
+        const diff = await ScansHandler.getDiff('scan-x');
+        expect(diff).toBeNull();
+    });
+
+    test('returns null when scan_id field is not a string', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ scan_id: 999, scan_type: 'sbom' }));
+        const diff = await ScansHandler.getDiff('scan-x');
+        expect(diff).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ScansHandler.setDescription
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.setDescription', () => {
+    test('returns true when PATCH succeeds', async () => {
+        fetchMock.mockResponseOnce('{}', { status: 200 });
+        const ok = await ScansHandler.setDescription('scan-1', 'My description');
+        expect(ok).toBe(true);
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/scans/scan-1'),
+            expect.objectContaining({ method: 'PATCH' })
+        );
+    });
+
+    test('returns false when PATCH fails', async () => {
+        fetchMock.mockResponseOnce('', { status: 400 });
+        const ok = await ScansHandler.setDescription('scan-1', 'Bad');
+        expect(ok).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ScansHandler.triggerGrypeScan
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.triggerGrypeScan', () => {
+    test('returns ok=true on 200 success', async () => {
+        fetchMock.mockResponseOnce('{}', { status: 200 });
+        const result = await ScansHandler.triggerGrypeScan('v1');
+        expect(result.ok).toBe(true);
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/variants/v1/grype-scan'),
+            expect.objectContaining({ method: 'POST' })
+        );
+    });
+
+    test('returns ok=true on 202 accepted', async () => {
+        fetchMock.mockResponseOnce('{}', { status: 202 });
+        const result = await ScansHandler.triggerGrypeScan('v1');
+        expect(result.ok).toBe(true);
+    });
+
+    test('returns ok=false with error field from body on failure', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ error: 'scan already running' }), { status: 409 });
+        const result = await ScansHandler.triggerGrypeScan('v1');
+        expect(result.ok).toBe(false);
+        expect(result.error).toBe('scan already running');
+    });
+
+    test('returns ok=false with HTTP status code when body is not JSON', async () => {
+        fetchMock.mockResponseOnce('not json', { status: 500 });
+        const result = await ScansHandler.triggerGrypeScan('v1');
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain('500');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ScansHandler.getGlobalResult
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.getGlobalResult', () => {
+    const mockResult = {
+        scan_id: 'scan-1',
+        scan_type: 'sbom',
+        packages: [],
+        findings: [],
+        vulnerabilities: [],
+        assessments: [],
+        package_count: 0,
+        finding_count: 0,
+        vuln_count: 0,
+        assessment_count: 0,
+    };
+
+    test('returns global result on success', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(mockResult));
+        const result = await ScansHandler.getGlobalResult('scan-1');
+        expect(result).not.toBeNull();
+        expect(result?.scan_id).toBe('scan-1');
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/scans/scan-1/global-result'),
+            expect.objectContaining({ mode: 'cors' })
+        );
+    });
+
+    test('returns null on non-ok response', async () => {
+        fetchMock.mockResponseOnce('', { status: 404 });
+        const result = await ScansHandler.getGlobalResult('scan-x');
+        expect(result).toBeNull();
+    });
+
+    test('returns null when scan_id field is not a string', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ scan_id: 42 }));
+        const result = await ScansHandler.getGlobalResult('scan-x');
+        expect(result).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ScansHandler.getGrypeScanStatus
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.getGrypeScanStatus', () => {
+    test('returns status data on success', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ status: 'running', progress: '50%' }));
+        const status = await ScansHandler.getGrypeScanStatus('v1');
+        expect(status.status).toBe('running');
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/variants/v1/grype-scan/status'),
+            expect.objectContaining({ mode: 'cors' })
+        );
+    });
+
+    test('returns { status: "unknown" } on non-ok response', async () => {
+        fetchMock.mockResponseOnce('', { status: 500 });
+        const status = await ScansHandler.getGrypeScanStatus('v1');
+        expect(status.status).toBe('unknown');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ScansHandler.triggerNvdScan
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.triggerNvdScan', () => {
+    test('returns ok=true on 200 success', async () => {
+        fetchMock.mockResponseOnce('{}', { status: 200 });
+        const result = await ScansHandler.triggerNvdScan('v1');
+        expect(result.ok).toBe(true);
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/variants/v1/nvd-scan'),
+            expect.objectContaining({ method: 'POST' })
+        );
+    });
+
+    test('returns ok=true on 202', async () => {
+        fetchMock.mockResponseOnce('{}', { status: 202 });
+        const result = await ScansHandler.triggerNvdScan('v1');
+        expect(result.ok).toBe(true);
+    });
+
+    test('returns ok=false with error on failure', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ error: 'NVD DB not found' }), { status: 400 });
+        const result = await ScansHandler.triggerNvdScan('v1');
+        expect(result.ok).toBe(false);
+        expect(result.error).toBe('NVD DB not found');
+    });
+
+    test('returns ok=false with HTTP status when body is not JSON', async () => {
+        fetchMock.mockResponseOnce('not json', { status: 503 });
+        const result = await ScansHandler.triggerNvdScan('v1');
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain('503');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ScansHandler.getNvdScanStatus
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.getNvdScanStatus', () => {
+    test('returns status data on success', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ status: 'done', progress: '100%' }));
+        const status = await ScansHandler.getNvdScanStatus('v1');
+        expect(status.status).toBe('done');
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/variants/v1/nvd-scan/status'),
+            expect.objectContaining({ mode: 'cors' })
+        );
+    });
+
+    test('returns { status: "unknown" } on non-ok response', async () => {
+        fetchMock.mockResponseOnce('', { status: 503 });
+        const status = await ScansHandler.getNvdScanStatus('v1');
+        expect(status.status).toBe('unknown');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ScansHandler.triggerOsvScan
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.triggerOsvScan', () => {
+    test('returns ok=true on 200 success', async () => {
+        fetchMock.mockResponseOnce('{}', { status: 200 });
+        const result = await ScansHandler.triggerOsvScan('v1');
+        expect(result.ok).toBe(true);
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/variants/v1/osv-scan'),
+            expect.objectContaining({ method: 'POST' })
+        );
+    });
+
+    test('returns ok=true on 202', async () => {
+        fetchMock.mockResponseOnce('{}', { status: 202 });
+        const result = await ScansHandler.triggerOsvScan('v1');
+        expect(result.ok).toBe(true);
+    });
+
+    test('returns ok=false with error on failure', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ error: 'OSV unavailable' }), { status: 503 });
+        const result = await ScansHandler.triggerOsvScan('v1');
+        expect(result.ok).toBe(false);
+        expect(result.error).toBe('OSV unavailable');
+    });
+
+    test('returns ok=false with HTTP status when body is not JSON', async () => {
+        fetchMock.mockResponseOnce('not json', { status: 400 });
+        const result = await ScansHandler.triggerOsvScan('v1');
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain('400');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ScansHandler.getOsvScanStatus
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.getOsvScanStatus', () => {
+    test('returns status data on success', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ status: 'queued' }));
+        const status = await ScansHandler.getOsvScanStatus('v1');
+        expect(status.status).toBe('queued');
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/variants/v1/osv-scan/status'),
+            expect.objectContaining({ mode: 'cors' })
+        );
+    });
+
+    test('returns { status: "unknown" } on non-ok response', async () => {
+        fetchMock.mockResponseOnce('', { status: 404 });
+        const status = await ScansHandler.getOsvScanStatus('v1');
+        expect(status.status).toBe('unknown');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ScansHandler.deleteScan
+// ---------------------------------------------------------------------------
+
+describe('ScansHandler.deleteScan', () => {
+    test('returns ok=true with orphaned_findings_removed count on success', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ orphaned_findings_removed: 42 }), { status: 200 });
+        const result = await ScansHandler.deleteScan('scan-1');
+        expect(result.ok).toBe(true);
+        expect(result.orphaned_findings_removed).toBe(42);
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/scans/scan-1'),
+            expect.objectContaining({ method: 'DELETE' })
+        );
+    });
+
+    test('returns ok=true with undefined orphaned count when field is absent', async () => {
+        fetchMock.mockResponseOnce('{}', { status: 200 });
+        const result = await ScansHandler.deleteScan('scan-1');
+        expect(result.ok).toBe(true);
+        expect(result.orphaned_findings_removed).toBeUndefined();
+    });
+
+    test('returns ok=false with error field from body on HTTP error', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ error: 'scan not found' }), { status: 404 });
+        const result = await ScansHandler.deleteScan('scan-x');
+        expect(result.ok).toBe(false);
+        expect(result.error).toBe('scan not found');
+    });
+
+    test('returns ok=false with HTTP status code when body is not JSON', async () => {
+        fetchMock.mockResponseOnce('not json', { status: 500 });
+        const result = await ScansHandler.deleteScan('scan-x');
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain('500');
+    });
+});


### PR DESCRIPTION
### Changes proposed in this pull request:

This PR reworks the UI of scan history.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

[test-supplier-vulns.grype.json](https://github.com/user-attachments/files/28155614/test-supplier-vulns.grype.json)
[test-supplier-distinction.spdx.json](https://github.com/user-attachments/files/28155615/test-supplier-distinction.spdx.json)

[test-scan2.grype.json](https://github.com/user-attachments/files/28155616/test-scan2.grype.json)
[test-scan2.spdx.json](https://github.com/user-attachments/files/28155617/test-scan2.spdx.json)

[test-scan3.grype.json](https://github.com/user-attachments/files/28155619/test-scan3.grype.json)
[test-scan3.spdx.json](https://github.com/user-attachments/files/28155620/test-scan3.spdx.json)

Download the files above and run the following commands to have a scan history with 3 entries:
```
 ./vulnscout --dev \
   --add-spdx example/spdx2/test-supplier-distinction.spdx.json \
   --add-grype example/spdx2/test-supplier-vulns.grype.json \
   --serve


 ./vulnscout --add-spdx example/spdx2/test-scan2.spdx.json \
             --add-grype example/spdx2/test-scan2.grype.json
 
 ./vulnscout --add-spdx example/spdx2/test-scan3.spdx.json \
             --add-grype example/spdx2/test-scan3.grype.json
```

Before this PR, the scan history:
<img width="945" height="935" alt="image" src="https://github.com/user-attachments/assets/a1bb9838-7fa4-4a53-a916-5256f776260c" />

Now:
<img width="945" height="935" alt="image" src="https://github.com/user-attachments/assets/382225c6-6687-492c-bfc6-ca2da293035d" />


### Additional notes

The information about the findings is removed as per the ticket requirement.

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [x] Added necessary reviewers


