### PR TITLE
Bulk EPSS + NVD refresh

### DIFF
--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -7,6 +7,9 @@ import type { PostTimeEstimate } from "./TimeEstimateEditor";
 import { asAssessment, Assessment } from "../handlers/assessments";
 import Iso8601Duration from '../handlers/iso8601duration';
 import Variants from '../handlers/variant';
+import { BulkNvdRefreshHandler, BulkEpssRefreshHandler } from "../handlers/bulkRefresh";
+import type { NVDProgress } from "../handlers/nvd_progress";
+import type { EPSSProgress } from "../handlers/epss_progress";
 
 type Props = {
     vulnerabilities: Vulnerability[];
@@ -21,9 +24,11 @@ type Props = {
     baseVariantId?: string;
     /** 'difference' or 'intersection' when compare mode is active */
     compareOperation?: string;
+    nvdProgress?: NVDProgress | null;
+    epssProgress?: EPSSProgress | null;
 };
 
-function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssessment, patchVuln, triggerBanner, hideBanner, variantId, baseVariantId, compareOperation} : Readonly<Props>) {
+function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssessment, patchVuln, triggerBanner, hideBanner, variantId, baseVariantId, compareOperation, nvdProgress, epssProgress} : Readonly<Props>) {
 
     const [panelOpened, setPanelOpened] = useState<number>(0)
     const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -337,6 +342,46 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
 
                         <button className="bg-sky-900 p-1 px-2" onClick={() => { hideBanner(); setPanelOpened(panelOpened == 1 ? 0 : 1); }}>Change status</button>
                         <button className="bg-sky-900 p-1 px-2 mr-4" onClick={() => { hideBanner(); setPanelOpened(panelOpened == 2 ? 0 : 2); }}>Change estimated time</button>
+
+                        <button
+                            className="bg-sky-900 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                            disabled={nvdProgress?.in_progress ?? false}
+                            title="Refresh NVD data for selected CVEs"
+                            onClick={() => {
+                                hideBanner();
+                                BulkNvdRefreshHandler.trigger(selectedVulns).then(res => {
+                                    if (res) triggerBanner(`NVD refresh started for ${res.total} CVE(s)`, 'success');
+                                    else triggerBanner('Failed to start NVD refresh', 'error');
+                                }).catch(() => triggerBanner('Failed to start NVD refresh', 'error'));
+                            }}
+                        >Refresh NVD</button>
+                        <button
+                            className="bg-sky-900 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                            disabled={epssProgress?.in_progress ?? false}
+                            title="Refresh EPSS scores for selected CVEs"
+                            onClick={() => {
+                                hideBanner();
+                                BulkEpssRefreshHandler.trigger(selectedVulns).then(res => {
+                                    if (res) triggerBanner(`EPSS refresh started for ${res.total} CVE(s)`, 'success');
+                                    else triggerBanner('Failed to start EPSS refresh', 'error');
+                                }).catch(() => triggerBanner('Failed to start EPSS refresh', 'error'));
+                            }}
+                        >Refresh EPSS</button>
+                        <button
+                            className="bg-sky-900 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                            disabled={(nvdProgress?.in_progress ?? false) || (epssProgress?.in_progress ?? false)}
+                            title="Refresh both NVD and EPSS for selected CVEs"
+                            onClick={() => {
+                                hideBanner();
+                                Promise.all([
+                                    BulkNvdRefreshHandler.trigger(selectedVulns),
+                                    BulkEpssRefreshHandler.trigger(selectedVulns),
+                                ]).then(([nvd, epss]) => {
+                                    if (nvd || epss) triggerBanner(`Refresh started: NVD ${nvd ? nvd.total : 0} CVE(s), EPSS ${epss ? epss.total : 0} CVE(s)`, 'success');
+                                    else triggerBanner('Failed to start NVD + EPSS refresh', 'error');
+                                }).catch(() => triggerBanner('Failed to start NVD + EPSS refresh', 'error'));
+                            }}
+                        >Refresh NVD + EPSS</button>
                     </div>
                 </div>
             </div>

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -7,7 +7,7 @@ import type { PostTimeEstimate } from "./TimeEstimateEditor";
 import { asAssessment, Assessment } from "../handlers/assessments";
 import Iso8601Duration from '../handlers/iso8601duration';
 import Variants from '../handlers/variant';
-import { BulkNvdRefreshHandler, BulkEpssRefreshHandler } from "../handlers/bulkRefresh";
+import { BulkNvdRefreshHandler, BulkEpssRefreshHandler, BulkNvdRefreshCancelHandler, BulkEpssRefreshCancelHandler } from "../handlers/bulkRefresh";
 import type { NVDProgress } from "../handlers/nvd_progress";
 import type { EPSSProgress } from "../handlers/epss_progress";
 
@@ -34,6 +34,8 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
     const [isLoading, setIsLoading] = useState<boolean>(false)
     const [affectedVariantNames, setAffectedVariantNames] = useState<string[]>([])
     const [isAllVariantsMode, setIsAllVariantsMode] = useState<boolean>(false)
+    const [nvdCancelling, setNvdCancelling] = useState<boolean>(false)
+    const [epssCancelling, setEpssCancelling] = useState<boolean>(false)
     const loadingLabel = selectedVulns.length === 1 ? 'Editing selected CVE...' : 'Editing selected CVEs...'
     const closePanel = () => {
         if (!isLoading) setPanelOpened(0)
@@ -60,6 +62,15 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
             document.removeEventListener('keydown', handleKeyDown);
         };
     }, [panelOpened, isLoading]);
+
+    // Reset cancelling flag when NVD or EPSS refresh ends
+    useEffect(() => {
+        if (!nvdProgress?.in_progress) setNvdCancelling(false);
+    }, [nvdProgress?.in_progress]);
+
+    useEffect(() => {
+        if (!epssProgress?.in_progress) setEpssCancelling(false);
+    }, [epssProgress?.in_progress]);
 
     // Recompute affected variants whenever the status panel opens or the selection changes
     useEffect(() => {
@@ -355,6 +366,21 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                                 }).catch(() => triggerBanner('Failed to start NVD refresh', 'error'));
                             }}
                         >Refresh NVD</button>
+                        {(nvdProgress?.in_progress) && (
+                            <button
+                                className="bg-red-800 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                                disabled={nvdCancelling}
+                                title="Cancel in-progress NVD refresh"
+                                data-testid="cancel-nvd-refresh"
+                                onClick={() => {
+                                    setNvdCancelling(true);
+                                    BulkNvdRefreshCancelHandler.trigger().then(res => {
+                                        if (res) triggerBanner('NVD refresh cancellation requested', 'success');
+                                        else { setNvdCancelling(false); triggerBanner('Failed to cancel NVD refresh', 'error'); }
+                                    }).catch(() => { setNvdCancelling(false); triggerBanner('Failed to cancel NVD refresh', 'error'); });
+                                }}
+                            >{nvdCancelling ? 'Cancelling…' : 'Cancel NVD'}</button>
+                        )}
                         <button
                             className="bg-sky-900 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
                             disabled={epssProgress?.in_progress ?? false}
@@ -367,6 +393,21 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                                 }).catch(() => triggerBanner('Failed to start EPSS refresh', 'error'));
                             }}
                         >Refresh EPSS</button>
+                        {(epssProgress?.in_progress) && (
+                            <button
+                                className="bg-red-800 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                                disabled={epssCancelling}
+                                title="Cancel in-progress EPSS refresh"
+                                data-testid="cancel-epss-refresh"
+                                onClick={() => {
+                                    setEpssCancelling(true);
+                                    BulkEpssRefreshCancelHandler.trigger().then(res => {
+                                        if (res) triggerBanner('EPSS refresh cancellation requested', 'success');
+                                        else { setEpssCancelling(false); triggerBanner('Failed to cancel EPSS refresh', 'error'); }
+                                    }).catch(() => { setEpssCancelling(false); triggerBanner('Failed to cancel EPSS refresh', 'error'); });
+                                }}
+                            >{epssCancelling ? 'Cancelling…' : 'Cancel EPSS'}</button>
+                        )}
                         <button
                             className="bg-sky-900 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
                             disabled={(nvdProgress?.in_progress ?? false) || (epssProgress?.in_progress ?? false)}

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import type { Vulnerability } from "../handlers/vulnerabilities";
 import StatusEditor from "./StatusEditor";
 import type { PostAssessment } from './StatusEditor';
@@ -36,6 +36,9 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
     const [isAllVariantsMode, setIsAllVariantsMode] = useState<boolean>(false)
     const [nvdCancelling, setNvdCancelling] = useState<boolean>(false)
     const [epssCancelling, setEpssCancelling] = useState<boolean>(false)
+    const [refreshMenuOpen, setRefreshMenuOpen] = useState<boolean>(false)
+    const [selectedRefreshTypes, setSelectedRefreshTypes] = useState<Set<'nvd' | 'epss'>>(new Set(['nvd', 'epss']))
+    const refreshMenuRef = useRef<HTMLDivElement>(null)
     const loadingLabel = selectedVulns.length === 1 ? 'Editing selected CVE...' : 'Editing selected CVEs...'
     const closePanel = () => {
         if (!isLoading) setPanelOpened(0)
@@ -71,6 +74,57 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
     useEffect(() => {
         if (!epssProgress?.in_progress) setEpssCancelling(false);
     }, [epssProgress?.in_progress]);
+
+    useEffect(() => {
+        function handleClickOutside(e: MouseEvent) {
+            if (refreshMenuRef.current && !refreshMenuRef.current.contains(e.target as Node)) {
+                setRefreshMenuOpen(false);
+            }
+        }
+        if (refreshMenuOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+            return () => document.removeEventListener('mousedown', handleClickOutside);
+        }
+    }, [refreshMenuOpen]);
+
+    function toggleRefreshType(type: 'nvd' | 'epss') {
+        setSelectedRefreshTypes(prev => {
+            const next = new Set(prev);
+            if (next.has(type)) next.delete(type); else next.add(type);
+            return next;
+        });
+    }
+
+    const nvdInProgress = nvdProgress?.in_progress ?? false;
+    const epssInProgress = epssProgress?.in_progress ?? false;
+
+    // Number of selected targets that are not currently refreshing (actionable)
+    const actionableRefreshCount = (selectedRefreshTypes.has('nvd') && !nvdInProgress ? 1 : 0)
+        + (selectedRefreshTypes.has('epss') && !epssInProgress ? 1 : 0);
+
+    const allSelectedRefreshing = selectedRefreshTypes.size === 0 || actionableRefreshCount === 0;
+
+    function handleRefresh() {
+        hideBanner();
+        const promises: Promise<void>[] = [];
+        if (selectedRefreshTypes.has('nvd') && !nvdInProgress) {
+            promises.push(
+                BulkNvdRefreshHandler.trigger(selectedVulns).then(res => {
+                    if (res) triggerBanner(`NVD refresh started for ${res.total} CVE(s)`, 'success');
+                    else triggerBanner('Failed to start NVD refresh', 'error');
+                }).catch(() => triggerBanner('Failed to start NVD refresh', 'error'))
+            );
+        }
+        if (selectedRefreshTypes.has('epss') && !epssInProgress) {
+            promises.push(
+                BulkEpssRefreshHandler.trigger(selectedVulns).then(res => {
+                    if (res) triggerBanner(`EPSS refresh started for ${res.total} CVE(s)`, 'success');
+                    else triggerBanner('Failed to start EPSS refresh', 'error');
+                }).catch(() => triggerBanner('Failed to start EPSS refresh', 'error'))
+            );
+        }
+        if (promises.length > 0) setRefreshMenuOpen(false);
+    }
 
     // Recompute affected variants whenever the status panel opens or the selection changes
     useEffect(() => {
@@ -354,75 +408,104 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                         <button className="bg-sky-900 p-1 px-2" onClick={() => { hideBanner(); setPanelOpened(panelOpened == 1 ? 0 : 1); }}>Change status</button>
                         <button className="bg-sky-900 p-1 px-2 mr-4" onClick={() => { hideBanner(); setPanelOpened(panelOpened == 2 ? 0 : 2); }}>Change estimated time</button>
 
-                        <button
-                            className="bg-sky-900 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                            disabled={nvdProgress?.in_progress ?? false}
-                            title="Refresh NVD data for selected CVEs"
-                            onClick={() => {
-                                hideBanner();
-                                BulkNvdRefreshHandler.trigger(selectedVulns).then(res => {
-                                    if (res) triggerBanner(`NVD refresh started for ${res.total} CVE(s)`, 'success');
-                                    else triggerBanner('Failed to start NVD refresh', 'error');
-                                }).catch(() => triggerBanner('Failed to start NVD refresh', 'error'));
-                            }}
-                        >Refresh NVD</button>
-                        {(nvdProgress?.in_progress) && (
+                        {/* Refresh dropdown */}
+                        <div className="relative" ref={refreshMenuRef}>
                             <button
-                                className="bg-red-800 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                                disabled={nvdCancelling}
-                                title="Cancel in-progress NVD refresh"
-                                data-testid="cancel-nvd-refresh"
-                                onClick={() => {
-                                    setNvdCancelling(true);
-                                    BulkNvdRefreshCancelHandler.trigger().then(res => {
-                                        if (res) triggerBanner('NVD refresh cancellation requested', 'success');
-                                        else { setNvdCancelling(false); triggerBanner('Failed to cancel NVD refresh', 'error'); }
-                                    }).catch(() => { setNvdCancelling(false); triggerBanner('Failed to cancel NVD refresh', 'error'); });
-                                }}
-                            >{nvdCancelling ? 'Cancelling…' : 'Cancel NVD'}</button>
-                        )}
-                        <button
-                            className="bg-sky-900 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                            disabled={epssProgress?.in_progress ?? false}
-                            title="Refresh EPSS scores for selected CVEs"
-                            onClick={() => {
-                                hideBanner();
-                                BulkEpssRefreshHandler.trigger(selectedVulns).then(res => {
-                                    if (res) triggerBanner(`EPSS refresh started for ${res.total} CVE(s)`, 'success');
-                                    else triggerBanner('Failed to start EPSS refresh', 'error');
-                                }).catch(() => triggerBanner('Failed to start EPSS refresh', 'error'));
-                            }}
-                        >Refresh EPSS</button>
-                        {(epssProgress?.in_progress) && (
-                            <button
-                                className="bg-red-800 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                                disabled={epssCancelling}
-                                title="Cancel in-progress EPSS refresh"
-                                data-testid="cancel-epss-refresh"
-                                onClick={() => {
-                                    setEpssCancelling(true);
-                                    BulkEpssRefreshCancelHandler.trigger().then(res => {
-                                        if (res) triggerBanner('EPSS refresh cancellation requested', 'success');
-                                        else { setEpssCancelling(false); triggerBanner('Failed to cancel EPSS refresh', 'error'); }
-                                    }).catch(() => { setEpssCancelling(false); triggerBanner('Failed to cancel EPSS refresh', 'error'); });
-                                }}
-                            >{epssCancelling ? 'Cancelling…' : 'Cancel EPSS'}</button>
-                        )}
-                        <button
-                            className="bg-sky-900 p-1 px-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                            disabled={(nvdProgress?.in_progress ?? false) || (epssProgress?.in_progress ?? false)}
-                            title="Refresh both NVD and EPSS for selected CVEs"
-                            onClick={() => {
-                                hideBanner();
-                                Promise.all([
-                                    BulkNvdRefreshHandler.trigger(selectedVulns),
-                                    BulkEpssRefreshHandler.trigger(selectedVulns),
-                                ]).then(([nvd, epss]) => {
-                                    if (nvd || epss) triggerBanner(`Refresh started: NVD ${nvd ? nvd.total : 0} CVE(s), EPSS ${epss ? epss.total : 0} CVE(s)`, 'success');
-                                    else triggerBanner('Failed to start NVD + EPSS refresh', 'error');
-                                }).catch(() => triggerBanner('Failed to start NVD + EPSS refresh', 'error'));
-                            }}
-                        >Refresh NVD + EPSS</button>
+                                data-testid="refresh-dropdown-toggle"
+                                className="bg-sky-900 p-1 px-2 flex items-center gap-1"
+                                onClick={() => setRefreshMenuOpen(o => !o)}
+                                title="Select refresh targets"
+                            >
+                                Refresh
+                                {(nvdInProgress || epssInProgress) && (
+                                    <span className="inline-block w-2 h-2 rounded-full bg-cyan-400 animate-pulse ml-1" title="Refresh in progress" />
+                                )}
+                                <span className="ml-1">▾</span>
+                            </button>
+
+                            {refreshMenuOpen && (
+                                <div className="absolute left-0 top-full mt-1 z-50 w-64 rounded-lg border border-sky-700/60 bg-neutral-900 shadow-xl p-3">
+                                    <div className="text-xs font-semibold text-sky-300 mb-2">Refresh targets</div>
+
+                                    {/* NVD row */}
+                                    <div className="flex items-center justify-between py-1 px-1 rounded hover:bg-sky-900/40">
+                                        <div className="flex items-center gap-2 text-sm text-neutral-200">
+                                            {nvdInProgress ? (
+                                                <span className="inline-block w-4 h-4 border-2 border-cyan-400 border-t-transparent rounded-full animate-spin flex-shrink-0" title="NVD refresh in progress" />
+                                            ) : (
+                                                <input
+                                                    type="checkbox"
+                                                    aria-label="NVD"
+                                                    checked={selectedRefreshTypes.has('nvd')}
+                                                    onChange={() => toggleRefreshType('nvd')}
+                                                    className="rounded accent-cyan-500"
+                                                />
+                                            )}
+                                            NVD
+                                        </div>
+                                        {nvdInProgress && (
+                                            <button
+                                                className="text-xs bg-red-800 hover:bg-red-700 px-2 py-0.5 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                                                disabled={nvdCancelling}
+                                                title="Cancel in-progress NVD refresh"
+                                                data-testid="cancel-nvd-refresh"
+                                                onClick={() => {
+                                                    setNvdCancelling(true);
+                                                    BulkNvdRefreshCancelHandler.trigger().then(res => {
+                                                        if (res) triggerBanner('NVD refresh cancellation requested', 'success');
+                                                        else { setNvdCancelling(false); triggerBanner('Failed to cancel NVD refresh', 'error'); }
+                                                    }).catch(() => { setNvdCancelling(false); triggerBanner('Failed to cancel NVD refresh', 'error'); });
+                                                }}
+                                            >{nvdCancelling ? 'Cancelling…' : 'Cancel'}</button>
+                                        )}
+                                    </div>
+
+                                    {/* EPSS row */}
+                                    <div className="flex items-center justify-between py-1 px-1 rounded hover:bg-sky-900/40">
+                                        <div className="flex items-center gap-2 text-sm text-neutral-200">
+                                            {epssInProgress ? (
+                                                <span className="inline-block w-4 h-4 border-2 border-cyan-400 border-t-transparent rounded-full animate-spin flex-shrink-0" title="EPSS refresh in progress" />
+                                            ) : (
+                                                <input
+                                                    type="checkbox"
+                                                    aria-label="EPSS"
+                                                    checked={selectedRefreshTypes.has('epss')}
+                                                    onChange={() => toggleRefreshType('epss')}
+                                                    className="rounded accent-cyan-500"
+                                                />
+                                            )}
+                                            EPSS
+                                        </div>
+                                        {epssInProgress && (
+                                            <button
+                                                className="text-xs bg-red-800 hover:bg-red-700 px-2 py-0.5 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                                                disabled={epssCancelling}
+                                                title="Cancel in-progress EPSS refresh"
+                                                data-testid="cancel-epss-refresh"
+                                                onClick={() => {
+                                                    setEpssCancelling(true);
+                                                    BulkEpssRefreshCancelHandler.trigger().then(res => {
+                                                        if (res) triggerBanner('EPSS refresh cancellation requested', 'success');
+                                                        else { setEpssCancelling(false); triggerBanner('Failed to cancel EPSS refresh', 'error'); }
+                                                    }).catch(() => { setEpssCancelling(false); triggerBanner('Failed to cancel EPSS refresh', 'error'); });
+                                                }}
+                                            >{epssCancelling ? 'Cancelling…' : 'Cancel'}</button>
+                                        )}
+                                    </div>
+
+                                    <div className="mt-2 pt-2 border-t border-sky-800">
+                                        <button
+                                            className="w-full py-1 rounded text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-cyan-700 hover:bg-cyan-600 text-white disabled:bg-neutral-700 disabled:text-neutral-500"
+                                            disabled={allSelectedRefreshing}
+                                            title={allSelectedRefreshing ? 'All selected targets are already refreshing' : 'Start refresh for selected targets'}
+                                            onClick={handleRefresh}
+                                        >
+                                            Refresh {actionableRefreshCount} target{actionableRefreshCount !== 1 ? 's' : ''}
+                                        </button>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -414,9 +414,9 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                                 data-testid="refresh-dropdown-toggle"
                                 className="bg-sky-900 p-1 px-2 flex items-center gap-1"
                                 onClick={() => setRefreshMenuOpen(o => !o)}
-                                title="Select refresh targets"
+                                title="Select databases to fetch latest vulnerability data from"
                             >
-                                Refresh
+                                Refresh Vulnerability Data
                                 {(nvdInProgress || epssInProgress) && (
                                     <span className="inline-block w-2 h-2 rounded-full bg-cyan-400 animate-pulse ml-1" title="Refresh in progress" />
                                 )}
@@ -425,7 +425,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
 
                             {refreshMenuOpen && (
                                 <div className="absolute left-0 top-full mt-1 z-50 w-64 rounded-lg border border-sky-700/60 bg-neutral-900 shadow-xl p-3">
-                                    <div className="text-xs font-semibold text-sky-300 mb-2">Refresh targets</div>
+                                    <div className="text-xs font-semibold text-sky-300 mb-2">Fetch latest data from:</div>
 
                                     {/* NVD row */}
                                     <div className="flex items-center justify-between py-1 px-1 rounded hover:bg-sky-900/40">
@@ -500,7 +500,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                                             title={allSelectedRefreshing ? 'All selected targets are already refreshing' : 'Start refresh for selected targets'}
                                             onClick={handleRefresh}
                                         >
-                                            Refresh {actionableRefreshCount} target{actionableRefreshCount !== 1 ? 's' : ''}
+                                            Start
                                         </button>
                                     </div>
                                 </div>

--- a/frontend/src/handlers/bulkRefresh.ts
+++ b/frontend/src/handlers/bulkRefresh.ts
@@ -1,0 +1,47 @@
+/**
+ * Bulk NVD and EPSS refresh handlers.
+ *
+ * These fire-and-forget endpoints return 202 immediately; actual progress
+ * is tracked via /api/nvd/progress and /api/epss/progress respectively.
+ */
+
+export interface BulkRefreshResponse {
+    status: string;
+    total: number;
+}
+
+export class BulkNvdRefreshHandler {
+    static async trigger(cveIds: string[]): Promise<BulkRefreshResponse | null> {
+        const url = `${import.meta.env.VITE_API_URL}/api/vulnerabilities/bulk-nvd-refresh`;
+        try {
+            const response = await fetch(url, {
+                method: "POST",
+                mode: "cors",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ cve_ids: cveIds }),
+            });
+            if (!response.ok) return null;
+            return response.json().catch(() => null);
+        } catch {
+            return null;
+        }
+    }
+}
+
+export class BulkEpssRefreshHandler {
+    static async trigger(cveIds: string[]): Promise<BulkRefreshResponse | null> {
+        const url = `${import.meta.env.VITE_API_URL}/api/vulnerabilities/bulk-epss-refresh`;
+        try {
+            const response = await fetch(url, {
+                method: "POST",
+                mode: "cors",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ cve_ids: cveIds }),
+            });
+            if (!response.ok) return null;
+            return response.json().catch(() => null);
+        } catch {
+            return null;
+        }
+    }
+}

--- a/frontend/src/handlers/bulkRefresh.ts
+++ b/frontend/src/handlers/bulkRefresh.ts
@@ -45,3 +45,39 @@ export class BulkEpssRefreshHandler {
         }
     }
 }
+
+export interface CancelRefreshResponse {
+    status: string;
+}
+
+export class BulkNvdRefreshCancelHandler {
+    static async trigger(): Promise<CancelRefreshResponse | null> {
+        const url = `${import.meta.env.VITE_API_URL}/api/vulnerabilities/cancel-nvd-refresh`;
+        try {
+            const response = await fetch(url, {
+                method: "POST",
+                mode: "cors",
+            });
+            if (!response.ok) return null;
+            return response.json().catch(() => null);
+        } catch {
+            return null;
+        }
+    }
+}
+
+export class BulkEpssRefreshCancelHandler {
+    static async trigger(): Promise<CancelRefreshResponse | null> {
+        const url = `${import.meta.env.VITE_API_URL}/api/vulnerabilities/cancel-epss-refresh`;
+        try {
+            const response = await fetch(url, {
+                method: "POST",
+                mode: "cors",
+            });
+            if (!response.ok) return null;
+            return response.json().catch(() => null);
+        } catch {
+            return null;
+        }
+    }
+}

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -123,6 +123,10 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         loadData(currentVariantId, currentVariantId ? undefined : currentProjectId);
     }, [loadData, currentVariantId, currentProjectId]);
 
