### PR TITLE
Link CVSS and time estimate to a variant

### DIFF
--- a/frontend/src/components/CustomCvss.tsx
+++ b/frontend/src/components/CustomCvss.tsx
@@ -1,12 +1,23 @@
 import { useState } from "react";
+import type { Variant } from "../handlers/variant";
 
 type Props = {
   onCancel: () => void;
   onAddCvss: (vector: string) => void;
   triggerBanner: (message: string, type: "error" | "success") => void;
+  variants?: Variant[];
+  selectedVariantIds?: string[];
+  onSelectedVariantIdsChange?: (variantIds: string[]) => void;
 };
 
-function CustomCvss({ onCancel, onAddCvss, triggerBanner }: Props) {
+function CustomCvss({
+  onCancel,
+  onAddCvss,
+  triggerBanner,
+  variants,
+  selectedVariantIds,
+  onSelectedVariantIdsChange,
+}: Props) {
   const [vectorString, setVectorString] = useState("");
 
   const handleAdd = () => {
@@ -25,6 +36,31 @@ function CustomCvss({ onCancel, onAddCvss, triggerBanner }: Props) {
         You can enter a custom CVSS vector to assess the vulnerability with your own parameters. 
         You can use an online CVSS calculator to help you generate the vector.
       </p>
+
+      {variants && variants.length > 0 && selectedVariantIds && onSelectedVariantIdsChange && (
+        <div className="mt-2 mb-1">
+          <p className="text-sm font-medium text-gray-300 mb-1">Select variants:</p>
+          <div className="flex flex-wrap gap-x-4 gap-y-1">
+            {variants.map(v => (
+              <label key={v.id} className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={selectedVariantIds.includes(v.id)}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      onSelectedVariantIdsChange([...selectedVariantIds, v.id]);
+                    } else {
+                      onSelectedVariantIdsChange(selectedVariantIds.filter(id => id !== v.id));
+                    }
+                  }}
+                  className="accent-blue-500"
+                />
+                <span className="text-gray-200">{v.name}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div>
         <label className="block text-sm text-gray-300 mb-1">Vector String</label>

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -219,16 +219,51 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
     const saveTimeEstimation = async (content: PostTimeEstimate) => {
         setIsLoading(true);
 
-        // Prepare batch request payload
-        const vulnerabilityUpdates = selectedVulns.map(vuln_id => ({
-            id: vuln_id,
-            ...(variantId ? { variant_id: variantId } : {}),
+        // Build variant-scoped updates for every selected vulnerability.
+        const vulnerabilityUpdates: Array<{
+            id: string;
+            variant_id: string;
             effort: {
-                optimistic: content.optimistic.formatAsIso8601(),
-                likely: content.likely.formatAsIso8601(),
-                pessimistic: content.pessimistic.formatAsIso8601()
+                optimistic: string;
+                likely: string;
+                pessimistic: string;
+            };
+        }> = [];
+
+        if (variantId) {
+            for (const vuln_id of selectedVulns) {
+                vulnerabilityUpdates.push({
+                    id: vuln_id,
+                    variant_id: variantId,
+                    effort: {
+                        optimistic: content.optimistic.formatAsIso8601(),
+                        likely: content.likely.formatAsIso8601(),
+                        pessimistic: content.pessimistic.formatAsIso8601()
+                    }
+                });
             }
-        }));
+        } else {
+            await Promise.all(selectedVulns.map(async (vuln_id) => {
+                const variants = await Variants.listByVuln(vuln_id).catch(() => []);
+                for (const variant of variants) {
+                    vulnerabilityUpdates.push({
+                        id: vuln_id,
+                        variant_id: variant.id,
+                        effort: {
+                            optimistic: content.optimistic.formatAsIso8601(),
+                            likely: content.likely.formatAsIso8601(),
+                            pessimistic: content.pessimistic.formatAsIso8601()
+                        }
+                    });
+                }
+            }));
+        }
+
+        if (vulnerabilityUpdates.length === 0) {
+            triggerBanner('No variants found for selected vulnerabilities.', 'error');
+            setIsLoading(false);
+            return;
+        }
 
         try {
             const response = await fetch(import.meta.env.VITE_API_URL + '/api/vulnerabilities/batch', {
@@ -259,7 +294,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                 }
 
                 const errorMsg = data.error_count ? ` (${data.error_count} failed)` : '';
-                triggerBanner(`Successfully updated time estimates for ${data.count} vulnerabilities${errorMsg}`, 'success');
+                triggerBanner(`Successfully updated ${data.count} variant-scoped time estimates${errorMsg}`, 'success');
                 resetVulns();
             } else {
                 const errorMsg = data?.errors?.length

--- a/frontend/src/components/TimeEstimateEditor.tsx
+++ b/frontend/src/components/TimeEstimateEditor.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleQuestion } from '@fortawesome/free-regular-svg-icons';
 import Iso8601Duration from '../handlers/iso8601duration';
 import MessageBanner from './MessageBanner';
+import type { Variant } from '../handlers/variant';
 
 type PostTimeEstimate = {
     optimistic: Iso8601Duration,
@@ -24,9 +25,12 @@ type Props = {
     onFieldsChange?: (hasChanges: boolean) => void;
     triggerBanner?: (message: string, type: "error" | "success") => void;
     hideInputs?: boolean;
+    variants?: Variant[];
+    selectedVariantIds?: string[];
+    onSelectedVariantIdsChange?: (variantIds: string[]) => void;
 }
 
-function TimeEstimateEditor ({onSaveTimeEstimation, clearFields: shouldClearFields, progressBar, actualEstimate, onFieldsChange, triggerBanner, hideInputs}: Readonly<Props>) {
+function TimeEstimateEditor ({onSaveTimeEstimation, clearFields: shouldClearFields, progressBar, actualEstimate, onFieldsChange, triggerBanner, hideInputs, variants, selectedVariantIds, onSelectedVariantIdsChange}: Readonly<Props>) {
     const [estimateHelp, setEstimateHelp] = useState(false);
     const [newOptimistic, setNewOptimistic] = useState("");
     const [newLikely, setNewLikely] = useState("");
@@ -125,6 +129,31 @@ function TimeEstimateEditor ({onSaveTimeEstimation, clearFields: shouldClearFiel
                 <FontAwesomeIcon icon={faCircleQuestion} size='lg' className='pr-2' data-testid='estimated-effort-helper-button' />
             </button>
         </div>
+
+        {!hideInputs && variants && variants.length > 0 && selectedVariantIds && onSelectedVariantIdsChange && (
+            <div className="mt-2 mb-2 ml-1">
+                <p className="text-sm font-medium text-gray-300 mb-1">Select variants:</p>
+                <div className="flex flex-wrap gap-x-4 gap-y-1">
+                    {variants.map(v => (
+                        <label key={v.id} className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
+                            <input
+                                type="checkbox"
+                                checked={selectedVariantIds.includes(v.id)}
+                                onChange={(e) => {
+                                    if (e.target.checked) {
+                                        onSelectedVariantIdsChange([...selectedVariantIds, v.id]);
+                                    } else {
+                                        onSelectedVariantIdsChange(selectedVariantIds.filter(id => id !== v.id));
+                                    }
+                                }}
+                                className="accent-blue-500"
+                            />
+                            <span className="text-gray-200">{v.name}</span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+        )}
 
         <div className="flex flex-row space-x-4 max-w-[900px]">
             <div className="flex-1">

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -683,6 +683,11 @@ type AssessmentGroup = {
     };
 
     const addCvss = async (vector: string) => {
+        if (!variantId) {
+            showMessage("Please select a variant before adding a custom CVSS score.", "error");
+            return;
+        }
+
         const content = appendCVSS(vuln.id, vector);
 
         if (content === null) {
@@ -698,6 +703,7 @@ type AssessmentGroup = {
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
+                variant_id: variantId,
                 cvss: content
             })
         });
@@ -723,14 +729,19 @@ type AssessmentGroup = {
     };
 
     const saveEstimation = async (content: PostTimeEstimate) => {
+        if (!variantId) {
+            showMessage("Please select a variant before saving an estimate.", "error");
+            return;
+        }
+
         const body: Record<string, unknown> = {
+            variant_id: variantId,
             effort: {
                 optimistic: content.optimistic.formatAsIso8601(),
                 likely: content.likely.formatAsIso8601(),
                 pessimistic: content.pessimistic.formatAsIso8601()
             }
         };
-        if (variantId) body.variant_id = variantId;
         const response = await fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}`, {
             method: 'PATCH',
             mode: 'cors',

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -89,6 +89,7 @@ type VariantScopedSnapshot = {
     const [allVulnAssessments, setAllVulnAssessments] = useState<Assessment[]>([]);
     const [selectedTargetVariantIds, setSelectedTargetVariantIds] = useState<string[]>([]);
     const [variantSnapshots, setVariantSnapshots] = useState<VariantScopedSnapshot[]>([]);
+    const [snapshotVersion, setSnapshotVersion] = useState(0);
     const [submittingMessage, setSubmittingMessage] = useState<string | null>(null);
     const [editingGroup, setEditingGroup] = useState<AssessmentGroup | null>(null);
 
@@ -184,7 +185,7 @@ type VariantScopedSnapshot = {
         })();
 
         return () => { cancelled = true; };
-    }, [variantId, availableVariants, vuln.id]);
+    }, [variantId, availableVariants, vuln.id, snapshotVersion]);
 
     const [hasTimeChanges, setHasTimeChanges] = useState(false);
     const [hasAssessmentChanges, setHasAssessmentChanges] = useState(false);
@@ -807,14 +808,16 @@ type VariantScopedSnapshot = {
                 ? data?.vulnerabilities?.[0]?.severity?.cvss
                 : data?.severity?.cvss;
 
-            if (Array.isArray(updatedSeverity)) {
-                // Update the local vuln object immediately for instant UI update
+            if (Array.isArray(updatedSeverity) && variantId) {
+                // Only update the local vuln object when viewing a specific variant.
+                // In all-variants mode the snapshot refresh below handles the display.
                 vuln.severity.cvss = updatedSeverity;
-
-                // Also patch the vulnerability for real-time refresh in other views
                 patchVuln(vuln.id, vuln);
             }
 
+            // Refresh per-variant snapshots immediately so the panel reflects the
+            // new data without requiring the modal to be closed and reopened.
+            setSnapshotVersion(v => v + 1);
             setShowCustomCvss(false);
             showMessage("Successfully added Custom CVSS.", "success");
         } else {
@@ -866,16 +869,24 @@ type VariantScopedSnapshot = {
                 ? data?.vulnerabilities?.[0]?.effort
                 : data?.effort;
 
-            // Update the local vuln object immediately for instant UI update
-            if (typeof updatedEffort?.optimistic === "string")
-                vuln.effort.optimistic = new Iso8601Duration(updatedEffort.optimistic);
-            if (typeof updatedEffort?.likely === "string")
-                vuln.effort.likely = new Iso8601Duration(updatedEffort.likely);
-            if (typeof updatedEffort?.pessimistic === "string")
-                vuln.effort.pessimistic = new Iso8601Duration(updatedEffort.pessimistic);
+            if (variantId) {
+                // Only update the local vuln object when viewing a specific variant.
+                // In all-variants mode the snapshot refresh below handles the display,
+                // so we must not overwrite the global vuln with variant-scoped values.
+                if (typeof updatedEffort?.optimistic === "string")
+                    vuln.effort.optimistic = new Iso8601Duration(updatedEffort.optimistic);
+                if (typeof updatedEffort?.likely === "string")
+                    vuln.effort.likely = new Iso8601Duration(updatedEffort.likely);
+                if (typeof updatedEffort?.pessimistic === "string")
+                    vuln.effort.pessimistic = new Iso8601Duration(updatedEffort.pessimistic);
 
-            // Also patch the vulnerability for real-time refresh in other views
-            patchVuln(vuln.id, vuln);
+                // Also patch the vulnerability for real-time refresh in other views
+                patchVuln(vuln.id, vuln);
+            }
+
+            // Refresh per-variant snapshots immediately so the panel reflects the
+            // new data without requiring the modal to be closed and reopened.
+            setSnapshotVersion(v => v + 1);
             setClearTimeFields(true);
             setTimeout(() => setClearTimeFields(false), 100);
             showMessage("Successfully added estimation.", "success");

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -1,5 +1,6 @@
 import type { Vulnerability } from "../handlers/vulnerabilities";
 import type { CVSS } from "../handlers/vulnerabilities";
+import { asVulnerability } from "../handlers/vulnerabilities";
 import type { Assessment } from "../handlers/assessments";
 import { asAssessment } from "../handlers/assessments";
 import { escape } from "lodash-es";
@@ -58,6 +59,18 @@ type AssessmentGroup = {
     packages: string[];
 };
 
+type VariantScopedSnapshot = {
+    variantId: string;
+    variantName: string;
+    hasEffort: boolean;
+    effort: {
+        optimistic?: string;
+        likely?: string;
+        pessimistic?: string;
+    };
+    customCvss: CVSS[];
+};
+
   function VulnModal(props: Readonly<Props>) {
     const { vuln, isEditing: initialIsEditing, readOnly = false, onClose, appendAssessment, appendCVSS, patchVuln, vulnerabilities, currentIndex, onNavigate, variantId, projectId } = props;
     const docUrl = useDocUrl("interactive-mode.html#vulnerability-details");
@@ -74,6 +87,8 @@ type AssessmentGroup = {
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [availableVariants, setAvailableVariants] = useState<Variant[]>([]);
     const [allVulnAssessments, setAllVulnAssessments] = useState<Assessment[]>([]);
+    const [selectedTargetVariantIds, setSelectedTargetVariantIds] = useState<string[]>([]);
+    const [variantSnapshots, setVariantSnapshots] = useState<VariantScopedSnapshot[]>([]);
     const [submittingMessage, setSubmittingMessage] = useState<string | null>(null);
     const [editingGroup, setEditingGroup] = useState<AssessmentGroup | null>(null);
 
@@ -107,6 +122,69 @@ type AssessmentGroup = {
             })
             .catch(() => {});
     }, [vuln.id]);
+
+    // In all-variants mode, default to all variant targets for custom CVSS/time edits.
+    useEffect(() => {
+        if (variantId || availableVariants.length === 0) {
+            setSelectedTargetVariantIds([]);
+            return;
+        }
+        setSelectedTargetVariantIds(availableVariants.map(v => v.id));
+    }, [variantId, vuln.id, availableVariants]);
+
+    // Build per-variant snapshots so the modal can show where custom CVSS and
+    // effort differ across variants directly in all-variants mode.
+    useEffect(() => {
+        let cancelled = false;
+        if (variantId || availableVariants.length === 0) {
+            setVariantSnapshots([]);
+            return;
+        }
+
+        (async () => {
+            const snapshots = await Promise.all(availableVariants.map(async (variant): Promise<VariantScopedSnapshot | null> => {
+                try {
+                    const response = await fetch(
+                        import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}?variant_id=${encodeURIComponent(variant.id)}`,
+                        { mode: 'cors' }
+                    );
+                    if (!response.ok) return null;
+                    const raw = await response.json();
+                    const vulnData = asVulnerability(raw);
+                    if (Array.isArray(vulnData)) return null;
+                    const customCvss = Array.isArray(vulnData?.severity?.cvss)
+                        ? vulnData.severity.cvss.filter(score => score.origin === 'custom')
+                        : [];
+
+                    const optimisticDuration = vulnData?.effort?.optimistic;
+                    const likelyDuration = vulnData?.effort?.likely;
+                    const pessimisticDuration = vulnData?.effort?.pessimistic;
+                    const hasEffort = [optimisticDuration, likelyDuration, pessimisticDuration].some((duration) => {
+                        return typeof duration?.total_seconds === 'number' && duration.total_seconds > 0;
+                    });
+                    return {
+                        variantId: variant.id,
+                        variantName: variant.name,
+                        hasEffort,
+                        effort: {
+                            optimistic: typeof optimisticDuration?.formatHumanShort === 'function' && optimisticDuration.total_seconds > 0 ? optimisticDuration.formatHumanShort() : undefined,
+                            likely: typeof likelyDuration?.formatHumanShort === 'function' && likelyDuration.total_seconds > 0 ? likelyDuration.formatHumanShort() : undefined,
+                            pessimistic: typeof pessimisticDuration?.formatHumanShort === 'function' && pessimisticDuration.total_seconds > 0 ? pessimisticDuration.formatHumanShort() : undefined,
+                        },
+                        customCvss,
+                    };
+                } catch {
+                    return null;
+                }
+            }));
+
+            if (!cancelled) {
+                setVariantSnapshots(snapshots.filter((s): s is VariantScopedSnapshot => s !== null));
+            }
+        })();
+
+        return () => { cancelled = true; };
+    }, [variantId, availableVariants, vuln.id]);
 
     const [hasTimeChanges, setHasTimeChanges] = useState(false);
     const [hasAssessmentChanges, setHasAssessmentChanges] = useState(false);
@@ -683,11 +761,6 @@ type AssessmentGroup = {
     };
 
     const addCvss = async (vector: string) => {
-        if (!variantId) {
-            showMessage("Please select a variant before adding a custom CVSS score.", "error");
-            return;
-        }
-
         const content = appendCVSS(vuln.id, vector);
 
         if (content === null) {
@@ -695,25 +768,48 @@ type AssessmentGroup = {
             return;
         }
 
+        const targetVariantIds: Array<string | undefined> =
+            variantId
+                ? [variantId]
+                : (availableVariants.length > 0
+                    ? (selectedTargetVariantIds.length > 0 ? selectedTargetVariantIds : [])
+                    : [undefined]);
 
-        const response = await fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}`, {
+        if (!variantId && availableVariants.length > 0 && targetVariantIds.length === 0) {
+            showMessage("Please select at least one variant before adding a custom CVSS score.", "error");
+            return;
+        }
+
+        const updates = targetVariantIds.map((vid) => ({
+            id: vuln.id,
+            ...(vid ? { variant_id: vid } : {}),
+            cvss: content,
+        }));
+
+        const url = updates.length > 1
+            ? import.meta.env.VITE_API_URL + '/api/vulnerabilities/batch'
+            : import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}`;
+        const body = updates.length > 1 ? { vulnerabilities: updates } : updates[0];
+
+        const response = await fetch(url, {
             method: 'PATCH',
             mode: 'cors',
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify({
-                variant_id: variantId,
-                cvss: content
-            })
+            body: JSON.stringify(body)
         });
 
         if (response.status == 200) {
             const data = await response.json();
 
-            if (Array.isArray(data?.severity?.cvss)) {
+            const updatedSeverity = updates.length > 1
+                ? data?.vulnerabilities?.[0]?.severity?.cvss
+                : data?.severity?.cvss;
+
+            if (Array.isArray(updatedSeverity)) {
                 // Update the local vuln object immediately for instant UI update
-                vuln.severity.cvss = data.severity.cvss;
+                vuln.severity.cvss = updatedSeverity;
 
                 // Also patch the vulnerability for real-time refresh in other views
                 patchVuln(vuln.id, vuln);
@@ -729,37 +825,54 @@ type AssessmentGroup = {
     };
 
     const saveEstimation = async (content: PostTimeEstimate) => {
-        if (!variantId) {
-            showMessage("Please select a variant before saving an estimate.", "error");
+        const targetVariantIds: Array<string | undefined> =
+            variantId
+                ? [variantId]
+                : (availableVariants.length > 0
+                    ? (selectedTargetVariantIds.length > 0 ? selectedTargetVariantIds : [])
+                    : [undefined]);
+
+        if (!variantId && availableVariants.length > 0 && targetVariantIds.length === 0) {
+            showMessage("Please select at least one variant before saving an estimate.", "error");
             return;
         }
 
-        const body: Record<string, unknown> = {
-            variant_id: variantId,
+        const updates = targetVariantIds.map((vid) => ({
+            id: vuln.id,
+            ...(vid ? { variant_id: vid } : {}),
             effort: {
                 optimistic: content.optimistic.formatAsIso8601(),
                 likely: content.likely.formatAsIso8601(),
                 pessimistic: content.pessimistic.formatAsIso8601()
             }
-        };
-        const response = await fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}`, {
+        }));
+
+        const url = updates.length > 1
+            ? import.meta.env.VITE_API_URL + '/api/vulnerabilities/batch'
+            : import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}`;
+
+        const response = await fetch(url, {
             method: 'PATCH',
             mode: 'cors',
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify(body)
+            body: JSON.stringify(updates.length > 1 ? { vulnerabilities: updates } : updates[0])
         })
         if (response.status == 200) {
             const data = await response.json()
 
+            const updatedEffort = updates.length > 1
+                ? data?.vulnerabilities?.[0]?.effort
+                : data?.effort;
+
             // Update the local vuln object immediately for instant UI update
-            if (typeof data?.effort?.optimistic === "string")
-                vuln.effort.optimistic = new Iso8601Duration(data.effort.optimistic);
-            if (typeof data?.effort?.likely === "string")
-                vuln.effort.likely = new Iso8601Duration(data.effort.likely);
-            if (typeof data?.effort?.pessimistic === "string")
-                vuln.effort.pessimistic = new Iso8601Duration(data.effort.pessimistic);
+            if (typeof updatedEffort?.optimistic === "string")
+                vuln.effort.optimistic = new Iso8601Duration(updatedEffort.optimistic);
+            if (typeof updatedEffort?.likely === "string")
+                vuln.effort.likely = new Iso8601Duration(updatedEffort.likely);
+            if (typeof updatedEffort?.pessimistic === "string")
+                vuln.effort.pessimistic = new Iso8601Duration(updatedEffort.pessimistic);
 
             // Also patch the vulnerability for real-time refresh in other views
             patchVuln(vuln.id, vuln);
@@ -978,6 +1091,9 @@ type AssessmentGroup = {
                                                             addCvss(vector);
                                                         }}
                                                         triggerBanner={showMessage}
+                                                        variants={!variantId ? availableVariants : undefined}
+                                                        selectedVariantIds={!variantId ? selectedTargetVariantIds : undefined}
+                                                        onSelectedVariantIdsChange={!variantId ? setSelectedTargetVariantIds : undefined}
                                                     />
                                                 </div>
                                             )}
@@ -994,10 +1110,35 @@ type AssessmentGroup = {
                                         className="bg-gray-800 p-2 rounded-xl min-w-[216px]"
                                     >
                                         <h3 className="text-center font-bold">CVSS {cvss.version}</h3>
+                                        {cvss.variant_id && (
+                                            <div className="flex justify-center mb-1">
+                                                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                                                    {availableVariants.find(v => v.id === cvss.variant_id)?.name ?? cvss.variant_id}
+                                                </span>
+                                            </div>
+                                        )}
                                         <CvssGauge data={cvss} />
                                     </div>
                                     ))}
                                 </div>
+
+                                {!variantId && variantSnapshots.some(s => s.customCvss.length > 0) && (
+                                    <div className="mt-3 p-3 rounded-lg bg-gray-800/70 border border-gray-600">
+                                        <h4 className="font-semibold text-gray-200 mb-2">Custom CVSS by variant</h4>
+                                        <div className="space-y-2">
+                                            {variantSnapshots
+                                                .filter(snapshot => snapshot.customCvss.length > 0)
+                                                .map(snapshot => (
+                                                    <div key={snapshot.variantId} className="text-sm">
+                                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 mr-2">{snapshot.variantName}</span>
+                                                        <span className="text-gray-300">
+                                                            {snapshot.customCvss.map(score => `CVSS ${score.version} (${score.base_score})`).join(', ')}
+                                                        </span>
+                                                    </div>
+                                                ))}
+                                        </div>
+                                    </div>
+                                )}
                             </div>
 
                         </div>
@@ -1029,12 +1170,31 @@ type AssessmentGroup = {
                                 onFieldsChange={setHasTimeChanges}
                                 triggerBanner={showMessage}
                                 hideInputs={!isEditing}
+                                variants={!variantId && isEditing ? availableVariants : undefined}
+                                selectedVariantIds={!variantId && isEditing ? selectedTargetVariantIds : undefined}
+                                onSelectedVariantIdsChange={!variantId && isEditing ? setSelectedTargetVariantIds : undefined}
                                 actualEstimate={{
                                     optimistic: vuln?.effort?.optimistic?.formatHumanShort(),
                                     likely: vuln?.effort?.likely?.formatHumanShort(),
                                     pessimistic: vuln?.effort?.pessimistic?.formatHumanShort(),
                                 }}
                             />
+
+                            {!variantId && variantSnapshots.some(s => s.hasEffort) && (
+                                <div className="mt-3 p-3 rounded-lg bg-gray-800/70 border border-gray-600">
+                                    <h4 className="font-semibold text-gray-200 mb-2">Time estimate by variant</h4>
+                                    <div className="space-y-1 text-sm text-gray-300">
+                                        {variantSnapshots
+                                            .filter(snapshot => snapshot.hasEffort)
+                                            .map(snapshot => (
+                                                <div key={snapshot.variantId}>
+                                                    <span className="inline-flex items-center px-2 py-0.5 rounded-full font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 mr-2">{snapshot.variantName}</span>
+                                                    <span>O: {snapshot.effort.optimistic ?? 'N/A'} | L: {snapshot.effort.likely ?? 'N/A'} | P: {snapshot.effort.pessimistic ?? 'N/A'}</span>
+                                                </div>
+                                            ))}
+                                    </div>
+                                </div>
+                            )}
                         </div>
 
                         <div className="mt-6">

--- a/frontend/src/handlers/assessments.ts
+++ b/frontend/src/handlers/assessments.ts
@@ -33,6 +33,7 @@ export type { Assessment };
 
 type ReviewTimeEstimate = {
     vuln_id: string;
+    variant_id?: string;
     optimistic: number;
     likely: number;
     pessimistic: number;
@@ -44,6 +45,7 @@ type ReviewTimeEstimate = {
 
 type ReviewCustomCvss = {
     vuln_id: string;
+    variant_id?: string;
     version: string;
     vector_string: string;
     base_score: number;

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -6,6 +6,7 @@ import { Cvss2, Cvss3P0, Cvss3P1, Cvss4P0 } from 'ae-cvss-calculator';
 type CVSS = {
     author: string;
     origin?: string;
+    variant_id?: string;
     severity: string;
     version: string;
     vector_string: string;
@@ -68,6 +69,7 @@ const asCVSS = (data: any): CVSS | [] => {
     let score: CVSS = {
         author: "unknown",
         origin: "scanner",
+        variant_id: undefined,
         severity: "unknown",
         version: data.version,
         vector_string: "",
@@ -78,6 +80,7 @@ const asCVSS = (data: any): CVSS | [] => {
     };
     if (typeof data?.author === "string") score.author = data.author
     if (typeof data?.origin === "string") score.origin = data.origin
+    if (typeof data?.variant_id === "string") score.variant_id = data.variant_id
     if (typeof data?.severity === "string") score.severity = data.severity
     if (typeof data?.vector_string === "string") {
         score.vector_string = data.vector_string

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -729,6 +729,23 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                 </div>
             ),
         }),
+        teColumnHelper.accessor("variant_id", {
+            header: () => <div className="flex items-center justify-center">Variant</div>,
+            size: 150,
+            cell: info => {
+                const variant = info.getValue();
+                if (!variant) {
+                    return <div className="flex items-center justify-center h-full"><span className="text-gray-500 italic">-</span></div>;
+                }
+                return (
+                    <div className="flex items-center justify-center h-full">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                            {variantNames[variant] ?? variant.slice(0, 8)}
+                        </span>
+                    </div>
+                );
+            },
+        }),
         teColumnHelper.accessor("optimistic", {
             header: () => <div className="flex items-center justify-center">Optimistic (h)</div>,
             size: 120,
@@ -756,7 +773,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                 </div>
             ),
         }),
-    ], [handleVulnClick]);
+    ], [handleVulnClick, variantNames]);
 
     const cvssColumns = useMemo(() => [
         cvssColumnHelper.accessor("vuln_id", {
@@ -772,6 +789,23 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     <span className="font-mono text-sm">{info.getValue()}</span>
                 </div>
             ),
+        }),
+        cvssColumnHelper.accessor("variant_id", {
+            header: () => <div className="flex items-center justify-center">Variant</div>,
+            size: 150,
+            cell: info => {
+                const variant = info.getValue();
+                if (!variant) {
+                    return <div className="flex items-center justify-center h-full"><span className="text-gray-500 italic">-</span></div>;
+                }
+                return (
+                    <div className="flex items-center justify-center h-full">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                            {variantNames[variant] ?? variant.slice(0, 8)}
+                        </span>
+                    </div>
+                );
+            },
         }),
         cvssColumnHelper.accessor("version", {
             header: () => <div className="flex items-center justify-center">CVSS Version</div>,
@@ -817,7 +851,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                 </div>
             ),
         }),
-    ], [handleVulnClick]);
+    ], [handleVulnClick, variantNames]);
 
     if (loading) {
         return (
@@ -1089,7 +1123,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                             texts: vulnDescriptions[te.vuln_id] ?? [],
                         }))}
                         search={search}
-                        fuseKeys={["vuln_id"]}
+                        fuseKeys={["vuln_id", "variant_id"]}
                         estimateRowHeight={50}
                         hasPagination={true}
                         hoverField="texts"
@@ -1114,7 +1148,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                             texts: vulnDescriptions[c.vuln_id] ?? [],
                         }))}
                         search={search}
