### PR TITLE
Allow lone boolean elements in CI conditions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -175,7 +175,7 @@ If you want to use the non-interactive mode, without the web interface, you can 
 
 [source,shell]
 ----
-./vulnscout --project demo --match-condition "((cvss >= 9.0 or (cvss >= 7.0 and epss >= 30%)) and (pending == true or affected == true))"
+./vulnscout --project demo --match-condition "((cvss >= 9.0 or (cvss >= 7.0 and epss >= 30%)) and (pending or affected))"
 ----
 
 The command exits with code `2` if any vulnerability matches the condition, enabling use in CI pipelines.
@@ -189,7 +189,7 @@ You can combine inputs with a match condition in a single invocation:
 ./vulnscout --project demo \
   --add-spdx /path/to/sbom.spdx.json \
   --add-cve-check /path/to/cve-check.json \
-  --match-condition "((cvss >= 9.0) and (pending == true or affected == true)) "
+  --match-condition "((cvss >= 9.0) and (pending or affected)) "
 ----
 
 ===  Performing a Grype Scan

--- a/doc/source/ci_conditions.md
+++ b/doc/source/ci_conditions.md
@@ -20,7 +20,7 @@ Match conditions can be combined with input files in a single invocation:
 ./vulnscout --project demo \
   --add-spdx /path/to/sbom.spdx.json \
   --add-cve-check /path/to/cve-check.json \
-    --match-condition "((cvss >= 9.0 or (cvss >= 7.0 and epss >= 30%)) and (pending == true or affected == true))"
+    --match-condition "((cvss >= 9.0 or (cvss >= 7.0 and epss >= 30%)) and (pending or affected))"
 ```
 
 If the `CONDITION` is invalid, the configuration is not found, or an error occurs during the process, the command returns an exit code of **1**. This allows users to differentiate between a configuration error and a condition match.
@@ -45,21 +45,21 @@ This example will cause the command to exit with code **2** if any vulnerability
 
 ## Global Syntax and Language Definition
 
-The full language definition can be found in `src/controllers/conditions_parser.py`. The following keywords are recognized:
+The full language definition can be found in `src/controllers/conditions_parser.py`.
 
-- `true`, `false`
-- `and`, `or`, `not`
-- `>`, `>=`, `<`, `<=`, `==`, `!=`
-- `0`, `5`, `2.3`, `-1`, `.42`, `25%` are recognized as numbers. Percentages are divided by 100 internally.
-- `(` ... `)` are used to group expressions.
+A condition is always expressed as either:
+- `<left condition> <operator> <right condition>` where `<operator>` is :
+  - `and`, `or`, `not`
+  - `>`, `>=`, `<`, `<=`, `==`, `!=`
+- `( <condition> )`: can be used to group expressions
+- `<boolean expression>`: as an alias to `<token> == {true|false}`
 
-Any condition is always expressed as `<left token> <operator> <right token>`.
+Tokens can be:
+- `true`, `false`: mapped to the corresponding boolean values
+- `0`, `5`, `2.3`, `-1`, `.42`, `25%`: recognized as numbers. Percentages are divided by 100 internally.
+- any unrecognised token is treated as a string identifier. String tokens can start with `[a-zA-Z_]` and contain `[a-zA-Z0-9_-:]`.
 
-**Example:** `cvss >= 5 or ignored == true`
-
-> **Note:** `true` alone is not a valid expression, but `true == true` is.
-
-Any unrecognised token is treated as a string identifier. String tokens can start with `[a-zA-Z_]` and contain `[a-zA-Z0-9_-:]`.
+**Example:** `cvss >= 5 or ignored`
 
 ---
 
@@ -100,27 +100,22 @@ cvss >= 9.0 or (cvss >= 7.0 and epss >= 50%)
 
 **Fail if any vulnerability was not reviewed by a human yet:**
 ```
-pending == true
+pending
 ```
 
 **Fail if there are important vulnerabilities not fixed or ignored:**
 ```
-cvss >= 7.0 and (not fixed == true and not ignored == true)
-```
-
-Or more concisely:
-```
-cvss >= 7 and fixed == false and ignored == false
+cvss >= 7 and not fixed and not ignored
 ```
 
 **Fail if a vulnerability with affected status doesn't have an effort set already:**
 ```
-affected == true and effort == false
+affected and not effort
 ```
 
 **Fail if a high vulnerability is affecting the product and needs less than an hour to fix:**
 ```
-cvss >= 7.0 and affected == true and effort < 3600
+cvss >= 7.0 and affected and effort < 3600
 ```
 
 **Fail if Log4j is found:**
@@ -130,5 +125,5 @@ id == CVE-2021-44228
 
 **Fail if any new (previously unseen) vulnerability is critical:**
 ```
-new == true and cvss >= 9.0
+new and cvss >= 9.0
 ```

--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -193,7 +193,7 @@ For CI pipelines or automated scans, use the `--match-condition` argument instea
 ./vulnscout --project demo \
   --add-spdx /path/to/sbom.spdx.json \
   --add-cve-check /path/to/cve-check.json \
-  --match-condition "((cvss >= 9.0 or (cvss >= 7.0 and epss >= 30%)) and (pending == true or affected == true))"
+  --match-condition "((cvss >= 9.0 or (cvss >= 7.0 and epss >= 30%)) and (pending or affected))"
 ```
 
 If vulnerabilities match the condition, the script exits with **code 2**, allowing CI systems to fail the pipeline.