+    const handleRefreshComplete = useCallback(() => {
+        loadData(currentVariantId, currentVariantId ? undefined : currentProjectId);
+    }, [loadData, currentVariantId, currentProjectId]);
+
 
     function appendAssessment(added: Assessment) {
         const updatedVulns = Vulnerabilities.append_assessment(vulns, added);
@@ -273,6 +277,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     projectId={currentProjectId}
                     baseVariantId={currentBaseVariantId}
                     compareOperation={currentOperation}
+                    onRefreshComplete={handleRefreshComplete}
                 />}
                 {tab === 'scans' && <ScanHistory variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onScanComplete={handleScanComplete} />}
                 {tab === 'review' && <Review variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onAssessmentChanged={handleAssessmentChanged} />}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -300,7 +300,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
     const [searchFilteredData, setSearchFilteredData] = useState<Vulnerability[]>([]);
     const [visibleColumns, setVisibleColumns] = useState<string[]>([
-        'ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Updated', 'Published Date'
+        'ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Updated'
     ]);
     const [focusedRowIndex, setFocusedRowIndex] = useState<number | null>(null);
 
@@ -737,7 +737,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     return <div className="flex items-center justify-center h-full text-center"><span className="text-xs text-gray-500 italic">fetching…</span></div>;
                 }
                 if (!published) {
-                    return <div className="flex items-center justify-center h-full text-center text-gray-400">Unknown</div>;
+                    return <div className="flex items-center justify-center h-full text-center text-gray-400">Requires a NVD refresh</div>;
                 }
                 const publishedDate = new Date(published);
                 const formattedDate = publishedDate.toLocaleDateString(undefined, {
@@ -1028,7 +1028,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         setPublishedDateFrom('');
         setPublishedDateTo('');
         setSelectedRows({});
-        setVisibleColumns(['ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Updated', 'Published Date']);
+        setVisibleColumns(['ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Updated']);
         setShowCustomSeverityFilter(false);
         setSeverityRange({ min: SEVERITY_RANGE_MIN, max: SEVERITY_RANGE_MAX });
         setShowCustomEpssFilter(false);

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -4,7 +4,7 @@ import type { Assessment } from "../handlers/assessments";
 import type { NVDProgress } from "../handlers/nvd_progress";
 import type { EPSSProgress } from "../handlers/epss_progress";
 import { createColumnHelper, SortingFn, RowSelectionState, Row, Table } from '@tanstack/react-table'
-import { useMemo, useState, useEffect, useCallback, useRef } from "react";
+import React, { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import SeverityTag from "../components/SeverityTag";
 import { SEVERITY_ORDER } from "../handlers/vulnerabilities";
 import TableGeneric from "../components/TableGeneric";
@@ -19,6 +19,57 @@ import { formatPkgId } from "../helpers/pkgId";
 import MessageBanner from "../components/MessageBanner";
 import NVDProgressHandler from "../handlers/nvd_progress";
 import EPSSProgressHandler from "../handlers/epss_progress";
+
+/**
+ * Shared hook for NVD/EPSS progress banner logic.
+ * Detects in-progress updates and phase transitions (completed/cancelled),
+ * updates the banner accordingly, and calls onRefreshComplete when done.
+ */
+function useRefreshProgressEffect(
+    progress: { in_progress: boolean; phase?: string; current: number; total: number } | null,
+    label: string,
+    prevInProgress: React.MutableRefObject<boolean | null>,
+    prevPhase: React.MutableRefObject<string | null>,
+    setBannerMessage: (msg: string) => void,
+    setBannerType: (type: 'error' | 'success') => void,
+    setBannerVisible: (visible: boolean) => void,
+    onRefreshComplete?: () => void,
+) {
+    useEffect(() => {
+        const inProgress = progress?.in_progress ?? false;
+        const phase = progress?.phase;
+        const justCompleted = prevPhase.current !== null && (
+            prevInProgress.current === true ||
+            (prevPhase.current !== 'completed' &&
+             prevPhase.current !== 'cancelled' &&
+             (phase === 'completed' || phase === 'cancelled')));
+        if (inProgress) {
+            if (progress && progress.total > 0 && progress.current > 0) {
+                setBannerMessage(`${label} refresh in progress: ${progress.current}/${progress.total}`);
+                setBannerType('success');
+                setBannerVisible(true);
+            }
+        } else if (justCompleted) {
+            onRefreshComplete?.();
+            if (phase === 'cancelled') {
+                const current = progress?.current ?? 0;
+                const total = progress?.total ?? 0;
+                setBannerMessage(`${label} refresh cancelled${current > 0 ? ` (${current}/${total} CVEs)` : ''}`);
+                setBannerType('error');
+            } else {
+                const total = progress?.total ?? 0;
+                setBannerMessage(`${label} refresh complete${total > 0 ? ` (${total} CVEs)` : ''}`);
+                setBannerType('success');
+            }
+            setBannerVisible(true);
+        }
+        if (progress !== null) {
+            prevInProgress.current = inProgress;
+            prevPhase.current = phase ?? 'idle';
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [progress, onRefreshComplete]);
+}
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimes, faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
 import RangeSlider from "../components/RangeSlider";
@@ -349,76 +400,19 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         if (filterLabel === "Package") setSelectedPackages([filterValue]);
     }, [filterLabel, filterValue]);
 
-    // Update banner with live NVD progress; reload data when the refresh completes
-    useEffect(() => {
-        const inProgress = nvdProgress?.in_progress ?? false;
-        const phase = nvdProgress?.phase;
-        const justCompleted = prevNvdPhase.current !== null && (
-            prevNvdInProgress.current === true ||
-            (prevNvdPhase.current !== 'completed' &&
-             prevNvdPhase.current !== 'cancelled' &&
-             (phase === 'completed' || phase === 'cancelled')));
-        if (inProgress) {
-            if (nvdProgress && nvdProgress.total > 0 && nvdProgress.current > 0) {
-                setBannerMessage(`NVD refresh in progress: ${nvdProgress.current}/${nvdProgress.total}`);
-                setBannerType('success');
-                setBannerVisible(true);
-            }
-        } else if (justCompleted) {
-            onRefreshComplete?.();
-            if (phase === 'cancelled') {
-                const current = nvdProgress?.current ?? 0;
-                const total = nvdProgress?.total ?? 0;
-                setBannerMessage(`NVD refresh cancelled${current > 0 ? ` (${current}/${total} CVEs)` : ''}`);
-                setBannerType('error');
-            } else {
-                const total = nvdProgress?.total ?? 0;
-                setBannerMessage(`NVD refresh complete${total > 0 ? ` (${total} CVEs)` : ''}`);
-                setBannerType('success');
-            }
-            setBannerVisible(true);
-        }
-        if (nvdProgress !== null) {
-            prevNvdInProgress.current = inProgress;
-            prevNvdPhase.current = phase ?? 'idle';
-        }
-    }, [nvdProgress, onRefreshComplete]);
-
-    // Update banner with live EPSS progress; reload data when the refresh completes
-    useEffect(() => {
-        const inProgress = epssProgress?.in_progress ?? false;
-        // EPSS can complete before the 5-second poll catches in_progress: true, so also detect completion via phase transition.
-        const phase = epssProgress?.phase;
-        const justCompleted = prevEpssPhase.current !== null && (
-            prevEpssInProgress.current === true ||
-            (prevEpssPhase.current !== 'completed' &&
-             prevEpssPhase.current !== 'cancelled' &&
-             (phase === 'completed' || phase === 'cancelled')));
-        if (inProgress) {
-            if (epssProgress && epssProgress.total > 0 && epssProgress.current > 0) {
-                setBannerMessage(`EPSS refresh in progress: ${epssProgress.current}/${epssProgress.total}`);
-                setBannerType('success');
-                setBannerVisible(true);
-            }
-        } else if (justCompleted) {
-            onRefreshComplete?.();
-            if (phase === 'cancelled') {
-                const current = epssProgress?.current ?? 0;
-                const total = epssProgress?.total ?? 0;
-                setBannerMessage(`EPSS refresh cancelled${current > 0 ? ` (${current}/${total} CVEs)` : ''}`);
-                setBannerType('error');
-            } else {
-                const total = epssProgress?.total ?? 0;
-                setBannerMessage(`EPSS refresh complete${total > 0 ? ` (${total} CVEs)` : ''}`);
-                setBannerType('success');
-            }
-            setBannerVisible(true);
-        }
-        if (epssProgress !== null) {
-            prevEpssInProgress.current = inProgress;
-            prevEpssPhase.current = phase ?? 'idle';
-        }
-    }, [epssProgress, onRefreshComplete]);
+    // Update banner with live NVD/EPSS progress; reload data when each refresh completes
+    useRefreshProgressEffect(
+        nvdProgress, 'NVD',
+        prevNvdInProgress, prevNvdPhase,
+        setBannerMessage, setBannerType, setBannerVisible,
+        onRefreshComplete,
+    );
+    useRefreshProgressEffect(
+        epssProgress, 'EPSS',
+        prevEpssInProgress, prevEpssPhase,
+        setBannerMessage, setBannerType, setBannerVisible,
+        onRefreshComplete,
+    );
 
     // Fetch NVD progress on mount and periodically
     useEffect(() => {

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -36,6 +36,8 @@ type Props = {
     baseVariantId?: string;
     /** 'difference' or 'intersection' when compare mode is active */
     compareOperation?: string;
+    /** Called when an NVD or EPSS bulk refresh completes, so the parent can reload data */
+    onRefreshComplete?: () => void;
 };
 
 const dt_options: Intl.DateTimeFormatOptions = {
@@ -273,7 +275,7 @@ function PublishedDateFilter({
 const SEVERITY_RANGE_MIN = 0;
 const SEVERITY_RANGE_MAX = 10;
 
-function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln, variantId, projectId, baseVariantId, compareOperation }: Readonly<Props>) {
+function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appendAssessment, appendCVSS, patchVuln, variantId, projectId, baseVariantId, compareOperation, onRefreshComplete }: Readonly<Props>) {
 
     const docUrl = useDocUrl("interactive-mode.html#vulnerability-table");
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);
@@ -318,6 +320,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const searchHelperButtonRef = useRef<HTMLButtonElement>(null);
     const searchHelperDropdownRef = useRef<HTMLDivElement>(null);
     const moreFiltersRef = useRef<HTMLDivElement>(null);
+    const prevNvdInProgress = useRef<boolean | null>(null);
+    const prevEpssInProgress = useRef<boolean | null>(null);
 
     const keyboardShortcuts = [
         { key: '/', description: 'Focus search bar' },
@@ -342,6 +346,44 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         if (filterLabel === "Status") setSelectedStatuses([filterValue]);
         if (filterLabel === "Package") setSelectedPackages([filterValue]);
     }, [filterLabel, filterValue]);
+
+    // Update banner with live NVD progress; reload data when the refresh completes
+    useEffect(() => {
+        const inProgress = nvdProgress?.in_progress ?? false;
+        if (inProgress) {
+            if (nvdProgress && nvdProgress.total > 0 && nvdProgress.current > 0) {
+                setBannerMessage(`NVD refresh in progress: ${nvdProgress.current}/${nvdProgress.total}`);
+                setBannerType('success');
+                setBannerVisible(true);
+            }
+        } else if (prevNvdInProgress.current === true) {
+            onRefreshComplete?.();
+            const total = nvdProgress?.total ?? 0;
+            setBannerMessage(`NVD refresh complete${total > 0 ? ` (${total} CVEs)` : ''}`);
+            setBannerType('success');
+            setBannerVisible(true);
+        }
+        prevNvdInProgress.current = inProgress;
+    }, [nvdProgress, onRefreshComplete]);
+
+    // Update banner with live EPSS progress; reload data when the refresh completes
+    useEffect(() => {
+        const inProgress = epssProgress?.in_progress ?? false;
+        if (inProgress) {
+            if (epssProgress && epssProgress.total > 0 && epssProgress.current > 0) {
+                setBannerMessage(`EPSS refresh in progress: ${epssProgress.current}/${epssProgress.total}`);
+                setBannerType('success');
+                setBannerVisible(true);
+            }
+        } else if (prevEpssInProgress.current === true) {
+            onRefreshComplete?.();
+            const total = epssProgress?.total ?? 0;
+            setBannerMessage(`EPSS refresh complete${total > 0 ? ` (${total} CVEs)` : ''}`);
+            setBannerType('success');
+            setBannerVisible(true);
+        }
+        prevEpssInProgress.current = inProgress;
+    }, [epssProgress, onRefreshComplete]);
 
     // Fetch NVD progress on mount and periodically
     useEffect(() => {
@@ -1385,6 +1427,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             variantId={variantId}
             baseVariantId={baseVariantId}
             compareOperation={compareOperation}
+            nvdProgress={nvdProgress}
+            epssProgress={epssProgress}
         />
 
         <TableGeneric

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -321,7 +321,9 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const searchHelperDropdownRef = useRef<HTMLDivElement>(null);
     const moreFiltersRef = useRef<HTMLDivElement>(null);
     const prevNvdInProgress = useRef<boolean | null>(null);
+    const prevNvdPhase = useRef<string | null>(null);
     const prevEpssInProgress = useRef<boolean | null>(null);
+    const prevEpssPhase = useRef<string | null>(null);
 
     const keyboardShortcuts = [
         { key: '/', description: 'Focus search bar' },
@@ -350,39 +352,72 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     // Update banner with live NVD progress; reload data when the refresh completes
     useEffect(() => {
         const inProgress = nvdProgress?.in_progress ?? false;
+        const phase = nvdProgress?.phase;
+        const justCompleted = prevNvdPhase.current !== null && (
+            prevNvdInProgress.current === true ||
+            (prevNvdPhase.current !== 'completed' &&
+             prevNvdPhase.current !== 'cancelled' &&
+             (phase === 'completed' || phase === 'cancelled')));
         if (inProgress) {
             if (nvdProgress && nvdProgress.total > 0 && nvdProgress.current > 0) {
                 setBannerMessage(`NVD refresh in progress: ${nvdProgress.current}/${nvdProgress.total}`);
                 setBannerType('success');
                 setBannerVisible(true);
             }
-        } else if (prevNvdInProgress.current === true) {
+        } else if (justCompleted) {
             onRefreshComplete?.();
-            const total = nvdProgress?.total ?? 0;
-            setBannerMessage(`NVD refresh complete${total > 0 ? ` (${total} CVEs)` : ''}`);
-            setBannerType('success');
+            if (phase === 'cancelled') {
+                const current = nvdProgress?.current ?? 0;
+                const total = nvdProgress?.total ?? 0;
+                setBannerMessage(`NVD refresh cancelled${current > 0 ? ` (${current}/${total} CVEs)` : ''}`);
+                setBannerType('error');
+            } else {
+                const total = nvdProgress?.total ?? 0;
+                setBannerMessage(`NVD refresh complete${total > 0 ? ` (${total} CVEs)` : ''}`);
+                setBannerType('success');
+            }
             setBannerVisible(true);
         }
-        prevNvdInProgress.current = inProgress;
+        if (nvdProgress !== null) {
+            prevNvdInProgress.current = inProgress;
+            prevNvdPhase.current = phase ?? 'idle';
+        }
     }, [nvdProgress, onRefreshComplete]);
 
     // Update banner with live EPSS progress; reload data when the refresh completes
     useEffect(() => {
         const inProgress = epssProgress?.in_progress ?? false;
+        // EPSS can complete before the 5-second poll catches in_progress: true, so also detect completion via phase transition.
+        const phase = epssProgress?.phase;
+        const justCompleted = prevEpssPhase.current !== null && (
+            prevEpssInProgress.current === true ||
+            (prevEpssPhase.current !== 'completed' &&
+             prevEpssPhase.current !== 'cancelled' &&
+             (phase === 'completed' || phase === 'cancelled')));
         if (inProgress) {
             if (epssProgress && epssProgress.total > 0 && epssProgress.current > 0) {
                 setBannerMessage(`EPSS refresh in progress: ${epssProgress.current}/${epssProgress.total}`);
                 setBannerType('success');
                 setBannerVisible(true);
             }
-        } else if (prevEpssInProgress.current === true) {
+        } else if (justCompleted) {
             onRefreshComplete?.();
-            const total = epssProgress?.total ?? 0;
-            setBannerMessage(`EPSS refresh complete${total > 0 ? ` (${total} CVEs)` : ''}`);
-            setBannerType('success');
+            if (phase === 'cancelled') {
+                const current = epssProgress?.current ?? 0;
+                const total = epssProgress?.total ?? 0;
+                setBannerMessage(`EPSS refresh cancelled${current > 0 ? ` (${current}/${total} CVEs)` : ''}`);
+                setBannerType('error');
+            } else {
+                const total = epssProgress?.total ?? 0;
+                setBannerMessage(`EPSS refresh complete${total > 0 ? ` (${total} CVEs)` : ''}`);
+                setBannerType('success');
+            }
             setBannerVisible(true);
         }
-        prevEpssInProgress.current = inProgress;
+        if (epssProgress !== null) {
+            prevEpssInProgress.current = inProgress;
+            prevEpssPhase.current = phase ?? 'idle';
+        }
     }, [epssProgress, onRefreshComplete]);
 
     // Fetch NVD progress on mount and periodically

--- a/frontend/tests/handlers/bulkRefresh.test.ts
+++ b/frontend/tests/handlers/bulkRefresh.test.ts
@@ -1,5 +1,5 @@
-import { BulkNvdRefreshHandler, BulkEpssRefreshHandler } from "../../src/handlers/bulkRefresh";
-import type { BulkRefreshResponse } from "../../src/handlers/bulkRefresh";
+import { BulkNvdRefreshHandler, BulkEpssRefreshHandler, BulkNvdRefreshCancelHandler, BulkEpssRefreshCancelHandler } from "../../src/handlers/bulkRefresh";
+import type { BulkRefreshResponse, CancelRefreshResponse } from "../../src/handlers/bulkRefresh";
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch as typeof fetch;
@@ -112,6 +112,72 @@ describe("BulkEpssRefreshHandler.trigger", () => {
             json: async () => { throw new Error("bad json"); },
         } as unknown as Response);
         const result = await BulkEpssRefreshHandler.trigger(["CVE-2024-0001"]);
+        expect(result).toBeNull();
+    });
+});
+
+const makeOkCancelResponse = (body: CancelRefreshResponse) => ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+} as Response);
+
+describe("BulkNvdRefreshCancelHandler.trigger", () => {
+    it("returns CancelRefreshResponse on 200", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkCancelResponse({ status: "cancelling" }));
+        const result = await BulkNvdRefreshCancelHandler.trigger();
+        expect(result).not.toBeNull();
+        expect(result!.status).toBe("cancelling");
+    });
+
+    it("sends POST to the correct cancel endpoint", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkCancelResponse({ status: "cancelling" }));
+        await BulkNvdRefreshCancelHandler.trigger();
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/vulnerabilities/cancel-nvd-refresh"),
+            expect.objectContaining({ method: "POST" }),
+        );
+    });
+
+    it("returns null on 409 (nothing in progress)", async () => {
+        mockFetch.mockResolvedValueOnce(makeErrorResponse(409));
+        const result = await BulkNvdRefreshCancelHandler.trigger();
+        expect(result).toBeNull();
+    });
+
+    it("returns null when fetch rejects", async () => {
+        mockFetch.mockRejectedValueOnce(new Error("network error"));
+        const result = await BulkNvdRefreshCancelHandler.trigger();
+        expect(result).toBeNull();
+    });
+});
+
+describe("BulkEpssRefreshCancelHandler.trigger", () => {
+    it("returns CancelRefreshResponse on 200", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkCancelResponse({ status: "cancelling" }));
+        const result = await BulkEpssRefreshCancelHandler.trigger();
+        expect(result).not.toBeNull();
+        expect(result!.status).toBe("cancelling");
+    });
+
+    it("sends POST to the correct cancel endpoint", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkCancelResponse({ status: "cancelling" }));
+        await BulkEpssRefreshCancelHandler.trigger();
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/vulnerabilities/cancel-epss-refresh"),
+            expect.objectContaining({ method: "POST" }),
+        );
+    });
+
+    it("returns null on 409 (nothing in progress)", async () => {
+        mockFetch.mockResolvedValueOnce(makeErrorResponse(409));
+        const result = await BulkEpssRefreshCancelHandler.trigger();
+        expect(result).toBeNull();
+    });
+
+    it("returns null when fetch rejects", async () => {
+        mockFetch.mockRejectedValueOnce(new Error("network error"));
+        const result = await BulkEpssRefreshCancelHandler.trigger();
         expect(result).toBeNull();
     });
 });