-                        fuseKeys={["vuln_id", "vector_string", "author"]}
+                        fuseKeys={["vuln_id", "variant_id", "vector_string", "author"]}
                         estimateRowHeight={50}
                         hasPagination={true}
                         hoverField="texts"

--- a/frontend/tests/handlers/epssRefresh.test.ts
+++ b/frontend/tests/handlers/epssRefresh.test.ts
@@ -73,4 +73,17 @@ describe("EpssRefreshHandler.triggerSingleRefresh", () => {
         expect(calledUrl).toContain("/epss-refresh");
         expect(calledUrl).not.toContain("/nvd-refresh");
     });
+
+    it("returns null when response body is not valid JSON", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => {
+                throw new Error("invalid json");
+            },
+        } as unknown as Response);
+
+        const result = await EpssRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
+        expect(result).toBeNull();
+    });
 });

--- a/frontend/tests/unit_tests/test_custom_cvss.tsx
+++ b/frontend/tests/unit_tests/test_custom_cvss.tsx
@@ -31,4 +31,63 @@ describe('CustomCvss component', () => {
     expect(onCancel).not.toHaveBeenCalled();
   });
 
+  test('submits valid vector then closes editor', () => {
+    const onCancel = jest.fn();
+    const onAddCvss = jest.fn();
+    const triggerBanner = jest.fn();
+    render(<CustomCvss onCancel={onCancel} onAddCvss={onAddCvss} triggerBanner={triggerBanner} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/CVSS:3\.1/), {
+      target: { value: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/i }));
+
+    expect(onAddCvss).toHaveBeenCalledWith('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(triggerBanner).not.toHaveBeenCalled();
+  });
+
+  test('renders variant selector and updates selection from checkbox changes', () => {
+    const onCancel = jest.fn();
+    const onAddCvss = jest.fn();
+    const triggerBanner = jest.fn();
+    const onSelectedVariantIdsChange = jest.fn();
+    const variants = [
+      { id: 'v1', name: 'Variant A', project_id: 'p1' },
+      { id: 'v2', name: 'Variant B', project_id: 'p1' },
+    ];
+
+    const { rerender } = render(
+      <CustomCvss
+        onCancel={onCancel}
+        onAddCvss={onAddCvss}
+        triggerBanner={triggerBanner}
+        variants={variants}
+        selectedVariantIds={[]}
+        onSelectedVariantIdsChange={onSelectedVariantIdsChange}
+      />
+    );
+
+    expect(screen.getByText(/select variants/i)).toBeInTheDocument();
+
+    const variantACheckbox = screen.getByLabelText('Variant A');
+    fireEvent.click(variantACheckbox);
+    expect(onSelectedVariantIdsChange).toHaveBeenCalledWith(['v1']);
+
+    onSelectedVariantIdsChange.mockClear();
+    rerender(
+      <CustomCvss
+        onCancel={onCancel}
+        onAddCvss={onAddCvss}
+        triggerBanner={triggerBanner}
+        variants={variants}
+        selectedVariantIds={['v1']}
+        onSelectedVariantIdsChange={onSelectedVariantIdsChange}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Variant A'));
+    expect(onSelectedVariantIdsChange).toHaveBeenCalledWith([]);
+  });
+
 });

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -319,6 +319,13 @@ describe('MultiEditBar', () => {
         const mockTriggerBanner = jest.fn();
         const mockPatchVuln = jest.fn();
         const mockResetVulns = jest.fn();
+        fetchMock.mockResponseOnce(JSON.stringify([
+            {
+                id: 'variant-1',
+                name: 'variant-a',
+                project_id: 'project-1'
+            }
+        ]));
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
             vulnerabilities: [{
@@ -352,7 +359,7 @@ describe('MultiEditBar', () => {
 
         await waitFor(() => {
             expect(mockTriggerBanner).toHaveBeenCalledWith(
-                expect.stringContaining('Successfully updated time estimates'),
+                expect.stringContaining('Successfully updated'),
                 'success'
             );
         });
@@ -449,6 +456,13 @@ describe('MultiEditBar', () => {
 
     test('saveTimeEstimation error path: triggers error banner with error details', async () => {
         const mockTriggerBanner = jest.fn();
+        fetchMock.mockResponseOnce(JSON.stringify([
+            {
+                id: 'variant-1',
+                name: 'variant-a',
+                project_id: 'project-1'
+            }
+        ]));
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'error',
             errors: [{ error: 'invalid duration' }]
@@ -480,6 +494,13 @@ describe('MultiEditBar', () => {
 
     test('saveTimeEstimation error path: triggers error banner with HTTP status when no errors array', async () => {
         const mockTriggerBanner = jest.fn();
+        fetchMock.mockResponseOnce(JSON.stringify([
+            {
+                id: 'variant-1',
+                name: 'variant-a',
+                project_id: 'project-1'
+            }
+        ]));
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'fail'
         }), { status: 500 });
@@ -510,6 +531,13 @@ describe('MultiEditBar', () => {
 
     test('saveTimeEstimation catch: triggers error banner on network failure', async () => {
         const mockTriggerBanner = jest.fn();
+        fetchMock.mockResponseOnce(JSON.stringify([
+            {
+                id: 'variant-1',
+                name: 'variant-a',
+                project_id: 'project-1'
+            }
+        ]));
         fetchMock.mockRejectOnce(new Error('Network error'));
 
         const props = {

--- a/frontend/tests/unit_tests/test_settings_handlers.ts
+++ b/frontend/tests/unit_tests/test_settings_handlers.ts
@@ -55,6 +55,18 @@ describe('Projects.rename', () => {
 
         await expect(Projects.rename('p1', 'X')).rejects.toThrow('Rename failed (500)');
     });
+
+    test('throws generic message when rename error body cannot be parsed', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 502,
+                json: () => Promise.reject(new Error('invalid json')),
+            } as Response)
+        );
+
+        await expect(Projects.rename('p1', 'Broken')).rejects.toThrow('Rename failed (502)');
+    });
 });
 
 
@@ -84,6 +96,18 @@ describe('Projects.create', () => {
         fetchMock.mockResponseOnce(JSON.stringify({ error: 'already exists' }), { status: 409 });
 
         await expect(Projects.create('Dup')).rejects.toThrow('already exists');
+    });
+
+    test('throws generic message when error body cannot be parsed', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 500,
+                json: () => Promise.reject(new Error('invalid json')),
+            } as Response)
+        );
+
+        await expect(Projects.create('Broken')).rejects.toThrow('Create failed (500)');
     });
 });
 
@@ -121,6 +145,18 @@ describe('Projects.delete', () => {
         fetchMock.mockResponseOnce(JSON.stringify({ error: 'Not found' }), { status: 404 });
 
         await expect(Projects.delete('missing')).rejects.toThrow('Not found');
+    });
+
+    test('throws generic message when delete error body cannot be parsed', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 502,
+                json: () => Promise.reject(new Error('invalid json')),
+            } as Response)
+        );
+
+        await expect(Projects.delete('broken')).rejects.toThrow('Delete failed (502)');
     });
 });
 
