### PR TITLE
Map all yocto sources to yocto_cve_check

### DIFF
--- a/frontend/src/helpers/sourceNames.ts
+++ b/frontend/src/helpers/sourceNames.ts
@@ -2,6 +2,7 @@
 export const SOURCE_DISPLAY_NAMES: Record<string, string> = {
     openvex: 'OpenVex',
     local_user_data: 'Local User Data',
+    yocto_cve_check: 'Yocto',
     yocto: 'Yocto',
     grype: 'Grype',
     cyclonedx: 'CycloneDx',

--- a/frontend/src/helpers/sourceNames.ts
+++ b/frontend/src/helpers/sourceNames.ts
@@ -2,8 +2,7 @@
 export const SOURCE_DISPLAY_NAMES: Record<string, string> = {
     openvex: 'OpenVex',
     local_user_data: 'Local User Data',
-    yocto_cve_check: 'Yocto',
-    yocto: 'Yocto',
+    yocto_cve_check: 'Yocto CVE Check',
     grype: 'Grype',
     cyclonedx: 'CycloneDx',
     spdx3: 'SPDX3',

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -466,8 +466,8 @@ const packageColumns = [
                 // so that the sum of all bars equals the total vulnerability count.
                 const SOURCE_PRIORITY: Record<string, number> = {
                     grype: 1,
-                  yocto_cve_check: 2,
-                  yocto: 2,
+                    yocto_cve_check: 2,
+                    yocto: 2,
                     nvd_cpe: 3,
                     osv: 4,
                     cyclonedx: 5,

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -466,7 +466,8 @@ const packageColumns = [
                 // so that the sum of all bars equals the total vulnerability count.
                 const SOURCE_PRIORITY: Record<string, number> = {
                     grype: 1,
-                    yocto: 2,
+                  yocto_cve_check: 2,
+                  yocto: 2,
                     nvd_cpe: 3,
                     osv: 4,
                     cyclonedx: 5,

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -20,6 +20,7 @@ import type { ScanManagerSnapshot } from "../handlers/scanStateManager";
 import ScanProgressPanel from "../components/ScanProgressPanel";
 import { useDocUrl } from "../helpers/useDocUrl";
 import { extractSupplierName } from "../helpers/pkgId";
+import { formatSourceName } from "../helpers/sourceNames";
 import { downloadJson } from "../helpers/exportJson";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook, faDownload } from "@fortawesome/free-solid-svg-icons";
@@ -421,7 +422,7 @@ function VulnDiffList({ vulns, label, colorClass, originMap }: {
                             {filtered.map((v) => (
                                 <tr key={v} className="border-t border-gray-600 hover:bg-gray-600/40">
                                     <td className="px-3 py-1.5 font-mono">{v}</td>
-                                    {hasOrigin && <td className="px-3 py-1.5 text-gray-400">{(originMap?.[v] || []).join(', ')}</td>}
+                                    {hasOrigin && <td className="px-3 py-1.5 text-gray-400">{(originMap?.[v] || []).map(formatSourceName).join(', ')}</td>}
                                 </tr>
                             ))}
                         </tbody>
@@ -559,7 +560,7 @@ function GlobalResultModal({ scanId, onClose }: { scanId: string; onClose: () =>
                                                 <td className="px-3 py-1.5 font-mono">{p.package_name}</td>
                                                 <td className="px-3 py-1.5 font-mono text-gray-400">{p.package_version}</td>
                                                 <td className="px-3 py-1.5 text-gray-400">{extractSupplierName(p.package_supplier || '') || '—'}</td>
-                                                <td className="px-3 py-1.5 text-gray-400">{p.sources.join(', ')}</td>
+                                                <td className="px-3 py-1.5 text-gray-400">{p.sources.map(formatSourceName).join(', ')}</td>
                                             </tr>
                                         ))}
                                     </tbody>
@@ -586,7 +587,7 @@ function GlobalResultModal({ scanId, onClose }: { scanId: string; onClose: () =>
                                                 <td className="px-3 py-1.5 font-mono text-gray-400">{f.package_version}</td>
                                                 <td className="px-3 py-1.5 text-gray-400">{extractSupplierName(f.package_supplier || '') || '—'}</td>
                                                 <td className="px-3 py-1.5 font-mono">{f.vulnerability_id}</td>
-                                                <td className="px-3 py-1.5 text-gray-400">{f.sources.join(', ')}</td>
+                                                <td className="px-3 py-1.5 text-gray-400">{f.sources.map(formatSourceName).join(', ')}</td>
                                             </tr>
                                         ))}
                                     </tbody>
@@ -607,7 +608,7 @@ function GlobalResultModal({ scanId, onClose }: { scanId: string; onClose: () =>
                                         {filteredVulns.map(v => (
                                             <tr key={v.vulnerability_id} className="border-t border-gray-600 hover:bg-gray-600/40">
                                                 <td className="px-3 py-1.5 font-mono">{v.vulnerability_id}</td>
-                                                <td className="px-3 py-1.5 text-gray-400">{v.sources.join(', ')}</td>
+                                                <td className="px-3 py-1.5 text-gray-400">{v.sources.map(formatSourceName).join(', ')}</td>
                                             </tr>
                                         ))}
                                     </tbody>

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -10,6 +10,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleQuestion, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
 import { useDocUrl } from '../helpers/useDocUrl';
 import { extractSupplierName } from '../helpers/pkgId';
+import { formatSourceName, getOriginalSourceName } from '../helpers/sourceNames';
 
 type Props = {
     packages: Package[];
@@ -135,6 +136,11 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         }
         return acc;
     }, []), [packages])
+
+    const sources_display_list = useMemo(
+        () => sources_list.map(formatSourceName),
+        [sources_list]
+    );
 
     const hasSupplierInfo = useMemo(() => packages.some(pkg => !!pkg.supplier), [packages]);
 
@@ -309,7 +315,11 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
             columnHelper.accessor('source', {
                 id: 'source',
                 header: () => <div className="flex items-center justify-center">Sources</div>,
-                cell: info => <div className="flex items-center justify-center h-full text-center">{info.getValue()?.join(', ')}</div>,
+                cell: info => (
+                    <div className="flex items-center justify-center h-full text-center">
+                        {info.getValue()?.map(formatSourceName).join(', ')}
+                    </div>
+                ),
                 enableSorting: false
             }),
             columnHelper.accessor('sbom_documents', {
@@ -437,9 +447,9 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
 
             <FilterOption
                 label="Source"
-                options={sources_list}
-                selected={selectedSources}
-                setSelected={setSelectedSources}
+                options={sources_display_list}
+                selected={selectedSources.map(formatSourceName)}
+                setSelected={(displayNames) => setSelectedSources(displayNames.map(getOriginalSourceName))}
             />
 
             <FilterOption

--- a/src/migrations/versions/l8a9b0c1d2e3_normalize_yocto_cve_check_format_name.py
+++ b/src/migrations/versions/l8a9b0c1d2e3_normalize_yocto_cve_check_format_name.py
@@ -1,0 +1,36 @@
+"""normalize yocto cve check format name in sbom documents
+
+Revision ID: l8a9b0c1d2e3
+Revises: k7f8a9b0c1d2
+Create Date: 2026-06-02 00:00:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'l8a9b0c1d2e3'
+down_revision = 'k7f8a9b0c1d2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Canonicalize legacy Yocto format key.
+    op.execute(
+        """
+        UPDATE sbom_documents
+        SET format = 'yocto_cve_check'
+        WHERE format = 'yocto'
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        UPDATE sbom_documents
+        SET format = 'yocto'
+        WHERE format = 'yocto_cve_check'
+        """
+    )

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -57,13 +57,12 @@ def _sbom_pkg_filter(pkg_ids):
 # Formats that are exclusively vulnerability scanners (never pure package BOMs)
 _DEDICATED_SCANNER_FORMATS = frozenset({"grype", "yocto_cve_check"})
 
-# Mapping from SBOMDocument.format to the legacy found_by string the front-end expects
+# Mapping from SBOMDocument.format to the found_by string exposed by the API
 _FORMAT_TO_FOUND_BY: dict[str, str] = {
     "grype": "grype",
     "spdx": "spdx3",
     "cdx": "cyclonedx",
     "openvex": "openvex",
-    "yocto_cve_check": "yocto",
 }
 
 # Mapping from Scan.scan_source to the found_by string for tool scans

--- a/src/views/yocto_vulns.py
+++ b/src/views/yocto_vulns.py
@@ -43,7 +43,7 @@ class YoctoVulns:
                 for issue in pkg.get("issue", []):
                     vuln = Vulnerability(
                         issue.get("id").upper(),
-                        ["yocto"],
+                        ["yocto_cve_check"],
                         issue.get("link", ""),
                         "unknown"
                     )


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

Some Yocto source names were appearing as yocto, this fixes the issue by mapping yocto_cve_check to all such ingestion sources, and converts existing yocto sources to yocto_cve_check.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Launch VS with existing yocto sources, they should now appear as yocto_cve_check
* Add new cve_check input file, they also should appear as yocto_cve_check source.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


