### PR TITLE
supplier: do not render tooltip when unknown

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -1023,10 +1023,12 @@ type AssessmentGroup = {
                                             <div className="text-sm mb-2 flex flex-wrap gap-1">
                                                 {group.packages.map(pkg => {
                                                     const { nameVersion, supplier } = splitPkgId(pkg);
+                                                    const supplierName = extractSupplierName(supplier);
                                                     return (
-                                                        <span key={pkg} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300" title={`Supplier: ${extractSupplierName(supplier) || 'unknown supplier'}`}>
+                                                        <span key={pkg} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300" title={supplierName ? `Supplier: ${supplierName}` : undefined}>
                                                             <FontAwesomeIcon icon={faBox} className="w-3 h-3 mr-1" />
-                                                            {nameVersion}<span className="ml-1 opacity-70 text-xs">({extractSupplierName(supplier) || 'unknown supplier'})</span>
+                                                            {nameVersion}
+                                                            {supplierName && <span className="ml-1 opacity-70 text-xs">({supplierName})</span>}
                                                         </span>
                                                     );
                                                 })}

--- a/frontend/src/helpers/pkgId.ts
+++ b/frontend/src/helpers/pkgId.ts
@@ -17,10 +17,10 @@ export function extractSupplierName(supplier: string): string {
 }
 
 /**
- * Format a package ID for display, always showing supplier name (falling back to 'unknown supplier').
+ * Format a package ID for display, showing supplier name only when present.
  */
 export function formatPkgId(id: string): string {
     const { nameVersion, supplier } = splitPkgId(id);
     const supplierName = supplier ? extractSupplierName(supplier) : '';
-    return `${nameVersion} (${supplierName || 'unknown supplier'})`;
+    return supplierName ? `${nameVersion} (${supplierName})` : nameVersion;
 }

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -746,8 +746,8 @@ describe('EditAssessment Component', () => {
         );
 
         expect(screen.getByText('Apply to packages:')).toBeInTheDocument();
-        expect(screen.getByText('pkg1@1.0.0 (unknown supplier)')).toBeInTheDocument();
-        expect(screen.getByText('pkg2@2.0.0 (unknown supplier)')).toBeInTheDocument();
+        expect(screen.getByText('pkg1@1.0.0')).toBeInTheDocument();
+        expect(screen.getByText('pkg2@2.0.0')).toBeInTheDocument();
     });
 
     test('shows external error when no package selected', async () => {

--- a/frontend/tests/unit_tests/test_pkg_id.ts
+++ b/frontend/tests/unit_tests/test_pkg_id.ts
@@ -45,8 +45,8 @@ describe('formatPkgId', () => {
         expect(formatPkgId('mylib@1.2.3::Organization: Acme Corp')).toBe('mylib@1.2.3 (Acme Corp)');
     });
 
-    test('falls back to "unknown supplier" when no supplier', () => {
-        expect(formatPkgId('mylib@1.2.3')).toBe('mylib@1.2.3 (unknown supplier)');
+    test('returns name@version when supplier is missing', () => {
+        expect(formatPkgId('mylib@1.2.3')).toBe('mylib@1.2.3');
     });
 
     test('uses raw supplier name when no prefix', () => {

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -365,7 +365,7 @@ describe('StatusEditor', () => {
         render(<StatusEditor {...defaultProps} availablePackages={packages} />);
 
         expect(screen.getByText('Apply to packages:')).toBeInTheDocument();
-        expect(screen.getByText('only-pkg@1.0.0 (unknown supplier)')).toBeInTheDocument();
+        expect(screen.getByText('only-pkg@1.0.0')).toBeInTheDocument();
     });
 
     test('should render package checkboxes when more than one package is available', () => {
@@ -373,8 +373,8 @@ describe('StatusEditor', () => {
         render(<StatusEditor {...defaultProps} availablePackages={packages} />);
 
         expect(screen.getByText('Apply to packages:')).toBeInTheDocument();
-        expect(screen.getByText('pkg1@1.0.0 (unknown supplier)')).toBeInTheDocument();
-        expect(screen.getByText('pkg2@2.0.0 (unknown supplier)')).toBeInTheDocument();
+        expect(screen.getByText('pkg1@1.0.0')).toBeInTheDocument();
+        expect(screen.getByText('pkg2@2.0.0')).toBeInTheDocument();
     });
 
     test('should show external error when no package selected', async () => {

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2057,9 +2057,9 @@ describe('Vulnerability Modal', () => {
         />);
 
         // Only the project-scoped package (from packages_current) should appear as checkbox
-        await screen.findByText('pkg-alpha@1.0.0 (unknown supplier)');
-        expect(screen.queryByText('pkg-beta@2.0.0 (unknown supplier)')).not.toBeInTheDocument();
-        expect(screen.queryByText('pkg-gamma@3.0.0 (unknown supplier)')).not.toBeInTheDocument();
+        await screen.findByText('pkg-alpha@1.0.0');
+        expect(screen.queryByText('pkg-beta@2.0.0')).not.toBeInTheDocument();
+        expect(screen.queryByText('pkg-gamma@3.0.0')).not.toBeInTheDocument();
     });
 
     test('falls back to all packages when packages_current is empty', async () => {
@@ -2085,8 +2085,8 @@ describe('Vulnerability Modal', () => {
         />);
 
         // Both packages should appear since packages_current is empty (fallback)
-        await screen.findByText('pkg-x@1.0.0 (unknown supplier)');
-        expect(screen.getByText('pkg-y@2.0.0 (unknown supplier)')).toBeInTheDocument();
+        await screen.findByText('pkg-x@1.0.0');
+        expect(screen.getByText('pkg-y@2.0.0')).toBeInTheDocument();
     });
 });
 


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* supplier: do not render tooltip when unknown

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open the web dashboard, pick a vuln whose package have unknown supplier. Observe the change

Before

<img width="478" height="44" alt="image" src="https://github.com/user-attachments/assets/fc5e6d10-e008-4c30-a8be-e17db7b1d4dc" />

After

<img width="375" height="32" alt="image" src="https://github.com/user-attachments/assets/4822dd0d-f601-4798-8abb-fa74e07f7dad" />

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