@@ -193,6 +229,18 @@ describe('Variants.create', () => {
 
         await expect(Variants.create('p1', 'Dup')).rejects.toThrow('exists');
     });
+
+    test('throws generic message when create error body cannot be parsed', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 503,
+                json: () => Promise.reject(new Error('invalid json')),
+            } as Response)
+        );
+
+        await expect(Variants.create('p1', 'release')).rejects.toThrow('Create failed (503)');
+    });
 });
 
 
@@ -218,6 +266,18 @@ describe('Variants.delete', () => {
         fetchMock.mockResponseOnce(JSON.stringify({ error: 'Not found' }), { status: 404 });
 
         await expect(Variants.delete('missing')).rejects.toThrow('Not found');
+    });
+
+    test('throws generic message when delete error body cannot be parsed', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 500,
+                json: () => Promise.reject(new Error('invalid json')),
+            } as Response)
+        );
+
+        await expect(Variants.delete('broken')).rejects.toThrow('Delete failed (500)');
     });
 });
 
@@ -284,6 +344,19 @@ describe('Variants.uploadSBOM', () => {
 
         const file = new File(['{}'], 'test.json');
         await expect(Variants.uploadSBOM('p1', 'v1', [file])).rejects.toThrow('Upload failed (500)');
+    });
+
+    test('throws generic message when upload error body cannot be parsed', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 503,
+                json: () => Promise.reject(new Error('invalid json')),
+            } as Response)
+        );
+
+        const file = new File(['{}'], 'test.json');
+        await expect(Variants.uploadSBOM('p1', 'v1', [file])).rejects.toThrow('Upload failed (503)');
     });
 });
 

--- a/frontend/tests/unit_tests/test_time_estimate_editor.tsx
+++ b/frontend/tests/unit_tests/test_time_estimate_editor.tsx
@@ -146,4 +146,110 @@ describe('TimeEstimateEditor component', () => {
     expect(screen.queryByText(/Invalid optimistic duration/i)).not.toBeInTheDocument();
   });
 