--- a/frontend/tests/handlers/bulkRefresh.test.ts
+++ b/frontend/tests/handlers/bulkRefresh.test.ts
@@ -1,0 +1,117 @@
+import { BulkNvdRefreshHandler, BulkEpssRefreshHandler } from "../../src/handlers/bulkRefresh";
+import type { BulkRefreshResponse } from "../../src/handlers/bulkRefresh";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as typeof fetch;
+
+beforeEach(() => {
+    mockFetch.mockReset();
+});
+
+const makeOkResponse = (body: BulkRefreshResponse) => ({
+    ok: true,
+    status: 202,
+    json: async () => body,
+} as Response);
+
+const makeErrorResponse = (status: number) => ({
+    ok: false,
+    status,
+    json: async () => ({ error: "error" }),
+} as Response);
+
+describe("BulkNvdRefreshHandler.trigger", () => {
+    it("returns BulkRefreshResponse on 202", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkResponse({ status: "started", total: 5 }));
+        const result = await BulkNvdRefreshHandler.trigger(["CVE-2024-0001", "CVE-2024-0002"]);
+        expect(result).not.toBeNull();
+        expect(result!.status).toBe("started");
+        expect(result!.total).toBe(5);
+    });
+
+    it("sends the correct request body", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkResponse({ status: "started", total: 1 }));
+        const cveIds = ["CVE-2024-0001"];
+        await BulkNvdRefreshHandler.trigger(cveIds);
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/vulnerabilities/bulk-nvd-refresh"),
+            expect.objectContaining({
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ cve_ids: cveIds }),
+            }),
+        );
+    });
+
+    it("returns null on 409 (already in progress)", async () => {
+        mockFetch.mockResolvedValueOnce(makeErrorResponse(409));
+        const result = await BulkNvdRefreshHandler.trigger(["CVE-2024-0001"]);
+        expect(result).toBeNull();
+    });
+
+    it("returns null on 400 (bad request)", async () => {
+        mockFetch.mockResolvedValueOnce(makeErrorResponse(400));
+        const result = await BulkNvdRefreshHandler.trigger([]);
+        expect(result).toBeNull();
+    });
+
+    it("returns null when fetch rejects", async () => {
+        mockFetch.mockRejectedValueOnce(new Error("network error"));
+        const result = await BulkNvdRefreshHandler.trigger(["CVE-2024-0001"]);
+        expect(result).toBeNull();
+    });
+
+    it("returns null when json() throws (malformed 202 body)", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 202,
+            json: async () => { throw new Error("bad json"); },
+        } as unknown as Response);
+        const result = await BulkNvdRefreshHandler.trigger(["CVE-2024-0001"]);
+        expect(result).toBeNull();
+    });
+});
+
+describe("BulkEpssRefreshHandler.trigger", () => {
+    it("returns BulkRefreshResponse on 202", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkResponse({ status: "started", total: 10 }));
+        const result = await BulkEpssRefreshHandler.trigger(["CVE-2024-0001"]);
+        expect(result).not.toBeNull();
+        expect(result!.total).toBe(10);
+    });
+
+    it("sends the correct request body", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkResponse({ status: "started", total: 1 }));
+        const cveIds = ["CVE-2024-0001", "CVE-2024-0002"];
+        await BulkEpssRefreshHandler.trigger(cveIds);
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/vulnerabilities/bulk-epss-refresh"),
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ cve_ids: cveIds }),
+            }),
+        );
+    });
+
+    it("returns null on 409", async () => {
+        mockFetch.mockResolvedValueOnce(makeErrorResponse(409));
+        const result = await BulkEpssRefreshHandler.trigger(["CVE-2024-0001"]);
+        expect(result).toBeNull();
+    });
+
+    it("returns null on 400", async () => {
+        mockFetch.mockResolvedValueOnce(makeErrorResponse(400));
+        const result = await BulkEpssRefreshHandler.trigger([]);
+        expect(result).toBeNull();
+    });
+
+    it("returns null when json() throws (malformed 202 body)", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 202,
+            json: async () => { throw new Error("bad json"); },
+        } as unknown as Response);
+        const result = await BulkEpssRefreshHandler.trigger(["CVE-2024-0001"]);
+        expect(result).toBeNull();
+    });
+});

--- a/frontend/tests/handlers/epssRefresh.test.ts
+++ b/frontend/tests/handlers/epssRefresh.test.ts
@@ -86,4 +86,26 @@ describe("EpssRefreshHandler.triggerSingleRefresh", () => {
         const result = await EpssRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
         expect(result).toBeNull();
     });
+
+    it("returns null when vulnerabilities array is empty", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ vulnerabilities: [] }),
+        } as Response);
+
+        const result = await EpssRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
+        expect(result).toBeNull();
+    });
+
+    it("returns null when json() throws (malformed response)", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => { throw new Error("invalid json"); },
+        } as unknown as Response);
+
+        const result = await EpssRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
+        expect(result).toBeNull();
+    });
 });

--- a/frontend/tests/handlers/nvdRefresh.test.ts
+++ b/frontend/tests/handlers/nvdRefresh.test.ts
@@ -82,4 +82,34 @@ describe("NvdRefreshHandler.triggerSingleRefresh", () => {
             expect(result.apiKeyConfigured).toBe(true);
         }
     });
+
+    it("returns kind:error code:unavailable when vulnerabilities array is empty", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ vulnerabilities: [] }),
+        } as Response);
+
+        const result = await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
+        expect(result.kind).toBe("error");
+        if (result.kind === "error") {
+            expect(result.code).toBe("unavailable");
+            expect(result.apiKeyConfigured).toBe(true);
+        }
+    });
+
+    it("returns kind:error code:unavailable when json() throws (malformed response)", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => { throw new Error("invalid json"); },
+        } as unknown as Response);
+
+        const result = await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
+        expect(result.kind).toBe("error");
+        if (result.kind === "error") {
+            expect(result.code).toBe("unavailable");
+            expect(result.apiKeyConfigured).toBe(true);
+        }
+    });
 });

