### PR TITLE
Review: show heading UI when there is no data

### DIFF
--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -840,29 +840,6 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         );
     }
 
-    const hasAnyData = assessments.length > 0 || timeEstimates.length > 0 || customCvss.length > 0;
-
-    if (!hasAnyData) {
-        return (
-            <div>
-                {showBanner && (
-                    <MessageBanner
-                        type={bannerType}
-                        message={bannerMessage}
-                        isVisible={showBanner}
-                        onClose={() => setShowBanner(false)}
-                    />
-                )}
-                <div className="text-center py-10 text-gray-400">
-                    <p className="text-lg">No custom data found</p>
-                    <p className="text-sm mt-2">
-                        Assessments, time estimates or custom CVSS scores created directly in VulnScout will appear here.
-                    </p>
-                </div>
-            </div>
-        );
-    }
-
     const filteredAssessments = assessments.filter((a) => {
         if (selectedStatuses.length && !selectedStatuses.includes(a.simplified_status)) {
             return false;


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Review: show heading UI when there is no data

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

In the web dashboard, open the Review tab (when there is no custom user data) and observe the change

Before

<img width="1687" height="224" alt="image" src="https://github.com/user-attachments/assets/d54fa75c-de73-4798-95fc-2019872b8f70" />

After

<img width="1687" height="338" alt="image" src="https://github.com/user-attachments/assets/b38730b4-bad3-49f8-9a86-788633e51987" />

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