+  test('uses external triggerBanner when provided', () => {
+    const onSave = jest.fn();
+    const triggerBanner = jest.fn();
+    render(
+      <TimeEstimateEditor
+        actualEstimate={{}}
+        onSaveTimeEstimation={onSave}
+        triggerBanner={triggerBanner}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Save estimation/i }));
+
+    expect(triggerBanner).toHaveBeenCalledWith('All time estimate fields must be filled.', 'error');
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test('renders variant selector and updates selection from checkbox changes', () => {
+    const onSave = jest.fn();
+    const onSelectedVariantIdsChange = jest.fn();
+    const variants = [
+      { id: 'v1', name: 'Variant A', project_id: 'p1' },
+      { id: 'v2', name: 'Variant B', project_id: 'p1' },
+    ];
+
+    const { rerender } = render(
+      <TimeEstimateEditor
+        actualEstimate={{}}
+        onSaveTimeEstimation={onSave}
+        variants={variants}
+        selectedVariantIds={[]}
+        onSelectedVariantIdsChange={onSelectedVariantIdsChange}
+      />
+    );
+
+    expect(screen.getByText(/select variants/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Variant A'));
+    expect(onSelectedVariantIdsChange).toHaveBeenCalledWith(['v1']);
+
+    onSelectedVariantIdsChange.mockClear();
+    rerender(
+      <TimeEstimateEditor
+        actualEstimate={{}}
+        onSaveTimeEstimation={onSave}
+        variants={variants}
+        selectedVariantIds={['v1']}
+        onSelectedVariantIdsChange={onSelectedVariantIdsChange}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Variant A'));
+    expect(onSelectedVariantIdsChange).toHaveBeenCalledWith([]);
+  });
+
+  test('does not render variant selector when inputs are hidden', () => {
+    const onSave = jest.fn();
+    render(
+      <TimeEstimateEditor
+        actualEstimate={{}}
+        onSaveTimeEstimation={onSave}
+        hideInputs={true}
+        variants={[{ id: 'v1', name: 'Variant A', project_id: 'p1' }]}
+        selectedVariantIds={[]}
+        onSelectedVariantIdsChange={() => {}}
+      />
+    );
+
+    expect(screen.queryByText(/select variants/i)).not.toBeInTheDocument();
+  });
+
+  test('clears input fields when clearFields prop toggles', () => {
+    const onSave = jest.fn();
+    const { rerender } = render(
+      <TimeEstimateEditor
+        actualEstimate={{}}
+        onSaveTimeEstimation={onSave}
+        clearFields={false}
+      />
+    );
+
+    const optimistic = screen.getByPlaceholderText(optimisticPh) as HTMLInputElement;
+    const likely = screen.getByPlaceholderText(likelyPh) as HTMLInputElement;
+    const pessimistic = screen.getByPlaceholderText(pessimisticPh) as HTMLInputElement;
+
+    fireEvent.input(optimistic, { target: { value: '1h' } });
+    fireEvent.input(likely, { target: { value: '2h' } });
+    fireEvent.input(pessimistic, { target: { value: '3h' } });
+
+    expect(optimistic.value).toBe('1h');
+    expect(likely.value).toBe('2h');
+    expect(pessimistic.value).toBe('3h');
+
+    rerender(
+      <TimeEstimateEditor
+        actualEstimate={{}}
+        onSaveTimeEstimation={onSave}
+        clearFields={true}
+      />
+    );
+
+    expect((screen.getByPlaceholderText(optimisticPh) as HTMLInputElement).value).toBe('');
+    expect((screen.getByPlaceholderText(likelyPh) as HTMLInputElement).value).toBe('');
+    expect((screen.getByPlaceholderText(pessimisticPh) as HTMLInputElement).value).toBe('');
+  });
+
 });

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -240,7 +240,13 @@ describe('Vulnerability Modal', () => {
 
     test('edit effort estimations', async () => {
         fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([
+            {
+                id: 'variant-1',
+                name: 'variant-a',
+                project_id: 'project-1'
+            }
+        ])); // variants mount fetch
         fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockResponseOnce(JSON.stringify({
             id: vulnerability.id,
@@ -258,7 +264,7 @@ describe('Vulnerability Modal', () => {
         // ARRANGE
         const updateCb = jest.fn();
         const closeBtn = jest.fn();
-        render(<VulnModal vuln={vulnerability} isEditing={true} onClose={closeBtn} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={updateCb} />);
+        render(<VulnModal vuln={vulnerability} isEditing={true} onClose={closeBtn} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={updateCb} variantId="variant-1" />);
         const user = userEvent.setup();
 
         // ACT
@@ -287,7 +293,7 @@ describe('Vulnerability Modal', () => {
         // appendCVSS returns null -> invalid vector branch (lines 61-66)
         const appendCVSS = jest.fn().mockReturnValue(null);
 
-        render(<VulnModal vuln={vulnerability} onClose={closeCb} appendAssessment={() => {}} appendCVSS={appendCVSS} patchVuln={patchVuln} isEditing={true} />);
+        render(<VulnModal vuln={vulnerability} onClose={closeCb} appendAssessment={() => {}} appendCVSS={appendCVSS} patchVuln={patchVuln} isEditing={true} variantId="variant-1" />);
 
         const user = userEvent.setup();
         const addCustomBtn = await screen.getByRole('button', { name: /add custom cvss vector/i });
@@ -329,7 +335,7 @@ describe('Vulnerability Modal', () => {
             } as Response)
         );
 
-        render(<VulnModal vuln={vulnerability} onClose={closeCb} appendAssessment={() => {}} appendCVSS={appendCVSS} patchVuln={patchVuln} isEditing={true} />);
+        render(<VulnModal vuln={vulnerability} onClose={closeCb} appendAssessment={() => {}} appendCVSS={appendCVSS} patchVuln={patchVuln} isEditing={true} variantId="variant-1" />);
 
         const user = userEvent.setup();
         await user.click(await screen.getByRole('button', { name: /add custom cvss vector/i }));
@@ -381,7 +387,7 @@ describe('Vulnerability Modal', () => {
         // Use fresh copy so mutation in component doesn't leak to other tests
         const vulnCopy = { ...vulnerability, severity: { ...vulnerability.severity, cvss: [] } };
 
-        render(<VulnModal vuln={vulnCopy} onClose={closeCb} appendAssessment={() => {}} appendCVSS={appendCVSS} patchVuln={patchVuln} isEditing={true} />);
+        render(<VulnModal vuln={vulnCopy} onClose={closeCb} appendAssessment={() => {}} appendCVSS={appendCVSS} patchVuln={patchVuln} isEditing={true} variantId="variant-1" />);
 
         const user = userEvent.setup();
         await user.click(await screen.getByRole('button', { name: /add custom cvss vector/i }));
@@ -571,7 +577,7 @@ describe('Vulnerability Modal', () => {
         // Use fresh copy so mutation in component doesn't leak to other tests
         const vulnCopy = { ...vulnerability };
 
-        render(<VulnModal vuln={vulnCopy} onClose={closeCb} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={patchVuln} isEditing={true} />);
+        render(<VulnModal vuln={vulnCopy} onClose={closeCb} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={patchVuln} isEditing={true} variantId="variant-1" />);
 
         const user = userEvent.setup();
         const optimistic = await screen.getByPlaceholderText(/shortest estimate/i);

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -1851,6 +1851,8 @@ describe('Vulnerability Modal', () => {
             { id: 'v2', name: 'Variant Beta', project_id: 'proj1' }
         ]));
         fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify(vulnerability)); // variant snapshot for v1
+        fetchMock.mockResponseOnce(JSON.stringify(vulnerability)); // variant snapshot for v2
         // Two POST responses for two variants
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
@@ -1895,7 +1897,7 @@ describe('Vulnerability Modal', () => {
         const user = userEvent.setup();
 
         // Wait for variants to load, then select both
-        await screen.findByText('Variant Alpha');
+        expect((await screen.findAllByText('Variant Alpha')).length).toBeGreaterThan(0);
         const variantCheckboxes = screen.getAllByRole('checkbox');
         // Select both variants
         for (const cb of variantCheckboxes) {
@@ -2010,8 +2012,8 @@ describe('Vulnerability Modal', () => {
         />);
 
         // Wait for variants to load
-        await screen.findByText('Variant A');
-        expect(screen.getByText('Variant B')).toBeInTheDocument();
+        expect((await screen.findAllByText('Variant A')).length).toBeGreaterThan(0);
+        expect(screen.queryAllByText('Variant B').length).toBeGreaterThan(0);
         // Variant from the other project should NOT be shown
         expect(screen.queryByText('Variant Other')).not.toBeInTheDocument();
     });
@@ -2035,8 +2037,8 @@ describe('Vulnerability Modal', () => {
         />);
 
         // Wait for variants to load — both should be shown without projectId filter
-        await screen.findByText('Variant A');
-        expect(screen.getByText('Variant Other')).toBeInTheDocument();
+        expect((await screen.findAllByText('Variant A')).length).toBeGreaterThan(0);
+        expect(screen.queryAllByText('Variant Other').length).toBeGreaterThan(0);
     });
 
     test('packages_current scopes available packages to current project', async () => {

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -797,7 +797,7 @@ describe('Vulnerability Table', () => {
         await user.click(btn);
 
         // ASSERT
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
     })
 
     test('show description when hovering vulnerability', async () => {

--- a/src/controllers/metrics.py
+++ b/src/controllers/metrics.py
@@ -26,6 +26,7 @@ class MetricsController:
         return {
             "id": str(metrics.id),
             "vulnerability_id": metrics.vulnerability_id,
+            "variant_id": str(metrics.variant_id) if metrics.variant_id is not None else None,
             "version": metrics.version,
             "score": float(metrics.score) if metrics.score is not None else None,
             "vector": metrics.vector,
@@ -52,6 +53,15 @@ class MetricsController:
         """Return all metrics for the given vulnerability id."""
         return Metrics.get_by_vulnerability(vulnerability_id)
 
+    @staticmethod
+    def get_by_vulnerability_and_variant(
+        vulnerability_id: str,
+        variant_id: uuid.UUID | str,
+        include_unscoped: bool = True,
+    ) -> list[Metrics]:
+        """Return metrics for the given vulnerability and variant."""
+        return Metrics.get_by_vulnerability_and_variant(vulnerability_id, variant_id, include_unscoped)
+
     # ------------------------------------------------------------------
     # Mutations
     # ------------------------------------------------------------------
@@ -59,6 +69,7 @@ class MetricsController:
     @staticmethod
     def create(
         vulnerability_id: str,
+        variant_id: uuid.UUID | str | None = None,
         version: Optional[str] = None,
         score: Optional[float] = None,
         vector: Optional[str] = None,
@@ -72,6 +83,7 @@ class MetricsController:
         vulnerability_id = validate_non_empty(vulnerability_id, "Vulnerability id")
         return Metrics.create(
             vulnerability_id=vulnerability_id,
+            variant_id=variant_id,
             version=version,
             score=score,
             vector=vector,

--- a/src/controllers/metrics.py
+++ b/src/controllers/metrics.py
@@ -60,7 +60,11 @@ class MetricsController:
         include_unscoped: bool = True,
     ) -> list[Metrics]:
         """Return metrics for the given vulnerability and variant."""
-        return Metrics.get_by_vulnerability_and_variant(vulnerability_id, variant_id, include_unscoped)
+        return Metrics.get_by_vulnerability_and_variant(
+            vulnerability_id,
+            ensure_uuid(variant_id),
+            include_unscoped,
+        )
 
     # ------------------------------------------------------------------
     # Mutations
@@ -81,9 +85,10 @@ class MetricsController:
         :raises ValueError: if *vulnerability_id* is empty or blank.
         """
         vulnerability_id = validate_non_empty(vulnerability_id, "Vulnerability id")
+        normalized_variant_id = ensure_uuid(variant_id) if variant_id is not None else None
         return Metrics.create(
             vulnerability_id=vulnerability_id,
-            variant_id=variant_id,
+            variant_id=normalized_variant_id,
             version=version,
             score=score,
             vector=vector,

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -511,15 +511,13 @@ def build_custom_data_export(
     # Gather ALL custom CVSS entries, not just those linked to handmade
     # assessments.
     cvss_entries: list[dict] = []
+    metrics_query = db.select(Metrics).where(Metrics.origin == "custom")
+    if variant_ids is not None:
+        metrics_query = metrics_query.where(Metrics.variant_id.in_(variant_ids))
     all_metrics = list(db.session.execute(
-        db.select(Metrics).where(
-            Metrics.origin == "custom",
-        )
+        metrics_query.order_by(Metrics.vulnerability_id)
     ).scalars().all())
-    for m in sorted(all_metrics, key=lambda m: m.vulnerability_id):
-        if variant_ids is not None:
-            if m.variant_id is None or m.variant_id not in variant_ids:
-                continue
+    for m in all_metrics:
         cvss_entries.append({
             "vuln_id": m.vulnerability_id,
             "variant_id": str(m.variant_id) if m.variant_id is not None else None,
@@ -533,15 +531,6 @@ def build_custom_data_export(
     # Gather ALL non-zero time estimates, not just those linked to
     # handmade assessments.
     time_estimates: list[dict] = []
-    all_te = list(db.session.execute(
-        db.select(TimeEstimate).where(
-            db.or_(
-                TimeEstimate.optimistic > 0,
-                TimeEstimate.likely > 0,
-                TimeEstimate.pessimistic > 0,
-            )
-        )
-    ).scalars().all())
 
     def _hours_to_iso(h: int) -> str:
         try:
@@ -549,25 +538,41 @@ def build_custom_data_export(
         except (ValueError, TypeError):
             return f"PT{h}H"
 
+    from ..models.finding import Finding as _Finding
+    te_query = (
+        db.select(
+            _Finding.vulnerability_id,
+            TimeEstimate.variant_id,
+            TimeEstimate.optimistic,
+            TimeEstimate.likely,
+            TimeEstimate.pessimistic,
+        )
+        .join(_Finding, TimeEstimate.finding_id == _Finding.id)
+        .where(
+            db.or_(
+                TimeEstimate.optimistic > 0,
+                TimeEstimate.likely > 0,
+                TimeEstimate.pessimistic > 0,
+            )
+        )
+    )
+    if variant_ids is not None:
+        te_query = te_query.where(TimeEstimate.variant_id.in_(variant_ids))
+    te_rows = db.session.execute(te_query).all()
+
     seen_vulns_te: set[tuple[str, str]] = set()
-    for te in all_te:
-        if te.finding is None:
-            continue
-        if variant_ids is not None:
-            if te.variant_id is None or te.variant_id not in variant_ids:
-                continue
-        vid = te.finding.vulnerability_id
-        variant_key = str(te.variant_id) if te.variant_id is not None else ""
+    for vid, te_variant_id, opt, lik, pes in te_rows:
+        variant_key = str(te_variant_id) if te_variant_id is not None else ""
         dedup_key = (vid, variant_key)
         if dedup_key in seen_vulns_te:
             continue
         seen_vulns_te.add(dedup_key)
-        opt = te.optimistic or 0
-        lik = te.likely or 0
-        pes = te.pessimistic or 0
+        opt = opt or 0
+        lik = lik or 0
+        pes = pes or 0
         time_estimates.append({
             "vuln_id": vid,
-            "variant_id": str(te.variant_id) if te.variant_id is not None else None,
+            "variant_id": str(te_variant_id) if te_variant_id is not None else None,
             "optimistic": _hours_to_iso(opt),
             "likely": _hours_to_iso(lik),
             "pessimistic": _hours_to_iso(pes),
@@ -760,8 +765,13 @@ def import_custom_data(
                     cvss_variant_id = _uuid.UUID(c["variant_id"])
                 except (ValueError, TypeError):
                     mapped_variant = variant_by_name.get(c["variant_id"])
-                    if mapped_variant is not None:
-                        cvss_variant_id = mapped_variant.id
+                    if mapped_variant is None:
+                        result["errors"].append({
+                            "vuln_id": vuln_id,
+                            "error": f"Variant '{c['variant_id']}' not found",
+                        })
+                        continue
+                    cvss_variant_id = mapped_variant.id
 
             target_variant_ids: list[_uuid.UUID | None]
             if cvss_variant_id is not None:
@@ -814,8 +824,13 @@ def import_custom_data(
                     te_variant_id = _uuid.UUID(t["variant_id"])
                 except (ValueError, TypeError):
                     mapped_variant = variant_by_name.get(t["variant_id"])
-                    if mapped_variant is not None:
-                        te_variant_id = mapped_variant.id
+                    if mapped_variant is None:
+                        result["errors"].append({
+                            "vuln_id": vuln_id,
+                            "error": f"Variant '{t['variant_id']}' not found",
+                        })
+                        continue
+                    te_variant_id = mapped_variant.id
 
             if te_variant_id is not None:
                 target_variant_ids = [te_variant_id]

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -517,8 +517,12 @@ def build_custom_data_export(
         )
     ).scalars().all())
     for m in sorted(all_metrics, key=lambda m: m.vulnerability_id):
+        if variant_ids is not None:
+            if m.variant_id is None or m.variant_id not in variant_ids:
+                continue
         cvss_entries.append({
             "vuln_id": m.vulnerability_id,
+            "variant_id": str(m.variant_id) if m.variant_id is not None else None,
             "version": m.version or "",
             "vector_string": m.vector or "",
             "base_score": float(m.score) if m.score is not None else 0.0,
@@ -545,24 +549,30 @@ def build_custom_data_export(
         except (ValueError, TypeError):
             return f"PT{h}H"
 
-    seen_vulns_te: set[str] = set()
+    seen_vulns_te: set[tuple[str, str]] = set()
     for te in all_te:
         if te.finding is None:
             continue
+        if variant_ids is not None:
+            if te.variant_id is None or te.variant_id not in variant_ids:
+                continue
         vid = te.finding.vulnerability_id
-        if vid in seen_vulns_te:
+        variant_key = str(te.variant_id) if te.variant_id is not None else ""
+        dedup_key = (vid, variant_key)
+        if dedup_key in seen_vulns_te:
             continue
-        seen_vulns_te.add(vid)
+        seen_vulns_te.add(dedup_key)
         opt = te.optimistic or 0
         lik = te.likely or 0
         pes = te.pessimistic or 0
         time_estimates.append({
             "vuln_id": vid,
+            "variant_id": str(te.variant_id) if te.variant_id is not None else None,
             "optimistic": _hours_to_iso(opt),
             "likely": _hours_to_iso(lik),
             "pessimistic": _hours_to_iso(pes),
         })
-    time_estimates.sort(key=lambda t: t["vuln_id"])
+    time_estimates.sort(key=lambda t: (t["vuln_id"], t.get("variant_id") or ""))
 
     return {
         "version": 1,
@@ -607,6 +617,8 @@ def import_custom_data(
     from ..models.vulnerability import Vulnerability as DBVuln
     from ..models.package import Package
     from ..models.finding import Finding
+    from ..models.scan import Scan
+    from ..models.observation import Observation
     from .vuln_helpers import (
         _validate_effort,
         _validate_and_apply_cvss,
@@ -621,6 +633,16 @@ def import_custom_data(
         "time_estimates_imported": 0,
         "errors": [],
     }
+
+    def _variants_for_vuln_id(vuln_id: str) -> list[_uuid.UUID | None]:
+        rows = db.session.execute(
+            db.select(Scan.variant_id)
+            .join(Observation, Observation.scan_id == Scan.id)
+            .join(Finding, Observation.finding_id == Finding.id)
+            .where(Finding.vulnerability_id == vuln_id)
+            .distinct()
+        ).all()
+        return [variant_id for (variant_id,) in rows]
 
     # -- Import assessments --
     assessments_list = data.get("assessments", [])
@@ -732,11 +754,32 @@ def import_custom_data(
                 "exploitability_score": c.get("exploitability_score", 0.0),
                 "impact_score": c.get("impact_score", 0.0),
             }
-            err = _validate_and_apply_cvss(cvss_data, record.id,
-                                           log_prefix="import-custom-data")
-            if err:
-                result["errors"].append({"vuln_id": vuln_id, "error": err})
+            cvss_variant_id = variant_id
+            if cvss_variant_id is None and c.get("variant_id"):
+                try:
+                    cvss_variant_id = _uuid.UUID(c["variant_id"])
+                except (ValueError, TypeError):
+                    mapped_variant = variant_by_name.get(c["variant_id"])
+                    if mapped_variant is not None:
+                        cvss_variant_id = mapped_variant.id
+
+            target_variant_ids: list[_uuid.UUID | None]
+            if cvss_variant_id is not None:
+                target_variant_ids = [cvss_variant_id]
             else:
+                target_variant_ids = _variants_for_vuln_id(vuln_id)
+                if not target_variant_ids:
+                    target_variant_ids = [None]
+
+            cvss_failed = False
+            for target_variant_id in target_variant_ids:
+                err = _validate_and_apply_cvss(cvss_data, record.id, target_variant_id,
+                                               log_prefix="import-custom-data")
+                if err:
+                    result["errors"].append({"vuln_id": vuln_id, "error": err})
+                    cvss_failed = True
+                    break
+            if not cvss_failed:
                 result["cvss_imported"] += 1
 
     # -- Import time estimates --
@@ -770,10 +813,20 @@ def import_custom_data(
                 try:
                     te_variant_id = _uuid.UUID(t["variant_id"])
                 except (ValueError, TypeError):
-                    pass
+                    mapped_variant = variant_by_name.get(t["variant_id"])
+                    if mapped_variant is not None:
+                        te_variant_id = mapped_variant.id
 
-            _apply_effort(record, te_variant_id, opt, lik, pes,
-                          log_prefix="import-custom-data")
+            if te_variant_id is not None:
+                target_variant_ids = [te_variant_id]
+            else:
+                target_variant_ids = _variants_for_vuln_id(vuln_id)
+                if not target_variant_ids:
+                    target_variant_ids = [None]
+
+            for target_variant_id in target_variant_ids:
+                _apply_effort(record, target_variant_id, opt, lik, pes,
+                              log_prefix="import-custom-data")
             result["time_estimates_imported"] += 1
 
     if not result["assessments_imported"] and not result["cvss_imported"] and not result["time_estimates_imported"]:

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -490,8 +490,14 @@ def build_custom_data_export(
     from ..models.metrics import Metrics
     from ..models.time_estimate import TimeEstimate
     from ..models.iso8601_duration import Iso8601Duration
+    from ..models.variant import Variant as DBVariant
 
     handmade = DBAssessment.get_handmade(variant_ids)
+
+    variant_name_by_id: dict[str, str] = {}
+    variant_uuid_set: set[_uuid.UUID] = {
+        a.variant_id for a in handmade if a.variant_id is not None
+    }
 
     exported_assessments = []
     for a in handmade:
@@ -518,9 +524,12 @@ def build_custom_data_export(
         metrics_query.order_by(Metrics.vulnerability_id)
     ).scalars().all())
     for m in all_metrics:
+        if m.variant_id is not None:
+            variant_uuid_set.add(m.variant_id)
         cvss_entries.append({
             "vuln_id": m.vulnerability_id,
             "variant_id": str(m.variant_id) if m.variant_id is not None else None,
+            "variant": None,
             "version": m.version or "",
             "vector_string": m.vector or "",
             "base_score": float(m.score) if m.score is not None else 0.0,
@@ -562,6 +571,8 @@ def build_custom_data_export(
 
     seen_vulns_te: set[tuple[str, str]] = set()
     for vid, te_variant_id, opt, lik, pes in te_rows:
+        if te_variant_id is not None:
+            variant_uuid_set.add(te_variant_id)
         variant_key = str(te_variant_id) if te_variant_id is not None else ""
         dedup_key = (vid, variant_key)
         if dedup_key in seen_vulns_te:
@@ -573,11 +584,30 @@ def build_custom_data_export(
         time_estimates.append({
             "vuln_id": vid,
             "variant_id": str(te_variant_id) if te_variant_id is not None else None,
+            "variant": None,
             "optimistic": _hours_to_iso(opt),
             "likely": _hours_to_iso(lik),
             "pessimistic": _hours_to_iso(pes),
         })
     time_estimates.sort(key=lambda t: (t["vuln_id"], t.get("variant_id") or ""))
+
+    if variant_uuid_set:
+        variants = db.session.execute(
+            db.select(DBVariant).where(DBVariant.id.in_(variant_uuid_set))
+        ).scalars().all()
+        variant_name_by_id = {str(v.id): v.name for v in variants}
+
+    for item in exported_assessments:
+        vid = item.get("variant_id")
+        item["variant"] = variant_name_by_id.get(vid) if vid else None
+
+    for item in cvss_entries:
+        vid = item.get("variant_id")
+        item["variant"] = variant_name_by_id.get(vid) if vid else None
+
+    for item in time_estimates:
+        vid = item.get("variant_id")
+        item["variant"] = variant_name_by_id.get(vid) if vid else None
 
     return {
         "version": 1,
@@ -649,6 +679,25 @@ def import_custom_data(
         ).all()
         return [variant_id for (variant_id,) in rows]
 
+    def _resolve_variant(raw_item: dict) -> "_uuid.UUID | None":
+        if variant_id is not None:
+            return variant_id
+
+        variant_token = raw_item.get("variant_id")
+        if variant_token in (None, ""):
+            variant_token = raw_item.get("variant")
+
+        if variant_token in (None, ""):
+            return None
+
+        try:
+            return _uuid.UUID(str(variant_token))
+        except (ValueError, TypeError):
+            mapped_variant = variant_by_name.get(str(variant_token))
+            if mapped_variant is None:
+                return None
+            return mapped_variant.id
+
     # -- Import assessments --
     assessments_list = data.get("assessments", [])
     if isinstance(assessments_list, list):
@@ -672,14 +721,7 @@ def import_custom_data(
                 continue
 
             # Determine which variant to attach to
-            target_variant_id = variant_id
-            if target_variant_id is None and a.get("variant_id"):
-                try:
-                    target_variant_id = _uuid.UUID(a["variant_id"])
-                except (ValueError, TypeError):
-                    v = variant_by_name.get(a["variant_id"])
-                    if v:
-                        target_variant_id = v.id
+            target_variant_id = _resolve_variant(a)
 
             justification = a.get("justification", "")
             impact_statement = a.get("impact_statement", "")
@@ -759,19 +801,17 @@ def import_custom_data(
                 "exploitability_score": c.get("exploitability_score", 0.0),
                 "impact_score": c.get("impact_score", 0.0),
             }
-            cvss_variant_id = variant_id
-            if cvss_variant_id is None and c.get("variant_id"):
-                try:
-                    cvss_variant_id = _uuid.UUID(c["variant_id"])
-                except (ValueError, TypeError):
-                    mapped_variant = variant_by_name.get(c["variant_id"])
-                    if mapped_variant is None:
-                        result["errors"].append({
-                            "vuln_id": vuln_id,
-                            "error": f"Variant '{c['variant_id']}' not found",
-                        })
-                        continue
-                    cvss_variant_id = mapped_variant.id
+            cvss_variant_id = _resolve_variant(c)
+
+            variant_token = c.get("variant_id")
+            if variant_token in (None, ""):
+                variant_token = c.get("variant")
+            if cvss_variant_id is None and variant_token not in (None, ""):
+                result["errors"].append({
+                    "vuln_id": vuln_id,
+                    "error": f"Variant '{variant_token}' not found",
+                })
+                continue
 
             target_variant_ids: list[_uuid.UUID | None]
             if cvss_variant_id is not None:
@@ -818,19 +858,17 @@ def import_custom_data(
                 result["errors"].append({"vuln_id": vuln_id, "error": err})
                 continue
 
-            te_variant_id = variant_id
-            if te_variant_id is None and t.get("variant_id"):
-                try:
-                    te_variant_id = _uuid.UUID(t["variant_id"])
-                except (ValueError, TypeError):
-                    mapped_variant = variant_by_name.get(t["variant_id"])
-                    if mapped_variant is None:
-                        result["errors"].append({
-                            "vuln_id": vuln_id,
-                            "error": f"Variant '{t['variant_id']}' not found",
-                        })
-                        continue
-                    te_variant_id = mapped_variant.id
+            te_variant_id = _resolve_variant(t)
+
+            variant_token = t.get("variant_id")
+            if variant_token in (None, ""):
+                variant_token = t.get("variant")
+            if te_variant_id is None and variant_token not in (None, ""):
+                result["errors"].append({
+                    "vuln_id": vuln_id,
+                    "error": f"Variant '{variant_token}' not found",
+                })
+                continue
 
             if te_variant_id is not None:
                 target_variant_ids = [te_variant_id]

--- a/src/helpers/vuln_helpers.py
+++ b/src/helpers/vuln_helpers.py
@@ -42,7 +42,12 @@ def _validate_effort(eff: dict):
     return opt, lik, pes, None
 
 
-def _validate_and_apply_cvss(new_cvss: dict, record_id: str, log_prefix: str = ""):
+def _validate_and_apply_cvss(
+    new_cvss: dict,
+    record_id: str,
+    variant_id,
+    log_prefix: str = "",
+):
     """Validate CVSS payload and persist to Metrics.
 
     Returns an error string on validation failure, ``None`` on success.
@@ -56,7 +61,7 @@ def _validate_and_apply_cvss(new_cvss: dict, record_id: str, log_prefix: str = "
         new_cvss["origin"] = "scanner"
     cvss_obj = CVSS.from_dict(new_cvss)
     try:
-        Metrics.from_cvss(cvss_obj, record_id)
+        Metrics.from_cvss(cvss_obj, record_id, variant_id)
     except Exception as e:
         verbose(f"[{log_prefix} cvss] {e}")
     return None

--- a/src/helpers/vuln_helpers.py
+++ b/src/helpers/vuln_helpers.py
@@ -14,7 +14,7 @@ from ..models import Metrics, CVSS, Iso8601Duration
 from ..helpers.verbose import verbose
 
 
-def _parse_effort_hours(value) -> int:
+def _parse_effort_hours(value: int | str) -> int:
     """Parse an effort value (ISO 8601 duration string or integer hours) to whole hours."""
     if isinstance(value, int):
         return value

--- a/src/migrations/versions/k7f8a9b0c1d2_add_origin_to_metrics.py
+++ b/src/migrations/versions/k7f8a9b0c1d2_add_origin_to_metrics.py
@@ -1,7 +1,7 @@
 """add origin column to metrics
 
 Revision ID: k7f8a9b0c1d2
-Revises: j6e7f8a9b0c1
+Revises: l8a9b0c1d2e3
 Create Date: 2026-05-26 00:00:00.000000
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'k7f8a9b0c1d2'
-down_revision = 'j6e7f8a9b0c1'
+down_revision = 'l8a9b0c1d2e3'
 branch_labels = None
 depends_on = None
 

--- a/src/migrations/versions/k7f8a9b0c1d2_add_origin_to_metrics.py
+++ b/src/migrations/versions/k7f8a9b0c1d2_add_origin_to_metrics.py
@@ -1,7 +1,7 @@
 """add origin column to metrics
 
 Revision ID: k7f8a9b0c1d2
-Revises: l8a9b0c1d2e3
+Revises: j6e7f8a9b0c1
 Create Date: 2026-05-26 00:00:00.000000
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'k7f8a9b0c1d2'
-down_revision = 'l8a9b0c1d2e3'
+down_revision = 'j6e7f8a9b0c1'
 branch_labels = None
 depends_on = None
 

--- a/src/migrations/versions/k7f8a9b0c1d2_add_variant_to_metrics_and_backfill.py
+++ b/src/migrations/versions/k7f8a9b0c1d2_add_variant_to_metrics_and_backfill.py
@@ -1,0 +1,114 @@
+"""add variant_id to metrics and backfill legacy CVSS rows
+
+Revision ID: k7f8a9b0c1d2
+Revises: j6e7f8a9b0c1
+Create Date: 2026-05-26 00:00:00.000000
+"""
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'k7f8a9b0c1d2'
+down_revision = 'j6e7f8a9b0c1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('metrics', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('variant_id', sa.Uuid(), nullable=True))
+        batch_op.create_index('ix_metrics_variant_id', ['variant_id'], unique=False)
+        batch_op.create_foreign_key('fk_metrics_variant_id_variants', 'variants', ['variant_id'], ['id'])
+
+    conn = op.get_bind()
+
+    legacy_rows = conn.execute(
+        sa.text(
+            """
+            SELECT id, vulnerability_id, version, score, vector, author
+            FROM metrics
+            WHERE variant_id IS NULL
+            """
+        )
+    ).fetchall()
+
+    for row in legacy_rows:
+        related_variants = conn.execute(
+            sa.text(
+                """
+                SELECT DISTINCT s.variant_id
+                FROM findings f
+                JOIN observations o ON o.finding_id = f.id
+                JOIN scans s ON s.id = o.scan_id
+                WHERE f.vulnerability_id = :vulnerability_id
+                """
+            ),
+            {"vulnerability_id": row.vulnerability_id},
+        ).fetchall()
+
+        if not related_variants:
+            continue
+
+        inserted_any = False
+        for variant_row in related_variants:
+            variant_id = variant_row.variant_id
+            exists = conn.execute(
+                sa.text(
+                    """
+                    SELECT 1
+                    FROM metrics
+                    WHERE vulnerability_id = :vulnerability_id
+                      AND variant_id = :variant_id
+                      AND (version = :version OR (version IS NULL AND :version IS NULL))
+                      AND (score = :score OR (score IS NULL AND :score IS NULL))
+                      AND (vector = :vector OR (vector IS NULL AND :vector IS NULL))
+                      AND (author = :author OR (author IS NULL AND :author IS NULL))
+                    LIMIT 1
+                    """
+                ),
+                {
+                    "vulnerability_id": row.vulnerability_id,
+                    "variant_id": variant_id,
+                    "version": row.version,
+                    "score": row.score,
+                    "vector": row.vector,
+                    "author": row.author,
+                },
+            ).fetchone()
+            if exists:
+                inserted_any = True
+                continue
+
+            conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO metrics (id, vulnerability_id, variant_id, version, score, vector, author)
+                    VALUES (:id, :vulnerability_id, :variant_id, :version, :score, :vector, :author)
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "vulnerability_id": row.vulnerability_id,
+                    "variant_id": variant_id,
+                    "version": row.version,
+                    "score": row.score,
+                    "vector": row.vector,
+                    "author": row.author,
+                },
+            )
+            inserted_any = True
+
+        if inserted_any:
+            conn.execute(
+                sa.text("DELETE FROM metrics WHERE id = :id"),
+                {"id": row.id},
+            )
+
+
+def downgrade():
+    with op.batch_alter_table('metrics', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_metrics_variant_id_variants', type_='foreignkey')
+        batch_op.drop_index('ix_metrics_variant_id')
+        batch_op.drop_column('variant_id')

--- a/src/migrations/versions/l8a9b0c1d2e3_add_variant_to_metrics_and_backfill.py
+++ b/src/migrations/versions/l8a9b0c1d2e3_add_variant_to_metrics_and_backfill.py
@@ -1,7 +1,7 @@
 """add variant_id to metrics and backfill legacy CVSS rows
 
 Revision ID: l8a9b0c1d2e3
-Revises: j6e7f8a9b0c1
+Revises: k7f8a9b0c1d2
 Create Date: 2026-05-26 00:00:00.000000
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = 'l8a9b0c1d2e3'
-down_revision = 'j6e7f8a9b0c1'
+down_revision = 'k7f8a9b0c1d2'
 branch_labels = None
 depends_on = None
 

--- a/src/migrations/versions/l8a9b0c1d2e3_add_variant_to_metrics_and_backfill.py
+++ b/src/migrations/versions/l8a9b0c1d2e3_add_variant_to_metrics_and_backfill.py
@@ -1,6 +1,6 @@
 """add variant_id to metrics and backfill legacy CVSS rows
 
-Revision ID: k7f8a9b0c1d2
+Revision ID: l8a9b0c1d2e3
 Revises: j6e7f8a9b0c1
 Create Date: 2026-05-26 00:00:00.000000
 """
@@ -10,7 +10,7 @@ import uuid
 from alembic import op
 import sqlalchemy as sa
 
-revision = 'k7f8a9b0c1d2'
+revision = 'l8a9b0c1d2e3'
 down_revision = 'j6e7f8a9b0c1'
 branch_labels = None
 depends_on = None

--- a/src/migrations/versions/m9b0c1d2e3f4_normalize_yocto_cve_check_format_name.py
+++ b/src/migrations/versions/m9b0c1d2e3f4_normalize_yocto_cve_check_format_name.py
@@ -1,6 +1,6 @@
 """normalize yocto cve check format name in sbom documents
 
-Revision ID: l8a9b0c1d2e3
+Revision ID: m9b0c1d2e3f4
 Revises: k7f8a9b0c1d2
 Create Date: 2026-06-02 00:00:00.000000
 
@@ -9,7 +9,7 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = 'l8a9b0c1d2e3'
+revision = 'm9b0c1d2e3f4'
 down_revision = 'k7f8a9b0c1d2'
 branch_labels = None
 depends_on = None

--- a/src/migrations/versions/m9b0c1d2e3f4_normalize_yocto_cve_check_format_name.py
+++ b/src/migrations/versions/m9b0c1d2e3f4_normalize_yocto_cve_check_format_name.py
@@ -1,7 +1,7 @@
 """normalize yocto cve check format name in sbom documents
 
 Revision ID: m9b0c1d2e3f4
-Revises: k7f8a9b0c1d2
+Revises: l8a9b0c1d2e3
 Create Date: 2026-06-02 00:00:00.000000
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'm9b0c1d2e3f4'
-down_revision = 'k7f8a9b0c1d2'
+down_revision = 'l8a9b0c1d2e3'
 branch_labels = None
 depends_on = None
 

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import uuid
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, cast
 from ..extensions import db, Base
 
 if TYPE_CHECKING:
@@ -147,11 +147,12 @@ class Metrics(Base):
         cvss: "CVSS",
         vulnerability_id: str,
         variant_id: uuid.UUID | None = None,
-    ) -> "Metrics":
+    ) -> Optional["Metrics"]:
         """Create a :class:`Metrics` record from an in-memory :class:`CVSS` object.
 
         If a matching record (same vulnerability_id + version + score) already exists it is
-        returned unchanged; otherwise a new one is persisted.
+        returned unchanged when insert fallback is triggered; otherwise a new one is persisted.
+        When the session dedup cache hits, ``None`` is returned to signal a no-op.
         """
         vid = vulnerability_id.upper()
 
@@ -162,15 +163,8 @@ class Metrics(Base):
             float(cvss.base_score) if cvss.base_score is not None else None,
         )
         if dedup_key in cls._seen:
-            # Already persisted in this session — return the existing record.
-            return db.session.execute(
-                db.select(Metrics).where(
-                    Metrics.vulnerability_id == vid,
-                    Metrics.variant_id == variant_id,
-                    Metrics.version == cvss.version,
-                    Metrics.score == cvss.base_score,
-                )
-            ).scalar_one_or_none()
+            # Already persisted in this session: no-op.
+            return None
         cls._seen.add(dedup_key)
 
         # _seen is pre-populated from the DB at startup for all existing metrics.
@@ -204,4 +198,4 @@ class Metrics(Base):
             ).scalar_one_or_none()
             if existing is None:
                 raise exc
-            return existing
+            return cast("Metrics", existing)

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -39,7 +39,7 @@ class Metrics(Base):
     @staticmethod
     def create(
         vulnerability_id: str,
-        variant_id: Optional[uuid.UUID | str] = None,
+        variant_id: Optional[uuid.UUID] = None,
         version: Optional[str] = None,
         score: Optional[float] = None,
         vector: Optional[str] = None,
@@ -47,8 +47,6 @@ class Metrics(Base):
         origin: Optional[str] = None,
     ) -> "Metrics":
         """Create a new metrics record, persist it and return it."""
-        if isinstance(variant_id, str):
-            variant_id = uuid.UUID(variant_id)
         metrics = Metrics(
             vulnerability_id=vulnerability_id.upper(),
             variant_id=variant_id,
@@ -79,7 +77,7 @@ class Metrics(Base):
     @staticmethod
     def get_by_vulnerability_and_variant(
         vulnerability_id: str,
-        variant_id: uuid.UUID | str,
+        variant_id: uuid.UUID,
         include_unscoped: bool = True,
     ) -> list["Metrics"]:
         """Return metrics for a vulnerability scoped to *variant_id*.
@@ -87,8 +85,6 @@ class Metrics(Base):
         When *include_unscoped* is ``True``, legacy records with
         ``variant_id is NULL`` are also included.
         """
-        if isinstance(variant_id, str):
-            variant_id = uuid.UUID(variant_id)
         query = db.select(Metrics).where(Metrics.vulnerability_id == vulnerability_id.upper())
         if include_unscoped:
             query = query.where(db.or_(Metrics.variant_id == variant_id, Metrics.variant_id.is_(None)))
@@ -137,7 +133,7 @@ class Metrics(Base):
         cls,
         cvss: "CVSS",
         vulnerability_id: str,
-        variant_id: uuid.UUID | str | None = None,
+        variant_id: uuid.UUID | None = None,
     ) -> "Metrics":
         """Create a :class:`Metrics` record from an in-memory :class:`CVSS` object.
 
@@ -145,8 +141,6 @@ class Metrics(Base):
         returned unchanged; otherwise a new one is persisted.
         """
         vid = vulnerability_id.upper()
-        if isinstance(variant_id, str):
-            variant_id = uuid.UUID(variant_id)
 
         dedup_key = (
             vid,

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -16,6 +16,7 @@ class Metrics(Base):
 
     id = db.Column(db.Uuid, primary_key=True, default=uuid.uuid4)
     vulnerability_id = db.Column(db.String(50), db.ForeignKey("vulnerabilities.id"), nullable=False, index=True)
+    variant_id = db.Column(db.Uuid, db.ForeignKey("variants.id"), nullable=True, index=True)
     version = db.Column(db.String, nullable=True)
     score = db.Column(db.Numeric, nullable=True)
     vector = db.Column(db.Text, nullable=True)
@@ -23,6 +24,7 @@ class Metrics(Base):
     origin = db.Column(db.String, nullable=True)
 
     vulnerability = db.relationship("Vulnerability", back_populates="metrics")
+    variant = db.relationship("Variant", back_populates="metrics")
 
     def __repr__(self) -> str:
         return (
@@ -37,6 +39,7 @@ class Metrics(Base):
     @staticmethod
     def create(
         vulnerability_id: str,
+        variant_id: Optional[uuid.UUID | str] = None,
         version: Optional[str] = None,
         score: Optional[float] = None,
         vector: Optional[str] = None,
@@ -44,8 +47,11 @@ class Metrics(Base):
         origin: Optional[str] = None,
     ) -> "Metrics":
         """Create a new metrics record, persist it and return it."""
+        if isinstance(variant_id, str):
+            variant_id = uuid.UUID(variant_id)
         metrics = Metrics(
             vulnerability_id=vulnerability_id.upper(),
+            variant_id=variant_id,
             version=version,
             score=score,
             vector=vector,
@@ -69,6 +75,26 @@ class Metrics(Base):
         return list(db.session.execute(
             db.select(Metrics).where(Metrics.vulnerability_id == vulnerability_id.upper())
         ).scalars().all())
+
+    @staticmethod
+    def get_by_vulnerability_and_variant(
+        vulnerability_id: str,
+        variant_id: uuid.UUID | str,
+        include_unscoped: bool = True,
+    ) -> list["Metrics"]:
+        """Return metrics for a vulnerability scoped to *variant_id*.
+
+        When *include_unscoped* is ``True``, legacy records with
+        ``variant_id is NULL`` are also included.
+        """
+        if isinstance(variant_id, str):
+            variant_id = uuid.UUID(variant_id)
+        query = db.select(Metrics).where(Metrics.vulnerability_id == vulnerability_id.upper())
+        if include_unscoped:
+            query = query.where(db.or_(Metrics.variant_id == variant_id, Metrics.variant_id.is_(None)))
+        else:
+            query = query.where(Metrics.variant_id == variant_id)
+        return list(db.session.execute(query).scalars().all())
 
     def update(
         self,
@@ -107,14 +133,27 @@ class Metrics(Base):
         cls._seen = set()
 
     @classmethod
-    def from_cvss(cls, cvss: "CVSS", vulnerability_id: str) -> "Metrics":
+    def from_cvss(
+        cls,
+        cvss: "CVSS",
+        vulnerability_id: str,
+        variant_id: uuid.UUID | str | None = None,
+    ) -> "Metrics":
         """Create a :class:`Metrics` record from an in-memory :class:`CVSS` object.
 
         If a matching record (same vulnerability_id + version + score) already exists it is
         returned unchanged; otherwise a new one is persisted.
         """
         vid = vulnerability_id.upper()
-        dedup_key = (vid, cvss.version, float(cvss.base_score) if cvss.base_score is not None else None)
+        if isinstance(variant_id, str):
+            variant_id = uuid.UUID(variant_id)
+
+        dedup_key = (
+            vid,
+            variant_id,
+            cvss.version,
+            float(cvss.base_score) if cvss.base_score is not None else None,
+        )
         if dedup_key in cls._seen:
             # Already persisted in this session — skip the SELECT entirely.
             return None  # type: ignore[return-value]
@@ -130,6 +169,7 @@ class Metrics(Base):
             with db.session.begin_nested():
                 record = cls(
                     vulnerability_id=vid,
+                    variant_id=variant_id,
                     version=cvss.version,
                     score=cvss.base_score,
                     vector=cvss.vector_string,
@@ -143,6 +183,7 @@ class Metrics(Base):
             return db.session.execute(
                 db.select(Metrics).where(
                     Metrics.vulnerability_id == vid,
+                    Metrics.variant_id == variant_id,
                     Metrics.version == cvss.version,
                     Metrics.score == cvss.base_score,
                 )

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -119,6 +119,19 @@ class Metrics(Base):
         db.session.delete(self)
         db.session.commit()
 
+    def to_dict(self) -> dict:
+        """Return a CVSS-compatible dict representation of this metrics record."""
+        return {
+            "variant_id": str(self.variant_id) if self.variant_id is not None else None,
+            "version": self.version or "",
+            "vector_string": self.vector or "",
+            "author": self.author or "unknown",
+            "origin": self.origin or "scanner",
+            "base_score": float(self.score) if self.score is not None else 0.0,
+            "exploitability_score": 0.0,
+            "impact_score": 0.0,
+        }
+
     # Session-level dedup cache: avoids repeated 3-column SELECTs during
     # bulk ingestion.  Cleared automatically when the session is reset.
     _seen: set[tuple] = set()
@@ -149,8 +162,15 @@ class Metrics(Base):
             float(cvss.base_score) if cvss.base_score is not None else None,
         )
         if dedup_key in cls._seen:
-            # Already persisted in this session — skip the SELECT entirely.
-            return None  # type: ignore[return-value]
+            # Already persisted in this session — return the existing record.
+            return db.session.execute(
+                db.select(Metrics).where(
+                    Metrics.vulnerability_id == vid,
+                    Metrics.variant_id == variant_id,
+                    Metrics.version == cvss.version,
+                    Metrics.score == cvss.base_score,
+                )
+            ).scalar_one_or_none()
         cls._seen.add(dedup_key)
 
         # _seen is pre-populated from the DB at startup for all existing metrics.
@@ -173,12 +193,15 @@ class Metrics(Base):
                 db.session.add(record)
                 db.session.flush()
                 return record
-        except Exception:
-            return db.session.execute(
+        except Exception as exc:
+            existing = db.session.execute(
                 db.select(Metrics).where(
                     Metrics.vulnerability_id == vid,
                     Metrics.variant_id == variant_id,
                     Metrics.version == cvss.version,
                     Metrics.score == cvss.base_score,
                 )
-            ).scalar_one()
+            ).scalar_one_or_none()
+            if existing is None:
+                raise exc
+            return existing

--- a/src/models/variant.py
+++ b/src/models/variant.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if typing.TYPE_CHECKING:
-    from ..models import Project, Scan, Assessment, TimeEstimate
+    from ..models import Project, Scan, Assessment, TimeEstimate, Metrics
 
 
 class Variant(Base):
@@ -38,6 +38,10 @@ class Variant(Base):
         cascade="all, delete-orphan"
     )
     time_estimates: Mapped[list["TimeEstimate"]] = relationship(
+        back_populates="variant",
+        cascade="all, delete-orphan"
+    )
+    metrics: Mapped[list["Metrics"]] = relationship(
         back_populates="variant",
         cascade="all, delete-orphan"
     )

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -120,7 +120,7 @@ class Vulnerability(Base):
         # Set to True by _apply_variant_scoped_metrics_and_effort to prevent
         # to_dict() from lazily falling back to Finding.time_estimate, which
         # is not variant-aware and may return a different variant's data.
-        self._effort_variant_loaded: bool = False
+        self.effort_variant_loaded: bool = False
         self.advisories: list[str] = []
         self.packages: list[str] = []
         # Initialise from the DB column when reconstructing from a persisted record.
@@ -285,7 +285,7 @@ class Vulnerability(Base):
             "likely": None if self.effort["likely"] is None else str(self.effort["likely"]),
             "pessimistic": None if self.effort["pessimistic"] is None else str(self.effort["pessimistic"]),
         }
-        if not any(effort_dict.values()) and not self._effort_variant_loaded:
+        if not any(effort_dict.values()) and not self.effort_variant_loaded:
             try:
                 for f in (self.findings or []):
                     te = f.time_estimate

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -263,6 +263,7 @@ class Vulnerability(Base):
             try:
                 for m in (self.metrics or []):
                     cvss_list.append({
+                        "variant_id": str(m.variant_id) if m.variant_id is not None else None,
                         "version": m.version,
                         "vector_string": m.vector or "",
                         "author": m.author or "unknown",

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -261,17 +261,7 @@ class Vulnerability(Base):
             ]
         else:
             try:
-                for m in (self.metrics or []):
-                    cvss_list.append({
-                        "variant_id": str(m.variant_id) if m.variant_id is not None else None,
-                        "version": m.version,
-                        "vector_string": m.vector or "",
-                        "author": m.author or "unknown",
-                        "origin": m.origin or "scanner",
-                        "base_score": float(m.score) if m.score is not None else 0.0,
-                        "exploitability_score": 0.0,
-                        "impact_score": 0.0,
-                    })
+                cvss_list = [m.to_dict() for m in (self.metrics or [])]
             except Exception as e:
                 verbose(f"[Vulnerability.to_dict metrics {self.id!r}] {e}")
 

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -117,6 +117,10 @@ class Vulnerability(Base):
             "likely": None,
             "pessimistic": None,
         }
+        # Set to True by _apply_variant_scoped_metrics_and_effort to prevent
+        # to_dict() from lazily falling back to Finding.time_estimate, which
+        # is not variant-aware and may return a different variant's data.
+        self._effort_variant_loaded: bool = False
         self.advisories: list[str] = []
         self.packages: list[str] = []
         # Initialise from the DB column when reconstructing from a persisted record.
@@ -281,7 +285,7 @@ class Vulnerability(Base):
             "likely": None if self.effort["likely"] is None else str(self.effort["likely"]),
             "pessimistic": None if self.effort["pessimistic"] is None else str(self.effort["pessimistic"]),
         }
-        if not any(effort_dict.values()):
+        if not any(effort_dict.values()) and not self._effort_variant_loaded:
             try:
                 for f in (self.findings or []):
                     te = f.time_estimate

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -378,6 +378,7 @@ def init_app(app):
 
         query = (
             db.select(TimeEstimate)
+            .join(Finding, TimeEstimate.finding_id == Finding.id)
             .options(joinedload(TimeEstimate.finding))
             .where(
                 db.or_(
@@ -416,19 +417,26 @@ def init_app(app):
             except (ValueError, TypeError):
                 return f"PT{h}H"
 
+        # Bulk-load vulnerability texts to avoid N+1 queries
+        vuln_ids_for_te = {te.finding.vulnerability_id for te in all_te}
+        vuln_texts_map: dict[str, dict] = {}
+        if vuln_ids_for_te:
+            for vuln in db.session.execute(
+                db.select(DBVuln).where(DBVuln.id.in_(vuln_ids_for_te))
+            ).scalars().all():
+                vuln_texts_map[vuln.id] = dict(vuln.texts or {})
+
         vuln_map: dict[str, dict] = {}
         for te in all_te:
-            if te.finding is None:
-                continue
             vid = te.finding.vulnerability_id
             current = vuln_map.get(vid)
             is_scoped = te.variant_id is not None
+            # Prefer variant-scoped entries over unscoped ones for the same vuln
             if current is not None and current.get("variant_id") and not is_scoped:
                 continue
             opt = te.optimistic or 0
             lik = te.likely or 0
             pes = te.pessimistic or 0
-            vuln = DBVuln.get_by_id(vid)
             vuln_map[vid] = {
                 "vuln_id": vid,
                 "variant_id": str(te.variant_id) if te.variant_id else None,
@@ -438,7 +446,7 @@ def init_app(app):
                 "optimistic_iso": _hours_to_iso(opt),
                 "likely_iso": _hours_to_iso(lik),
                 "pessimistic_iso": _hours_to_iso(pes),
-                "vuln_texts": dict(vuln.texts or {}) if vuln else {},
+                "vuln_texts": vuln_texts_map.get(vid, {}),
             }
 
         return sorted(vuln_map.values(), key=lambda x: x["vuln_id"])

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -421,7 +421,9 @@ def init_app(app):
             if te.finding is None:
                 continue
             vid = te.finding.vulnerability_id
-            if vid in vuln_map:
+            current = vuln_map.get(vid)
+            is_scoped = te.variant_id is not None
+            if current is not None and current.get("variant_id") and not is_scoped:
                 continue
             opt = te.optimistic or 0
             lik = te.likely or 0
@@ -429,6 +431,7 @@ def init_app(app):
             vuln = DBVuln.get_by_id(vid)
             vuln_map[vid] = {
                 "vuln_id": vid,
+                "variant_id": str(te.variant_id) if te.variant_id else None,
                 "optimistic": opt,
                 "likely": lik,
                 "pessimistic": pes,
@@ -447,44 +450,25 @@ def init_app(app):
         A custom CVSS score is identified by ``origin == 'custom'``.
         """
         from ..models.metrics import Metrics
-        from ..models.observation import Observation
-        from ..models.scan import Scan
 
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
 
         query = db.select(Metrics).where(Metrics.origin == "custom")
-
-        vuln_ids_filter = None
         if variant_id:
             vid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:
                 return err
-            vuln_ids_filter = db.select(Finding.vulnerability_id).join(
-                Observation, Finding.id == Observation.finding_id
-            ).join(
-                Scan, Observation.scan_id == Scan.id
-            ).where(
-                Scan.variant_id == vid
-            ).distinct()
+            query = query.where(db.or_(Metrics.variant_id == vid, Metrics.variant_id.is_(None)))
         elif project_id:
             pid, err = parse_uuid_or_400(project_id, "project_id")
             if err:
                 return err
             variant_ids = [v.id for v in DBVariant.get_by_project(pid)]
             if variant_ids:
-                vuln_ids_filter = db.select(Finding.vulnerability_id).join(
-                    Observation, Finding.id == Observation.finding_id
-                ).join(
-                    Scan, Observation.scan_id == Scan.id
-                ).where(
-                    Scan.variant_id.in_(variant_ids)
-                ).distinct()
+                query = query.where(db.or_(Metrics.variant_id.in_(variant_ids), Metrics.variant_id.is_(None)))
             else:
-                vuln_ids_filter = db.select(Finding.vulnerability_id).where(db.false())
-
-        if vuln_ids_filter is not None:
-            query = query.where(Metrics.vulnerability_id.in_(vuln_ids_filter))
+                query = query.where(db.false())
 
         all_metrics = list(db.session.execute(query).scalars().all())
 
@@ -495,6 +479,7 @@ def init_app(app):
             vuln = DBVuln.get_by_id(m.vulnerability_id)
             result.append({
                 "vuln_id": m.vulnerability_id,
+                "variant_id": str(m.variant_id) if m.variant_id else None,
                 "version": m.version or "",
                 "vector_string": m.vector or "",
                 "base_score": float(m.score) if m.score is not None else 0.0,

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -585,6 +585,15 @@ def init_app(app):
         if not record:
             return "Not found", 404
 
+        if request.method == 'GET':
+            variant_id = request.args.get("variant_id")
+            if variant_id:
+                variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
+                if err:
+                    return err
+                _apply_variant_scoped_metrics_and_effort([record], variant_uuid)
+            return record.to_dict()
+
         if request.method == 'PATCH':
             payload_data = request.get_json()
             if payload_data is None:
@@ -647,6 +656,8 @@ def init_app(app):
 
             if response_variant_id is not None:
                 _apply_variant_scoped_metrics_and_effort([record], response_variant_id)
+
+            return record.to_dict()
 
         return record.to_dict()
 

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -139,7 +139,7 @@ def _apply_variant_scoped_metrics_and_effort(records: list, variant_uuid) -> Non
         # Mark the effort as already resolved so to_dict() does not fall back
         # to Finding.time_estimate, which is not variant-aware and could return
         # data belonging to a different variant.
-        r._effort_variant_loaded = True
+        r.effort_variant_loaded = True
 
 
 def _variant_ids_for_vulnerability(vulnerability_id: str) -> list:

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -136,6 +136,10 @@ def _apply_variant_scoped_metrics_and_effort(records: list, variant_uuid) -> Non
                 "likely": None if like is None else Iso8601Duration(f"PT{like}H"),
                 "pessimistic": None if pess is None else Iso8601Duration(f"PT{pess}H"),
             }
+        # Mark the effort as already resolved so to_dict() does not fall back
+        # to Finding.time_estimate, which is not variant-aware and could return
+        # data belonging to a different variant.
+        r._effort_variant_loaded = True
 
 
 def _variant_ids_for_vulnerability(vulnerability_id: str) -> list:

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -3,6 +3,7 @@
 
 import datetime
 import os
+import dataclasses
 
 from flask import jsonify, request
 from sqlalchemy import func, select
@@ -72,7 +73,29 @@ _TOOL_SOURCE_TO_FOUND_BY: dict[str, str] = {
 }
 
 
-def _variant_scoped_metrics_and_effort_overrides(records: list, variant_uuid) -> dict[str, dict]:
+@dataclasses.dataclass
+class _Effort:
+    optimistic: int | None
+    likely: int | None
+    pessimistic: int | None
+
+    def to_dict(self):
+        return {
+            "optimistic": str(Iso8601Duration(f"PT{self.optimistic}H")) if self.optimistic else None,
+            "likely": str(Iso8601Duration(f"PT{self.likely}H")) if self.likely else None,
+            "pessimistic": str(Iso8601Duration(f"PT{self.pessimistic}H")) if self.pessimistic else None,
+        }
+
+
+@dataclasses.dataclass
+class _ScopedOverrides:
+    cvss: list[Metrics]
+    effort: _Effort
+
+
+def _variant_scoped_metrics_and_effort_overrides(
+    records: list[Vulnerability], variant_uuid
+) -> dict[str, _ScopedOverrides]:
     """Build response-level overrides for variant-scoped metrics/effort.
 
     Returns a mapping keyed by vulnerability id with:
@@ -116,44 +139,29 @@ def _variant_scoped_metrics_and_effort_overrides(records: list, variant_uuid) ->
         )
     ).all()
 
-    effort_by_vuln: dict[str, tuple[int | None, int | None, int | None]] = {}
-    fallback_effort_by_vuln: dict[str, tuple[int | None, int | None, int | None]] = {}
+    effort_by_vuln: dict[str, _Effort] = {}
+    fallback_effort_by_vuln: dict[str, _Effort] = {}
     for vuln_id, te_variant_id, opti, like, pess in raw_te_rows:
-        packed = (opti, like, pess)
+        packed = _Effort(opti, like, pess)
         if te_variant_id == variant_uuid and vuln_id not in effort_by_vuln:
             effort_by_vuln[vuln_id] = packed
         elif te_variant_id is None and vuln_id not in fallback_effort_by_vuln:
             fallback_effort_by_vuln[vuln_id] = packed
 
-    overrides: dict[str, dict] = {}
+    overrides: dict[str, _ScopedOverrides] = {}
     for r in records:
         metric_bucket = metrics_by_vuln.get(r.id, {"scoped": [], "fallback": []})
         selected_metrics = metric_bucket["scoped"] or metric_bucket["fallback"]
 
         chosen_effort = effort_by_vuln.get(r.id) or fallback_effort_by_vuln.get(r.id)
-        if chosen_effort is not None:
-            opti, like, pess = chosen_effort
-            effort_dict = {
-                "optimistic": None if opti is None else str(Iso8601Duration(f"PT{opti}H")),
-                "likely": None if like is None else str(Iso8601Duration(f"PT{like}H")),
-                "pessimistic": None if pess is None else str(Iso8601Duration(f"PT{pess}H")),
-            }
-        else:
-            effort_dict = {
-                "optimistic": None,
-                "likely": None,
-                "pessimistic": None,
-            }
-
-        overrides[str(r.id)] = {
-            "cvss": [m.to_dict() for m in selected_metrics],
-            "effort": effort_dict,
-        }
+        overrides[str(r.id)] = _ScopedOverrides(selected_metrics, chosen_effort or _Effort(None, None, None))
 
     return overrides
 
 
-def _apply_variant_scoped_overrides_to_vuln_dicts(vulns: dict[str, dict], overrides: dict[str, dict]) -> None:
+def _apply_variant_scoped_overrides_to_vuln_dicts(
+    vulns: dict[str, dict], overrides: dict[str, _ScopedOverrides]
+) -> None:
     """Apply variant-scoped metrics/effort overrides to serialized vulnerability dicts."""
     if not vulns or not overrides:
         return
@@ -162,8 +170,8 @@ def _apply_variant_scoped_overrides_to_vuln_dicts(vulns: dict[str, dict], overri
         scoped = overrides.get(str(vuln_id))
         if scoped is None:
             continue
-        vuln.setdefault("severity", {})["cvss"] = scoped["cvss"]
-        vuln["effort"] = scoped["effort"]
+        vuln.setdefault("severity", {})["cvss"] = [m.to_dict() for m in scoped.cvss]
+        vuln["effort"] = scoped.effort.to_dict()
 
 
 def _variant_ids_for_vulnerability(vulnerability_id: str) -> list:
@@ -280,7 +288,7 @@ def init_app(app):
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
         compare_variant_id = request.args.get('compare_variant_id')
-        variant_scoped_overrides: dict[str, dict] = {}
+        variant_scoped_overrides: dict[str, _ScopedOverrides] = {}
         current_scan_ids: list = []
         if variant_id and compare_variant_id:
             base_uuid, err = parse_uuid_or_400(variant_id, "variant_id")

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -6,7 +6,7 @@ import os
 
 from flask import jsonify, request
 from sqlalchemy import func, select
-from sqlalchemy.orm import selectinload, aliased
+from sqlalchemy.orm import selectinload, aliased, attributes as orm_attrs
 from ..models import (
     Vulnerability,
     Finding,
@@ -70,6 +70,84 @@ _TOOL_SOURCE_TO_FOUND_BY: dict[str, str] = {
     "nvd": "nvd_cpe",
     "osv": "osv",
 }
+
+
+def _apply_variant_scoped_metrics_and_effort(records: list, variant_uuid) -> None:
+    """Inject variant-scoped metrics/effort into in-memory vulnerability records.
+
+    This keeps list responses deterministic for the currently selected variant,
+    while still allowing legacy unscoped records as a fallback.
+    """
+    if not records:
+        return
+
+    vuln_ids = [r.id for r in records]
+
+    metric_rows = db.session.execute(
+        db.select(Metrics).where(
+            Metrics.vulnerability_id.in_(vuln_ids),
+            db.or_(Metrics.variant_id == variant_uuid, Metrics.variant_id.is_(None)),
+        )
+    ).scalars().all()
+
+    metrics_by_vuln: dict[str, dict[str, list]] = {}
+    for m in metric_rows:
+        bucket = metrics_by_vuln.setdefault(m.vulnerability_id, {"scoped": [], "fallback": []})
+        if m.variant_id == variant_uuid:
+            bucket["scoped"].append(m)
+        else:
+            bucket["fallback"].append(m)
+
+    from ..models.time_estimate import TimeEstimate
+    raw_te_rows = db.session.execute(
+        db.select(
+            Finding.vulnerability_id,
+            TimeEstimate.variant_id,
+            TimeEstimate.optimistic,
+            TimeEstimate.likely,
+            TimeEstimate.pessimistic,
+        )
+        .join(Finding, TimeEstimate.finding_id == Finding.id)
+        .where(
+            Finding.vulnerability_id.in_(vuln_ids),
+            db.or_(TimeEstimate.variant_id == variant_uuid, TimeEstimate.variant_id.is_(None)),
+        )
+    ).all()
+
+    effort_by_vuln: dict[str, tuple[int | None, int | None, int | None]] = {}
+    fallback_effort_by_vuln: dict[str, tuple[int | None, int | None, int | None]] = {}
+    for vuln_id, te_variant_id, opti, like, pess in raw_te_rows:
+        packed = (opti, like, pess)
+        if te_variant_id == variant_uuid and vuln_id not in effort_by_vuln:
+            effort_by_vuln[vuln_id] = packed
+        elif te_variant_id is None and vuln_id not in fallback_effort_by_vuln:
+            fallback_effort_by_vuln[vuln_id] = packed
+
+    for r in records:
+        metric_bucket = metrics_by_vuln.get(r.id, {"scoped": [], "fallback": []})
+        selected_metrics = metric_bucket["scoped"] or metric_bucket["fallback"]
+        orm_attrs.set_committed_value(r, 'metrics', selected_metrics)
+
+        chosen_effort = effort_by_vuln.get(r.id) or fallback_effort_by_vuln.get(r.id)
+        if chosen_effort is not None:
+            opti, like, pess = chosen_effort
+            r.effort = {
+                "optimistic": None if opti is None else Iso8601Duration(f"PT{opti}H"),
+                "likely": None if like is None else Iso8601Duration(f"PT{like}H"),
+                "pessimistic": None if pess is None else Iso8601Duration(f"PT{pess}H"),
+            }
+
+
+def _variant_ids_for_vulnerability(vulnerability_id: str) -> list:
+    """Return distinct variant IDs where a vulnerability is observed."""
+    rows = db.session.execute(
+        db.select(Scan.variant_id)
+        .join(Observation, Observation.scan_id == Scan.id)
+        .join(Finding, Observation.finding_id == Finding.id)
+        .where(Finding.vulnerability_id == vulnerability_id)
+        .distinct()
+    ).all()
+    return [variant_id for (variant_id,) in rows]
 
 
 def _populate_found_by(
@@ -244,6 +322,7 @@ def init_app(app):
                     if base_ids:
                         query = query.where(~Vulnerability.id.in_(list(base_ids)))
                     records = list(db.session.execute(query).scalars().all())
+            _apply_variant_scoped_metrics_and_effort(records, compare_uuid)
         elif variant_id:
             variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:
@@ -300,6 +379,7 @@ def init_app(app):
                         _pkgs_by_vuln_var.setdefault(str(_vid), []).append(_sid)
                     for r in records:
                         r.packages = _pkgs_by_vuln_var.get(str(r.id), [])
+                _apply_variant_scoped_metrics_and_effort(records, variant_uuid)
         elif project_id:
             project_uuid, err = parse_uuid_or_400(project_id, "project_id")
             if err:
@@ -377,7 +457,6 @@ def init_app(app):
                         effort_by_vuln[vid] = (opti, like, pess)
 
                 # Pre-populate transient fields so to_dict() won't lazy-load findings
-                from sqlalchemy.orm import attributes as orm_attrs
                 for r in records:
                     r.packages = pkgs_by_vuln.get(r.id, [])
                     te = effort_by_vuln.get(r.id)
@@ -510,6 +589,7 @@ def init_app(app):
             payload_data = request.get_json()
             if payload_data is None:
                 return {"error": "Invalid request data"}, 400
+            response_variant_id = None
 
             if "effort" in payload_data:
                 eff = payload_data["effort"]
@@ -521,18 +601,52 @@ def init_app(app):
                     variant_id, err = parse_uuid_or_400(variant_id, "variant_id")
                     if err:
                         return err
-                _apply_effort(record, variant_id, opt, lik, pes,
-                              log_prefix=f"PATCH /api/vulnerabilities/{record.id}")
+                    target_variant_ids = [variant_id]
+                else:
+                    target_variant_ids = _variant_ids_for_vulnerability(record.id)
+                    if not target_variant_ids:
+                        target_variant_ids = [None]
+
+                for target_variant_id in target_variant_ids:
+                    _apply_effort(record, target_variant_id, opt, lik, pes,
+                                  log_prefix=f"PATCH /api/vulnerabilities/{record.id}")
+
+                if len(target_variant_ids) == 1 and target_variant_ids[0] is not None:
+                    response_variant_id = target_variant_ids[0]
+                record.effort = {
+                    "optimistic": Iso8601Duration(f"PT{opt}H"),
+                    "likely": Iso8601Duration(f"PT{lik}H"),
+                    "pessimistic": Iso8601Duration(f"PT{pes}H"),
+                }
 
             if "cvss" in payload_data:
+                variant_id = payload_data.get("variant_id")
+                if variant_id is not None:
+                    variant_id, err = parse_uuid_or_400(variant_id, "variant_id")
+                    if err:
+                        return err
+                    target_variant_ids = [variant_id]
+                else:
+                    target_variant_ids = _variant_ids_for_vulnerability(record.id)
+                    if not target_variant_ids:
+                        target_variant_ids = [None]
+
                 if isinstance(payload_data["cvss"], dict):
                     payload_data["cvss"].setdefault("origin", "custom")
-                cvss_err = _validate_and_apply_cvss(
-                    payload_data["cvss"], record.id,
-                    log_prefix=f"PATCH /api/vulnerabilities/{record.id}")
-                if cvss_err:
-                    return cvss_err, 400
+
+                for target_variant_id in target_variant_ids:
+                    cvss_err = _validate_and_apply_cvss(
+                        payload_data["cvss"], record.id, target_variant_id,
+                        log_prefix=f"PATCH /api/vulnerabilities/{record.id}")
+                    if cvss_err:
+                        return cvss_err, 400
+
+                if len(target_variant_ids) == 1 and target_variant_ids[0] is not None:
+                    response_variant_id = target_variant_ids[0]
                 db.session.expire(record, ['metrics'])
+
+            if response_variant_id is not None:
+                _apply_variant_scoped_metrics_and_effort([record], response_variant_id)
 
         return record.to_dict()
 
@@ -557,6 +671,8 @@ def init_app(app):
                 errors.append({"id": item["id"], "error": "Vulnerability not found"})
                 continue
 
+            response_variant_id = None
+
             if "effort" in item:
                 eff = item["effort"]
                 opt, lik, pes, err = _validate_effort(eff)
@@ -569,19 +685,59 @@ def init_app(app):
                     if err:
                         errors.append({"id": item["id"], "error": "Invalid variant_id"})
                         continue
-                _apply_effort(record, item_variant_id, opt, lik, pes,
-                              log_prefix=f"PATCH /api/vulnerabilities/batch {item['id']!r}")
+                    target_variant_ids = [item_variant_id]
+                else:
+                    target_variant_ids = _variant_ids_for_vulnerability(record.id)
+                    if not target_variant_ids:
+                        target_variant_ids = [None]
+
+                for target_variant_id in target_variant_ids:
+                    _apply_effort(record, target_variant_id, opt, lik, pes,
+                                  log_prefix=f"PATCH /api/vulnerabilities/batch {item['id']!r}")
+
+                if len(target_variant_ids) == 1 and target_variant_ids[0] is not None:
+                    response_variant_id = target_variant_ids[0]
+                record.effort = {
+                    "optimistic": Iso8601Duration(f"PT{opt}H"),
+                    "likely": Iso8601Duration(f"PT{lik}H"),
+                    "pessimistic": Iso8601Duration(f"PT{pes}H"),
+                }
 
             if "cvss" in item:
+                cvss_variant_id = item.get("variant_id")
+                if cvss_variant_id is not None:
+                    cvss_variant_id, err = parse_uuid_or_400(cvss_variant_id, "variant_id")
+                    if err:
+                        errors.append({"id": item["id"], "error": "Invalid variant_id"})
+                        continue
+                    target_variant_ids = [cvss_variant_id]
+                else:
+                    target_variant_ids = _variant_ids_for_vulnerability(record.id)
+                    if not target_variant_ids:
+                        target_variant_ids = [None]
+
                 if isinstance(item["cvss"], dict):
                     item["cvss"].setdefault("origin", "custom")
-                cvss_err = _validate_and_apply_cvss(
-                    item["cvss"], record.id,
-                    log_prefix=f"PATCH /api/vulnerabilities/batch {item['id']!r}")
-                if cvss_err:
-                    errors.append({"id": item["id"], "error": cvss_err})
+
+                cvss_failed = False
+                for target_variant_id in target_variant_ids:
+                    cvss_err = _validate_and_apply_cvss(
+                        item["cvss"], record.id, target_variant_id,
+                        log_prefix=f"PATCH /api/vulnerabilities/batch {item['id']!r}")
+                    if cvss_err:
+                        errors.append({"id": item["id"], "error": cvss_err})
+                        cvss_failed = True
+                        break
+
+                if cvss_failed:
                     continue
+
+                if len(target_variant_ids) == 1 and target_variant_ids[0] is not None:
+                    response_variant_id = target_variant_ids[0]
                 db.session.expire(record, ['metrics'])
+
+            if response_variant_id is not None:
+                _apply_variant_scoped_metrics_and_effort([record], response_variant_id)
 
             results.append(record.to_dict())
 

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -579,87 +579,93 @@ def init_app(app):
             case _ as fmt:
                 raise ValueError("Unknown format", fmt)
 
-    @app.route('/api/vulnerabilities/<id>', methods=['GET', 'PATCH'])
-    def update_vuln(id):
+    @app.get('/api/vulnerabilities/<id>')
+    def get_vuln(id):
         record = Vulnerability.get_by_id(id)
         if not record:
             return "Not found", 404
 
-        if request.method == 'GET':
-            variant_id = request.args.get("variant_id")
-            if variant_id:
-                variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
+        variant_id = request.args.get("variant_id")
+        if variant_id:
+            variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
+            if err:
+                return err
+            _apply_variant_scoped_metrics_and_effort([record], variant_uuid)
+        return record.to_dict()
+
+    @app.patch('/api/vulnerabilities/<id>')
+    def patch_vuln(id):
+        record = Vulnerability.get_by_id(id)
+        if not record:
+            return "Not found", 404
+
+        payload_data = request.get_json()
+        if payload_data is None:
+            return {"error": "Invalid request data"}, 400
+        response_variant_id = None
+        _updated_effort: dict | None = None
+
+        if "effort" in payload_data:
+            eff = payload_data["effort"]
+            opt, lik, pes, err = _validate_effort(eff)
+            if err:
+                return err, 400
+            variant_id = payload_data.get("variant_id")
+            if variant_id is not None:
+                variant_id, err = parse_uuid_or_400(variant_id, "variant_id")
                 if err:
                     return err
-                _apply_variant_scoped_metrics_and_effort([record], variant_uuid)
-            return record.to_dict()
+                target_variant_ids = [variant_id]
+            else:
+                target_variant_ids = _variant_ids_for_vulnerability(record.id)
+                if not target_variant_ids:
+                    target_variant_ids = [None]
 
-        if request.method == 'PATCH':
-            payload_data = request.get_json()
-            if payload_data is None:
-                return {"error": "Invalid request data"}, 400
-            response_variant_id = None
+            for target_variant_id in target_variant_ids:
+                _apply_effort(record, target_variant_id, opt, lik, pes,
+                              log_prefix=f"PATCH /api/vulnerabilities/{record.id}")
 
-            if "effort" in payload_data:
-                eff = payload_data["effort"]
-                opt, lik, pes, err = _validate_effort(eff)
+            if len(target_variant_ids) == 1 and target_variant_ids[0] is not None:
+                response_variant_id = target_variant_ids[0]
+            _updated_effort = {
+                "optimistic": str(Iso8601Duration(f"PT{opt}H")),
+                "likely": str(Iso8601Duration(f"PT{lik}H")),
+                "pessimistic": str(Iso8601Duration(f"PT{pes}H")),
+            }
+
+        if "cvss" in payload_data:
+            variant_id = payload_data.get("variant_id")
+            if variant_id is not None:
+                variant_id, err = parse_uuid_or_400(variant_id, "variant_id")
                 if err:
-                    return err, 400
-                variant_id = payload_data.get("variant_id")
-                if variant_id is not None:
-                    variant_id, err = parse_uuid_or_400(variant_id, "variant_id")
-                    if err:
-                        return err
-                    target_variant_ids = [variant_id]
-                else:
-                    target_variant_ids = _variant_ids_for_vulnerability(record.id)
-                    if not target_variant_ids:
-                        target_variant_ids = [None]
+                    return err
+                target_variant_ids = [variant_id]
+            else:
+                target_variant_ids = _variant_ids_for_vulnerability(record.id)
+                if not target_variant_ids:
+                    target_variant_ids = [None]
 
-                for target_variant_id in target_variant_ids:
-                    _apply_effort(record, target_variant_id, opt, lik, pes,
-                                  log_prefix=f"PATCH /api/vulnerabilities/{record.id}")
+            if isinstance(payload_data["cvss"], dict):
+                payload_data["cvss"].setdefault("origin", "custom")
 
-                if len(target_variant_ids) == 1 and target_variant_ids[0] is not None:
-                    response_variant_id = target_variant_ids[0]
-                record.effort = {
-                    "optimistic": Iso8601Duration(f"PT{opt}H"),
-                    "likely": Iso8601Duration(f"PT{lik}H"),
-                    "pessimistic": Iso8601Duration(f"PT{pes}H"),
-                }
+            for target_variant_id in target_variant_ids:
+                cvss_err = _validate_and_apply_cvss(
+                    payload_data["cvss"], record.id, target_variant_id,
+                    log_prefix=f"PATCH /api/vulnerabilities/{record.id}")
+                if cvss_err:
+                    return cvss_err, 400
 
-            if "cvss" in payload_data:
-                variant_id = payload_data.get("variant_id")
-                if variant_id is not None:
-                    variant_id, err = parse_uuid_or_400(variant_id, "variant_id")
-                    if err:
-                        return err
-                    target_variant_ids = [variant_id]
-                else:
-                    target_variant_ids = _variant_ids_for_vulnerability(record.id)
-                    if not target_variant_ids:
-                        target_variant_ids = [None]
+            if len(target_variant_ids) == 1 and target_variant_ids[0] is not None:
+                response_variant_id = target_variant_ids[0]
+            db.session.expire(record, ['metrics'])
 
-                if isinstance(payload_data["cvss"], dict):
-                    payload_data["cvss"].setdefault("origin", "custom")
+        if response_variant_id is not None:
+            _apply_variant_scoped_metrics_and_effort([record], response_variant_id)
 
-                for target_variant_id in target_variant_ids:
-                    cvss_err = _validate_and_apply_cvss(
-                        payload_data["cvss"], record.id, target_variant_id,
-                        log_prefix=f"PATCH /api/vulnerabilities/{record.id}")
-                    if cvss_err:
-                        return cvss_err, 400
-
-                if len(target_variant_ids) == 1 and target_variant_ids[0] is not None:
-                    response_variant_id = target_variant_ids[0]
-                db.session.expire(record, ['metrics'])
-
-            if response_variant_id is not None:
-                _apply_variant_scoped_metrics_and_effort([record], response_variant_id)
-
-            return record.to_dict()
-
-        return record.to_dict()
+        response = record.to_dict()
+        if _updated_effort is not None and response_variant_id is None:
+            response["effort"] = _updated_effort
+        return response
 
     @app.route('/api/vulnerabilities/batch', methods=['PATCH'])
     def update_vulns_batch():
@@ -683,6 +689,7 @@ def init_app(app):
                 continue
 
             response_variant_id = None
+            _updated_effort: dict | None = None
 
             if "effort" in item:
                 eff = item["effort"]
@@ -708,10 +715,10 @@ def init_app(app):
 
                 if len(target_variant_ids) == 1 and target_variant_ids[0] is not None:
                     response_variant_id = target_variant_ids[0]
-                record.effort = {
-                    "optimistic": Iso8601Duration(f"PT{opt}H"),
-                    "likely": Iso8601Duration(f"PT{lik}H"),
-                    "pessimistic": Iso8601Duration(f"PT{pes}H"),
+                _updated_effort = {
+                    "optimistic": str(Iso8601Duration(f"PT{opt}H")),
+                    "likely": str(Iso8601Duration(f"PT{lik}H")),
+                    "pessimistic": str(Iso8601Duration(f"PT{pes}H")),
                 }
 
             if "cvss" in item:
@@ -750,7 +757,10 @@ def init_app(app):
             if response_variant_id is not None:
                 _apply_variant_scoped_metrics_and_effort([record], response_variant_id)
 
-            results.append(record.to_dict())
+            result_dict = record.to_dict()
+            if _updated_effort is not None and response_variant_id is None:
+                result_dict["effort"] = _updated_effort
+            results.append(result_dict)
 
         response = {
             "status": "success" if results else "error",

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -72,14 +72,15 @@ _TOOL_SOURCE_TO_FOUND_BY: dict[str, str] = {
 }
 
 
-def _apply_variant_scoped_metrics_and_effort(records: list, variant_uuid) -> None:
-    """Inject variant-scoped metrics/effort into in-memory vulnerability records.
+def _variant_scoped_metrics_and_effort_overrides(records: list, variant_uuid) -> dict[str, dict]:
+    """Build response-level overrides for variant-scoped metrics/effort.
 
-    This keeps list responses deterministic for the currently selected variant,
-    while still allowing legacy unscoped records as a fallback.
+    Returns a mapping keyed by vulnerability id with:
+      - ``cvss``: selected metric dicts (scoped first, legacy fallback)
+      - ``effort``: selected effort dict (scoped first, legacy fallback)
     """
     if not records:
-        return
+        return {}
 
     vuln_ids = [r.id for r in records]
 
@@ -99,6 +100,7 @@ def _apply_variant_scoped_metrics_and_effort(records: list, variant_uuid) -> Non
             bucket["fallback"].append(m)
 
     from ..models.time_estimate import TimeEstimate
+
     raw_te_rows = db.session.execute(
         db.select(
             Finding.vulnerability_id,
@@ -123,23 +125,45 @@ def _apply_variant_scoped_metrics_and_effort(records: list, variant_uuid) -> Non
         elif te_variant_id is None and vuln_id not in fallback_effort_by_vuln:
             fallback_effort_by_vuln[vuln_id] = packed
 
+    overrides: dict[str, dict] = {}
     for r in records:
         metric_bucket = metrics_by_vuln.get(r.id, {"scoped": [], "fallback": []})
         selected_metrics = metric_bucket["scoped"] or metric_bucket["fallback"]
-        orm_attrs.set_committed_value(r, 'metrics', selected_metrics)
 
         chosen_effort = effort_by_vuln.get(r.id) or fallback_effort_by_vuln.get(r.id)
         if chosen_effort is not None:
             opti, like, pess = chosen_effort
-            r.effort = {
-                "optimistic": None if opti is None else Iso8601Duration(f"PT{opti}H"),
-                "likely": None if like is None else Iso8601Duration(f"PT{like}H"),
-                "pessimistic": None if pess is None else Iso8601Duration(f"PT{pess}H"),
+            effort_dict = {
+                "optimistic": None if opti is None else str(Iso8601Duration(f"PT{opti}H")),
+                "likely": None if like is None else str(Iso8601Duration(f"PT{like}H")),
+                "pessimistic": None if pess is None else str(Iso8601Duration(f"PT{pess}H")),
             }
-        # Mark the effort as already resolved so to_dict() does not fall back
-        # to Finding.time_estimate, which is not variant-aware and could return
-        # data belonging to a different variant.
-        r.effort_variant_loaded = True
+        else:
+            effort_dict = {
+                "optimistic": None,
+                "likely": None,
+                "pessimistic": None,
+            }
+
+        overrides[str(r.id)] = {
+            "cvss": [m.to_dict() for m in selected_metrics],
+            "effort": effort_dict,
+        }
+
+    return overrides
+
+
+def _apply_variant_scoped_overrides_to_vuln_dicts(vulns: dict[str, dict], overrides: dict[str, dict]) -> None:
+    """Apply variant-scoped metrics/effort overrides to serialized vulnerability dicts."""
+    if not vulns or not overrides:
+        return
+
+    for vuln_id, vuln in vulns.items():
+        scoped = overrides.get(str(vuln_id))
+        if scoped is None:
+            continue
+        vuln.setdefault("severity", {})["cvss"] = scoped["cvss"]
+        vuln["effort"] = scoped["effort"]
 
 
 def _variant_ids_for_vulnerability(vulnerability_id: str) -> list:
@@ -256,6 +280,7 @@ def init_app(app):
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
         compare_variant_id = request.args.get('compare_variant_id')
+        variant_scoped_overrides: dict[str, dict] = {}
         current_scan_ids: list = []
         if variant_id and compare_variant_id:
             base_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
@@ -326,7 +351,7 @@ def init_app(app):
                     if base_ids:
                         query = query.where(~Vulnerability.id.in_(list(base_ids)))
                     records = list(db.session.execute(query).scalars().all())
-            _apply_variant_scoped_metrics_and_effort(records, compare_uuid)
+            variant_scoped_overrides = _variant_scoped_metrics_and_effort_overrides(records, compare_uuid)
         elif variant_id:
             variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:
@@ -383,7 +408,7 @@ def init_app(app):
                         _pkgs_by_vuln_var.setdefault(str(_vid), []).append(_sid)
                     for r in records:
                         r.packages = _pkgs_by_vuln_var.get(str(r.id), [])
-                _apply_variant_scoped_metrics_and_effort(records, variant_uuid)
+                variant_scoped_overrides = _variant_scoped_metrics_and_effort_overrides(records, variant_uuid)
         elif project_id:
             project_uuid, err = parse_uuid_or_400(project_id, "project_id")
             if err:
@@ -487,6 +512,7 @@ def init_app(app):
         _populate_found_by(records, _scope_variant, _scope_project,
                            active_scan_ids=current_scan_ids or None)
         vulns = {r.id: r.to_dict() for r in records}
+        _apply_variant_scoped_overrides_to_vuln_dicts(vulns, variant_scoped_overrides)
         vuln_ids = vulns.keys()
 
         if vulns:
@@ -590,12 +616,14 @@ def init_app(app):
             return "Not found", 404
 
         variant_id = request.args.get("variant_id")
+        response = record.to_dict()
         if variant_id:
             variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:
                 return err
-            _apply_variant_scoped_metrics_and_effort([record], variant_uuid)
-        return record.to_dict()
+            overrides = _variant_scoped_metrics_and_effort_overrides([record], variant_uuid)
+            _apply_variant_scoped_overrides_to_vuln_dicts({response["id"]: response}, overrides)
+        return response
 
     @app.patch('/api/vulnerabilities/<id>')
     def patch_vuln(id):
@@ -663,10 +691,10 @@ def init_app(app):
                 response_variant_id = target_variant_ids[0]
             db.session.expire(record, ['metrics'])
 
-        if response_variant_id is not None:
-            _apply_variant_scoped_metrics_and_effort([record], response_variant_id)
-
         response = record.to_dict()
+        if response_variant_id is not None:
+            overrides = _variant_scoped_metrics_and_effort_overrides([record], response_variant_id)
+            _apply_variant_scoped_overrides_to_vuln_dicts({response["id"]: response}, overrides)
         if _updated_effort is not None and response_variant_id is None:
             response["effort"] = _updated_effort
         return response
@@ -758,10 +786,10 @@ def init_app(app):
                     response_variant_id = target_variant_ids[0]
                 db.session.expire(record, ['metrics'])
 
-            if response_variant_id is not None:
-                _apply_variant_scoped_metrics_and_effort([record], response_variant_id)
-
             result_dict = record.to_dict()
+            if response_variant_id is not None:
+                overrides = _variant_scoped_metrics_and_effort_overrides([record], response_variant_id)
+                _apply_variant_scoped_overrides_to_vuln_dicts({result_dict["id"]: result_dict}, overrides)
             if _updated_effort is not None and response_variant_id is None:
                 result_dict["effort"] = _updated_effort
             results.append(result_dict)

--- a/tests/unit_tests/test_new_db_models.py
+++ b/tests/unit_tests/test_new_db_models.py
@@ -575,6 +575,12 @@ class TestMetricsController:
         assert data["vulnerability_id"] == "CVE-2024-1234"
         assert data["version"] == "3.1"
         assert data["score"] == pytest.approx(7.5)
+        assert data["variant_id"] is None
+
+    def test_serialize_with_variant_id(self, app, vuln, variant):
+        m = Metrics.create(vulnerability_id=vuln.id, variant_id=variant.id, score=6.0)
+        data = MetricsController.serialize(m)
+        assert data["variant_id"] == str(variant.id)
 
     def test_serialize_list(self, metrics):
         lst = MetricsController.serialize_list([metrics])
@@ -587,9 +593,19 @@ class TestMetricsController:
         results = MetricsController.get_by_vulnerability(vuln.id)
         assert any(m.id == metrics.id for m in results)
 
+    def test_get_by_vulnerability_and_variant(self, app, vuln, variant):
+        m = Metrics.create(vulnerability_id=vuln.id, variant_id=variant.id, version="3.1", score=7.5)
+        results = MetricsController.get_by_vulnerability_and_variant(vuln.id, variant.id)
+        assert any(metric.id == m.id for metric in results)
+
     def test_create(self, app, vuln):
         m = MetricsController.create(vuln.id, version="2.0", score=5.0, author="NVD")
         assert float(m.score) == pytest.approx(5.0)
+
+    def test_create_with_variant_id(self, app, vuln, variant):
+        m = MetricsController.create(vuln.id, variant_id=variant.id, version="3.1", score=8.5)
+        assert m.variant_id == variant.id
+        assert float(m.score) == pytest.approx(8.5)
 
     def test_create_empty_vuln_id_raises(self, app):
         with pytest.raises(ValueError):
@@ -723,6 +739,64 @@ class TestFindingModelExtra:
 
 class TestMetricsModelExtra:
     """Cover Metrics model paths not in the main TestMetricsModel."""
+
+    def test_create_with_variant_id(self, app, vuln, variant):
+        """create() with variant_id parameter persists the variant relationship."""
+        m = Metrics.create(vulnerability_id=vuln.id, variant_id=variant.id, score=5.5)
+        assert m.variant_id == variant.id
+        assert Metrics.get_by_id(m.id).variant_id == variant.id
+
+    def test_create_with_string_variant_id(self, app, vuln, variant):
+        """create() converts string variant_id to UUID (line 47)."""
+        m = Metrics.create(vulnerability_id=vuln.id, variant_id=str(variant.id), score=4.5)
+        assert m.variant_id == variant.id
+
+    def test_get_by_vulnerability_and_variant_include_unscoped(self, app, vuln, variant):
+        """get_by_vulnerability_and_variant() includes legacy unscoped records."""
+        m1 = Metrics.create(vulnerability_id=vuln.id, variant_id=variant.id, score=7.0)
+        m2 = Metrics.create(vulnerability_id=vuln.id, score=6.0)  # No variant_id
+        results = Metrics.get_by_vulnerability_and_variant(vuln.id, variant.id, include_unscoped=True)
+        assert any(m.id == m1.id for m in results)
+        assert any(m.id == m2.id for m in results)
+
+    def test_get_by_vulnerability_and_variant_scoped_only(self, app, vuln, variant):
+        """get_by_vulnerability_and_variant() can exclude unscoped records."""
+        m1 = Metrics.create(vulnerability_id=vuln.id, variant_id=variant.id, score=7.0)
+        m2 = Metrics.create(vulnerability_id=vuln.id, score=6.0)  # No variant_id
+        results = Metrics.get_by_vulnerability_and_variant(vuln.id, variant.id, include_unscoped=False)
+        assert any(m.id == m1.id for m in results)
+        assert not any(m.id == m2.id for m in results)
+
+    def test_from_cvss_with_variant_id(self, app, vuln, variant):
+        """from_cvss() with variant_id parameter creates scoped metrics."""
+        from src.models.cvss import CVSS
+        cvss = CVSS(
+            version="3.1",
+            vector_string="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            author="NVD",
+            base_score=7.5,
+            exploitability_score=3.9,
+            impact_score=3.6,
+        )
+        Metrics._seen = set()
+        m = Metrics.from_cvss(cvss, vuln.id, variant_id=variant.id)
+        assert m.variant_id == variant.id
+        assert m.vulnerability_id == vuln.id
+
+    def test_from_cvss_with_string_variant_id(self, app, vuln, variant):
+        """from_cvss() converts string variant_id to UUID (line 130)."""
+        from src.models.cvss import CVSS
+        cvss = CVSS(
+            version="3.0",
+            vector_string="CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            author="NVD",
+            base_score=7.5,
+            exploitability_score=3.9,
+            impact_score=3.6,
+        )
+        Metrics._seen = set()
+        m = Metrics.from_cvss(cvss, vuln.id, variant_id=str(variant.id))
+        assert m.variant_id == variant.id
 
     def test_get_by_id_with_string_uuid(self, app, metrics):
         """get_by_id() accepts a string UUID (line 62)."""

--- a/tests/unit_tests/test_new_db_models.py
+++ b/tests/unit_tests/test_new_db_models.py
@@ -607,6 +607,11 @@ class TestMetricsController:
         assert m.variant_id == variant.id
         assert float(m.score) == pytest.approx(8.5)
 
+    def test_create_with_string_variant_id(self, app, vuln, variant):
+        m = MetricsController.create(vuln.id, variant_id=str(variant.id), version="3.1", score=8.5)
+        assert m.variant_id == variant.id
+        assert float(m.score) == pytest.approx(8.5)
+
     def test_create_empty_vuln_id_raises(self, app):
         with pytest.raises(ValueError):
             MetricsController.create("  ")
@@ -746,11 +751,6 @@ class TestMetricsModelExtra:
         assert m.variant_id == variant.id
         assert Metrics.get_by_id(m.id).variant_id == variant.id
 
-    def test_create_with_string_variant_id(self, app, vuln, variant):
-        """create() converts string variant_id to UUID (line 47)."""
-        m = Metrics.create(vulnerability_id=vuln.id, variant_id=str(variant.id), score=4.5)
-        assert m.variant_id == variant.id
-
     def test_get_by_vulnerability_and_variant_include_unscoped(self, app, vuln, variant):
         """get_by_vulnerability_and_variant() includes legacy unscoped records."""
         m1 = Metrics.create(vulnerability_id=vuln.id, variant_id=variant.id, score=7.0)
@@ -782,21 +782,6 @@ class TestMetricsModelExtra:
         m = Metrics.from_cvss(cvss, vuln.id, variant_id=variant.id)
         assert m.variant_id == variant.id
         assert m.vulnerability_id == vuln.id
-
-    def test_from_cvss_with_string_variant_id(self, app, vuln, variant):
-        """from_cvss() converts string variant_id to UUID (line 130)."""
-        from src.models.cvss import CVSS
-        cvss = CVSS(
-            version="3.0",
-            vector_string="CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            author="NVD",
-            base_score=7.5,
-            exploitability_score=3.9,
-            impact_score=3.6,
-        )
-        Metrics._seen = set()
-        m = Metrics.from_cvss(cvss, vuln.id, variant_id=str(variant.id))
-        assert m.variant_id == variant.id
 
     def test_get_by_id_with_string_uuid(self, app, metrics):
         """get_by_id() accepts a string UUID (line 62)."""

--- a/tests/unit_tests/test_webapp_coverage_boost.py
+++ b/tests/unit_tests/test_webapp_coverage_boost.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+from src.bin import webapp as webapp_mod
+import src.controllers.vulnerabilities as vulnerabilities_mod
+
+
+class _InlineThread:
+    """Replace threading.Thread so targets run immediately in tests."""
+
+    def __init__(self, target, name=None, daemon=None):
+        self._target = target
+        self.name = name
+        self.daemon = daemon
+
+    def start(self):
+        self._target()
+
+
+def test_launch_enrichment_executes_epss_and_nvd(monkeypatch):
+    calls: list[str] = []
+
+    fake_session = SimpleNamespace(autoflush=True)
+    fake_db = SimpleNamespace(session=fake_session)
+
+    def _record_post_treatment(_controllers):
+        calls.append("epss")
+
+    def _record_fetch_nvd(self):
+        calls.append("nvd")
+
+    monkeypatch.setattr(webapp_mod, "db", fake_db)
+    monkeypatch.setattr(webapp_mod.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(webapp_mod, "post_treatment", _record_post_treatment)
+    monkeypatch.setattr(
+        vulnerabilities_mod.VulnerabilitiesController,
+        "fetch_nvd_data",
+        _record_fetch_nvd,
+    )
+
+    app = Flask(__name__)
+    webapp_mod._launch_enrichment(app)
+
+    assert fake_session.autoflush is False
+    assert "epss" in calls
+    assert "nvd" in calls
+
+
+def test_launch_enrichment_catches_and_logs_failures(monkeypatch, capsys):
+    fake_session = SimpleNamespace(autoflush=True)
+    fake_db = SimpleNamespace(session=fake_session)
+
+    def _raise_in_fetch(self):
+        raise RuntimeError("nvd failure")
+
+    def _raise_in_post_treatment(_controllers):
+        raise RuntimeError("epss failure")
+
+    monkeypatch.setattr(webapp_mod, "db", fake_db)
+    monkeypatch.setattr(webapp_mod.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(webapp_mod, "post_treatment", _raise_in_post_treatment)
+    monkeypatch.setattr(
+        vulnerabilities_mod.VulnerabilitiesController,
+        "fetch_nvd_data",
+        _raise_in_fetch,
+    )
+
+    app = Flask(__name__)
+    webapp_mod._launch_enrichment(app)
+
+    out = capsys.readouterr().out
+    assert "[enrichment/epss]" in out
+    assert "[enrichment/nvd]" in out
+
+
+def test_create_app_triggers_enrichment_when_scan_finished(monkeypatch, tmp_path):
+    status_file = tmp_path / "status.txt"
+    status_file.write_text("__END_OF_SCAN_SCRIPT__")
+
+    calls: list[str] = []
+
+    def _record_launch(_app):
+        calls.append("launched")
+
+    def _register_api_ping(app):
+        @app.route("/api/ping")
+        def _ping():
+            return {"ok": True}
+
+    monkeypatch.setenv("FLASK_SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
+    monkeypatch.setattr(webapp_mod, "_launch_enrichment", _record_launch)
+    monkeypatch.setattr(webapp_mod, "init_app", _register_api_ping)
+    monkeypatch.setattr(webapp_mod, "init_merger_cli", lambda _app: None)
+
+    app = webapp_mod.create_app()
+    app.config["SCAN_FILE"] = str(status_file)
+    app.config["TESTING"] = False
+
+    client = app.test_client()
+    response = client.get("/api/ping")
+
+    assert response.status_code == 200
+    assert calls == ["launched"]
+
+
+def test_create_app_swallows_pragma_setup_error(monkeypatch):
+    def _broken_text(*_args, **_kwargs):
+        raise RuntimeError("broken pragma")
+
+    monkeypatch.setenv("FLASK_SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
+    monkeypatch.setattr(webapp_mod.db, "text", _broken_text)
+
+    app = webapp_mod.create_app()
+
+    assert app is not None
+
+
+def test_stop_handler_prints_and_exits(capsys):
+    with pytest.raises(SystemExit) as err:
+        webapp_mod.stop_handler(None, None)
+
+    assert err.value.code == 0
+    assert "Stopping Flask server" in capsys.readouterr().out

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -643,6 +643,7 @@ def test_export_custom_data_basic(client):
     assert "vuln_id" in a
     assert "status" in a
     assert "packages" in a
+    assert "variant" in a
 
 
 def test_export_custom_data_by_variant(client):
@@ -696,6 +697,8 @@ def test_export_custom_data_with_cvss(client):
     data = json.loads(resp.data)
     # The CVSS entry should exist (author may vary depending on Metrics.from_cvss logic)
     assert isinstance(data["cvss"], list)
+    if data["cvss"]:
+        assert "variant" in data["cvss"][0]
 
 
 def test_export_custom_data_with_time_estimate(client):
@@ -722,6 +725,7 @@ def test_export_custom_data_with_time_estimate(client):
     assert "optimistic" in te
     assert "likely" in te
     assert "pessimistic" in te
+    assert "variant" in te
 
 
 def test_export_custom_data_filename_by_variant(client):
@@ -806,6 +810,43 @@ def test_import_custom_data_assessments(client):
     assert result["assessments_imported"] >= 1
 
 
+def test_import_custom_data_assessments_without_variant_field(client):
+    """Import remains backward compatible when variant fields are missing."""
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2020-35492",
+        "status": "affected",
+        "packages": ["cairo@1.16.0"],
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload,
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["status"] == "success"
+    assert result["assessments_imported"] >= 1
+
+
+def test_import_custom_data_assessments_with_variant_name(client):
+    """Assessment import accepts the human-readable variant name field."""
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2020-35492",
+        "status": "affected",
+        "packages": ["cairo@1.16.0"],
+        "variant": "default",
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload,
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["status"] == "success"
+    assert result["assessments_imported"] >= 1
+
+
 def test_import_custom_data_duplicate_skipped(client):
     """Same assessment imported twice → second is skipped."""
     payload = _custom_data_payload(assessments=[{
@@ -851,10 +892,47 @@ def test_import_custom_data_cvss(client):
     assert result["cvss_imported"] >= 1
 
 
+def test_import_custom_data_cvss_with_variant_name(client):
+    """CVSS import accepts the human-readable variant name field."""
+    payload = _custom_data_payload(cvss=[{
+        "vuln_id": "CVE-2020-35492",
+        "variant": "default",
+        "version": "3.1",
+        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "base_score": 7.5,
+        "author": "custom-author",
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["cvss_imported"] >= 1
+
+
 def test_import_custom_data_time_estimates(client):
     """Import time estimates via the custom-data endpoint."""
     payload = _custom_data_payload(time_estimates=[{
         "vuln_id": "CVE-2020-35492",
+        "optimistic": "PT2H",
+        "likely": "PT4H",
+        "pessimistic": "PT8H",
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["time_estimates_imported"] >= 1
+
+
+def test_import_custom_data_time_estimates_with_variant_name(client):
+    """Time-estimate import accepts the human-readable variant name field."""
+    payload = _custom_data_payload(time_estimates=[{
+        "vuln_id": "CVE-2020-35492",
+        "variant": "default",
         "optimistic": "PT2H",
         "likely": "PT4H",
         "pessimistic": "PT8H",


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Link CVSS and time estimate to a variant

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Open vulnerability modal without selecting a variant.  
   Expected: you can pick what variants are concerned by the custom CVSS and saving estimate 

2. Select a variant in vulnerability modal and save CVSS/time estimate.  
   Expected: request includes `variant_id`; persisted values are variant-scoped.

3. Multi-edit bar:
   - with selected variant: updates are applied for selected vulns in that variant.
   - without selected variant: app expands updates across found variants.
   - no variants found: shows error banner.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