--- a/frontend/tests/unit_tests/test_dropdown_menu.tsx
+++ b/frontend/tests/unit_tests/test_dropdown_menu.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import DropdownMenu from '../../src/components/DropdownMenu';
+
+describe('DropdownMenu', () => {
+    const items = [
+        { label: 'Edit', onClick: jest.fn() },
+        { label: 'Delete', onClick: jest.fn() },
+    ];
+
+    beforeEach(() => {
+        jest.restoreAllMocks();
+        items.forEach((item) => item.onClick.mockReset());
+    });
+
+    const mockButtonPosition = (rect: Partial<DOMRect>, innerHeight: number) => {
+        Object.defineProperty(window, 'innerHeight', {
+            configurable: true,
+            value: innerHeight,
+        });
+
+        jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            toJSON: () => {},
+            ...rect,
+        } as DOMRect);
+    };
+
+    it('opens the menu, invokes an item and closes it again', async () => {
+        const user = userEvent.setup();
+        render(<DropdownMenu items={items} />);
+
+        await user.click(screen.getByRole('button', { name: /actions menu/i }));
+        await user.click(screen.getByText('Edit'));
+
+        expect(items[0].onClick).toHaveBeenCalledTimes(1);
+        expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    });
+
+    it('closes when clicking outside the portal', async () => {
+        const user = userEvent.setup();
+        render(<DropdownMenu items={items} />);
+
+        await user.click(screen.getByRole('button', { name: /actions menu/i }));
+        expect(screen.getByText('Delete')).toBeInTheDocument();
+
+        await user.click(document.body);
+        expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    });
+
+    it('positions the menu above the button when space below is limited', async () => {
+        const user = userEvent.setup();
+        mockButtonPosition({ top: 250, bottom: 290, right: 400 }, 320);
+        render(<DropdownMenu items={items} />);
+
+        await user.click(screen.getByRole('button', { name: /actions menu/i }));
+
+        const menu = document.body.querySelector('div.fixed') as HTMLElement;
+        expect(menu).toHaveStyle({ top: '154px' });
+    });
+
+    it('positions the menu below the button when there is enough space', async () => {
+        const user = userEvent.setup();
+        mockButtonPosition({ top: 50, bottom: 70, right: 240 }, 900);
+        render(<DropdownMenu items={items} />);
+
+        await user.click(screen.getByRole('button', { name: /actions menu/i }));
+
+        const menu = document.body.querySelector('div.fixed') as HTMLElement;
+        expect(menu).toHaveStyle({ top: '74px' });
+    });
+});

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -289,21 +289,84 @@ describe('MultiEditBar', () => {
 
         render(<MultiEditBar {...props} />);
 
+        // Open the refresh dropdown, then click the trigger button (both NVD and EPSS selected by default)
         await act(async () => {
-            await userEvent.click(screen.getByRole('button', { name: 'Refresh NVD' }));
-            await userEvent.click(screen.getByRole('button', { name: 'Refresh EPSS' }));
-            await userEvent.click(screen.getByRole('button', { name: 'Refresh NVD + EPSS' }));
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        await act(async () => {
+            await userEvent.click(screen.getByRole('button', { name: /Refresh 2 targets/i }));
         });
 
         await waitFor(() => {
             expect(mockTriggerBanner).toHaveBeenCalledWith('NVD refresh started for 2 CVE(s)', 'success');
             expect(mockTriggerBanner).toHaveBeenCalledWith('EPSS refresh started for 2 CVE(s)', 'success');
-            expect(mockTriggerBanner).toHaveBeenCalledWith('Refresh started: NVD 2 CVE(s), EPSS 2 CVE(s)', 'success');
         });
 
-        expect(mockHideBanner).toHaveBeenCalledTimes(3);
+        expect(mockHideBanner).toHaveBeenCalledTimes(1);
         expect(mockBulkNvdTrigger).toHaveBeenCalledWith(['vuln-1', 'vuln-2']);
         expect(mockBulkEpssTrigger).toHaveBeenCalledWith(['vuln-1', 'vuln-2']);
+    });
+
+    test('does not trigger NVD refresh when NVD is already in progress', async () => {
+        const mockTriggerBanner = jest.fn();
+        const mockBulkNvdTrigger = BulkNvdRefreshHandler.trigger as jest.Mock;
+        const mockBulkEpssTrigger = BulkEpssRefreshHandler.trigger as jest.Mock;
+
+        mockBulkEpssTrigger.mockResolvedValue({ status: 'success', total: 2 });
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1', 'vuln-2'],
+            triggerBanner: mockTriggerBanner,
+            hideBanner: jest.fn(),
+            nvdProgress: { in_progress: true, phase: 'bulk_nvd_refresh', current: 1, total: 10, message: '' },
+        };
+
+        render(<MultiEditBar {...props} />);
+
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        // Button shows only 1 actionable target (EPSS)
+        await act(async () => {
+            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+        });
+
+        await waitFor(() => {
+            expect(mockBulkEpssTrigger).toHaveBeenCalledWith(['vuln-1', 'vuln-2']);
+        });
+        expect(mockBulkNvdTrigger).not.toHaveBeenCalled();
+    });
+
+    test('does not trigger EPSS refresh when EPSS is already in progress', async () => {
+        const mockTriggerBanner = jest.fn();
+        const mockBulkNvdTrigger = BulkNvdRefreshHandler.trigger as jest.Mock;
+        const mockBulkEpssTrigger = BulkEpssRefreshHandler.trigger as jest.Mock;
+
+        mockBulkNvdTrigger.mockResolvedValue({ status: 'success', total: 2 });
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1', 'vuln-2'],
+            triggerBanner: mockTriggerBanner,
+            hideBanner: jest.fn(),
+            epssProgress: { in_progress: true, phase: 'bulk_epss_refresh', current: 1, total: 10, message: '' },
+        };
+
+        render(<MultiEditBar {...props} />);
+
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        // Button shows only 1 actionable target (NVD)
+        await act(async () => {
+            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+        });
+
+        await waitFor(() => {
+            expect(mockBulkNvdTrigger).toHaveBeenCalledWith(['vuln-1', 'vuln-2']);
+        });
+        expect(mockBulkEpssTrigger).not.toHaveBeenCalled();
     });
 
     test('shows loading spinner when isLoading is true', () => {
@@ -850,33 +913,42 @@ describe('MultiEditBar', () => {
         expect(variantIds).toContain('v-base');
     });
 
-    test('shows Cancel NVD button only when nvdProgress.in_progress is true', () => {
+    test('shows Cancel NVD button only when nvdProgress.in_progress is true', async () => {
         const props = {
             ...mockProps,
             selectedVulns: ['vuln-1'],
             nvdProgress: { in_progress: true, phase: 'bulk_nvd_refresh', current: 1, total: 10, message: '' },
         };
         render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
         expect(screen.getByTestId('cancel-nvd-refresh')).toBeInTheDocument();
     });
 
-    test('does not show Cancel NVD button when nvdProgress.in_progress is false', () => {
+    test('does not show Cancel NVD button when nvdProgress.in_progress is false', async () => {
         const props = {
             ...mockProps,
             selectedVulns: ['vuln-1'],
             nvdProgress: { in_progress: false, phase: 'idle', current: 0, total: 0, message: '' },
         };
         render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
         expect(screen.queryByTestId('cancel-nvd-refresh')).toBeNull();
     });
 
-    test('shows Cancel EPSS button only when epssProgress.in_progress is true', () => {
+    test('shows Cancel EPSS button only when epssProgress.in_progress is true', async () => {
         const props = {
             ...mockProps,
             selectedVulns: ['vuln-1'],
             epssProgress: { in_progress: true, phase: 'bulk_epss_refresh', current: 1, total: 10, message: '' },
         };
         render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
         expect(screen.getByTestId('cancel-epss-refresh')).toBeInTheDocument();
     });
 
@@ -893,6 +965,9 @@ describe('MultiEditBar', () => {
         };
         render(<MultiEditBar {...props} />);
 
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
         await act(async () => {
             await userEvent.click(screen.getByTestId('cancel-nvd-refresh'));
         });
@@ -917,6 +992,9 @@ describe('MultiEditBar', () => {
         render(<MultiEditBar {...props} />);
 
         await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        await act(async () => {
             await userEvent.click(screen.getByTestId('cancel-epss-refresh'));
         });
 
@@ -939,6 +1017,10 @@ describe('MultiEditBar', () => {
         };
         render(<MultiEditBar {...props} />);
 
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+
         const button = screen.getByTestId('cancel-nvd-refresh');
         expect(button).not.toBeDisabled();
 
@@ -946,5 +1028,283 @@ describe('MultiEditBar', () => {
 
         expect(button).toBeDisabled();
         expect(button.textContent).toBe('Cancelling…');
+    });
+
+    // ---- Refresh dropdown: checkbox toggles ----
+
+    test('unchecking NVD reduces actionable count to 1', async () => {
+        const props = { ...mockProps, selectedVulns: ['vuln-1'] };
+        render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        // Both checked by default → button says "Refresh 2 targets"
+        expect(screen.getByRole('button', { name: /Refresh 2 targets/i })).toBeInTheDocument();
+
+        // Uncheck NVD
+        const nvdCheckbox = screen.getByRole('checkbox', { name: /NVD/i });
+        await act(async () => { await userEvent.click(nvdCheckbox); });
+        expect(screen.getByRole('button', { name: /Refresh 1 target$/i })).toBeInTheDocument();
+    });
+
+    test('unchecking EPSS reduces actionable count to 1', async () => {
+        const props = { ...mockProps, selectedVulns: ['vuln-1'] };
+        render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        const epssCheckbox = screen.getByRole('checkbox', { name: /EPSS/i });
+        await act(async () => { await userEvent.click(epssCheckbox); });
+        expect(screen.getByRole('button', { name: /Refresh 1 target$/i })).toBeInTheDocument();
+    });
+
+    test('refresh button is disabled when all targets are unchecked', async () => {
+        const props = { ...mockProps, selectedVulns: ['vuln-1'] };
+        render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        await act(async () => {
+            await userEvent.click(screen.getByRole('checkbox', { name: /NVD/i }));
+        });
+        await act(async () => {
+            await userEvent.click(screen.getByRole('checkbox', { name: /EPSS/i }));
+        });
+        expect(screen.getByRole('button', { name: /Refresh 0 targets/i })).toBeDisabled();
+    });
+
+    test('clicking outside the refresh dropdown closes it', async () => {
+        const props = { ...mockProps, selectedVulns: ['vuln-1'] };
+        render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        expect(screen.getByRole('button', { name: /Refresh 2 targets/i })).toBeInTheDocument();
+
+        // Click outside
+        await act(async () => {
+            fireEvent.mouseDown(document.body);
+        });
+        expect(screen.queryByRole('button', { name: /Refresh 2 targets/i })).toBeNull();
+    });
+
+    // ---- Refresh handler: failure and catch paths ----
+
+    test('shows error banner when NVD refresh trigger returns null', async () => {
+        const mockTriggerBanner = jest.fn();
+        (BulkNvdRefreshHandler.trigger as jest.Mock).mockResolvedValue(null);
+        (BulkEpssRefreshHandler.trigger as jest.Mock).mockResolvedValue({ status: 'success', total: 1 });
+
+        const props = { ...mockProps, selectedVulns: ['vuln-1'], triggerBanner: mockTriggerBanner, hideBanner: jest.fn() };
+        render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        // Uncheck EPSS so only NVD is triggered
+        await act(async () => {
+            await userEvent.click(screen.getByRole('checkbox', { name: /EPSS/i }));
+        });
+        await act(async () => {
+            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+        });
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to start NVD refresh', 'error');
+        });
+    });
+
+    test('shows error banner when NVD refresh trigger throws', async () => {
+        const mockTriggerBanner = jest.fn();
+        (BulkNvdRefreshHandler.trigger as jest.Mock).mockRejectedValue(new Error('network'));
+
+        const props = { ...mockProps, selectedVulns: ['vuln-1'], triggerBanner: mockTriggerBanner, hideBanner: jest.fn() };
+        render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        await act(async () => {
+            await userEvent.click(screen.getByRole('checkbox', { name: /EPSS/i }));
+        });
+        await act(async () => {
+            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+        });
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to start NVD refresh', 'error');
+        });
+    });
+
+    test('shows error banner when EPSS refresh trigger returns null', async () => {
+        const mockTriggerBanner = jest.fn();
+        (BulkEpssRefreshHandler.trigger as jest.Mock).mockResolvedValue(null);
+
+        const props = { ...mockProps, selectedVulns: ['vuln-1'], triggerBanner: mockTriggerBanner, hideBanner: jest.fn() };
+        render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        await act(async () => {
+            await userEvent.click(screen.getByRole('checkbox', { name: /NVD/i }));
+        });
+        await act(async () => {
+            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+        });
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to start EPSS refresh', 'error');
+        });
+    });
+
+    test('shows error banner when EPSS refresh trigger throws', async () => {
+        const mockTriggerBanner = jest.fn();
+        (BulkEpssRefreshHandler.trigger as jest.Mock).mockRejectedValue(new Error('network'));
+
+        const props = { ...mockProps, selectedVulns: ['vuln-1'], triggerBanner: mockTriggerBanner, hideBanner: jest.fn() };
+        render(<MultiEditBar {...props} />);
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        });
+        await act(async () => {
+            await userEvent.click(screen.getByRole('checkbox', { name: /NVD/i }));
+        });
+        await act(async () => {
+            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+        });
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to start EPSS refresh', 'error');
+        });
+    });
+
+    // ---- Cancel handlers: failure paths ----
+
+    test('Cancel NVD: shows error banner and resets cancelling when trigger returns null', async () => {
+        const mockTriggerBanner = jest.fn();
+        (BulkNvdRefreshCancelHandler.trigger as jest.Mock).mockResolvedValue(null);
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            nvdProgress: { in_progress: true, phase: 'bulk_nvd_refresh', current: 1, total: 10, message: '' },
+            triggerBanner: mockTriggerBanner,
+        };
+        render(<MultiEditBar {...props} />);
+        await act(async () => { await userEvent.click(screen.getByTestId('refresh-dropdown-toggle')); });
+        await act(async () => { await userEvent.click(screen.getByTestId('cancel-nvd-refresh')); });
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to cancel NVD refresh', 'error');
+        });
+        // Cancelling flag should reset so button is enabled again
+        expect(screen.getByTestId('cancel-nvd-refresh')).not.toBeDisabled();
+    });
+
+    test('Cancel NVD: shows error banner and resets cancelling when trigger throws', async () => {
+        const mockTriggerBanner = jest.fn();
+        (BulkNvdRefreshCancelHandler.trigger as jest.Mock).mockRejectedValue(new Error('network'));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            nvdProgress: { in_progress: true, phase: 'bulk_nvd_refresh', current: 1, total: 10, message: '' },
+            triggerBanner: mockTriggerBanner,
+        };
+        render(<MultiEditBar {...props} />);
+        await act(async () => { await userEvent.click(screen.getByTestId('refresh-dropdown-toggle')); });
+        await act(async () => { await userEvent.click(screen.getByTestId('cancel-nvd-refresh')); });
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to cancel NVD refresh', 'error');
+        });
+        expect(screen.getByTestId('cancel-nvd-refresh')).not.toBeDisabled();
+    });
+
+    test('Cancel EPSS: shows error banner and resets cancelling when trigger returns null', async () => {
+        const mockTriggerBanner = jest.fn();
+        (BulkEpssRefreshCancelHandler.trigger as jest.Mock).mockResolvedValue(null);
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            epssProgress: { in_progress: true, phase: 'bulk_epss_refresh', current: 1, total: 10, message: '' },
+            triggerBanner: mockTriggerBanner,
+        };
+        render(<MultiEditBar {...props} />);
+        await act(async () => { await userEvent.click(screen.getByTestId('refresh-dropdown-toggle')); });
+        await act(async () => { await userEvent.click(screen.getByTestId('cancel-epss-refresh')); });
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to cancel EPSS refresh', 'error');
+        });
+        expect(screen.getByTestId('cancel-epss-refresh')).not.toBeDisabled();
+    });
+
+    test('Cancel EPSS: shows error banner and resets cancelling when trigger throws', async () => {
+        const mockTriggerBanner = jest.fn();
+        (BulkEpssRefreshCancelHandler.trigger as jest.Mock).mockRejectedValue(new Error('network'));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            epssProgress: { in_progress: true, phase: 'bulk_epss_refresh', current: 1, total: 10, message: '' },
+            triggerBanner: mockTriggerBanner,
+        };
+        render(<MultiEditBar {...props} />);
+        await act(async () => { await userEvent.click(screen.getByTestId('refresh-dropdown-toggle')); });
+        await act(async () => { await userEvent.click(screen.getByTestId('cancel-epss-refresh')); });
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to cancel EPSS refresh', 'error');
+        });
+        expect(screen.getByTestId('cancel-epss-refresh')).not.toBeDisabled();
+    });
+
+    // ---- addAssessment: errors array and catch paths (using variantId to bypass listByVuln) ----
+
+    test('addAssessment error path: shows errors array message when batch returns errors (variantId set)', async () => {
+        const mockTriggerBanner = jest.fn();
+        // First fetch: Variants.listAll() triggered when status panel opens with variantId set
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'variant-1', project_id: 'p1' }]));
+        // Second fetch: batch POST
+        fetchMock.mockResponseOnce(JSON.stringify({
+            status: 'error',
+            errors: [{ error: 'vuln not found' }, { error: 'invalid status' }]
+        }), { status: 400 });
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            variantId: 'v1',
+            triggerBanner: mockTriggerBanner,
+        };
+        const { getByText } = render(<MultiEditBar {...props} />);
+        await act(async () => { getByText('Change status').click(); });
+        const select = document.querySelector('[name="new_assessment_status"]') as HTMLSelectElement;
+        fireEvent.change(select, { target: { value: 'affected' } });
+        await act(async () => { getByText('Add assessment').click(); });
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith(
+                'Failed to add assessments: Errors: vuln not found, invalid status',
+                'error'
+            );
+        });
+    });
+
+    test('addAssessment catch path: shows error banner when batch POST throws (variantId set)', async () => {
+        const mockTriggerBanner = jest.fn();
+        // First fetch: Variants.listAll() triggered when status panel opens with variantId set
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'variant-1', project_id: 'p1' }]));
+        // Second fetch: batch POST rejects
+        fetchMock.mockRejectOnce(new Error('Network failure'));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            variantId: 'v1',
+            triggerBanner: mockTriggerBanner,
+        };
+        const { getByText } = render(<MultiEditBar {...props} />);
+        await act(async () => { getByText('Change status').click(); });
+        const select = document.querySelector('[name="new_assessment_status"]') as HTMLSelectElement;
+        fireEvent.change(select, { target: { value: 'affected' } });
+        await act(async () => { getByText('Add assessment').click(); });
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith(
+                expect.stringContaining('Failed to add assessments'),
+                'error'
+            );
+        });
     });
 });

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -294,7 +294,7 @@ describe('MultiEditBar', () => {
             await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
         });
         await act(async () => {
-            await userEvent.click(screen.getByRole('button', { name: /Refresh 2 targets/i }));
+            await userEvent.click(screen.getByRole('button', { name: /^Start$/i }));
         });
 
         await waitFor(() => {
@@ -329,7 +329,7 @@ describe('MultiEditBar', () => {
         });
         // Button shows only 1 actionable target (EPSS)
         await act(async () => {
-            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+            await userEvent.click(screen.getByRole('button', { name: /^Start$/i }));
         });
 
         await waitFor(() => {
@@ -360,7 +360,7 @@ describe('MultiEditBar', () => {
         });
         // Button shows only 1 actionable target (NVD)
         await act(async () => {
-            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+            await userEvent.click(screen.getByRole('button', { name: /^Start$/i }));
         });
 
         await waitFor(() => {
@@ -1032,22 +1032,22 @@ describe('MultiEditBar', () => {
 
     // ---- Refresh dropdown: checkbox toggles ----
 
-    test('unchecking NVD reduces actionable count to 1', async () => {
+    test('unchecking NVD keeps Start button present and enabled', async () => {
         const props = { ...mockProps, selectedVulns: ['vuln-1'] };
         render(<MultiEditBar {...props} />);
         await act(async () => {
             await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
         });
-        // Both checked by default → button says "Refresh 2 targets"
-        expect(screen.getByRole('button', { name: /Refresh 2 targets/i })).toBeInTheDocument();
+        // Both checked by default → Start button is enabled
+        expect(screen.getByRole('button', { name: /^Start$/i })).toBeEnabled();
 
         // Uncheck NVD
         const nvdCheckbox = screen.getByRole('checkbox', { name: /NVD/i });
         await act(async () => { await userEvent.click(nvdCheckbox); });
-        expect(screen.getByRole('button', { name: /Refresh 1 target$/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^Start$/i })).toBeEnabled();
     });
 
-    test('unchecking EPSS reduces actionable count to 1', async () => {
+    test('unchecking EPSS keeps Start button present and enabled', async () => {
         const props = { ...mockProps, selectedVulns: ['vuln-1'] };
         render(<MultiEditBar {...props} />);
         await act(async () => {
@@ -1055,7 +1055,7 @@ describe('MultiEditBar', () => {
         });
         const epssCheckbox = screen.getByRole('checkbox', { name: /EPSS/i });
         await act(async () => { await userEvent.click(epssCheckbox); });
-        expect(screen.getByRole('button', { name: /Refresh 1 target$/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^Start$/i })).toBeEnabled();
     });
 
     test('refresh button is disabled when all targets are unchecked', async () => {
@@ -1070,7 +1070,7 @@ describe('MultiEditBar', () => {
         await act(async () => {
             await userEvent.click(screen.getByRole('checkbox', { name: /EPSS/i }));
         });
-        expect(screen.getByRole('button', { name: /Refresh 0 targets/i })).toBeDisabled();
+        expect(screen.getByRole('button', { name: /^Start$/i })).toBeDisabled();
     });
 
     test('clicking outside the refresh dropdown closes it', async () => {
@@ -1079,13 +1079,13 @@ describe('MultiEditBar', () => {
         await act(async () => {
             await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
         });
-        expect(screen.getByRole('button', { name: /Refresh 2 targets/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^Start$/i })).toBeInTheDocument();
 
         // Click outside
         await act(async () => {
             fireEvent.mouseDown(document.body);
         });
-        expect(screen.queryByRole('button', { name: /Refresh 2 targets/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /^Start$/i })).toBeNull();
     });
 
     // ---- Refresh handler: failure and catch paths ----
@@ -1105,7 +1105,7 @@ describe('MultiEditBar', () => {
             await userEvent.click(screen.getByRole('checkbox', { name: /EPSS/i }));
         });
         await act(async () => {
-            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+            await userEvent.click(screen.getByRole('button', { name: /^Start$/i }));
         });
         await waitFor(() => {
             expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to start NVD refresh', 'error');
@@ -1125,7 +1125,7 @@ describe('MultiEditBar', () => {
             await userEvent.click(screen.getByRole('checkbox', { name: /EPSS/i }));
         });
         await act(async () => {
-            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+            await userEvent.click(screen.getByRole('button', { name: /^Start$/i }));
         });
         await waitFor(() => {
             expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to start NVD refresh', 'error');
@@ -1145,7 +1145,7 @@ describe('MultiEditBar', () => {
             await userEvent.click(screen.getByRole('checkbox', { name: /NVD/i }));
         });
         await act(async () => {
-            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+            await userEvent.click(screen.getByRole('button', { name: /^Start$/i }));
         });
         await waitFor(() => {
             expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to start EPSS refresh', 'error');
@@ -1165,7 +1165,7 @@ describe('MultiEditBar', () => {
             await userEvent.click(screen.getByRole('checkbox', { name: /NVD/i }));
         });
         await act(async () => {
-            await userEvent.click(screen.getByRole('button', { name: /Refresh 1 target/i }));
+            await userEvent.click(screen.getByRole('button', { name: /^Start$/i }));
         });
         await waitFor(() => {
             expect(mockTriggerBanner).toHaveBeenCalledWith('Failed to start EPSS refresh', 'error');

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -14,10 +14,16 @@ jest.mock('../../src/handlers/bulkRefresh', () => ({
     BulkEpssRefreshHandler: {
         trigger: jest.fn(),
     },
+    BulkNvdRefreshCancelHandler: {
+        trigger: jest.fn(),
+    },
+    BulkEpssRefreshCancelHandler: {
+        trigger: jest.fn(),
+    },
 }));
 
 import MultiEditBar from '../../src/components/MultiEditBar';
-import { BulkNvdRefreshHandler, BulkEpssRefreshHandler } from '../../src/handlers/bulkRefresh';
+import { BulkNvdRefreshHandler, BulkEpssRefreshHandler, BulkNvdRefreshCancelHandler, BulkEpssRefreshCancelHandler } from '../../src/handlers/bulkRefresh';
 import type { Vulnerability } from '../../src/handlers/vulnerabilities';
 
 describe('MultiEditBar', () => {
@@ -842,5 +848,103 @@ describe('MultiEditBar', () => {
         const variantIds = body.assessments.map((a: any) => a.variant_id);
         expect(variantIds).toContain('v-cmp');
         expect(variantIds).toContain('v-base');
+    });
+
+    test('shows Cancel NVD button only when nvdProgress.in_progress is true', () => {
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            nvdProgress: { in_progress: true, phase: 'bulk_nvd_refresh', current: 1, total: 10, message: '' },
+        };
+        render(<MultiEditBar {...props} />);
+        expect(screen.getByTestId('cancel-nvd-refresh')).toBeInTheDocument();
+    });
+
+    test('does not show Cancel NVD button when nvdProgress.in_progress is false', () => {
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            nvdProgress: { in_progress: false, phase: 'idle', current: 0, total: 0, message: '' },
+        };
+        render(<MultiEditBar {...props} />);
+        expect(screen.queryByTestId('cancel-nvd-refresh')).toBeNull();
+    });
+
+    test('shows Cancel EPSS button only when epssProgress.in_progress is true', () => {
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            epssProgress: { in_progress: true, phase: 'bulk_epss_refresh', current: 1, total: 10, message: '' },
+        };
+        render(<MultiEditBar {...props} />);
+        expect(screen.getByTestId('cancel-epss-refresh')).toBeInTheDocument();
+    });
+
+    test('clicking Cancel NVD calls BulkNvdRefreshCancelHandler.trigger and shows banner', async () => {
+        const mockTriggerBanner = jest.fn();
+        const mockCancelTrigger = BulkNvdRefreshCancelHandler.trigger as jest.Mock;
+        mockCancelTrigger.mockResolvedValue({ status: 'cancelling' });
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            nvdProgress: { in_progress: true, phase: 'bulk_nvd_refresh', current: 1, total: 10, message: '' },
+            triggerBanner: mockTriggerBanner,
+        };
+        render(<MultiEditBar {...props} />);
+
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('cancel-nvd-refresh'));
+        });
+
+        await waitFor(() => {
+            expect(mockCancelTrigger).toHaveBeenCalled();
+            expect(mockTriggerBanner).toHaveBeenCalledWith('NVD refresh cancellation requested', 'success');
+        });
+    });
+
+    test('clicking Cancel EPSS calls BulkEpssRefreshCancelHandler.trigger and shows banner', async () => {
+        const mockTriggerBanner = jest.fn();
+        const mockCancelTrigger = BulkEpssRefreshCancelHandler.trigger as jest.Mock;
+        mockCancelTrigger.mockResolvedValue({ status: 'cancelling' });
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            epssProgress: { in_progress: true, phase: 'bulk_epss_refresh', current: 1, total: 10, message: '' },
+            triggerBanner: mockTriggerBanner,
+        };
+        render(<MultiEditBar {...props} />);
+
+        await act(async () => {
+            await userEvent.click(screen.getByTestId('cancel-epss-refresh'));
+        });
+
+        await waitFor(() => {
+            expect(mockCancelTrigger).toHaveBeenCalled();
+            expect(mockTriggerBanner).toHaveBeenCalledWith('EPSS refresh cancellation requested', 'success');
+        });
+    });
+
+    test('Cancel NVD button becomes disabled after click (cancelling state)', async () => {
+        const mockCancelTrigger = BulkNvdRefreshCancelHandler.trigger as jest.Mock;
+        // Never resolves so we can check intermediate state
+        mockCancelTrigger.mockReturnValue(new Promise(() => {}));
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1'],
+            nvdProgress: { in_progress: true, phase: 'bulk_nvd_refresh', current: 1, total: 10, message: '' },
+            triggerBanner: jest.fn(),
+        };
+        render(<MultiEditBar {...props} />);
+
+        const button = screen.getByTestId('cancel-nvd-refresh');
+        expect(button).not.toBeDisabled();
+
+        await act(async () => { await userEvent.click(button); });
+
+        expect(button).toBeDisabled();
+        expect(button.textContent).toBe('Cancelling…');
     });
 });

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -1,11 +1,23 @@
-import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, fireEvent, waitFor, act, screen } from '@testing-library/react';
 import "@testing-library/jest-dom";
 // @ts-expect-error TS6133
 import React from 'react';
 import fetchMock from 'jest-fetch-mock';
+import userEvent from '@testing-library/user-event';
 fetchMock.enableMocks();
 
+jest.mock('../../src/handlers/bulkRefresh', () => ({
+    __esModule: true,
+    BulkNvdRefreshHandler: {
+        trigger: jest.fn(),
+    },
+    BulkEpssRefreshHandler: {
+        trigger: jest.fn(),
+    },
+}));
+
 import MultiEditBar from '../../src/components/MultiEditBar';
+import { BulkNvdRefreshHandler, BulkEpssRefreshHandler } from '../../src/handlers/bulkRefresh';
 import type { Vulnerability } from '../../src/handlers/vulnerabilities';
 
 describe('MultiEditBar', () => {
@@ -251,6 +263,41 @@ describe('MultiEditBar', () => {
         resetButton.click();
 
         expect(mockResetVulns).toHaveBeenCalled();
+    });
+
+    test('triggers the bulk refresh buttons and reports success', async () => {
+        const mockTriggerBanner = jest.fn();
+        const mockHideBanner = jest.fn();
+        const mockBulkNvdTrigger = BulkNvdRefreshHandler.trigger as jest.Mock;
+        const mockBulkEpssTrigger = BulkEpssRefreshHandler.trigger as jest.Mock;
+
+        mockBulkNvdTrigger.mockResolvedValue({ status: 'success', total: 2 });
+        mockBulkEpssTrigger.mockResolvedValue({ status: 'success', total: 2 });
+
+        const props = {
+            ...mockProps,
+            selectedVulns: ['vuln-1', 'vuln-2'],
+            triggerBanner: mockTriggerBanner,
+            hideBanner: mockHideBanner
+        };
+
+        render(<MultiEditBar {...props} />);
+
+        await act(async () => {
+            await userEvent.click(screen.getByRole('button', { name: 'Refresh NVD' }));
+            await userEvent.click(screen.getByRole('button', { name: 'Refresh EPSS' }));
+            await userEvent.click(screen.getByRole('button', { name: 'Refresh NVD + EPSS' }));
+        });
+
+        await waitFor(() => {
+            expect(mockTriggerBanner).toHaveBeenCalledWith('NVD refresh started for 2 CVE(s)', 'success');
+            expect(mockTriggerBanner).toHaveBeenCalledWith('EPSS refresh started for 2 CVE(s)', 'success');
+            expect(mockTriggerBanner).toHaveBeenCalledWith('Refresh started: NVD 2 CVE(s), EPSS 2 CVE(s)', 'success');
+        });
+
+        expect(mockHideBanner).toHaveBeenCalledTimes(3);
+        expect(mockBulkNvdTrigger).toHaveBeenCalledWith(['vuln-1', 'vuln-2']);
+        expect(mockBulkEpssTrigger).toHaveBeenCalledWith(['vuln-1', 'vuln-2']);
     });
 
     test('shows loading spinner when isLoading is true', () => {

--- a/frontend/tests/unit_tests/test_notification_modal.tsx
+++ b/frontend/tests/unit_tests/test_notification_modal.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import NotificationModal, { type Notification } from '../../src/components/NotificationModal';
+
+describe('NotificationModal', () => {
+    const baseNotification = {
+        level: 'warning',
+        title: 'Check the scan results',
+        message: 'A vulnerability requires attention.',
+        action: 'Run vulnscout --refresh',
+    } satisfies Notification;
+
+    it.each([
+        ['warning', 'text-yellow-400', 'border-yellow-500'],
+        ['error', 'text-red-400', 'border-red-500'],
+        ['info', 'text-cyan-300', 'border-cyan-500'],
+    ] as const)('renders the %s style variant', (level, labelClass, borderClass) => {
+        render(<NotificationModal notification={{ ...baseNotification, level }} />);
+
+        expect(screen.getByText(level)).toHaveClass(labelClass);
+        expect(document.body.querySelector(`.${borderClass}`)).toBeInTheDocument();
+        expect(screen.getByText(baseNotification.title)).toBeInTheDocument();
+        expect(screen.getByText(baseNotification.message)).toBeInTheDocument();
+        expect(screen.getByText(baseNotification.action as string)).toBeInTheDocument();
+    });
+
+    it('omits the action box when no action is provided', () => {
+        render(<NotificationModal notification={{ ...baseNotification, action: undefined }} />);
+
+        expect(screen.queryByText(baseNotification.action as string)).not.toBeInTheDocument();
+    });
+});

--- a/frontend/tests/unit_tests/test_scan_progress_panel.tsx
+++ b/frontend/tests/unit_tests/test_scan_progress_panel.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
+
+import ScanProgressPanel from '../../src/components/ScanProgressPanel';
+import type { ScanEntryState } from '../../src/handlers/scanStateManager';
+
+describe('ScanProgressPanel', () => {
+    const colors = {
+        border: 'border-cyan-500/60',
+        headerBg: 'bg-cyan-900/40',
+        iconText: 'text-cyan-300',
+        titleText: 'text-cyan-200',
+        subtitleText: 'text-cyan-300/80',
+        bar: 'bg-cyan-500',
+    };
+
+    const makeEntry = (status: ScanEntryState['status'], overrides: Partial<ScanEntryState> = {}): ScanEntryState => ({
+        variantId: 'variant-1',
+        variantName: 'Variant 1',
+        status,
+        error: null,
+        progress: status === 'done' ? 'Done' : 'Running',
+        logs: [],
+        total: 4,
+        doneCount: status === 'done' ? 4 : 2,
+        ...overrides,
+    });
+
+    it('shows the queued state without a dismiss button', () => {
+        render(
+            <ScanProgressPanel
+                entry={makeEntry('queued', { progress: 'Queued', logs: ['Waiting for previous scan to finish…'] })}
+                label="Grype Scan"
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText(/grype scan – variant 1 queued/i)).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+        expect(document.body.querySelector('.animate-pulse')).toBeInTheDocument();
+    });
+
+    it('renders running and complete states with the expected log styling', async () => {
+        const user = userEvent.setup();
+        const onDismiss = jest.fn();
+
+        const { rerender } = render(
+            <ScanProgressPanel
+                entry={makeEntry('running', {
+                    progress: '2 / 4',
+                        logs: ['[ERROR] scanning', '✓ finished step'],
+                })}
+                label="NVD Scan"
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={onDismiss}
+            />,
+        );
+
+        expect(screen.getByText(/nvd scan – variant 1 in progress/i)).toBeInTheDocument();
+        expect(screen.queryByText('Waiting for first results…')).not.toBeInTheDocument();
+        expect(screen.getByText('[ERROR] scanning')).toHaveClass('text-red-400');
+        expect(screen.getByText('✓ finished step')).toHaveClass('text-green-400', 'font-semibold');
+
+        rerender(
+            <ScanProgressPanel
+                entry={makeEntry('done', {
+                    progress: '4 / 4',
+                    logs: ['✓ completed'],
+                })}
+                label="NVD Scan"
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={onDismiss}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /close/i }));
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+        expect(screen.getByText(/nvd scan – variant 1 complete/i)).toBeInTheDocument();
+        expect(document.body.querySelector('.bg-green-500')).toBeInTheDocument();
+    });
+});

--- a/frontend/tests/unit_tests/test_versions_line.tsx
+++ b/frontend/tests/unit_tests/test_versions_line.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import VersionsLine, { type version } from '../../src/components/VersionsLine';
+
+describe('VersionsLine', () => {
+    const versions: version[] = [
+        { title: '1.0', highlight: 'alpha', details: 'first release', left_color: 'bg-red-500' },
+        { title: '2.0', details: 'second release' },
+        { title: '3.0' },
+    ];
+
+    it('renders the version markers, labels and details', () => {
+        const { container } = render(<VersionsLine versions={versions} />);
+
+        expect(screen.getByText('1.0')).toBeInTheDocument();
+        expect(screen.getByText('alpha')).toBeInTheDocument();
+        expect(screen.getByText('first release')).toBeInTheDocument();
+        expect(screen.getByText('2.0')).toBeInTheDocument();
+        expect(screen.getByText('second release')).toBeInTheDocument();
+        expect(screen.getByText('3.0')).toBeInTheDocument();
+        expect(container.querySelector('.bg-red-500')).toBeInTheDocument();
+    });
+
+    it('switches to the compact label sizes when reduce_size is true', () => {
+        const { container } = render(<VersionsLine versions={versions} reduce_size />);
+
+        expect(screen.getByText('1.0')).toHaveClass('text-sm');
+        expect(container.querySelector('.text-xs')).toBeInTheDocument();
+    });
+});

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -4,7 +4,7 @@ fetchMock.enableMocks();
 
 jest.setTimeout(15000);
 
-import { fireEvent, render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import "@testing-library/jest-dom";
 // @ts-expect-error TS6133
@@ -2506,5 +2506,133 @@ describe('NVD timestamp columns', () => {
             const html = document.body.innerHTML;
             expect(html.indexOf('CVE-LATER')).toBeLessThan(html.indexOf('CVE-EARLIER'));
         });
+    });
+
+    test('shows NVD completion banner via phase transition (fast-complete path)', async () => {
+        jest.useFakeTimers();
+        try {
+            const NVDProgressHandler = require('../../src/handlers/nvd_progress').default;
+            NVDProgressHandler.getProgress
+                .mockResolvedValueOnce({ in_progress: false, phase: 'idle', current: 0, total: 0, message: '' })
+                .mockResolvedValueOnce({ in_progress: false, phase: 'completed', current: 10, total: 10, message: '' });
+
+            render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+            await act(async () => { await Promise.resolve(); });
+            await act(async () => { jest.advanceTimersByTime(5001); });
+            await act(async () => { await Promise.resolve(); });
+
+            await waitFor(() => {
+                expect(screen.getByText(/NVD refresh complete \(10 CVEs\)/i)).toBeInTheDocument();
+            });
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('shows NVD cancelled banner when phase transitions to cancelled', async () => {
+        jest.useFakeTimers();
+        try {
+            const NVDProgressHandler = require('../../src/handlers/nvd_progress').default;
+            NVDProgressHandler.getProgress
+                .mockResolvedValueOnce({ in_progress: true, phase: 'bulk_nvd_refresh', current: 3, total: 10, message: '' })
+                .mockResolvedValueOnce({ in_progress: false, phase: 'cancelled', current: 3, total: 10, message: '' });
+
+            render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+            await act(async () => { await Promise.resolve(); });
+            await act(async () => { jest.advanceTimersByTime(5001); });
+            await act(async () => { await Promise.resolve(); });
+
+            await waitFor(() => {
+                expect(screen.getByText(/NVD refresh cancelled \(3\/10 CVEs\)/i)).toBeInTheDocument();
+            });
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('shows EPSS completion banner via phase transition (fast-complete path)', async () => {
+        jest.useFakeTimers();
+        try {
+            const EPSSProgressHandler = require('../../src/handlers/epss_progress').default;
+            EPSSProgressHandler.getProgress
+                .mockResolvedValueOnce({ in_progress: false, phase: 'idle', current: 0, total: 0, message: '' })
+                .mockResolvedValueOnce({ in_progress: false, phase: 'completed', current: 50, total: 50, message: '' });
+
+            render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+            await act(async () => { await Promise.resolve(); });
+            await act(async () => { jest.advanceTimersByTime(5001); });
+            await act(async () => { await Promise.resolve(); });
+
+            await waitFor(() => {
+                expect(screen.getByText(/EPSS refresh complete \(50 CVEs\)/i)).toBeInTheDocument();
+            });
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('shows EPSS cancelled banner when phase transitions to cancelled', async () => {
+        jest.useFakeTimers();
+        try {
+            const EPSSProgressHandler = require('../../src/handlers/epss_progress').default;
+            EPSSProgressHandler.getProgress
+                .mockResolvedValueOnce({ in_progress: true, phase: 'bulk_epss_refresh', current: 5, total: 20, message: '' })
+                .mockResolvedValueOnce({ in_progress: false, phase: 'cancelled', current: 5, total: 20, message: '' });
+
+            render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+            await act(async () => { await Promise.resolve(); });
+            await act(async () => { jest.advanceTimersByTime(5001); });
+            await act(async () => { await Promise.resolve(); });
+
+            await waitFor(() => {
+                expect(screen.getByText(/EPSS refresh cancelled \(5\/20 CVEs\)/i)).toBeInTheDocument();
+            });
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('does not show EPSS banner on first load when phase is already completed', async () => {
+        jest.useFakeTimers();
+        try {
+            const EPSSProgressHandler = require('../../src/handlers/epss_progress').default;
+            // First poll returns completed — as if the server finished before the page loaded.
+            EPSSProgressHandler.getProgress.mockResolvedValue({
+                in_progress: false, phase: 'completed', current: 50, total: 50, message: ''
+            });
+
+            render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+            // Flush the initial fetch
+            await act(async () => { await Promise.resolve(); });
+
+            expect(screen.queryByText(/EPSS refresh complete/i)).not.toBeInTheDocument();
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('does not show NVD banner on first load when phase is already completed', async () => {
+        jest.useFakeTimers();
+        try {
+            const NVDProgressHandler = require('../../src/handlers/nvd_progress').default;
+            // First poll returns completed — as if the server finished before the page loaded.
+            NVDProgressHandler.getProgress.mockResolvedValue({
+                in_progress: false, phase: 'completed', current: 10, total: 10, message: ''
+            });
+
+            render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+            // Flush the initial fetch
+            await act(async () => { await Promise.resolve(); });
+
+            expect(screen.queryByText(/NVD refresh complete/i)).not.toBeInTheDocument();
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -1770,34 +1770,34 @@ describe('Vulnerability Table', () => {
         });
     });
 
-    test('published date column can be disabled', async () => {
+    test('published date column is hidden by default but can be enabled', async () => {
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
 
-        // Published Date column is visible by default
-        expect(screen.queryByRole('columnheader', { name: /published date/i })).toBeInTheDocument();
+        // Published Date column is hidden by default
+        expect(screen.queryByRole('columnheader', { name: /published date/i })).not.toBeInTheDocument();
 
-        // Disable Published Date column via Columns filter
+        // Enable Published Date column via Columns filter
         const buttons = await screen.getAllByRole('button', { name: /columns/i });
         await user.click(buttons[0]);
 
         const publishedDateCheckbox = await screen.getByRole('checkbox', { name: 'Published Date' });
         await user.click(publishedDateCheckbox);
 
-        // Published Date column should not be visible
+        // Published Date column should now be visible
         await waitFor(() => {
-            expect(screen.queryByRole('columnheader', { name: /published date/i })).not.toBeInTheDocument();
+            expect(screen.queryByRole('columnheader', { name: /published date/i })).toBeInTheDocument();
         });
 
-        // Check that dates are not rendered (formatted as short month)
+        // Check that dates are rendered (formatted as short month)
         await waitFor(() => {
             [/May 15, 2010/, /Jul 22, 2018/].forEach(date => {
-            expect(screen.queryByText(date)).not.toBeInTheDocument();
+            expect(screen.queryByText(date)).toBeInTheDocument();
             });
         });
     });
 
-    test('published date column shows "Unknown" for vulnerabilities without published date', async () => {
+    test('published date column shows "Requires a NVD refresh" for vulnerabilities without published date', async () => {
         const vulnsWithMissing: Vulnerability[] = [
             ...vulnerabilities,
             {
@@ -1833,11 +1833,19 @@ describe('Vulnerability Table', () => {
         ];
 
         render(<TableVulnerabilities vulnerabilities={vulnsWithMissing} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
 
-        // "Unknown" should appear for the vuln without published date
+        // Published Date column is hidden by default, so enable it first
+        const buttons = await screen.getAllByRole('button', { name: /columns/i });
+        await user.click(buttons[0]);
+
+        const publishedDateCheckbox = await screen.getByRole('checkbox', { name: 'Published Date' });
+        await user.click(publishedDateCheckbox);
+
+        // Now "Requires a NVD refresh" should appear for the vuln without published date
         await waitFor(() => {
-            const unknownElements = screen.getAllByText('Unknown');
-            expect(unknownElements.length).toBeGreaterThan(0);
+            const refreshElements = screen.getAllByText('Requires a NVD refresh');
+            expect(refreshElements.length).toBeGreaterThan(0);
         });
     });
 

--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -23,10 +23,10 @@ DEFAULT_DB_URI = "sqlite:////cache/vulnscout/vulnscout.db"
 
 
 def _launch_enrichment(app):
-    """Spawn background threads for EPSS and NVD enrichment.
+    """Spawn background thread for EPSS enrichment.
 
-    Each runs in its own thread so they execute in parallel and neither
-    blocks Flask request handlers (WAL journal mode allows concurrent reads).
+    Runs in its own thread so it doesn't block Flask request handlers
+    (WAL journal mode allows concurrent reads).
     """
     def _enrich_epss():
         with app.app_context():
@@ -44,20 +44,7 @@ def _launch_enrichment(app):
             except Exception as e:
                 print(f"[enrichment/epss] {e}", flush=True)
 
-    def _enrich_nvd():
-        with app.app_context():
-            db.session.autoflush = False
-            try:
-                from ..controllers.packages import PackagesController
-                from ..controllers.vulnerabilities import VulnerabilitiesController
-                pkgCtrl = PackagesController()
-                vulnCtrl = VulnerabilitiesController(pkgCtrl)
-                vulnCtrl.fetch_nvd_data()
-            except Exception as e:
-                print(f"[enrichment/nvd] {e}", flush=True)
-
     threading.Thread(target=_enrich_epss, name="enrichment-epss", daemon=True).start()
-    threading.Thread(target=_enrich_nvd, name="enrichment-nvd", daemon=True).start()
 
 
 def create_app():

--- a/src/controllers/nvd_apply.py
+++ b/src/controllers/nvd_apply.py
@@ -2,6 +2,39 @@
 
 import datetime
 
+from ..models import Metrics
+
+
+def apply_cvss_update(rec, details: dict, db) -> None:
+    """Upsert the CVSS Metrics row for *rec* from NVD *details* (in-place, no commit).
+
+    *db* must be the SQLAlchemy extension instance (passed in to keep this module
+    free of Flask extension imports at load time).
+    """
+    base_score = details.get("base_score")
+    cvss_version = details.get("cvss_version")
+    cvss_vector = details.get("cvss_vector")
+    if base_score is None or cvss_version is None:
+        return
+    existing = db.session.execute(
+        db.select(Metrics).where(
+            Metrics.vulnerability_id == rec.id,
+            Metrics.version == cvss_version,
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        if float(existing.score or 0) != float(base_score) or existing.vector != cvss_vector:
+            existing.score = base_score
+            existing.vector = cvss_vector or existing.vector
+    else:
+        db.session.add(Metrics(
+            vulnerability_id=rec.id,
+            version=cvss_version,
+            score=base_score,
+            vector=cvss_vector or "",
+            author="nvd",
+        ))
+
 
 def apply_nvd_update(vuln_record, details: dict, now: datetime.datetime) -> bool:
     """Compare NVD *details* against *vuln_record* and update in place if different.

--- a/src/controllers/progress_tracker.py
+++ b/src/controllers/progress_tracker.py
@@ -17,6 +17,7 @@ class ProgressTracker:
         self._default_phase = default_phase
         self._completed_message = completed_message
         self._lock = Lock()
+        self._cancelled = False
         self._data = {
             "in_progress": False,
             "phase": "idle",
@@ -32,6 +33,7 @@ class ProgressTracker:
         phase = phase or self._default_phase
         now = datetime.now(timezone.utc).isoformat()
         with self._lock:
+            self._cancelled = False
             self._data = {
                 "in_progress": True,
                 "phase": phase,
@@ -58,6 +60,34 @@ class ProgressTracker:
             self._data["in_progress"] = False
             self._data["phase"] = "completed"
             self._data["message"] = self._completed_message
+            self._data["last_update"] = datetime.now(timezone.utc).isoformat()
+
+    def cancel(self):
+        """Request cancellation of the in-progress enrichment.
+
+        Thread-safe: the background thread must poll ``is_cancelled()`` and
+        call ``cancelled()`` itself once it has safely stopped.
+        Returns True if a cancellation was requested (refresh was in progress),
+        False if nothing was running.
+        """
+        with self._lock:
+            if not self._data["in_progress"]:
+                return False
+            self._cancelled = True
+            return True
+
+    def is_cancelled(self) -> bool:
+        """Return True if a cancellation has been requested."""
+        with self._lock:
+            return self._cancelled
+
+    def mark_cancelled(self):
+        """Called by the background thread once it has stopped gracefully."""
+        with self._lock:
+            self._cancelled = False
+            self._data["in_progress"] = False
+            self._data["phase"] = "cancelled"
+            self._data["message"] = "Bulk refresh cancelled"
             self._data["last_update"] = datetime.now(timezone.utc).isoformat()
 
     def error(self, message: str):

--- a/src/controllers/progress_tracker.py
+++ b/src/controllers/progress_tracker.py
@@ -44,6 +44,34 @@ class ProgressTracker:
                 "started_at": now,
             }
 
+    def start_if_idle(self, phase: Optional[str] = None) -> bool:
+        """Atomically start only if no operation is currently in progress.
+
+        Combines the in_progress check and the state transition into a single
+        lock acquisition, eliminating the TOCTOU race that exists when callers
+        do ``get_progress()["in_progress"]`` followed by a separate ``start()``.
+
+        Returns True when the tracker was idle and has been started.
+        Returns False when an operation was already in progress (caller should
+        return HTTP 409).
+        """
+        phase = phase or self._default_phase
+        now = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            if self._data["in_progress"]:
+                return False
+            self._cancelled = False
+            self._data = {
+                "in_progress": True,
+                "phase": phase,
+                "current": 0,
+                "total": 0,
+                "message": f"Starting {phase}",
+                "last_update": now,
+                "started_at": now,
+            }
+            return True
+
     def update(self, phase: str, current: int, total: int, message: Optional[str] = None):
         """Update progress information."""
         with self._lock:

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -21,13 +21,6 @@ from ..models.metrics import Metrics as MetricsModel
 from ..extensions import db
 
 
-# ---------------------------------------------------------------------------
-# Remote-refresh delay helpers
-# ---------------------------------------------------------------------------
-# DEPRECATED: Caching/staleness system has been removed.
-# All data fetches now attempt fresh data from remote sources.
-
-
 def _batch_commit(done: int, total: int, label: str) -> None:
     """Try to commit the DB session and log progress.
 

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -24,60 +24,8 @@ from ..extensions import db
 # ---------------------------------------------------------------------------
 # Remote-refresh delay helpers
 # ---------------------------------------------------------------------------
-
-_NEVER = datetime.timedelta.max
-_ALWAYS = None  # sentinel: always re-fetch
-
-
-def parse_refresh_delay(value: Optional[str]) -> Optional[datetime.timedelta]:
-    """Parse a REFRESH_REMOTE_DELAY string into a timedelta.
-
-    Accepted formats:
-      * ``\"never\"``  – only fetch data that was never fetched before
-      * ``\"always\"`` – always re-fetch regardless of age
-      * ``\"<N>h\"``   – re-fetch when data is older than N hours  (e.g. ``48h``, default)
-      * ``"<N>d"``   – re-fetch when data is older than N days   (e.g. ``7d``)
-      * ``"<N>w"``   – re-fetch when data is older than N weeks  (e.g. ``2w``)
-      * ``"<N>m"``   – re-fetch when data is older than N minutes (e.g. ``30m``)
-
-    Returns ``datetime.timedelta.max`` for ``"never"``, ``None`` for
-    ``"always"``, or a :class:`datetime.timedelta` for duration values.
-    """
-    if value is None:
-        return _NEVER
-    v = value.strip().lower()
-    if v == "never":
-        return _NEVER
-    if v == "always":
-        return _ALWAYS
-    units = {"h": "hours", "d": "days", "w": "weeks", "m": "minutes"}
-    if v and v[-1] in units:
-        try:
-            return datetime.timedelta(**{units[v[-1]]: float(v[:-1])})
-        except ValueError:
-            pass
-    raise ValueError(
-        f"Invalid REFRESH_REMOTE_DELAY value {value!r}. "
-        "Use 'never', 'always', or a duration like '48h', '7d', '2w', '30m'."
-    )
-
-
-def _should_refetch(fetched_at: Optional[datetime.datetime], delay: Optional[datetime.timedelta]) -> bool:
-    """Return True if the entry should be (re-)fetched.
-
-    * delay is ``None`` (always)         → always True
-    * ``fetched_at`` is ``None``         → True  (never fetched)
-    * delay is ``timedelta.max`` (never) → False (already fetched, skip)
-    * otherwise                          → True if the data is older than *delay*
-    """
-    if delay is _ALWAYS:
-        return True
-    if fetched_at is None:
-        return True
-    if delay is _NEVER:
-        return False
-    assert delay is not None
-    return (datetime.datetime.utcnow() - fetched_at) >= delay
+# DEPRECATED: Caching/staleness system has been removed.
+# All data fetches now attempt fresh data from remote sources.
 
 
 def _batch_commit(done: int, total: int, label: str) -> None:
@@ -352,29 +300,16 @@ class VulnerabilitiesController:
         start_time = time.time()
         nb_vuln = 0
 
-        refresh_delay = parse_refresh_delay(os.environ.get("REFRESH_REMOTE_DELAY"))
-
         # Only CVE-prefixed IDs exist in the EPSS database.
-        # Bulk-fetch epss_fetched_at timestamps to avoid N+1 queries.
         all_cve_ids = [vid for vid in self.vulnerabilities if vid.startswith("CVE-")]
-        fetched_at_map = Vulnerability.get_fetched_at_bulk(all_cve_ids)  # {id: (epss_fa, nvd_fa)}
 
-        cve_vulns = {}
+        cve_vulns = {vid: self.vulnerabilities[vid] for vid in all_cve_ids}
         skipped_non_cve = len(self.vulnerabilities) - len(all_cve_ids)
-        skipped_fresh = 0
-        for vid in all_cve_ids:
-            epss_fa = fetched_at_map.get(vid, (None, None))[0]
-            if _should_refetch(epss_fa, refresh_delay):
-                cve_vulns[vid] = self.vulnerabilities[vid]
-            else:
-                skipped_fresh += 1
 
         total = len(cve_vulns)
         msg = f"=== EPSS: starting enrichment for {total} CVEs"
         if skipped_non_cve:
             msg += f" ({skipped_non_cve} non-CVE IDs skipped)"
-        if skipped_fresh:
-            msg += f" ({skipped_fresh} already up-to-date, skipped)"
         print(msg, flush=True)
 
         tracker = EPSSProgressTracker
@@ -516,20 +451,9 @@ class VulnerabilitiesController:
         start_time = time.time()
         nb_vuln = 0
 
-        refresh_delay = parse_refresh_delay(os.environ.get("REFRESH_REMOTE_DELAY"))
-
-        # Bulk-fetch nvd_fetched_at timestamps to avoid N+1 queries.
-        all_ids = list(self.vulnerabilities.keys())
-        fetched_at_map = Vulnerability.get_fetched_at_bulk(all_ids)  # {id: (epss_fa, nvd_fa)}
-
         ghsa_vulns = {}
         nvd_vulns = []
-        skipped_fresh = 0
         for vuln in self.vulnerabilities.values():
-            nvd_fa = fetched_at_map.get(vuln.id, (None, None))[1]
-            if not _should_refetch(nvd_fa, refresh_delay):
-                skipped_fresh += 1
-                continue
             if "GHSA" in vuln.id:
                 ghsa_vulns[vuln.id] = vuln
             else:
@@ -537,8 +461,6 @@ class VulnerabilitiesController:
 
         total = len(nvd_vulns) + len(ghsa_vulns)
         msg = f"=== NVD: starting enrichment — {len(nvd_vulns)} CVEs + {len(ghsa_vulns)} GHSAs"
-        if skipped_fresh:
-            msg += f" ({skipped_fresh} already up-to-date, skipped)"
         print(msg, flush=True)
         tracker = NVDProgressTracker
         tracker.start("nvd_enrichment")
@@ -552,8 +474,6 @@ class VulnerabilitiesController:
                 result = nvd_api.fetch_cve_data(vuln.id)
                 if result and result.get("not_found"):
                     # NVD has no record for this CVE (404 or empty result set).
-                    # Persist nvd_fetched_at as a sentinel so it is not re-queried
-                    # on every restart; _should_refetch will retry after REFRESH_REMOTE_DELAY.
                     print(f"=== NVD: {vuln.id} not found in NVD database.", flush=True)
                     try:
                         rec = self._db_record_cache.get(vuln.id) or Vulnerability.get_by_id(vuln.id)

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
+from .bulk_refresh import init_app as init_bulk_refresh_app
 from .packages import init_app as init_pkg_app
 from .vulnerabilities import init_app as init_vuln_app
 from .assessments import init_app as init_assess_app
@@ -28,6 +29,7 @@ def init_app(app):
     init_variant_app(app)
     init_scans_app(app)
     init_scan_triggers_app(app)
+    init_bulk_refresh_app(app)
     init_config_app(app)
     init_notifications_app(app)
     init_settings_app(app)

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -96,7 +96,6 @@ def init_app(app):
                 sleep_between = _nvd_sleep_interval()
                 nvd_api_key = os.getenv("NVD_API_KEY")
                 nvd = NVD_DB(nvd_api_key=nvd_api_key)
-                now = datetime.datetime.now(datetime.timezone.utc)
                 done = 0
                 try:
                     for cve_id in cve_ids:
@@ -106,6 +105,7 @@ def init_app(app):
                             return
 
                         try:
+                            now = datetime.datetime.now(datetime.timezone.utc)
                             status_code, data = nvd.api_get_cve(cve_id, max_retries=2)
                             if status_code == 200 and data.get("vulnerabilities"):
                                 cve = data["vulnerabilities"][0]["cve"]

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -93,6 +93,11 @@ def init_app(app):
                 done = 0
                 try:
                     for cve_id in cve_ids:
+                        if NVDProgressTracker.is_cancelled():
+                            _safe_commit("bulk NVD refresh cancel")
+                            NVDProgressTracker.mark_cancelled()
+                            return
+
                         try:
                             status_code, data = nvd.api_get_cve(cve_id, max_retries=2)
                             if status_code == 200 and data.get("vulnerabilities"):
@@ -129,6 +134,17 @@ def init_app(app):
 
         threading.Thread(target=_run, name="bulk-nvd-refresh", daemon=True).start()
         return jsonify({"status": "started", "total": total}), 202
+
+    @app.route('/api/vulnerabilities/cancel-nvd-refresh', methods=['POST'])
+    def cancel_nvd_refresh():
+        """Request cancellation of an in-progress bulk NVD refresh.
+
+        Returns 200 when the cancellation was accepted (refresh was running).
+        Returns 409 when no bulk NVD refresh is currently in progress.
+        """
+        if NVDProgressTracker.cancel():
+            return jsonify({"status": "cancelling"}), 200
+        return jsonify({"error": "No bulk NVD refresh is currently in progress"}), 409
 
     @app.route('/api/vulnerabilities/bulk-epss-refresh', methods=['POST'])
     def bulk_epss_refresh():
@@ -170,6 +186,11 @@ def init_app(app):
                         for i in range(0, total, _EPSS_BATCH_SIZE)
                     ]
                     for chunk in chunks:
+                        if EPSSProgressTracker.is_cancelled():
+                            _safe_commit("bulk EPSS refresh cancel")
+                            EPSSProgressTracker.mark_cancelled()
+                            return
+
                         try:
                             results = epss.api_get_epss_batch(chunk)
                         except Exception as exc:
@@ -212,3 +233,14 @@ def init_app(app):
 
         threading.Thread(target=_run, name="bulk-epss-refresh", daemon=True).start()
         return jsonify({"status": "started", "total": total}), 202
+
+    @app.route('/api/vulnerabilities/cancel-epss-refresh', methods=['POST'])
+    def cancel_epss_refresh():
+        """Request cancellation of an in-progress bulk EPSS refresh.
+
+        Returns 200 when the cancellation was accepted (refresh was running).
+        Returns 409 when no bulk EPSS refresh is currently in progress.
+        """
+        if EPSSProgressTracker.cancel():
+            return jsonify({"status": "cancelling"}), 200
+        return jsonify({"error": "No bulk EPSS refresh is currently in progress"}), 409

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -1,0 +1,214 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Bulk NVD and EPSS refresh endpoints.
+
+Each endpoint accepts a list of CVE IDs and spawns a background daemon thread
+to perform the actual API calls for all of them.
+Progress is reported via the shared NVDProgressTracker / EPSSProgressTracker
+singletons, which are already polled by /api/nvd/progress and /api/epss/progress.
+"""
+
+import datetime
+import os
+import re
+import threading
+import time
+
+from flask import jsonify, request
+
+from ..models import Vulnerability
+from ..extensions import db
+from ..controllers.nvd_db import NVD_DB
+from ..controllers.nvd_apply import apply_nvd_update, apply_cvss_update
+from ..controllers.epss_db import EPSS_DB
+from ..controllers.nvd_progress import NVDProgressTracker
+from ..controllers.epss_progress import EPSSProgressTracker
+
+_EPSS_BATCH_SIZE = 100
+_NVD_COMMIT_EVERY = 50
+# HIGH: cap prevents unbounded background threads (no API key = 6 s/CVE × N seconds of work)
+_MAX_CVE_IDS = 1000
+# HIGH: only accept well-formed CVE identifiers to avoid wasting rate-limit quota
+_CVE_RE = re.compile(r'^CVE-\d{4}-\d{4,}$')
+
+
+def _nvd_sleep_interval() -> float:
+    """Return seconds to sleep between NVD API calls based on key presence.
+
+    Without an API key: 5 req / 30 s → 6 s per call.
+    With an API key:   50 req / 30 s → 0.6 s per call.
+
+    Reference: https://nvd.nist.gov/developers/start-here, section "Rate Limits"
+    """
+    return 0.6 if os.getenv("NVD_API_KEY") else 6.0
+
+
+def _safe_commit(label: str) -> None:
+    """Commit the current session; rollback and log on failure."""
+    try:
+        db.session.commit()
+    except Exception as exc:
+        print(f"[{label}] commit error: {exc}", flush=True)
+        db.session.rollback()
+
+
+def init_app(app):
+
+    @app.route('/api/vulnerabilities/bulk-nvd-refresh', methods=['POST'])
+    def bulk_nvd_refresh():
+        """Trigger a bulk NVD refresh for a list of CVE IDs.
+
+        Body: ``{"cve_ids": ["CVE-A", "CVE-B", ...]}``
+
+        Returns 202 immediately and runs the refresh in a background thread.
+        Returns 409 if a refresh is already in progress.
+        Returns 400 if cve_ids is empty or contains no valid CVE identifiers.
+        """
+        body = request.get_json(force=True, silent=True) or {}
+        raw_ids = body.get("cve_ids", [])
+        if not raw_ids or not isinstance(raw_ids, list):
+            return jsonify({"error": "cve_ids must be a non-empty list"}), 400
+
+        if NVDProgressTracker.get_progress()["in_progress"]:
+            return jsonify({"error": "A bulk NVD refresh is already in progress"}), 409
+
+        cve_ids = [c.strip().upper() for c in raw_ids if isinstance(c, str) and c.strip()]
+        cve_ids = [c for c in cve_ids if _CVE_RE.match(c)]
+        if not cve_ids:
+            return jsonify({"error": "cve_ids must contain valid CVE identifiers (e.g. CVE-2024-1234)"}), 400
+        if len(cve_ids) > _MAX_CVE_IDS:
+            return jsonify({"error": f"cve_ids must contain at most {_MAX_CVE_IDS} entries"}), 400
+
+        total = len(cve_ids)
+        NVDProgressTracker.start("bulk_nvd_refresh")
+        NVDProgressTracker.update("bulk_nvd_refresh", 0, total, f"Starting bulk NVD refresh: 0/{total}")
+
+        def _run():
+            with app.app_context():
+                sleep_between = _nvd_sleep_interval()
+                nvd_api_key = os.getenv("NVD_API_KEY")
+                nvd = NVD_DB(nvd_api_key=nvd_api_key)
+                now = datetime.datetime.now(datetime.timezone.utc)
+                done = 0
+                try:
+                    for cve_id in cve_ids:
+                        try:
+                            status_code, data = nvd.api_get_cve(cve_id, max_retries=2)
+                            if status_code == 200 and data.get("vulnerabilities"):
+                                cve = data["vulnerabilities"][0]["cve"]
+                                details = NVD_DB.extract_cve_details(cve)
+                                rec = db.session.get(Vulnerability, cve_id)
+                                if rec is not None:
+                                    apply_nvd_update(rec, details, now)
+                                    apply_cvss_update(rec, details, db)
+                            else:
+                                print(
+                                    f"[bulk NVD refresh] {cve_id}: status={status_code}, "
+                                    "skipping",
+                                    flush=True,
+                                )
+                        except Exception as exc:
+                            print(f"[bulk NVD refresh] error for {cve_id}: {exc}", flush=True)
+
+                        done += 1
+                        NVDProgressTracker.update(
+                            "bulk_nvd_refresh", done, total,
+                            f"NVD refresh: {done}/{total} ({cve_id})",
+                        )
+                        if done % _NVD_COMMIT_EVERY == 0:
+                            _safe_commit("bulk NVD refresh")
+                        if done < total:
+                            time.sleep(sleep_between)
+
+                    _safe_commit("bulk NVD refresh final")
+                    NVDProgressTracker.complete()
+                except Exception as exc:
+                    print(f"[bulk NVD refresh] unhandled error: {exc}", flush=True)
+                    NVDProgressTracker.error(str(exc)[:200])
+
+        threading.Thread(target=_run, name="bulk-nvd-refresh", daemon=True).start()
+        return jsonify({"status": "started", "total": total}), 202
+
+    @app.route('/api/vulnerabilities/bulk-epss-refresh', methods=['POST'])
+    def bulk_epss_refresh():
+        """Trigger a bulk EPSS refresh for a list of CVE IDs.
+
+        Body: ``{"cve_ids": ["CVE-A", "CVE-B", ...]}``
+
+        Returns 202 immediately and runs the refresh in a background thread.
+        Returns 409 if a refresh is already in progress.
+        Returns 400 if cve_ids is empty or contains no valid CVE identifiers.
+        """
+        body = request.get_json(force=True, silent=True) or {}
+        raw_ids = body.get("cve_ids", [])
+        if not raw_ids or not isinstance(raw_ids, list):
+            return jsonify({"error": "cve_ids must be a non-empty list"}), 400
+
+        if EPSSProgressTracker.get_progress()["in_progress"]:
+            return jsonify({"error": "A bulk EPSS refresh is already in progress"}), 409
+
+        cve_ids = [c.strip().upper() for c in raw_ids if isinstance(c, str) and c.strip()]
+        cve_ids = [c for c in cve_ids if _CVE_RE.match(c)]
+        if not cve_ids:
+            return jsonify({"error": "cve_ids must contain valid CVE identifiers (e.g. CVE-2024-1234)"}), 400
+        if len(cve_ids) > _MAX_CVE_IDS:
+            return jsonify({"error": f"cve_ids must contain at most {_MAX_CVE_IDS} entries"}), 400
+
+        total = len(cve_ids)
+        EPSSProgressTracker.start("bulk_epss_refresh")
+        EPSSProgressTracker.update("bulk_epss_refresh", 0, total, f"Starting bulk EPSS refresh: 0/{total}")
+
+        def _run():
+            with app.app_context():
+                epss = EPSS_DB()
+                now = datetime.datetime.now(datetime.timezone.utc)
+                processed = 0
+                try:
+                    chunks = [
+                        cve_ids[i:i + _EPSS_BATCH_SIZE]
+                        for i in range(0, total, _EPSS_BATCH_SIZE)
+                    ]
+                    for chunk in chunks:
+                        try:
+                            results = epss.api_get_epss_batch(chunk)
+                        except Exception as exc:
+                            print(f"[bulk EPSS refresh] batch error: {exc}", flush=True)
+                            processed += len(chunk)
+                            EPSSProgressTracker.update(
+                                "bulk_epss_refresh", processed, total,
+                                f"EPSS refresh: {processed}/{total}",
+                            )
+                            continue
+
+                        for cve_id in chunk:
+                            result = results.get(cve_id)
+                            if result:
+                                try:
+                                    rec = db.session.get(Vulnerability, cve_id)
+                                    if rec is not None:
+                                        rec.update_record(
+                                            epss_score=result["score"],
+                                            epss_fetched_at=now,
+                                            commit=False,
+                                        )
+                                except Exception as exc:
+                                    print(
+                                        f"[bulk EPSS refresh] error updating {cve_id}: {exc}",
+                                        flush=True,
+                                    )
+                            processed += 1
+
+                        _safe_commit("bulk EPSS refresh")
+                        EPSSProgressTracker.update(
+                            "bulk_epss_refresh", processed, total,
+                            f"EPSS refresh: {processed}/{total}",
+                        )
+
+                    EPSSProgressTracker.complete()
+                except Exception as exc:
+                    print(f"[bulk EPSS refresh] unhandled error: {exc}", flush=True)
+                    EPSSProgressTracker.error(str(exc)[:200])
+
+        threading.Thread(target=_run, name="bulk-epss-refresh", daemon=True).start()
+        return jsonify({"status": "started", "total": total}), 202

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -45,12 +45,19 @@ def _nvd_sleep_interval() -> float:
 
 
 def _safe_commit(label: str) -> None:
-    """Commit the current session; rollback and log on failure."""
+    """Commit the current session; rollback and log on failure.
+
+    Always expunges all objects from the session after commit or rollback so
+    that the SQLAlchemy identity map does not accumulate loaded records across
+    many loop iterations (fix for unbounded session-cache growth).
+    """
     try:
         db.session.commit()
     except Exception as exc:
         print(f"[{label}] commit error: {exc}", flush=True)
         db.session.rollback()
+    finally:
+        db.session.expunge_all()
 
 
 def init_app(app):

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -77,9 +77,6 @@ def init_app(app):
         if not raw_ids or not isinstance(raw_ids, list):
             return jsonify({"error": "cve_ids must be a non-empty list"}), 400
 
-        if NVDProgressTracker.get_progress()["in_progress"]:
-            return jsonify({"error": "A bulk NVD refresh is already in progress"}), 409
-
         cve_ids = [c.strip().upper() for c in raw_ids if isinstance(c, str) and c.strip()]
         cve_ids = [c for c in cve_ids if _CVE_RE.match(c)]
         if not cve_ids:
@@ -88,7 +85,8 @@ def init_app(app):
             return jsonify({"error": f"cve_ids must contain at most {_MAX_CVE_IDS} entries"}), 400
 
         total = len(cve_ids)
-        NVDProgressTracker.start("bulk_nvd_refresh")
+        if not NVDProgressTracker.start_if_idle("bulk_nvd_refresh"):
+            return jsonify({"error": "A bulk NVD refresh is already in progress"}), 409
         NVDProgressTracker.update("bulk_nvd_refresh", 0, total, f"Starting bulk NVD refresh: 0/{total}")
 
         def _run():
@@ -168,9 +166,6 @@ def init_app(app):
         if not raw_ids or not isinstance(raw_ids, list):
             return jsonify({"error": "cve_ids must be a non-empty list"}), 400
 
-        if EPSSProgressTracker.get_progress()["in_progress"]:
-            return jsonify({"error": "A bulk EPSS refresh is already in progress"}), 409
-
         cve_ids = [c.strip().upper() for c in raw_ids if isinstance(c, str) and c.strip()]
         cve_ids = [c for c in cve_ids if _CVE_RE.match(c)]
         if not cve_ids:
@@ -179,7 +174,8 @@ def init_app(app):
             return jsonify({"error": f"cve_ids must contain at most {_MAX_CVE_IDS} entries"}), 400
 
         total = len(cve_ids)
-        EPSSProgressTracker.start("bulk_epss_refresh")
+        if not EPSSProgressTracker.start_if_idle("bulk_epss_refresh"):
+            return jsonify({"error": "A bulk EPSS refresh is already in progress"}), 409
         EPSSProgressTracker.update("bulk_epss_refresh", 0, total, f"Starting bulk EPSS refresh: 0/{total}")
 
         def _run():

--- a/tests/unit_tests/test_bulk_refresh.py
+++ b/tests/unit_tests/test_bulk_refresh.py
@@ -118,11 +118,22 @@ class TestSafeCommit:
             mock_db.session.commit.assert_called_once()
             mock_db.session.rollback.assert_not_called()
 
+    def test_expunges_session_after_successful_commit(self):
+        with patch("src.routes.bulk_refresh.db") as mock_db:
+            _safe_commit("test")
+            mock_db.session.expunge_all.assert_called_once()
+
     def test_rolls_back_on_commit_error(self):
         with patch("src.routes.bulk_refresh.db") as mock_db:
             mock_db.session.commit.side_effect = Exception("DB error")
             _safe_commit("test")
             mock_db.session.rollback.assert_called_once()
+
+    def test_expunges_session_after_rollback(self):
+        with patch("src.routes.bulk_refresh.db") as mock_db:
+            mock_db.session.commit.side_effect = Exception("DB error")
+            _safe_commit("test")
+            mock_db.session.expunge_all.assert_called_once()
 
 
 class TestProgressTrackerCancel:

--- a/tests/unit_tests/test_bulk_refresh.py
+++ b/tests/unit_tests/test_bulk_refresh.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for bulk refresh helper functions."""
+
+import datetime
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.routes.bulk_refresh import _nvd_sleep_interval, _safe_commit
+from src.controllers.nvd_apply import apply_cvss_update
+
+
+class TestNvdSleepInterval:
+
+    def test_returns_six_seconds_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("NVD_API_KEY", raising=False)
+        assert _nvd_sleep_interval() == pytest.approx(6.0)
+
+    def test_returns_point_six_with_api_key(self, monkeypatch):
+        monkeypatch.setenv("NVD_API_KEY", "abc123")
+        assert _nvd_sleep_interval() == pytest.approx(0.6)
+
+
+class TestApplyCvssUpdate:
+
+    def _make_rec(self, vuln_id="CVE-2024-0001"):
+        rec = MagicMock()
+        rec.id = vuln_id
+        return rec
+
+    def _make_db(self):
+        mock_db = MagicMock()
+        mock_db.select = MagicMock(return_value=MagicMock())
+        return mock_db
+
+    def test_does_nothing_when_base_score_missing(self):
+        """No DB interaction when details has no base_score."""
+        rec = self._make_rec()
+        mock_db = self._make_db()
+        apply_cvss_update(rec, {}, mock_db)
+        mock_db.session.execute.assert_not_called()
+        mock_db.session.add.assert_not_called()
+
+    def test_does_nothing_when_cvss_version_missing(self):
+        rec = self._make_rec()
+        mock_db = self._make_db()
+        apply_cvss_update(rec, {"base_score": 7.5}, mock_db)
+        mock_db.session.execute.assert_not_called()
+
+    def test_updates_existing_metric_when_score_differs(self):
+        """When a Metrics row exists with a different score, it is updated."""
+        rec = self._make_rec()
+        existing = MagicMock()
+        existing.score = 5.0
+        existing.vector = "old-vector"
+        mock_db = self._make_db()
+        mock_db.session.execute.return_value.scalar_one_or_none.return_value = existing
+
+        with patch("src.controllers.nvd_apply.Metrics"):
+            apply_cvss_update(rec, {
+                "base_score": 8.1,
+                "cvss_version": "3.1",
+                "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+            }, mock_db)
+
+        assert float(existing.score) == pytest.approx(8.1)
+        assert existing.vector == "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+
+    def test_adds_new_metric_when_none_exists(self):
+        """When no Metrics row exists, a new one is added to the session."""
+        rec = self._make_rec()
+        mock_db = self._make_db()
+        mock_db.session.execute.return_value.scalar_one_or_none.return_value = None
+
+        with patch("src.controllers.nvd_apply.Metrics") as MockMetrics:
+            apply_cvss_update(rec, {
+                "base_score": 9.8,
+                "cvss_version": "3.1",
+                "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            }, mock_db)
+
+        mock_db.session.add.assert_called_once()
+        call_args = MockMetrics.call_args
+        assert call_args is not None
+        kwargs = call_args.kwargs if call_args.kwargs else call_args[1]
+        assert kwargs["score"] == pytest.approx(9.8)
+        assert kwargs["author"] == "nvd"
+
+    def test_does_not_update_metric_when_score_and_vector_unchanged(self):
+        """When the existing Metrics row already has the same score and vector, no write occurs."""
+        rec = self._make_rec()
+        vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+        existing = MagicMock()
+        existing.score = 8.1
+        existing.vector = vector
+        mock_db = self._make_db()
+        mock_db.session.execute.return_value.scalar_one_or_none.return_value = existing
+
+        with patch("src.controllers.nvd_apply.Metrics"):
+            apply_cvss_update(rec, {
+                "base_score": 8.1,
+                "cvss_version": "3.1",
+                "cvss_vector": vector,
+            }, mock_db)
+
+        mock_db.session.add.assert_not_called()
+        assert float(existing.score) == pytest.approx(8.1)
+
+
+class TestSafeCommit:
+
+    def test_commits_successfully(self):
+        with patch("src.routes.bulk_refresh.db") as mock_db:
+            _safe_commit("test")
+            mock_db.session.commit.assert_called_once()
+            mock_db.session.rollback.assert_not_called()
+
+    def test_rolls_back_on_commit_error(self):
+        with patch("src.routes.bulk_refresh.db") as mock_db:
+            mock_db.session.commit.side_effect = Exception("DB error")
+            _safe_commit("test")
+            mock_db.session.rollback.assert_called_once()

--- a/tests/unit_tests/test_bulk_refresh.py
+++ b/tests/unit_tests/test_bulk_refresh.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 from src.routes.bulk_refresh import _nvd_sleep_interval, _safe_commit
 from src.controllers.nvd_apply import apply_cvss_update
+from src.controllers.progress_tracker import ProgressTracker
 
 
 class TestNvdSleepInterval:
@@ -122,3 +123,61 @@ class TestSafeCommit:
             mock_db.session.commit.side_effect = Exception("DB error")
             _safe_commit("test")
             mock_db.session.rollback.assert_called_once()
+
+
+class TestProgressTrackerCancel:
+
+    def _tracker(self):
+        return ProgressTracker(default_phase="test", completed_message="done")
+
+    def test_cancel_returns_false_when_idle(self):
+        tracker = self._tracker()
+        assert tracker.cancel() is False
+
+    def test_cancel_returns_true_when_in_progress(self):
+        tracker = self._tracker()
+        tracker.start()
+        assert tracker.cancel() is True
+
+    def test_is_cancelled_false_before_cancel_called(self):
+        tracker = self._tracker()
+        tracker.start()
+        assert tracker.is_cancelled() is False
+
+    def test_is_cancelled_true_after_cancel(self):
+        tracker = self._tracker()
+        tracker.start()
+        tracker.cancel()
+        assert tracker.is_cancelled() is True
+
+    def test_mark_cancelled_resets_in_progress_and_flag(self):
+        tracker = self._tracker()
+        tracker.start()
+        tracker.cancel()
+        tracker.mark_cancelled()
+        progress = tracker.get_progress()
+        assert progress["in_progress"] is False
+        assert progress["phase"] == "cancelled"
+        assert tracker.is_cancelled() is False
+
+    def test_start_resets_cancelled_flag(self):
+        tracker = self._tracker()
+        tracker.start()
+        tracker.cancel()
+        assert tracker.is_cancelled() is True
+        tracker.mark_cancelled()
+        tracker.start()
+        assert tracker.is_cancelled() is False
+
+    def test_cancel_on_already_completed_returns_false(self):
+        tracker = self._tracker()
+        tracker.start()
+        tracker.complete()
+        assert tracker.cancel() is False
+
+    def test_cancel_on_already_cancelled_returns_false(self):
+        tracker = self._tracker()
+        tracker.start()
+        tracker.cancel()
+        tracker.mark_cancelled()
+        assert tracker.cancel() is False

--- a/tests/unit_tests/test_nvd_progress.py
+++ b/tests/unit_tests/test_nvd_progress.py
@@ -120,3 +120,58 @@ def test_thread_safety(fresh_tracker):
     assert tracker.get_progress()["in_progress"] is True
 
 
+def test_start_if_idle_returns_true_when_idle(fresh_tracker):
+    tracker = fresh_tracker
+    result = tracker.start_if_idle(phase="test_phase")
+    assert result is True
+    data = tracker.get_progress()
+    assert data["in_progress"] is True
+    assert data["phase"] == "test_phase"
+
+
+def test_start_if_idle_returns_false_when_in_progress(fresh_tracker):
+    tracker = fresh_tracker
+    tracker.start(phase="running")
+    result = tracker.start_if_idle(phase="new_phase")
+    assert result is False
+    # State must not have changed
+    assert tracker.get_progress()["phase"] == "running"
+
+
+def test_start_if_idle_uses_default_phase(fresh_tracker):
+    tracker = fresh_tracker
+    tracker.start_if_idle()
+    assert tracker.get_progress()["phase"] == "enrichment"
+
+
+def test_start_if_idle_resets_cancelled_flag(fresh_tracker):
+    tracker = fresh_tracker
+    tracker.start_if_idle()
+    tracker.cancel()
+    assert tracker.is_cancelled() is True
+    tracker.complete()
+    tracker.start_if_idle()
+    assert tracker.is_cancelled() is False
+
+
+def test_start_if_idle_atomic_under_concurrent_calls(fresh_tracker):
+    """Only one of N concurrent start_if_idle calls should succeed."""
+    import threading
+    tracker = fresh_tracker
+    successes = []
+    barrier = threading.Barrier(10)
+
+    def try_start():
+        barrier.wait()
+        if tracker.start_if_idle(phase="concurrent"):
+            successes.append(1)
+
+    threads = [threading.Thread(target=try_start) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(successes) == 1, f"Expected 1 success, got {len(successes)}"
+
+

--- a/tests/unit_tests/test_vulnerabilities_controller.py
+++ b/tests/unit_tests/test_vulnerabilities_controller.py
@@ -162,93 +162,11 @@ class TestFetchPublishedDates:
             vuln_ctrl.fetch_published_dates()  # must not raise
 
 
-# ---------------------------------------------------------------------------
-# parse_refresh_delay (lines 47-58)
-# ---------------------------------------------------------------------------
-
-class TestParseRefreshDelay:
-    def test_none_returns_never(self):
-        from src.controllers.vulnerabilities import parse_refresh_delay
-        import datetime
-        result = parse_refresh_delay(None)
-        assert result == datetime.timedelta.max
-
-    def test_never_string(self):
-        from src.controllers.vulnerabilities import parse_refresh_delay
-        import datetime
-        assert parse_refresh_delay("never") == datetime.timedelta.max
-        assert parse_refresh_delay("  Never  ") == datetime.timedelta.max
-
-    def test_always_string(self):
-        from src.controllers.vulnerabilities import parse_refresh_delay
-        assert parse_refresh_delay("always") is None
-        assert parse_refresh_delay("  ALWAYS  ") is None
-
-    def test_hours(self):
-        from src.controllers.vulnerabilities import parse_refresh_delay
-        import datetime
-        result = parse_refresh_delay("48h")
-        assert result == datetime.timedelta(hours=48)
-
-    def test_days(self):
-        from src.controllers.vulnerabilities import parse_refresh_delay
-        import datetime
-        result = parse_refresh_delay("7d")
-        assert result == datetime.timedelta(days=7)
-
-    def test_weeks(self):
-        from src.controllers.vulnerabilities import parse_refresh_delay
-        import datetime
-        result = parse_refresh_delay("2w")
-        assert result == datetime.timedelta(weeks=2)
-
-    def test_minutes(self):
-        from src.controllers.vulnerabilities import parse_refresh_delay
-        import datetime
-        result = parse_refresh_delay("30m")
-        assert result == datetime.timedelta(minutes=30)
-
-    def test_invalid_raises(self):
-        from src.controllers.vulnerabilities import parse_refresh_delay
-        import pytest
-        with pytest.raises(ValueError):
-            parse_refresh_delay("bogus")
-
-    def test_invalid_numeric_raises(self):
-        from src.controllers.vulnerabilities import parse_refresh_delay
-        import pytest
-        with pytest.raises(ValueError):
-            parse_refresh_delay("abch")
 
 
 # ---------------------------------------------------------------------------
-# _should_refetch (lines 73, 78)
+# NOTE: Tests for parse_refresh_delay() and _should_refetch() have been
+# removed as the caching system has been deprecated. All data fetches now
+# attempt fresh data from remote sources (EPSS, NVD).
 # ---------------------------------------------------------------------------
 
-class TestShouldRefetch:
-    def test_always_returns_true(self):
-        from src.controllers.vulnerabilities import _should_refetch, _ALWAYS
-        import datetime
-        assert _should_refetch(datetime.datetime.utcnow(), _ALWAYS) is True
-
-    def test_fetched_at_none_returns_true(self):
-        from src.controllers.vulnerabilities import _should_refetch
-        import datetime
-        assert _should_refetch(None, datetime.timedelta(hours=1)) is True
-
-    def test_never_with_existing_returns_false(self):
-        from src.controllers.vulnerabilities import _should_refetch, _NEVER
-        import datetime
-        assert _should_refetch(datetime.datetime.utcnow(), _NEVER) is False
-
-    def test_data_older_than_delay(self):
-        from src.controllers.vulnerabilities import _should_refetch
-        import datetime
-        old = datetime.datetime.utcnow() - datetime.timedelta(hours=50)
-        assert _should_refetch(old, datetime.timedelta(hours=48)) is True
-
-    def test_data_newer_than_delay(self):
-        from src.controllers.vulnerabilities import _should_refetch
-        import datetime
-        recent = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
-        assert _should_refetch(recent, datetime.timedelta(hours=48)) is False

--- a/tests/unit_tests/test_webapp_coverage_boost.py
+++ b/tests/unit_tests/test_webapp_coverage_boost.py
@@ -9,7 +9,6 @@ import pytest
 from flask import Flask
 
 from src.bin import webapp as webapp_mod
-import src.controllers.vulnerabilities as vulnerabilities_mod
 
 
 class _InlineThread:
@@ -24,7 +23,7 @@ class _InlineThread:
         self._target()
 
 
-def test_launch_enrichment_executes_epss_and_nvd(monkeypatch):
+def test_launch_enrichment_executes_epss(monkeypatch):
     calls: list[str] = []
 
     fake_session = SimpleNamespace(autoflush=True)
@@ -33,32 +32,20 @@ def test_launch_enrichment_executes_epss_and_nvd(monkeypatch):
     def _record_post_treatment(_controllers):
         calls.append("epss")
 
-    def _record_fetch_nvd(self):
-        calls.append("nvd")
-
     monkeypatch.setattr(webapp_mod, "db", fake_db)
     monkeypatch.setattr(webapp_mod.threading, "Thread", _InlineThread)
     monkeypatch.setattr(webapp_mod, "post_treatment", _record_post_treatment)
-    monkeypatch.setattr(
-        vulnerabilities_mod.VulnerabilitiesController,
-        "fetch_nvd_data",
-        _record_fetch_nvd,
-    )
 
     app = Flask(__name__)
     webapp_mod._launch_enrichment(app)
 
     assert fake_session.autoflush is False
     assert "epss" in calls
-    assert "nvd" in calls
 
 
 def test_launch_enrichment_catches_and_logs_failures(monkeypatch, capsys):
     fake_session = SimpleNamespace(autoflush=True)
     fake_db = SimpleNamespace(session=fake_session)
-
-    def _raise_in_fetch(self):
-        raise RuntimeError("nvd failure")
 
     def _raise_in_post_treatment(_controllers):
         raise RuntimeError("epss failure")
@@ -66,18 +53,12 @@ def test_launch_enrichment_catches_and_logs_failures(monkeypatch, capsys):
     monkeypatch.setattr(webapp_mod, "db", fake_db)
     monkeypatch.setattr(webapp_mod.threading, "Thread", _InlineThread)
     monkeypatch.setattr(webapp_mod, "post_treatment", _raise_in_post_treatment)
-    monkeypatch.setattr(
-        vulnerabilities_mod.VulnerabilitiesController,
-        "fetch_nvd_data",
-        _raise_in_fetch,
-    )
 
     app = Flask(__name__)
     webapp_mod._launch_enrichment(app)
 
     out = capsys.readouterr().out
     assert "[enrichment/epss]" in out
-    assert "[enrichment/nvd]" in out
 
 
 def test_create_app_triggers_enrichment_when_scan_finished(monkeypatch, tmp_path):

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -1,0 +1,570 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import pytest
+from unittest.mock import patch, MagicMock, ANY
+from src.bin.webapp import create_app
+from tests.webapp_tests import write_demo_files, setup_demo_db
+
+
+@pytest.fixture()
+def init_files(tmp_path):
+    files = {
+        "status": tmp_path / "status.txt",
+        "packages": tmp_path / "packages-merged.json",
+        "vulnerabilities": tmp_path / "vulnerabilities-merged.json",
+        "assessments": tmp_path / "assessments-merged.json",
+        "openvex": tmp_path / "openvex.json",
+        "time_estimates": tmp_path / "time_estimates.json",
+    }
+    write_demo_files(files)
+    return files
+
+
+@pytest.fixture()
+def app(init_files):
+    import os
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": init_files["status"],
+            "OPENVEX_FILE": init_files["openvex"],
+        })
+        setup_demo_db(application)
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def reset_progress_trackers():
+    """Reset NVD and EPSS progress tracker singletons between tests."""
+    from src.controllers.nvd_progress import NVDProgressTracker
+    from src.controllers.epss_progress import EPSSProgressTracker
+    NVDProgressTracker.complete()
+    EPSSProgressTracker.complete()
+    yield
+    NVDProgressTracker.complete()
+    EPSSProgressTracker.complete()
+
+
+@pytest.fixture()
+def existing_cve_id():
+    return "CVE-2020-35492"
+
+
+# ---------------------------------------------------------------------------
+# Bulk NVD refresh — /api/vulnerabilities/bulk-nvd-refresh
+# ---------------------------------------------------------------------------
+
+class TestBulkNvdRefreshEndpoint:
+
+    def test_returns_202_with_valid_cve_ids(self, client, existing_cve_id):
+        """POST with a known CVE ID returns 202 and starts the job."""
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": [existing_cve_id]},
+            )
+        assert resp.status_code == 202
+        data = resp.get_json()
+        assert data["status"] == "started"
+        assert data["total"] >= 1
+        MockThread.return_value.start.assert_called_once()
+
+    def test_returns_400_when_cve_ids_missing(self, client):
+        """400 when request body has no cve_ids."""
+        resp = client.post("/api/vulnerabilities/bulk-nvd-refresh", json={})
+        assert resp.status_code == 400
+        assert "error" in resp.get_json()
+
+    def test_returns_400_when_cve_ids_empty_list(self, client):
+        """400 when cve_ids is an empty list."""
+        resp = client.post(
+            "/api/vulnerabilities/bulk-nvd-refresh",
+            json={"cve_ids": []},
+        )
+        assert resp.status_code == 400
+
+    def test_always_refreshes_previously_fetched_cve(self, client, existing_cve_id):
+        """Manual refresh always runs even if the CVE was recently fetched."""
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": [existing_cve_id]},
+            )
+        assert resp.status_code == 202
+        assert resp.get_json()["total"] == 1
+
+    def test_returns_409_when_already_in_progress(self, client, existing_cve_id):
+        """409 when NVDProgressTracker reports in_progress=True."""
+        with patch(
+            "src.routes.bulk_refresh.NVDProgressTracker.get_progress",
+            return_value={"in_progress": True},
+        ):
+            resp = client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": [existing_cve_id]},
+            )
+        assert resp.status_code == 409
+        assert "already in progress" in resp.get_json()["error"]
+
+    def test_cve_ids_normalized_to_uppercase(self, client, existing_cve_id):
+        """Lowercase CVE IDs are normalized before processing."""
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": [existing_cve_id.lower()]},
+            )
+        assert resp.status_code == 202
+
+    def test_returns_400_when_all_ids_are_blank_or_non_string(self, client):
+        """400 when every element of cve_ids is empty/whitespace or non-string."""
+        resp = client.post(
+            "/api/vulnerabilities/bulk-nvd-refresh",
+            json={"cve_ids": ["", "   ", 42, None]},
+        )
+        assert resp.status_code == 400
+        assert "error" in resp.get_json()
+
+    def test_total_matches_input_count(self, client, existing_cve_id):
+        """Response total equals the number of CVE IDs submitted."""
+        second_id = "CVE-2024-99999"
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": [existing_cve_id, second_id]},
+            )
+        assert resp.status_code == 202
+        assert resp.get_json()["total"] == 2
+
+    def test_returns_400_when_all_ids_are_invalid_format(self, client):
+        """400 when every CVE ID has an invalid format."""
+        resp = client.post(
+            "/api/vulnerabilities/bulk-nvd-refresh",
+            json={"cve_ids": ["not-a-cve", "CVE-ABCD-1234", "CVE-2024-FRESH"]},
+        )
+        assert resp.status_code == 400
+        assert "valid CVE" in resp.get_json()["error"]
+
+    def test_returns_400_when_count_exceeds_max(self, client):
+        """400 when more than _MAX_CVE_IDS valid IDs are submitted."""
+        from src.routes.bulk_refresh import _MAX_CVE_IDS
+        ids = [f"CVE-2024-{i:05d}" for i in range(_MAX_CVE_IDS + 1)]
+        resp = client.post(
+            "/api/vulnerabilities/bulk-nvd-refresh",
+            json={"cve_ids": ids},
+        )
+        assert resp.status_code == 400
+        assert "at most" in resp.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Bulk EPSS refresh — /api/vulnerabilities/bulk-epss-refresh
+# ---------------------------------------------------------------------------
+
+class TestBulkEpssRefreshEndpoint:
+
+    def test_returns_202_with_valid_cve_ids(self, client, existing_cve_id):
+        """POST with a known CVE ID returns 202 and starts the job."""
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-epss-refresh",
+                json={"cve_ids": [existing_cve_id]},
+            )
+        assert resp.status_code == 202
+        data = resp.get_json()
+        assert data["status"] == "started"
+        assert data["total"] >= 1
+        MockThread.return_value.start.assert_called_once()
+
+    def test_returns_400_when_cve_ids_missing(self, client):
+        resp = client.post("/api/vulnerabilities/bulk-epss-refresh", json={})
+        assert resp.status_code == 400
+
+    def test_returns_400_when_cve_ids_empty_list(self, client):
+        resp = client.post(
+            "/api/vulnerabilities/bulk-epss-refresh",
+            json={"cve_ids": []},
+        )
+        assert resp.status_code == 400
+
+    def test_always_refreshes_previously_fetched_cve(self, client, existing_cve_id):
+        """Manual refresh always runs even if the CVE was recently fetched."""
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-epss-refresh",
+                json={"cve_ids": [existing_cve_id]},
+            )
+        assert resp.status_code == 202
+        assert resp.get_json()["total"] == 1
+
+    def test_returns_409_when_already_in_progress(self, client, existing_cve_id):
+        with patch(
+            "src.routes.bulk_refresh.EPSSProgressTracker.get_progress",
+            return_value={"in_progress": True},
+        ):
+            resp = client.post(
+                "/api/vulnerabilities/bulk-epss-refresh",
+                json={"cve_ids": [existing_cve_id]},
+            )
+        assert resp.status_code == 409
+        assert "already in progress" in resp.get_json()["error"]
+
+    def test_cve_ids_normalized_to_uppercase(self, client, existing_cve_id):
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-epss-refresh",
+                json={"cve_ids": [existing_cve_id.lower()]},
+            )
+        assert resp.status_code == 202
+
+    def test_returns_400_when_all_ids_are_blank_or_non_string(self, client):
+        """400 when every element of cve_ids is empty/whitespace or non-string."""
+        resp = client.post(
+            "/api/vulnerabilities/bulk-epss-refresh",
+            json={"cve_ids": ["", "   ", 42, None]},
+        )
+        assert resp.status_code == 400
+        assert "error" in resp.get_json()
+
+    def test_returns_400_when_all_ids_are_invalid_format(self, client):
+        """400 when every CVE ID has an invalid format."""
+        resp = client.post(
+            "/api/vulnerabilities/bulk-epss-refresh",
+            json={"cve_ids": ["not-a-cve", "CVE-ABCD-1234", "CVE-2024-FRESH"]},
+        )
+        assert resp.status_code == 400
+        assert "valid CVE" in resp.get_json()["error"]
+
+    def test_returns_400_when_count_exceeds_max(self, client):
+        """400 when more than _MAX_CVE_IDS valid IDs are submitted."""
+        from src.routes.bulk_refresh import _MAX_CVE_IDS
+        ids = [f"CVE-2024-{i:05d}" for i in range(_MAX_CVE_IDS + 1)]
+        resp = client.post(
+            "/api/vulnerabilities/bulk-epss-refresh",
+            json={"cve_ids": ids},
+        )
+        assert resp.status_code == 400
+        assert "at most" in resp.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# NVD background _run() — lines executed inside the daemon thread
+# ---------------------------------------------------------------------------
+
+class TestBulkNvdRefreshBackground:
+    """Tests for the _run() closure spawned by bulk_nvd_refresh."""
+
+    def _capture_target(self, client, cve_ids):
+        """POST to the endpoint and return the captured _run target without starting it."""
+        captured = {}
+
+        def fake_thread(target=None, **kwargs):
+            captured["target"] = target
+            return MagicMock()
+
+        with patch("src.routes.bulk_refresh.threading.Thread", side_effect=fake_thread):
+            resp = client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": cve_ids},
+            )
+        assert resp.status_code == 202
+        return captured["target"]
+
+    def test_run_applies_update_on_200(self, client, existing_cve_id):
+        """_run() calls apply_nvd_update and apply_cvss_update when API returns 200."""
+        target = self._capture_target(client, [existing_cve_id])
+        mock_rec = MagicMock()
+        mock_details = {"base_score": 7.5, "cvss_version": "3.1", "cvss_vector": "CVSS:3.1/X"}
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
+             patch("src.routes.bulk_refresh.apply_cvss_update") as mock_cvss, \
+             patch("src.routes.bulk_refresh.db") as mock_db, \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+            MockNVD.return_value.api_get_cve.return_value = (
+                200, {"vulnerabilities": [{"cve": {}}]}
+            )
+            MockNVD.extract_cve_details.return_value = mock_details
+            mock_db.session.get.return_value = mock_rec
+            target()
+
+        mock_apply.assert_called_once_with(mock_rec, mock_details, ANY)
+        mock_cvss.assert_called_once_with(mock_rec, mock_details, mock_db)
+
+    def test_run_skips_update_on_non_200(self, client, existing_cve_id):
+        """_run() skips the update and logs when API returns a non-200 status."""
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            target()
+
+        mock_apply.assert_not_called()
+
+    def test_run_skips_update_when_no_vulnerabilities_in_response(self, client, existing_cve_id):
+        """_run() skips update when 200 but vulnerabilities list is empty."""
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+            MockNVD.return_value.api_get_cve.return_value = (200, {"vulnerabilities": []})
+            target()
+
+        mock_apply.assert_not_called()
+
+    def test_run_skips_update_when_record_not_in_db(self, client, existing_cve_id):
+        """_run() skips apply_nvd_update when the vulnerability is absent from the local DB."""
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
+             patch("src.routes.bulk_refresh.db") as mock_db, \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+            MockNVD.return_value.api_get_cve.return_value = (
+                200, {"vulnerabilities": [{"cve": {}}]}
+            )
+            MockNVD.extract_cve_details.return_value = {}
+            mock_db.session.get.return_value = None
+            target()
+
+        mock_apply.assert_not_called()
+
+    def test_run_continues_after_per_cve_exception(self, client):
+        """_run() catches per-CVE exceptions and keeps processing remaining CVEs."""
+        cve_ids = ["CVE-2024-00001", "CVE-2024-00002"]
+        target = self._capture_target(client, cve_ids)
+        apply_counts = []
+
+        def fake_get_cve(cve_id, **kwargs):
+            if cve_id == "CVE-2024-00001":
+                raise RuntimeError("transient API error")
+            return (404, {})
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockNVD.return_value.api_get_cve.side_effect = fake_get_cve
+            target()
+
+        MockTracker.complete.assert_called()
+
+    def test_run_commits_at_batch_boundary(self, client):
+        """_run() calls _safe_commit after every _NVD_COMMIT_EVERY items (50)."""
+        cve_ids = [f"CVE-2024-{i:05d}" for i in range(50)]
+        target = self._capture_target(client, cve_ids)
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh._safe_commit") as mock_commit, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            target()
+
+        # Commit at item #50 (mod boundary) plus the final commit → at least 2 calls
+        assert mock_commit.call_count >= 2
+
+    def test_run_sleeps_between_cves_but_not_after_last(self, client):
+        """_run() sleeps between CVEs but not after the final one."""
+        cve_ids = ["CVE-2024-00001", "CVE-2024-00002"]
+        target = self._capture_target(client, cve_ids)
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep") as mock_sleep, \
+             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            target()
+
+        assert mock_sleep.call_count == 1
+
+    def test_run_calls_complete_on_success(self, client, existing_cve_id):
+        """_run() calls NVDProgressTracker.complete() after all CVEs are processed."""
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            target()
+
+        MockTracker.complete.assert_called()
+
+    def test_run_calls_error_on_outer_exception(self, client, existing_cve_id):
+        """_run() calls NVDProgressTracker.error() when an unhandled exception occurs."""
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            # complete() is inside the outer try, so making it raise triggers the outer except
+            MockTracker.complete.side_effect = RuntimeError("tracker failure")
+            target()
+
+        MockTracker.error.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# EPSS background _run() — lines executed inside the daemon thread
+# ---------------------------------------------------------------------------
+
+class TestBulkEpssRefreshBackground:
+    """Tests for the _run() closure spawned by bulk_epss_refresh."""
+
+    def _capture_target(self, client, cve_ids):
+        captured = {}
+
+        def fake_thread(target=None, **kwargs):
+            captured["target"] = target
+            return MagicMock()
+
+        with patch("src.routes.bulk_refresh.threading.Thread", side_effect=fake_thread):
+            resp = client.post(
+                "/api/vulnerabilities/bulk-epss-refresh",
+                json={"cve_ids": cve_ids},
+            )
+        assert resp.status_code == 202
+        return captured["target"]
+
+    def test_run_updates_record_when_epss_data_returned(self, client, existing_cve_id):
+        """_run() calls update_record when EPSS returns a score for the CVE."""
+        target = self._capture_target(client, [existing_cve_id])
+        mock_rec = MagicMock()
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh.db") as mock_db, \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker"):
+            MockEPSS.return_value.api_get_epss_batch.return_value = {
+                existing_cve_id: {"score": 0.42}
+            }
+            mock_db.session.get.return_value = mock_rec
+            target()
+
+        mock_rec.update_record.assert_called_once()
+
+    def test_run_skips_cve_with_no_epss_result(self, client, existing_cve_id):
+        """_run() skips update_record when EPSS returns no data for the CVE."""
+        target = self._capture_target(client, [existing_cve_id])
+        mock_rec = MagicMock()
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh.db") as mock_db, \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker"):
+            MockEPSS.return_value.api_get_epss_batch.return_value = {}
+            mock_db.session.get.return_value = mock_rec
+            target()
+
+        mock_rec.update_record.assert_not_called()
+
+    def test_run_skips_update_when_record_not_in_db(self, client, existing_cve_id):
+        """_run() skips update_record when the vulnerability is absent from the local DB."""
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh.db") as mock_db, \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker"):
+            MockEPSS.return_value.api_get_epss_batch.return_value = {
+                existing_cve_id: {"score": 0.5}
+            }
+            mock_db.session.get.return_value = None
+            target()
+        # No exception → None branch handled correctly
+
+    def test_run_continues_after_batch_exception(self, client, existing_cve_id):
+        """_run() continues processing after api_get_epss_batch raises."""
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockEPSS.return_value.api_get_epss_batch.side_effect = Exception("API timeout")
+            target()
+
+        MockTracker.complete.assert_called()
+
+    def test_run_continues_after_record_update_exception(self, client, existing_cve_id):
+        """_run() catches and logs exceptions raised by update_record."""
+        target = self._capture_target(client, [existing_cve_id])
+        mock_rec = MagicMock()
+        mock_rec.update_record.side_effect = Exception("DB constraint")
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh.db") as mock_db, \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockEPSS.return_value.api_get_epss_batch.return_value = {
+                existing_cve_id: {"score": 0.3}
+            }
+            mock_db.session.get.return_value = mock_rec
+            target()
+
+        MockTracker.complete.assert_called()
+
+    def test_run_processes_multiple_chunks(self, client):
+        """_run() batches CVEs into chunks of _EPSS_BATCH_SIZE (100)."""
+        cve_ids = [f"CVE-2024-{i:05d}" for i in range(150)]
+        target = self._capture_target(client, cve_ids)
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker"):
+            MockEPSS.return_value.api_get_epss_batch.return_value = {}
+            target()
+
+        assert MockEPSS.return_value.api_get_epss_batch.call_count == 2
+
+    def test_run_calls_complete_on_success(self, client, existing_cve_id):
+        """_run() calls EPSSProgressTracker.complete() after successful processing."""
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockEPSS.return_value.api_get_epss_batch.return_value = {}
+            target()
+
+        MockTracker.complete.assert_called()
+
+    def test_run_calls_error_on_outer_exception(self, client, existing_cve_id):
+        """_run() calls EPSSProgressTracker.error() on an unhandled outer exception."""
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockEPSS.return_value.api_get_epss_batch.return_value = {}
+            # complete() is inside the outer try, so making it raise triggers the outer except
+            MockTracker.complete.side_effect = RuntimeError("tracker failure")
+            target()
+
+        MockTracker.error.assert_called_once()
+

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -297,7 +297,8 @@ class TestBulkNvdRefreshBackground:
              patch("src.routes.bulk_refresh.apply_cvss_update") as mock_cvss, \
              patch("src.routes.bulk_refresh.db") as mock_db, \
              patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (
                 200, {"vulnerabilities": [{"cve": {}}]}
             )
@@ -316,7 +317,8 @@ class TestBulkNvdRefreshBackground:
              patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             target()
 
@@ -330,7 +332,8 @@ class TestBulkNvdRefreshBackground:
              patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (200, {"vulnerabilities": []})
             target()
 
@@ -344,7 +347,8 @@ class TestBulkNvdRefreshBackground:
              patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
              patch("src.routes.bulk_refresh.db") as mock_db, \
              patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (
                 200, {"vulnerabilities": [{"cve": {}}]}
             )
@@ -370,6 +374,7 @@ class TestBulkNvdRefreshBackground:
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.time.sleep"), \
              patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.side_effect = fake_get_cve
             target()
 
@@ -384,7 +389,8 @@ class TestBulkNvdRefreshBackground:
              patch("src.routes.bulk_refresh._safe_commit") as mock_commit, \
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             target()
 
@@ -399,7 +405,8 @@ class TestBulkNvdRefreshBackground:
         with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.time.sleep") as mock_sleep, \
-             patch("src.routes.bulk_refresh.NVDProgressTracker"):
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             target()
 
@@ -413,6 +420,7 @@ class TestBulkNvdRefreshBackground:
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.time.sleep"), \
              patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             target()
 
@@ -426,6 +434,7 @@ class TestBulkNvdRefreshBackground:
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.time.sleep"), \
              patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             # complete() is inside the outer try, so making it raise triggers the outer except
             MockTracker.complete.side_effect = RuntimeError("tracker failure")
@@ -463,7 +472,8 @@ class TestBulkEpssRefreshBackground:
 
         with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
              patch("src.routes.bulk_refresh.db") as mock_db, \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker"):
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {
                 existing_cve_id: {"score": 0.42}
             }
@@ -479,7 +489,8 @@ class TestBulkEpssRefreshBackground:
 
         with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
              patch("src.routes.bulk_refresh.db") as mock_db, \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker"):
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {}
             mock_db.session.get.return_value = mock_rec
             target()
@@ -492,7 +503,8 @@ class TestBulkEpssRefreshBackground:
 
         with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
              patch("src.routes.bulk_refresh.db") as mock_db, \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker"):
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {
                 existing_cve_id: {"score": 0.5}
             }
@@ -507,6 +519,7 @@ class TestBulkEpssRefreshBackground:
         with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.side_effect = Exception("API timeout")
             target()
 
@@ -521,6 +534,7 @@ class TestBulkEpssRefreshBackground:
         with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
              patch("src.routes.bulk_refresh.db") as mock_db, \
              patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {
                 existing_cve_id: {"score": 0.3}
             }
@@ -536,7 +550,8 @@ class TestBulkEpssRefreshBackground:
 
         with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
              patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker"):
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {}
             target()
 
@@ -549,6 +564,7 @@ class TestBulkEpssRefreshBackground:
         with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {}
             target()
 
@@ -561,6 +577,7 @@ class TestBulkEpssRefreshBackground:
         with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {}
             # complete() is inside the outer try, so making it raise triggers the outer except
             MockTracker.complete.side_effect = RuntimeError("tracker failure")
@@ -568,3 +585,160 @@ class TestBulkEpssRefreshBackground:
 
         MockTracker.error.assert_called_once()
 
+
+# ---------------------------------------------------------------------------
+# Cancel NVD refresh — /api/vulnerabilities/cancel-nvd-refresh
+# ---------------------------------------------------------------------------
+
+class TestCancelNvdRefreshEndpoint:
+
+    def test_returns_200_when_refresh_in_progress(self, client):
+        """POST to cancel-nvd-refresh returns 200 when a refresh is running."""
+        with patch(
+            "src.routes.bulk_refresh.NVDProgressTracker.cancel",
+            return_value=True,
+        ):
+            resp = client.post("/api/vulnerabilities/cancel-nvd-refresh")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "cancelling"
+
+    def test_returns_409_when_no_refresh_in_progress(self, client):
+        """POST to cancel-nvd-refresh returns 409 when nothing is running."""
+        with patch(
+            "src.routes.bulk_refresh.NVDProgressTracker.cancel",
+            return_value=False,
+        ):
+            resp = client.post("/api/vulnerabilities/cancel-nvd-refresh")
+        assert resp.status_code == 409
+        assert "currently in progress" in resp.get_json()["error"]
+
+
+class TestCancelEpssRefreshEndpoint:
+
+    def test_returns_200_when_refresh_in_progress(self, client):
+        """POST to cancel-epss-refresh returns 200 when a refresh is running."""
+        with patch(
+            "src.routes.bulk_refresh.EPSSProgressTracker.cancel",
+            return_value=True,
+        ):
+            resp = client.post("/api/vulnerabilities/cancel-epss-refresh")
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "cancelling"
+
+    def test_returns_409_when_no_refresh_in_progress(self, client):
+        """POST to cancel-epss-refresh returns 409 when nothing is running."""
+        with patch(
+            "src.routes.bulk_refresh.EPSSProgressTracker.cancel",
+            return_value=False,
+        ):
+            resp = client.post("/api/vulnerabilities/cancel-epss-refresh")
+        assert resp.status_code == 409
+        assert "currently in progress" in resp.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Cancellation checks inside _run() threads
+# ---------------------------------------------------------------------------
+
+def _capture_refresh_target(client, endpoint, cve_ids):
+    """Capture the thread target function without starting the thread."""
+    captured = {}
+
+    def fake_thread(target=None, **kwargs):
+        captured["target"] = target
+        return MagicMock()
+
+    with patch("src.routes.bulk_refresh.threading.Thread", side_effect=fake_thread):
+        resp = client.post(endpoint, json={"cve_ids": cve_ids})
+    assert resp.status_code == 202
+    return captured["target"]
+
+
+class TestBulkNvdRefreshCancellation:
+    """Tests that _run() respects the cancellation flag."""
+
+    def _capture_target(self, client, cve_ids):
+        return _capture_refresh_target(client, "/api/vulnerabilities/bulk-nvd-refresh", cve_ids)
+
+    def test_run_stops_and_commits_when_cancelled(self, client):
+        """_run() commits pending work and calls mark_cancelled when flag is set."""
+        cve_ids = ["CVE-2024-00001", "CVE-2024-00002"]
+        target = self._capture_target(client, cve_ids)
+
+        call_count = {"n": 0}
+
+        def fake_is_cancelled():
+            call_count["n"] += 1
+            # Cancel after first iteration
+            return call_count["n"] > 1
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh._safe_commit") as mock_commit, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            MockTracker.is_cancelled.side_effect = fake_is_cancelled
+            target()
+
+        MockTracker.mark_cancelled.assert_called_once()
+        MockTracker.complete.assert_not_called()
+        # commit must be called for the pending work
+        mock_commit.assert_called()
+
+    def test_run_does_not_process_all_cves_when_cancelled_early(self, client):
+        """_run() stops processing before all CVEs when cancelled."""
+        cve_ids = [f"CVE-2024-{i:05d}" for i in range(5)]
+        target = self._capture_target(client, cve_ids)
+
+        api_call_count = {"n": 0}
+        cancel_after = 2
+
+        def fake_api_get(cve_id, **kwargs):
+            api_call_count["n"] += 1
+            return (404, {})
+
+        def fake_is_cancelled():
+            return api_call_count["n"] >= cancel_after
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh._safe_commit"), \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockNVD.return_value.api_get_cve.side_effect = fake_api_get
+            MockTracker.is_cancelled.side_effect = fake_is_cancelled
+            target()
+
+        assert api_call_count["n"] < len(cve_ids)
+        MockTracker.mark_cancelled.assert_called_once()
+
+
+class TestBulkEpssRefreshCancellation:
+    """Tests that _run() in the EPSS thread respects the cancellation flag."""
+
+    def _capture_target(self, client, cve_ids):
+        return _capture_refresh_target(client, "/api/vulnerabilities/bulk-epss-refresh", cve_ids)
+
+    def test_run_stops_and_commits_when_cancelled(self, client):
+        """_run() commits pending work and calls mark_cancelled when flag is set."""
+        cve_ids = [f"CVE-2024-{i:05d}" for i in range(150)]  # 2 chunks
+        target = self._capture_target(client, cve_ids)
+
+        chunk_count = {"n": 0}
+
+        def fake_is_cancelled():
+            chunk_count["n"] += 1
+            return chunk_count["n"] > 1
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh._safe_commit") as mock_commit, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockEPSS.return_value.api_get_epss_batch.return_value = {}
+            MockTracker.is_cancelled.side_effect = fake_is_cancelled
+            target()
+
+        MockTracker.mark_cancelled.assert_called_once()
+        MockTracker.complete.assert_not_called()
+        mock_commit.assert_called()

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -106,10 +106,10 @@ class TestBulkNvdRefreshEndpoint:
         assert resp.get_json()["total"] == 1
 
     def test_returns_409_when_already_in_progress(self, client, existing_cve_id):
-        """409 when NVDProgressTracker reports in_progress=True."""
+        """409 when start_if_idle returns False (tracker already running)."""
         with patch(
-            "src.routes.bulk_refresh.NVDProgressTracker.get_progress",
-            return_value={"in_progress": True},
+            "src.routes.bulk_refresh.NVDProgressTracker.start_if_idle",
+            return_value=False,
         ):
             resp = client.post(
                 "/api/vulnerabilities/bulk-nvd-refresh",
@@ -117,6 +117,18 @@ class TestBulkNvdRefreshEndpoint:
             )
         assert resp.status_code == 409
         assert "already in progress" in resp.get_json()["error"]
+
+    def test_409_only_after_valid_input(self, client, existing_cve_id):
+        """Invalid input returns 400, not 409, even when tracker is running."""
+        with patch(
+            "src.routes.bulk_refresh.NVDProgressTracker.start_if_idle",
+            return_value=False,
+        ):
+            resp = client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": ["not-a-cve"]},
+            )
+        assert resp.status_code == 400
 
     def test_cve_ids_normalized_to_uppercase(self, client, existing_cve_id):
         """Lowercase CVE IDs are normalized before processing."""
@@ -213,9 +225,10 @@ class TestBulkEpssRefreshEndpoint:
         assert resp.get_json()["total"] == 1
 
     def test_returns_409_when_already_in_progress(self, client, existing_cve_id):
+        """409 when start_if_idle returns False (tracker already running)."""
         with patch(
-            "src.routes.bulk_refresh.EPSSProgressTracker.get_progress",
-            return_value={"in_progress": True},
+            "src.routes.bulk_refresh.EPSSProgressTracker.start_if_idle",
+            return_value=False,
         ):
             resp = client.post(
                 "/api/vulnerabilities/bulk-epss-refresh",
@@ -223,6 +236,18 @@ class TestBulkEpssRefreshEndpoint:
             )
         assert resp.status_code == 409
         assert "already in progress" in resp.get_json()["error"]
+
+    def test_409_only_after_valid_input(self, client, existing_cve_id):
+        """Invalid input returns 400, not 409, even when tracker is running."""
+        with patch(
+            "src.routes.bulk_refresh.EPSSProgressTracker.start_if_idle",
+            return_value=False,
+        ):
+            resp = client.post(
+                "/api/vulnerabilities/bulk-epss-refresh",
+                json={"cve_ids": ["not-a-cve"]},
+            )
+        assert resp.status_code == 400
 
     def test_cve_ids_normalized_to_uppercase(self, client, existing_cve_id):
         with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
@@ -742,3 +767,69 @@ class TestBulkEpssRefreshCancellation:
         MockTracker.mark_cancelled.assert_called_once()
         MockTracker.complete.assert_not_called()
         mock_commit.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-request tests — verify the atomic start_if_idle guard
+# ---------------------------------------------------------------------------
+
+class TestConcurrentBulkNvdRefresh:
+    """Verify that simultaneous POST requests yield exactly one 202 and one 409."""
+
+    def test_only_one_request_starts_when_concurrent(self, app, existing_cve_id):
+        """Two threads posting simultaneously must produce exactly one 202 and one 409."""
+        import threading
+        RealThread = threading.Thread
+        barrier = threading.Barrier(2)
+        results = []
+
+        def post():
+            barrier.wait()
+            with app.test_client() as c:
+                resp = c.post(
+                    "/api/vulnerabilities/bulk-nvd-refresh",
+                    json={"cve_ids": [existing_cve_id]},
+                )
+            results.append(resp.status_code)
+
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            threads = [RealThread(target=post) for _ in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        results.sort()
+        assert results == [202, 409], f"Expected [202, 409], got {results}"
+
+
+class TestConcurrentBulkEpssRefresh:
+    """Verify that simultaneous POST requests yield exactly one 202 and one 409."""
+
+    def test_only_one_request_starts_when_concurrent(self, app, existing_cve_id):
+        """Two threads posting simultaneously must produce exactly one 202 and one 409."""
+        import threading
+        RealThread = threading.Thread
+        barrier = threading.Barrier(2)
+        results = []
+
+        def post():
+            barrier.wait()
+            with app.test_client() as c:
+                resp = c.post(
+                    "/api/vulnerabilities/bulk-epss-refresh",
+                    json={"cve_ids": [existing_cve_id]},
+                )
+            results.append(resp.status_code)
+
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            threads = [RealThread(target=post) for _ in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        results.sort()
+        assert results == [202, 409], f"Expected [202, 409], got {results}"


### PR DESCRIPTION
 > ~~This PR depends on https://github.com/savoirfairelinux/vulnscout/pull/343~~

### Changes proposed in this pull request:

This PR adds bulk EPSS and NVD refresh.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Follow the instructions in https://github.com/savoirfairelinux/vulnscout/pull/343 to run VulnScout.

Go to the Vulnerability page and tick the boxes of any row. You should see the button that opens a dropdown to select the refresh targets EPSS and NVD.

<img width="1355" height="675" alt="image" src="https://github.com/user-attachments/assets/5bb942d2-5e4d-4a11-a791-baf321368f7d" />

<img width="1638" height="563" alt="image" src="https://github.com/user-attachments/assets/b0be46d1-3fa3-4204-bbd9-201b018c3012" />
 
A cancel button will show up while the refresh is in progress. When the refresh is cancelled, the vulnerabilities that have already been refreshed will be committed to the database.

<img width="1638" height="563" alt="Screenshot from 2026-06-05 14-53-46" src="https://github.com/user-attachments/assets/32d9e171-84d3-4453-aa1c-165f9c3a4913" />


### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


