### PR TITLE
Fix the file remaining in the input field after upload

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -26,6 +26,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
   // ---- Unmount guard for async operations ----
   const unmountedRef = useRef(false);
   useEffect(() => {
+    unmountedRef.current = false;
     return () => { unmountedRef.current = true; };
   }, []);
 


### PR DESCRIPTION
### Changes proposed in this pull request:

The bug is a React StrictMode issue. In development, React intentionally mounts → unmounts → remounts components. The cleanup sets unmountedRef.current = true, but the ref persists across remounts. After the useEffect cleanup set it to true in the first mount lifecycle, it stays true for the entire second mount lifecycle. Every poll iteration immediately hits the if (unmountedRef.current) guard and returns, skipping the setImportFiles([]).

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Go to `Settings` -> Import SBMO -> upload a file -> The file in the input field is gone after the upload is complete (It wasn't before)

### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