--- a/src/controllers/conditions_parser.py
+++ b/src/controllers/conditions_parser.py
@@ -35,6 +35,7 @@ class ConditionParser:
         condition = (
             pp.Group(LPAR + condition_base + RPAR)
             | condition_base
+            | element
         ).set_name("condition").set_debug(flag=debug)
 
         self.conditions = pp.Forward()

--- a/tests/end_to_end_tests/test_merger_ci.py
+++ b/tests/end_to_end_tests/test_merger_ci.py
@@ -131,10 +131,10 @@ def test_invalid_cdx(app, init_files, monkeypatch):
 
 
 def test_ci_mode(app, monkeypatch):
-    monkeypatch.setenv("MATCH_CONDITION", "false == true")
+    monkeypatch.setenv("MATCH_CONDITION", "false")
     _run_main()
 
-    monkeypatch.setenv("MATCH_CONDITION", "true == true")
+    monkeypatch.setenv("MATCH_CONDITION", "true")
     with pytest.raises(SystemExit) as e:
         _run_main()
     assert e.type == SystemExit

--- a/tests/unit_tests/test_conditions_parser.py
+++ b/tests/unit_tests/test_conditions_parser.py
@@ -18,6 +18,8 @@ def test_true_and_false(parser):
     WHEN parsing a string with True and False
     THEN check the result is correct
     """
+    assert parser.evaluate("true", None) is True
+    assert parser.evaluate("false", None) is False
     assert parser.evaluate("true == true", None) is True
     assert parser.evaluate("true == false", None) is False
     assert parser.evaluate("true != false", None) is True
@@ -29,6 +31,7 @@ def test_using_data(parser):
     WHEN parsing a string with data
     THEN check the result is correct
     """
+    assert parser.evaluate("true", {"true": False}) is False
     assert parser.evaluate("true == false", {"true": False}) is True
     assert parser.evaluate("a == 2", {"a": 2}) is True
     assert parser.evaluate("a == 2", {"a": 3}) is False
@@ -42,6 +45,8 @@ def test_not_operation(parser):
     WHEN parsing a string with not operation
     THEN check the result is correct
     """
+    assert parser.evaluate("not true", None) is False
+    assert parser.evaluate("not false", None) is True
     assert parser.evaluate("not true == true", None) is False
     assert parser.evaluate("not false == true", None) is True
     assert parser.evaluate("not a == 42", {"a": 42}) is False
@@ -72,6 +77,8 @@ def test_and_or_operations(parser):
     assert parser.evaluate("true == a and true == a", {"a": False}) is False
     assert parser.evaluate("true == a or a == false", {"a": True}) is True
     assert parser.evaluate("true == a or a == false", {"a": False}) is True
+    assert parser.evaluate("true == a or not a", {"a": True}) is True
+    assert parser.evaluate("true == a or not a", {"a": False}) is True
 
 
 def test_percentage(parser):
@@ -104,8 +111,6 @@ def test_invalid(parser):
     with pytest.raises(Exception):
         parser.evaluate("unknown == 2", None)
     with pytest.raises(Exception):
-        parser.evaluate("true", None)
-    with pytest.raises(Exception):
         parser.evaluate("true == true == true", None)
     with pytest.raises(Exception):
         parser.evaluate("true == true and", None)
@@ -119,8 +124,8 @@ def test_complex_scenario(parser):
     WHEN parsing a string with complex scenario
     THEN check the result is correct
     """
-    conditions = "(epss > 5% or (cvss >= 4 and fix_exist == true) or cvss >= 9)" \
-        + " and not (fixed == true or ignored == true)"
+    conditions = "(epss > 5% or (cvss >= 4 and fix_exist) or cvss >= 9)" \
+        + " and not (fixed or ignored)"
 
     assert parser.evaluate(conditions, {
         "epss": 0.06,
@@ -143,6 +148,20 @@ def test_complex_scenario(parser):
         "fixed": True,
         "ignored": False
     }) is False
+
+
+def test_simple_bool(parser):
+    assert parser.evaluate("var", {
+        "var": True
+    })
+
+    assert not parser.evaluate("var", {
+        "var": False
+    })
+
+    assert parser.evaluate("not var", {
+        "var": False
+    })
 
 
 def test_invalid_identifier(parser):


### PR DESCRIPTION
### Changes proposed in this pull request:

* Allow lone boolean elements in CI conditions
  * Previously, one had to use `xxx == true` or `xxx == false` boilerplate. It is expected to just being able to put `xxx` or `not xxx`
  * This allows to directly use boolean elements.
* Edited existing documentation to use lone boolean elements for clarity
  * e.g. `((cvss >= 9.0 or (cvss >= 7.0 and epss >= 30%)) and (pending == true or affected == true))` becomes `((cvss >= 9.0 or (cvss >= 7.0 and epss >= 30%)) and (pending or affected))`
* Reworked condition syntax documentation

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### Additional notes

*If applicable, explain the rationale behind your change.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


