### PR TITLE
summarize vulnerability status across current scope

### DIFF
--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -168,8 +168,8 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
         const selectedVulnerabilities = vulnerabilities.filter(vuln => selectedVulns.includes(vuln.id));
         if (selectedVulnerabilities.length === 0) return undefined;
 
-        const firstStatus = selectedVulnerabilities[0].status;
-        const allHaveSameStatus = selectedVulnerabilities.every(vuln => vuln.status === firstStatus);
+        const firstStatus = selectedVulnerabilities[0].assessments[selectedVulnerabilities[0].assessments.length - 1]?.status;
+        const allHaveSameStatus = selectedVulnerabilities.every(vuln => vuln.assessments[vuln.assessments.length - 1]?.status === firstStatus);
 
         // Debug logging
 
@@ -261,7 +261,6 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                         const vuln = vulnerabilities.find(v => v.id === casted.vuln_id);
                         if (vuln) {
                             vuln.assessments.push(casted);
-                            vuln.status = casted.status;
                             vuln.simplified_status = casted.simplified_status;
                             patchVuln(casted.vuln_id, vuln);
                         }

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect, useRef } from "react";
 import type { Vulnerability } from "../handlers/vulnerabilities";
+import { buildStatusSummary } from "../handlers/vulnerabilities";
 import StatusEditor from "./StatusEditor";
 import type { PostAssessment } from './StatusEditor';
 import TimeEstimateEditor from "./TimeEstimateEditor";
@@ -260,9 +261,14 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                         // Update the vulnerability
                         const vuln = vulnerabilities.find(v => v.id === casted.vuln_id);
                         if (vuln) {
-                            vuln.assessments.push(casted);
-                            vuln.simplified_status = casted.simplified_status;
-                            patchVuln(casted.vuln_id, vuln);
+                            const updatedAssessments = [...vuln.assessments, casted];
+                            const statusSummary = buildStatusSummary(updatedAssessments);
+                            patchVuln(casted.vuln_id, {
+                                ...vuln,
+                                assessments: updatedAssessments,
+                                simplified_status: statusSummary.dominant_status,
+                                status_summary: statusSummary,
+                            });
                         }
                     }
                 }

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -1,6 +1,6 @@
 import type { Vulnerability } from "../handlers/vulnerabilities";
 import type { CVSS } from "../handlers/vulnerabilities";
-import { asVulnerability } from "../handlers/vulnerabilities";
+import { asVulnerability, buildStatusSummary } from "../handlers/vulnerabilities";
 import type { Assessment } from "../handlers/assessments";
 import { asAssessment } from "../handlers/assessments";
 import { escape } from "lodash-es";
@@ -748,7 +748,15 @@ type VariantScopedSnapshot = {
         }
 
         if (lastCasted) {
-            patchVuln(vuln.id, vuln);
+            const updatedAssessments = [...vuln.assessments];
+            const statusSummary = buildStatusSummary(updatedAssessments);
+            patchVuln(vuln.id, {
+                ...vuln,
+                assessments: updatedAssessments,
+                status: lastCasted.status,
+                simplified_status: statusSummary.dominant_status,
+                status_summary: statusSummary,
+            });
             const msg = successCount > 1
                 ? `Successfully added assessment to ${successCount} variants.`
                 : 'Successfully added assessment.';

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -328,7 +328,6 @@ type VariantScopedSnapshot = {
             if (nvdUpdated || epssUpdated) {
                 if (nvdUpdated) {
                     const {
-                        status: _s,
                         simplified_status: _ss,
                         assessments: _a,
                         packages_current: _pc,
@@ -408,7 +407,6 @@ type VariantScopedSnapshot = {
                     const sortedAssessments = [...vuln.assessments].sort(
                         (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
                     );
-                    vuln.status = sortedAssessments[0].status;
                     vuln.simplified_status = sortedAssessments[0].simplified_status;
                 }
 
@@ -589,7 +587,6 @@ type VariantScopedSnapshot = {
                 (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
             )[0];
             if (latest) {
-                vuln.status = latest.status;
                 vuln.simplified_status = latest.simplified_status;
             }
             patchVuln(vuln.id, vuln);
@@ -738,7 +735,6 @@ type VariantScopedSnapshot = {
                         vuln.assessments.push(casted);
                         // Keep allVulnAssessments in sync so variant tags appear immediately
                         setAllVulnAssessments(prev => [...prev, casted]);
-                        vuln.status = casted.status;
                         vuln.simplified_status = casted.simplified_status;
                     }
                 }
@@ -753,7 +749,6 @@ type VariantScopedSnapshot = {
             patchVuln(vuln.id, {
                 ...vuln,
                 assessments: updatedAssessments,
-                status: lastCasted.status,
                 simplified_status: statusSummary.dominant_status,
                 status_summary: statusSummary,
             });

--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -16,7 +16,7 @@ type Package = {
 
 export type { Package, VulnCounts, Severities };
 import type { Vulnerability } from "./vulnerabilities";
-import { SEVERITY_ORDER, getVulnerabilityStatusSummary } from "./vulnerabilities";
+import { SEVERITY_ORDER, buildStatusSummary, getVulnerabilityStatusSummary } from "./vulnerabilities";
 
 const asPackage = (data: any): Package | [] => {
     if (typeof data !== "object") return [];
@@ -95,7 +95,18 @@ class Packages {
             let severities: Severities = {};
             const counts: VulnCounts = vulnerabilities.reduce((acc, vuln) => {
                 const severity = {label: vuln.severity.severity, index: SEVERITY_ORDER.indexOf(vuln.severity.severity.toUpperCase())};
-                const summary = getVulnerabilityStatusSummary(vuln);
+
+                // Build a summary scoped to this package + each variant:
+                // keep only assessments that explicitly cover this package (or
+                // carry no package list at all), then let buildStatusSummary
+                // group by variant_id so each variant contributes exactly one
+                // count — the last assessment for that (variant, package) pair.
+                const pkgAssessments = vuln.assessments.filter(
+                    (a) => a.packages.length === 0 || a.packages.includes(pkg.id)
+                );
+                const summary = pkgAssessments.length > 0
+                    ? buildStatusSummary(pkgAssessments)
+                    : getVulnerabilityStatusSummary(vuln);
 
                 // Aggregate status counts by scenario summary instead of only the dominant status.
                 Object.entries(summary.counts).forEach(([status, count]) => {

--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -16,7 +16,7 @@ type Package = {
 
 export type { Package, VulnCounts, Severities };
 import type { Vulnerability } from "./vulnerabilities";
-import { SEVERITY_ORDER } from "./vulnerabilities";
+import { SEVERITY_ORDER, getVulnerabilityStatusSummary } from "./vulnerabilities";
 
 const asPackage = (data: any): Package | [] => {
     if (typeof data !== "object") return [];
@@ -94,17 +94,17 @@ class Packages {
             const vulnerabilities = vulns_per_pkg[pkg.id] || [];
             let severities: Severities = {};
             const counts: VulnCounts = vulnerabilities.reduce((acc, vuln) => {
-                const status = vuln.simplified_status || "unknown";
-
-                // compute max severity per status
-                if (!severities[status]) {
-                    severities[status] = {label: "NONE", index: 0};
-                }
                 const severity = {label: vuln.severity.severity, index: SEVERITY_ORDER.indexOf(vuln.severity.severity.toUpperCase())};
-                if(severity.index > severities[status].index) severities[status] = severity;
+                const summary = getVulnerabilityStatusSummary(vuln);
 
-                // count vulnerabilities per status
-                acc[status] = acc[status] ? acc[status] + 1 : 1;
+                // Aggregate status counts by scenario summary instead of only the dominant status.
+                Object.entries(summary.counts).forEach(([status, count]) => {
+                    if (!severities[status]) {
+                        severities[status] = {label: "NONE", index: 0};
+                    }
+                    if (severity.index > severities[status].index) severities[status] = severity;
+                    acc[status] = (acc[status] || 0) + count;
+                });
                 return acc;
             }, {} as VulnCounts);
             return {

--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -108,14 +108,16 @@ class Packages {
                     ? buildStatusSummary(pkgAssessments)
                     : getVulnerabilityStatusSummary(vuln);
 
-                // Aggregate status counts by scenario summary instead of only the dominant status.
-                Object.entries(summary.counts).forEach(([status, count]) => {
-                    if (!severities[status]) {
-                        severities[status] = {label: "NONE", index: 0};
-                    }
-                    if (severity.index > severities[status].index) severities[status] = severity;
-                    acc[status] = (acc[status] || 0) + count;
-                });
+                // Count this CVE as 1 toward its dominant status so the badge
+                // always means "N distinct CVEs in this status", not
+                // "N (CVE × variant) pairs". Variant-aware logic still drives
+                // which status bucket each CVE lands in.
+                const status = summary.dominant_status;
+                if (!severities[status]) {
+                    severities[status] = {label: "NONE", index: 0};
+                }
+                if (severity.index > severities[status].index) severities[status] = severity;
+                acc[status] = (acc[status] || 0) + 1;
                 return acc;
             }, {} as VulnCounts);
             return {

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -99,20 +99,40 @@ const getStatusSummaryEntries = (counts: Record<string, number>): { status: stri
 }
 
 const buildStatusSummary = (assessments: Assessment[]): StatusSummary => {
-    const uniqueStatuses = assessments.reduce((acc, assessment) => {
-        const simplified = assessment.simplified_status || 'unknown';
-        acc.add(simplified);
-        return acc;
-    }, new Set<string>());
+    if (assessments.length === 0) {
+        return {
+            counts: { unknown: 1 },
+            ordered: [{ status: 'unknown', count: 1 }],
+            total_assessments: 0,
+            dominant_status: 'unknown',
+            has_active_status: false,
+        };
+    }
 
-    const counts = Array.from(uniqueStatuses).reduce((acc, status) => {
-        acc[status] = 1;
+    // Group assessments by variant_id. Assessments without a variant_id are
+    // grouped together under a single fallback key so they contribute one slot.
+    const byVariant = new Map<string, Assessment[]>();
+    assessments.forEach((assessment) => {
+        const key = assessment.variant_id ?? '__no_variant__';
+        if (!byVariant.has(key)) byVariant.set(key, []);
+        byVariant.get(key)!.push(assessment);
+    });
+
+    // For each variant keep only the most recent assessment.
+    const latestPerVariant: Assessment[] = [];
+    byVariant.forEach((variantAssessments) => {
+        const latest = variantAssessments.reduce((best, a) =>
+            new Date(a.timestamp).getTime() > new Date(best.timestamp).getTime() ? a : best
+        );
+        latestPerVariant.push(latest);
+    });
+
+    // Count how many variants share each simplified status.
+    const counts = latestPerVariant.reduce((acc, assessment) => {
+        const simplified = assessment.simplified_status || 'unknown';
+        acc[simplified] = (acc[simplified] || 0) + 1;
         return acc;
     }, {} as Record<string, number>);
-
-    if (Object.keys(counts).length === 0) {
-        counts.unknown = 1;
-    }
 
     const ordered = getStatusSummaryEntries(counts);
     const dominant_status = ordered[0]?.status ?? 'unknown';

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -55,12 +55,108 @@ type Vulnerability = {
     };
     status: string;
     simplified_status: string;
+    status_summary?: {
+        counts: Record<string, number>;
+        ordered: { status: string; count: number }[];
+        total_assessments: number;
+        dominant_status: string;
+        has_active_status: boolean;
+    };
     assessments: Assessment[];
 };
+
+type StatusSummary = NonNullable<Vulnerability['status_summary']>;
 
 export type { Vulnerability, CVSS };
 
 const SEVERITY_ORDER = ['NONE', 'UNKNOWN', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
+const STATUS_SORT_ORDER = ['unknown', 'Pending Assessment', 'Exploitable', 'Not affected', 'Fixed'];
+const STATUS_DOMINANT_PRIORITY = ['Exploitable', 'Pending Assessment', 'Not affected', 'Fixed', 'unknown'];
+
+const getStatusSortIndex = (status: string): number => {
+    const index = STATUS_SORT_ORDER.indexOf(status);
+    return index === -1 ? STATUS_SORT_ORDER.length : index;
+}
+
+const getStatusDominantIndex = (status: string): number => {
+    const index = STATUS_DOMINANT_PRIORITY.indexOf(status);
+    return index === -1 ? STATUS_DOMINANT_PRIORITY.length : index;
+}
+
+const isActiveStatus = (status: string): boolean => {
+    return status !== 'Fixed' && status !== 'Not affected' && status !== 'unknown';
+}
+
+const getStatusSummaryEntries = (counts: Record<string, number>): { status: string; count: number }[] => {
+    return Object.entries(counts)
+        .map(([status, count]) => ({ status, count }))
+        .sort((a, b) => {
+            if (b.count !== a.count) return b.count - a.count;
+            const priorityDelta = getStatusDominantIndex(a.status) - getStatusDominantIndex(b.status);
+            if (priorityDelta !== 0) return priorityDelta;
+            return a.status.localeCompare(b.status);
+        });
+}
+
+const buildStatusSummary = (assessments: Assessment[]): StatusSummary => {
+    const counts = assessments.reduce((acc, assessment) => {
+        const simplified = assessment.simplified_status || 'unknown';
+        acc[simplified] = (acc[simplified] || 0) + 1;
+        return acc;
+    }, {} as Record<string, number>);
+
+    if (Object.keys(counts).length === 0) {
+        counts.unknown = 1;
+    }
+
+    const ordered = getStatusSummaryEntries(counts);
+    const dominant_status = ordered[0]?.status ?? 'unknown';
+    return {
+        counts,
+        ordered,
+        total_assessments: assessments.length,
+        dominant_status,
+        has_active_status: ordered.some((entry) => isActiveStatus(entry.status)),
+    };
+}
+
+const buildFallbackStatusSummary = (simplified_status: string): StatusSummary => {
+    const fallbackStatus = simplified_status || 'unknown';
+    return {
+        counts: { [fallbackStatus]: 1 },
+        ordered: [{ status: fallbackStatus, count: 1 }],
+        total_assessments: 0,
+        dominant_status: fallbackStatus,
+        has_active_status: isActiveStatus(fallbackStatus),
+    };
+}
+
+const getVulnerabilityStatusSummary = (vulnerability: Pick<Vulnerability, 'status_summary' | 'simplified_status'>): StatusSummary => {
+    return vulnerability.status_summary ?? buildFallbackStatusSummary(vulnerability.simplified_status);
+}
+
+const getTopStatusSummaryLabel = (summary: StatusSummary, maxItems = 2): string => {
+    const top = summary.ordered.slice(0, maxItems).map((entry) => `${entry.status} (${entry.count})`);
+    const hiddenCount = summary.ordered.length - top.length;
+    if (hiddenCount > 0) {
+        top.push(`+${hiddenCount} more`);
+    }
+    return top.join(', ');
+}
+
+const getLegacyStatusFromSummary = (assessments: Assessment[], dominantStatus: string): string => {
+    for (let i = assessments.length - 1; i >= 0; i -= 1) {
+        const assessment = assessments[i];
+        if ((assessment.simplified_status || 'unknown') === dominantStatus) {
+            return assessment.status;
+        }
+    }
+    return assessments[assessments.length - 1]?.status ?? 'unknown';
+}
+
+const isVulnerabilityActive = (vulnerability: Vulnerability): boolean => {
+    return getVulnerabilityStatusSummary(vulnerability).has_active_status;
+}
 
 const asCVSS = (data: any): CVSS | [] => {
     if (typeof data !== "object") return [];
@@ -129,6 +225,7 @@ const asVulnerability = (data: any): Vulnerability | [] => {
         },
         status: 'unknown',
         simplified_status: 'unknown',
+        status_summary: buildStatusSummary([]),
         assessments: [],
     };
     if (typeof data?.namespace === "string") vuln.namespace = data.namespace
@@ -185,18 +282,27 @@ class Vulnerabilities {
         }, {} as {[key: string]: Assessment[]});
 
         return vulns.map((vuln) => {
-            if (!assessments_per_vuln[vuln.id]) return vuln;
-            if (assessments_per_vuln[vuln.id].length < 1) return vuln;
+            if (!assessments_per_vuln[vuln.id] || assessments_per_vuln[vuln.id].length < 1) {
+                return {
+                    ...vuln,
+                    status: 'unknown',
+                    simplified_status: 'unknown',
+                    status_summary: buildStatusSummary([]),
+                    assessments: [],
+                };
+            }
 
             assessments_per_vuln[vuln.id].sort((a, b) => {
                 return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
             });
-            const latest = assessments_per_vuln[vuln.id][assessments_per_vuln[vuln.id].length - 1];
+            const vulnAssessments = assessments_per_vuln[vuln.id];
+            const statusSummary = buildStatusSummary(vulnAssessments);
             return {
                 ...vuln,
-                status: latest?.status ?? 'unknown',
-                simplified_status: latest?.simplified_status ?? 'unknown',
-                assessments: assessments_per_vuln[vuln.id],
+                status: getLegacyStatusFromSummary(vulnAssessments, statusSummary.dominant_status),
+                simplified_status: statusSummary.dominant_status,
+                status_summary: statusSummary,
+                assessments: vulnAssessments,
             };
         });
     }
@@ -204,11 +310,16 @@ class Vulnerabilities {
     static append_assessment(vulns: Vulnerability[], assessment: Assessment): Vulnerability[] {
         return vulns.map((vuln) => {
             if (vuln.id === assessment.vuln_id) {
+                const assessments = [...vuln.assessments, assessment].sort((a, b) => {
+                    return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+                });
+                const statusSummary = buildStatusSummary(assessments);
                 return {
                     ...vuln,
-                    status: assessment.status,
-                    simplified_status: assessment.simplified_status,
-                    assessments: [...vuln.assessments, assessment],
+                    status: getLegacyStatusFromSummary(assessments, statusSummary.dominant_status),
+                    simplified_status: statusSummary.dominant_status,
+                    status_summary: statusSummary,
+                    assessments,
                 };
             }
 
@@ -294,4 +405,14 @@ class Vulnerabilities {
 
 
 export default Vulnerabilities;
-export { SEVERITY_ORDER, asVulnerability };
+export {
+    SEVERITY_ORDER,
+    STATUS_SORT_ORDER,
+    asVulnerability,
+    buildStatusSummary,
+    getStatusSortIndex,
+    getTopStatusSummaryLabel,
+    getVulnerabilityStatusSummary,
+    isActiveStatus,
+    isVulnerabilityActive,
+};

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -53,7 +53,6 @@ type Vulnerability = {
     fix: {
         state: string;
     };
-    status: string;
     simplified_status: string;
     status_summary?: {
         counts: Record<string, number>;
@@ -169,16 +168,6 @@ const getTopStatusSummaryLabel = (summary: StatusSummary, maxItems = 2): string 
     return top.join(', ');
 }
 
-const getLegacyStatusFromSummary = (assessments: Assessment[], dominantStatus: string): string => {
-    for (let i = assessments.length - 1; i >= 0; i -= 1) {
-        const assessment = assessments[i];
-        if ((assessment.simplified_status || 'unknown') === dominantStatus) {
-            return assessment.status;
-        }
-    }
-    return assessments[assessments.length - 1]?.status ?? 'unknown';
-}
-
 const isVulnerabilityActive = (vulnerability: Vulnerability): boolean => {
     return getVulnerabilityStatusSummary(vulnerability).has_active_status;
 }
@@ -248,7 +237,6 @@ const asVulnerability = (data: any): Vulnerability | [] => {
         fix: {
             state: "unknown",
         },
-        status: 'unknown',
         simplified_status: 'unknown',
         assessments: [],
     };
@@ -309,7 +297,6 @@ class Vulnerabilities {
             if (!assessments_per_vuln[vuln.id] || assessments_per_vuln[vuln.id].length < 1) {
                 return {
                     ...vuln,
-                    status: 'unknown',
                     simplified_status: 'unknown',
                     status_summary: buildStatusSummary([]),
                     assessments: [],
@@ -323,7 +310,6 @@ class Vulnerabilities {
             const statusSummary = buildStatusSummary(vulnAssessments);
             return {
                 ...vuln,
-                status: getLegacyStatusFromSummary(vulnAssessments, statusSummary.dominant_status),
                 simplified_status: statusSummary.dominant_status,
                 status_summary: statusSummary,
                 assessments: vulnAssessments,
@@ -340,7 +326,6 @@ class Vulnerabilities {
                 const statusSummary = buildStatusSummary(assessments);
                 return {
                     ...vuln,
-                    status: getLegacyStatusFromSummary(assessments, statusSummary.dominant_status),
                     simplified_status: statusSummary.dominant_status,
                     status_summary: statusSummary,
                     assessments,

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -91,17 +91,22 @@ const getStatusSummaryEntries = (counts: Record<string, number>): { status: stri
     return Object.entries(counts)
         .map(([status, count]) => ({ status, count }))
         .sort((a, b) => {
-            if (b.count !== a.count) return b.count - a.count;
             const priorityDelta = getStatusDominantIndex(a.status) - getStatusDominantIndex(b.status);
             if (priorityDelta !== 0) return priorityDelta;
+            if (b.count !== a.count) return b.count - a.count;
             return a.status.localeCompare(b.status);
         });
 }
 
 const buildStatusSummary = (assessments: Assessment[]): StatusSummary => {
-    const counts = assessments.reduce((acc, assessment) => {
+    const uniqueStatuses = assessments.reduce((acc, assessment) => {
         const simplified = assessment.simplified_status || 'unknown';
-        acc[simplified] = (acc[simplified] || 0) + 1;
+        acc.add(simplified);
+        return acc;
+    }, new Set<string>());
+
+    const counts = Array.from(uniqueStatuses).reduce((acc, status) => {
+        acc[status] = 1;
         return acc;
     }, {} as Record<string, number>);
 
@@ -136,7 +141,7 @@ const getVulnerabilityStatusSummary = (vulnerability: Pick<Vulnerability, 'statu
 }
 
 const getTopStatusSummaryLabel = (summary: StatusSummary, maxItems = 2): string => {
-    const top = summary.ordered.slice(0, maxItems).map((entry) => `${entry.status} (${entry.count})`);
+    const top = summary.ordered.slice(0, maxItems).map((entry) => entry.status);
     const hiddenCount = summary.ordered.length - top.length;
     if (hiddenCount > 0) {
         top.push(`+${hiddenCount} more`);

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -225,7 +225,6 @@ const asVulnerability = (data: any): Vulnerability | [] => {
         },
         status: 'unknown',
         simplified_status: 'unknown',
-        status_summary: buildStatusSummary([]),
         assessments: [],
     };
     if (typeof data?.namespace === "string") vuln.namespace = data.namespace

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -16,6 +16,14 @@ type CVSS = {
     impact_score: number;
 };
 
+type StatusSummary = {
+    counts: Record<string, number>;
+    ordered: { status: string; count: number }[];
+    total_assessments: number;
+    dominant_status: string;
+    has_active_status: boolean;
+};
+
 type Vulnerability = {
     id: string;
     aliases: string[];
@@ -54,17 +62,9 @@ type Vulnerability = {
         state: string;
     };
     simplified_status: string;
-    status_summary?: {
-        counts: Record<string, number>;
-        ordered: { status: string; count: number }[];
-        total_assessments: number;
-        dominant_status: string;
-        has_active_status: boolean;
-    };
+    status_summary?: StatusSummary;
     assessments: Assessment[];
 };
-
-type StatusSummary = NonNullable<Vulnerability['status_summary']>;
 
 export type { Vulnerability, CVSS };
 

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -185,7 +185,6 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                 {
                     ...vuln,
                     assessments: [],
-                    status: 'unknown',
                     simplified_status: 'unknown',
                 }
             ], newAssessments);

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -181,13 +181,15 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                         : a
                 );
             }
-            if (newAssessments.length === 0) {
-                return { ...vuln, assessments: [], status: 'unknown', simplified_status: 'unknown' };
-            }
-            const latest = [...newAssessments].sort(
-                (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-            )[0];
-            return { ...vuln, assessments: newAssessments, status: latest.status, simplified_status: latest.simplified_status };
+            const [enriched] = Vulnerabilities.enrich_with_assessments([
+                {
+                    ...vuln,
+                    assessments: [],
+                    status: 'unknown',
+                    simplified_status: 'unknown',
+                }
+            ], newAssessments);
+            return enriched;
         }));
     }, []);
 

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useCallback } from "react";
         import type { Package } from "../handlers/packages";
         import type { CVSS } from "../handlers/vulnerabilities";
         import type { Vulnerability } from "../handlers/vulnerabilities";
-        import { SEVERITY_ORDER } from "../handlers/vulnerabilities";
+        import { SEVERITY_ORDER, getVulnerabilityStatusSummary, isVulnerabilityActive } from "../handlers/vulnerabilities";
         import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement, BarElement, LogarithmicScale, ChartEvent, LegendItem, LegendElement } from 'chart.js';
         import { Pie, Line, Bar } from 'react-chartjs-2';
         import TableGeneric from "../components/TableGeneric";
@@ -337,9 +337,11 @@ const packageColumns = [
                     datasets: [{
                         label: '# of Vulnerabilities',
                         data: vulnerabilities.reduce((acc, vuln) => {
-                            const status = vuln.simplified_status;
-                            const index = status == 'Not affected' ? 0 : status == 'Fixed' ? 1 : status == 'Pending Assessment' ? 2 : 3;
-                            acc[index]++;
+                          const summary = getVulnerabilityStatusSummary(vuln);
+                          acc[0] += summary.counts['Not affected'] ?? 0;
+                          acc[1] += summary.counts['Fixed'] ?? 0;
+                          acc[2] += summary.counts['Pending Assessment'] ?? 0;
+                          acc[3] += summary.counts['Exploitable'] ?? 0;
                             return acc;
                         }, [0, 0, 0, 0]),
                         backgroundColor: [
@@ -430,7 +432,7 @@ const packageColumns = [
 
   const TopVulns = useMemo(() => {
     return [...vulnerabilities]
-      .filter((vuln) => vuln.simplified_status !== 'Fixed' && vuln.simplified_status !== 'Not affected')
+      .filter((vuln) => isVulnerabilityActive(vuln))
       .map((vuln, index) => {
         const maxCvss = vuln.severity.cvss?.length
           ? Math.max(...vuln.severity.cvss.map((cvss) => cvss.base_score || 0))
@@ -549,11 +551,11 @@ const packageColumns = [
                     const targetStatus = statusOrder[index];
 
                     const matchingStatus = vulnerabilities.find(v =>
-                        v.simplified_status === targetStatus
-                    )?.simplified_status;
+                      (getVulnerabilityStatusSummary(v).counts[targetStatus] ?? 0) > 0
+                    );
 
                     if (matchingStatus) {
-                        goToVulnsTabWithFilter("Status", matchingStatus);
+                      goToVulnsTabWithFilter("Status", targetStatus);
                     }
                 }
             }

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -728,7 +728,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                             <div className="space-y-1 text-gray-100">
                                 <p>Status aggregates all assessment outcomes for the vulnerability in the current scope.</p>
                                 <p>Scope follows your active project, variant, and compare selection.</p>
-                                <p>Display shows top outcomes with counts, for example: Fixed (2), Pending Assessment (1).</p>
+                                <p>Display shows top outcomes, for example: Exploitable, Pending Assessment.</p>
                                 <p>Filtering matches vulnerabilities when any selected status is present in the summary.</p>
                             </div>
                         </div>
@@ -738,7 +738,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             cell: info => {
                 const summary = getVulnerabilityStatusSummary(info.row.original);
                 const label = getTopStatusSummaryLabel(summary);
-                const details = summary.ordered.map(entry => `${entry.status} (${entry.count})`).join(', ');
+                const details = summary.ordered.map(entry => entry.status).join(', ');
                 return (
                     <div className="flex items-center justify-center h-full text-center" title={details}>
                         <code>{label}</code>

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -6,7 +6,7 @@ import type { EPSSProgress } from "../handlers/epss_progress";
 import { createColumnHelper, SortingFn, RowSelectionState, Row, Table } from '@tanstack/react-table'
 import React, { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import SeverityTag from "../components/SeverityTag";
-import { SEVERITY_ORDER } from "../handlers/vulnerabilities";
+import { SEVERITY_ORDER, getStatusSortIndex, getTopStatusSummaryLabel, getVulnerabilityStatusSummary } from "../handlers/vulnerabilities";
 import TableGeneric from "../components/TableGeneric";
 import VulnModal from "../components/VulnModal";
 import MultiEditBar from "../components/MultiEditBar";
@@ -113,9 +113,20 @@ const sortSeverityByScoreFn: SortingFn<Vulnerability> = (rowA, rowB) => {
 }
 
 const sortStatusFn: SortingFn<Vulnerability> = (rowA, rowB) => {
-    const indexA = ['unknown', 'Pending Assessment', 'Exploitable', 'Not affected', 'Fixed'].indexOf(rowA.original.simplified_status)
-    const indexB = ['unknown', 'Pending Assessment', 'Exploitable', 'Not affected', 'Fixed'].indexOf(rowB.original.simplified_status)
-    return indexA - indexB
+    const summaryA = getVulnerabilityStatusSummary(rowA.original);
+    const summaryB = getVulnerabilityStatusSummary(rowB.original);
+    const statusA = summaryA.dominant_status;
+    const statusB = summaryB.dominant_status;
+    const indexA = getStatusSortIndex(statusA);
+    const indexB = getStatusSortIndex(statusB);
+
+    if (indexA !== indexB) return indexA - indexB;
+
+    const dominantCountA = summaryA.counts[statusA] || 0;
+    const dominantCountB = summaryB.counts[statusB] || 0;
+    if (dominantCountA !== dominantCountB) return dominantCountA - dominantCountB;
+
+    return rowA.original.id.localeCompare(rowB.original.id);
 }
 
 const sortAttackVectorFn: SortingFn<Vulnerability> = (rowA, rowB) => {
@@ -689,9 +700,18 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             columnHelper.accessor('simplified_status', {
             id: 'simplified_status',
             header: () => <div className="flex items-center justify-center">Status</div>,
-            cell: info => <div className="flex items-center justify-center h-full text-center"><code>{info.renderValue()}</code></div>,
+            cell: info => {
+                const summary = getVulnerabilityStatusSummary(info.row.original);
+                const label = getTopStatusSummaryLabel(summary);
+                const details = summary.ordered.map(entry => `${entry.status} (${entry.count})`).join(', ');
+                return (
+                    <div className="flex items-center justify-center h-full text-center" title={details}>
+                        <code>{label}</code>
+                    </div>
+                );
+            },
             sortingFn: sortStatusFn,
-            size: 130
+            size: 220
             }),
             columnHelper.accessor('effort.likely', {
             id: 'effort.likely',
@@ -938,7 +958,11 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const dataToDisplay = useMemo(() => {
         return vulnerabilities.filter((el) => {
             if (selectedSeverities.length && !selectedSeverities.includes(el.severity.severity)) return false;
-            if (selectedStatuses.length && !selectedStatuses.includes(el.simplified_status)) return false;
+            if (selectedStatuses.length) {
+                const summary = getVulnerabilityStatusSummary(el);
+                const statusKeys = new Set(Object.keys(summary.counts));
+                if (!selectedStatuses.some(status => statusKeys.has(status))) return false;
+            }
             if (selectedSources.length && !selectedSources.some(src => el.found_by.includes(src))) return false;
             if (selectedPackages.length && !selectedPackages.some(pkg => el.packages_current.includes(pkg))) return false;
 
@@ -1037,6 +1061,15 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const selectedVulns = useMemo(() => {
         return Object.entries(selectedRows).flatMap(([id, selected]) => selected ? [id] : [])
     }, [selectedRows])
+
+    const availableStatuses = useMemo(() => {
+        const statuses = new Set<string>();
+        vulnerabilities.forEach(vuln => {
+            const summary = getVulnerabilityStatusSummary(vuln);
+            Object.keys(summary.counts).forEach(status => statuses.add(status));
+        });
+        return Array.from(statuses).sort((a, b) => getStatusSortIndex(a) - getStatusSortIndex(b));
+    }, [vulnerabilities]);
 
     const handleModalNavigation = (newIndex: number) => {
         if (newIndex >= 0 && newIndex < modalVulnSnapshot.length) {
@@ -1250,7 +1283,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
 
             <FilterOption
                 label="Status"
-                options={Array.from(new Set(vulnerabilities.map(v => v.simplified_status)))}
+                options={availableStatuses}
                 selected={selectedStatuses}
                 setSelected={setSelectedStatuses}
             />

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -374,6 +374,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const [selectedFirstScanDates, setSelectedFirstScanDates] = useState<string[]>([]);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
+    const [showStatusHelper, setShowStatusHelper] = useState(false);
     const [showMoreFilters, setShowMoreFilters] = useState(false);
 
     const searchInputRef = useRef<HTMLInputElement>(null);
@@ -381,6 +382,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const shortcutDropdownRef = useRef<HTMLDivElement>(null);
     const searchHelperButtonRef = useRef<HTMLButtonElement>(null);
     const searchHelperDropdownRef = useRef<HTMLDivElement>(null);
+    const statusHelperButtonRef = useRef<HTMLButtonElement>(null);
+    const statusHelperDropdownRef = useRef<HTMLDivElement>(null);
     const moreFiltersRef = useRef<HTMLDivElement>(null);
     const prevNvdInProgress = useRef<boolean | null>(null);
     const prevNvdPhase = useRef<string | null>(null);
@@ -699,7 +702,39 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             }),
             columnHelper.accessor('simplified_status', {
             id: 'simplified_status',
-            header: () => <div className="flex items-center justify-center">Status</div>,
+            header: () => (
+                <div className="relative flex items-center justify-center gap-1">
+                    <span>Status</span>
+                    <button
+                        ref={statusHelperButtonRef}
+                        type="button"
+                        aria-label="status summary helper"
+                        className="text-sky-300 hover:text-sky-100 transition-colors"
+                        onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            setShowStatusHelper(!showStatusHelper);
+                        }}
+                    >
+                        <FontAwesomeIcon icon={faCircleQuestion} />
+                    </button>
+                    {showStatusHelper && (
+                        <div
+                            ref={statusHelperDropdownRef}
+                            className="absolute top-full mt-1 right-0 bg-sky-900 border border-sky-700 rounded-lg shadow-lg p-3 z-50 w-[360px] text-sm text-left"
+                            onClick={(event) => event.stopPropagation()}
+                        >
+                            <h3 className="font-bold text-white mb-2">Status Summary</h3>
+                            <div className="space-y-1 text-gray-100">
+                                <p>Status aggregates all assessment outcomes for the vulnerability in the current scope.</p>
+                                <p>Scope follows your active project, variant, and compare selection.</p>
+                                <p>Display shows top outcomes with counts, for example: Fixed (2), Pending Assessment (1).</p>
+                                <p>Filtering matches vulnerabilities when any selected status is present in the summary.</p>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            ),
             cell: info => {
                 const summary = getVulnerabilityStatusSummary(info.row.original);
                 const label = getTopStatusSummaryLabel(summary);
@@ -944,7 +979,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 size: 20
             })
         ]
-    }, [handleEditClick, searchFilteredData, showCustomSeverityFilter, severityRange, nvdProgress, epssProgress]);
+    }, [handleEditClick, searchFilteredData, showCustomSeverityFilter, severityRange, nvdProgress, epssProgress, showStatusHelper]);
 
     const columns = useMemo(() => {
         return allColumns.filter(col => {
@@ -1159,16 +1194,24 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             ) {
                 setShowSearchHelper(false);
             }
+            if (
+                statusHelperDropdownRef.current &&
+                statusHelperButtonRef.current &&
+                !statusHelperDropdownRef.current.contains(event.target as Node) &&
+                !statusHelperButtonRef.current.contains(event.target as Node)
+            ) {
+                setShowStatusHelper(false);
+            }
         };
 
-        if (showShortcutHelper || showSearchHelper) {
+        if (showShortcutHelper || showSearchHelper || showStatusHelper) {
             document.addEventListener('mousedown', handleClickOutside);
         }
 
         return () => {
             document.removeEventListener('mousedown', handleClickOutside);
         };
-    }, [showShortcutHelper, showSearchHelper]);
+    }, [showShortcutHelper, showSearchHelper, showStatusHelper]);
 
     // Close "More Filters" on click outside
     useEffect(() => {

--- a/frontend/tests/unit_tests/test_assessments_handler.ts
+++ b/frontend/tests/unit_tests/test_assessments_handler.ts
@@ -1,5 +1,8 @@
 
-import { asAssessment, asStringArray } from '../../src/handlers/assessments';
+import fetchMock from 'jest-fetch-mock';
+fetchMock.enableMocks();
+
+import Assessments, { asAssessment, asStringArray, removeDuplicateAssessments } from '../../src/handlers/assessments';
 
 describe('asStringArray', () => {
   test('non array returns empty array', () => {
@@ -105,5 +108,192 @@ describe('asAssessment optional fields', () => {
     expect(assessed.workaround).toBeUndefined();
     expect(assessed.workaround_timestamp).toBeUndefined();
     expect(assessed.last_update).toBeUndefined();
+  });
+
+  test('sets origin from data when string', () => {
+    const data = { id: '4', vuln_id: 'CVE-B', status: 'fixed', timestamp: '2024-06-01T00:00:00', packages: [], responses: [], origin: 'custom' };
+    const assessed = asAssessment(data as any) as any;
+    expect(assessed.origin).toBe('custom');
+  });
+
+  test('sets vuln_texts when object and not null', () => {
+    const data = { id: '5', vuln_id: 'CVE-C', status: 'fixed', timestamp: '2024-07-01T00:00:00', packages: [], responses: [], vuln_texts: { key: 'val' } };
+    const assessed = asAssessment(data as any) as any;
+    expect(assessed.vuln_texts).toEqual({ key: 'val' });
+  });
+
+  test('ignores null vuln_texts', () => {
+    const data = { id: '6', vuln_id: 'CVE-D', status: 'fixed', timestamp: '2024-08-01T00:00:00', packages: [], responses: [], vuln_texts: null };
+    const assessed = asAssessment(data as any) as any;
+    expect(assessed.vuln_texts).toBeUndefined();
+  });
+});
+
+describe('removeDuplicateAssessments', () => {
+  const makeAssessment = (overrides: any = {}) => ({
+    id: 'a1',
+    vuln_id: 'CVE-2024-1',
+    packages: ['pkg@1.0'],
+    origin: 'sbom',
+    status: 'fixed',
+    simplified_status: 'Fixed',
+    timestamp: '2024-01-01T00:00:00',
+    responses: [],
+    variant_id: undefined,
+    ...overrides,
+  });
+
+  test('returns same assessments when no duplicates', () => {
+    const a1 = makeAssessment({ id: 'a1', vuln_id: 'CVE-1', packages: ['pkg@1'] });
+    const a2 = makeAssessment({ id: 'a2', vuln_id: 'CVE-2', packages: ['pkg@1'] });
+    expect(removeDuplicateAssessments([a1, a2])).toHaveLength(2);
+  });
+
+  test('removes exact duplicate assessment', () => {
+    const a1 = makeAssessment({ id: 'a1' });
+    const a2 = makeAssessment({ id: 'a2' }); // same content, different id
+    expect(removeDuplicateAssessments([a1, a2])).toHaveLength(1);
+  });
+
+  test('does not deduplicate when packages differ', () => {
+    const a1 = makeAssessment({ packages: ['pkg@1.0'] });
+    const a2 = makeAssessment({ packages: ['pkg@2.0'] });
+    expect(removeDuplicateAssessments([a1, a2])).toHaveLength(2);
+  });
+
+  test('does not deduplicate when status differs', () => {
+    const a1 = makeAssessment({ status: 'fixed' });
+    const a2 = makeAssessment({ status: 'affected' });
+    expect(removeDuplicateAssessments([a1, a2])).toHaveLength(2);
+  });
+
+  test('key includes descriptions so differing notes are not deduplicated', () => {
+    const a1 = makeAssessment({ status_notes: 'note1' });
+    const a2 = makeAssessment({ status_notes: 'note2' });
+    expect(removeDuplicateAssessments([a1, a2])).toHaveLength(2);
+  });
+
+  test('key includes variant_id', () => {
+    const a1 = makeAssessment({ variant_id: 'v1' });
+    const a2 = makeAssessment({ variant_id: 'v2' });
+    expect(removeDuplicateAssessments([a1, a2])).toHaveLength(2);
+  });
+
+  test('sorts packages before building key so order does not matter', () => {
+    const a1 = makeAssessment({ packages: ['pkg@1', 'pkg@2'] });
+    const a2 = makeAssessment({ packages: ['pkg@2', 'pkg@1'] });
+    expect(removeDuplicateAssessments([a1, a2])).toHaveLength(1);
+  });
+
+  test('empty array returns empty array', () => {
+    expect(removeDuplicateAssessments([])).toEqual([]);
+  });
+});
+
+describe('Assessments API', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  const sampleAssessmentData = [
+    { id: 'a1', vuln_id: 'CVE-1', status: 'fixed', timestamp: '2024-01-01T00:00:00', packages: [], responses: [] },
+    { id: 'a2', vuln_id: 'CVE-2', status: 'affected', timestamp: '2024-02-01T00:00:00', packages: [], responses: [] },
+  ];
+
+  test('list returns parsed assessments', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(sampleAssessmentData));
+    const result = await Assessments.list();
+    expect(result).toHaveLength(2);
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('format')).toBe('list');
+  });
+
+  test('list with variantId sets variant_id param', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+    await Assessments.list('var-1');
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('variant_id')).toBe('var-1');
+    expect(url.searchParams.has('project_id')).toBe(false);
+  });
+
+  test('list with projectId sets project_id param when no variantId', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+    await Assessments.list(undefined, 'proj-1');
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('project_id')).toBe('proj-1');
+    expect(url.searchParams.has('variant_id')).toBe(false);
+  });
+
+  test('list deduplicates returned assessments', async () => {
+    const dup = { id: 'a1', vuln_id: 'CVE-1', status: 'fixed', timestamp: '2024-01-01T00:00:00', packages: [], responses: [] };
+    fetchMock.mockResponseOnce(JSON.stringify([dup, dup]));
+    const result = await Assessments.list();
+    expect(result).toHaveLength(1);
+  });
+
+  test('listReview returns parsed assessments', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(sampleAssessmentData));
+    const result = await Assessments.listReview();
+    expect(result).toHaveLength(2);
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.pathname).toContain('/review');
+  });
+
+  test('listReview with variantId sets param', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+    await Assessments.listReview('var-2');
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('variant_id')).toBe('var-2');
+  });
+
+  test('listReview with projectId sets param when no variantId', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+    await Assessments.listReview(undefined, 'proj-2');
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('project_id')).toBe('proj-2');
+  });
+
+  test('listReviewTimeEstimates returns array', async () => {
+    const data = [{ vuln_id: 'CVE-1', optimistic: 1, likely: 2, pessimistic: 3, optimistic_iso: 'PT1H', likely_iso: 'PT2H', pessimistic_iso: 'PT3H' }];
+    fetchMock.mockResponseOnce(JSON.stringify(data));
+    const result = await Assessments.listReviewTimeEstimates('var-1');
+    expect(result).toHaveLength(1);
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('variant_id')).toBe('var-1');
+  });
+
+  test('listReviewTimeEstimates returns empty array for non-array response', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(null));
+    const result = await Assessments.listReviewTimeEstimates();
+    expect(result).toEqual([]);
+  });
+
+  test('listReviewTimeEstimates with projectId sets param', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+    await Assessments.listReviewTimeEstimates(undefined, 'proj-3');
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('project_id')).toBe('proj-3');
+  });
+
+  test('listReviewCustomCvss returns array', async () => {
+    const data = [{ vuln_id: 'CVE-1', version: '3.1', vector_string: 'CVSS:3.1/AV:N', base_score: 7.5, author: 'user' }];
+    fetchMock.mockResponseOnce(JSON.stringify(data));
+    const result = await Assessments.listReviewCustomCvss('var-1');
+    expect(result).toHaveLength(1);
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.pathname).toContain('custom-cvss');
+  });
+
+  test('listReviewCustomCvss returns empty array for non-array response', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify('not an array'));
+    const result = await Assessments.listReviewCustomCvss();
+    expect(result).toEqual([]);
+  });
+
+  test('listReviewCustomCvss with projectId sets param', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([]));
+    await Assessments.listReviewCustomCvss(undefined, 'proj-4');
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get('project_id')).toBe('proj-4');
   });
 });

--- a/frontend/tests/unit_tests/test_handlers.ts
+++ b/frontend/tests/unit_tests/test_handlers.ts
@@ -270,3 +270,145 @@ describe('Assessments', () => {
     });
 });
 
+describe('Packages additional coverage', () => {
+    beforeEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    test('asPackage parses variants, sources, and sbom_documents arrays', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                json: () => Promise.resolve([{
+                    name: 'mypkg',
+                    version: '3.0',
+                    cpe: ['cpe:2.3:a:x:mypkg:3.0:*'],
+                    purl: ['pkg:generic/mypkg@3.0'],
+                    variants: ['variant-a', 42, 'variant-b'],
+                    sources: ['scanner1', null, 'scanner2'],
+                    sbom_documents: ['doc1.spdx', 'doc2.spdx'],
+                }])
+            } as Response)
+        );
+        const packages = await Packages.list();
+        expect(packages[0].variants).toEqual(['variant-a', 'variant-b']);
+        expect(packages[0].source).toEqual(['scanner1', 'scanner2']);
+        expect(packages[0].sbom_documents).toEqual(['doc1.spdx', 'doc2.spdx']);
+    });
+
+    test('asPackage uses custom id when provided and non-empty', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                json: () => Promise.resolve([{
+                    id: 'custom-id-123',
+                    name: 'mypkg',
+                    version: '1.0',
+                    cpe: [],
+                    purl: [],
+                }])
+            } as Response)
+        );
+        const packages = await Packages.list();
+        expect(packages[0].id).toBe('custom-id-123');
+    });
+
+    test('asPackage falls back to name@version when id is empty string', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                json: () => Promise.resolve([{
+                    id: '',
+                    name: 'mypkg',
+                    version: '2.0',
+                    cpe: [],
+                    purl: [],
+                }])
+            } as Response)
+        );
+        const packages = await Packages.list();
+        expect(packages[0].id).toBe('mypkg@2.0');
+    });
+
+    test('list with compareVariantId and operation sets correct query params', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+        await Packages.list('var-1', undefined, 'var-2', 'intersection');
+        const url = new URL(fetchMock.mock.calls[0][0] as string);
+        expect(url.searchParams.get('variant_id')).toBe('var-1');
+        expect(url.searchParams.get('compare_variant_id')).toBe('var-2');
+        expect(url.searchParams.get('operation')).toBe('intersection');
+    });
+
+    test('list with compareVariantId but no operation omits operation param', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+        await Packages.list('var-1', undefined, 'var-2');
+        const url = new URL(fetchMock.mock.calls[0][0] as string);
+        expect(url.searchParams.get('variant_id')).toBe('var-1');
+        expect(url.searchParams.get('compare_variant_id')).toBe('var-2');
+        expect(url.searchParams.has('operation')).toBe(false);
+    });
+
+    test('list with projectId only sets project_id param', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+        await Packages.list(undefined, 'proj-5');
+        const url = new URL(fetchMock.mock.calls[0][0] as string);
+        expect(url.searchParams.get('project_id')).toBe('proj-5');
+        expect(url.searchParams.has('variant_id')).toBe(false);
+    });
+
+    test('enrich_with_vulns uses buildStatusSummary when pkg assessments exist', () => {
+        const pkg = {
+            id: 'mypkg@1.0',
+            name: 'mypkg',
+            version: '1.0',
+            cpe: [],
+            purl: [],
+            vulnerabilities: {},
+            maxSeverity: {},
+            source: [],
+            variants: [],
+            sbom_documents: [],
+            supplier: '',
+        };
+
+        const assessment = {
+            id: 'a1',
+            vuln_id: 'CVE-2024-1',
+            packages: ['mypkg@1.0'],
+            origin: 'sbom',
+            status: 'fixed',
+            simplified_status: 'Fixed',
+            timestamp: '2024-01-01T00:00:00',
+            responses: [],
+        };
+
+        const vuln = {
+            id: 'CVE-2024-1',
+            aliases: [],
+            related_vulnerabilities: [],
+            namespace: 'nvd:cve',
+            found_by: ['scanner'],
+            datasource: '',
+            packages: ['mypkg@1.0'],
+            packages_current: [],
+            variants: [],
+            urls: [],
+            texts: [],
+            severity: { severity: 'high', min_score: 7, max_score: 8, cvss: [] },
+            epss: { score: undefined, percentile: undefined },
+            effort: { optimistic: null, likely: null, pessimistic: null },
+            fix: { state: 'unknown' },
+            status: 'fixed',
+            simplified_status: 'Fixed',
+            assessments: [assessment],
+        } as any;
+
+        const result = Packages.enrich_with_vulns([pkg], [vuln]);
+        expect(result[0].vulnerabilities['Fixed']).toBe(1);
+        expect(result[0].maxSeverity['Fixed'].label).toBe('high');
+    });
+});
+

--- a/frontend/tests/unit_tests/test_handlers.ts
+++ b/frontend/tests/unit_tests/test_handlers.ts
@@ -240,11 +240,9 @@ describe('Vulnerabilities', () => {
         const enrichedvuln = Vulnerabilities.enrich_with_assessments(vulnerabilities, assessments);
         expect(enrichedvuln.length).toEqual(2);
 
-        expect(enrichedvuln[0].status).toEqual('fixed');
         expect(enrichedvuln[0].simplified_status).toEqual('Fixed');
         expect(enrichedvuln[0].assessments.length).toEqual(1);
 
-        expect(enrichedvuln[1].status).toEqual('affected');
         expect(enrichedvuln[1].simplified_status).toEqual('Exploitable');
         expect(enrichedvuln[1].assessments.length).toEqual(2);
     });

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -52,7 +52,6 @@ describe('MultiEditBar', () => {
             fix: {
                 state: 'unknown'
             },
-            status: 'not_affected',
             simplified_status: 'not_affected',
             variants: [],
             assessments: [],
@@ -86,7 +85,6 @@ describe('MultiEditBar', () => {
             fix: {
                 state: 'unknown'
             },
-            status: 'affected',
             simplified_status: 'affected',
             variants: [],
             assessments: [],
@@ -163,8 +161,8 @@ describe('MultiEditBar', () => {
 
     test('handles same status across vulnerabilities', () => {
         const sameStatusVulns = [
-            { ...mockVulnerabilities[0], id: 'vuln-1', status: 'affected' },
-            { ...mockVulnerabilities[0], id: 'vuln-2', status: 'affected' }
+            { ...mockVulnerabilities[0], id: 'vuln-1' },
+            { ...mockVulnerabilities[0], id: 'vuln-2' }
         ];
         const props = {
             ...mockProps,
@@ -177,8 +175,8 @@ describe('MultiEditBar', () => {
 
     test('handles different status across vulnerabilities', () => {
         const mixedStatusVulns = [
-            { ...mockVulnerabilities[0], id: 'vuln-1', status: 'affected' },
-            { ...mockVulnerabilities[0], id: 'vuln-2', status: 'not_affected' }
+            { ...mockVulnerabilities[0], id: 'vuln-1' },
+            { ...mockVulnerabilities[0], id: 'vuln-2' }
         ];
         const props = {
             ...mockProps,

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -48,7 +48,6 @@ describe('Vulnerability Modal', () => {
         fix: {
             state: 'unknown'
         },
-        status: 'affected',
         simplified_status: 'active',
         variants: [],
         assessments: [{
@@ -635,7 +634,6 @@ describe('Vulnerability Modal', () => {
             fix: {
                 state: 'unknown'
             },
-            status: 'affected',
             simplified_status: 'active',
             variants: [],
             assessments: []
@@ -2118,7 +2116,6 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
             pessimistic: new Iso8601Duration(undefined)
         },
         fix: { state: 'unknown' },
-        status: 'under_investigation',
         simplified_status: 'Pending Assessment',
         assessments: [],
         variants: [],
@@ -2183,7 +2180,6 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         const vulnWithAssessment: Vulnerability = {
             ...vulnerability,
             found_by: ['grype', 'osv'],
-            status: 'not_affected',
             simplified_status: 'Not Affected',
             assessments: [assessment],
             packages_current: ['libfoo@1.2.3'],
@@ -2207,7 +2203,6 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
                 vulnWithAssessment.id,
                 expect.objectContaining({
                     found_by: ['grype', 'osv'],
-                    status: 'not_affected',
                     simplified_status: 'Not Affected',
                     assessments: [assessment],
                     packages_current: ['libfoo@1.2.3'],

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -603,7 +603,7 @@ describe('Vulnerability Table', () => {
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         const user = userEvent.setup();
-        const statusBtn = await screen.getByRole('button', { name: /status/i });
+        const statusBtn = await screen.getByRole('button', { name: /^status$/i });
         expect(statusBtn).toBeInTheDocument();
         await user.click(statusBtn);
 
@@ -625,7 +625,7 @@ describe('Vulnerability Table', () => {
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         const user = userEvent.setup();
-        const statusBtn = await screen.getByRole('button', { name: /status/i });
+        const statusBtn = await screen.getByRole('button', { name: /^status$/i });
         expect(statusBtn).toBeInTheDocument();
         await user.click(statusBtn);
 

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -92,7 +92,6 @@ describe('Vulnerability Table', () => {
             fix: {
                 state: 'unknown'
             },
-            status: 'affected',
             simplified_status: 'Exploitable',
             assessments: [],
             variants: [],
@@ -153,7 +152,6 @@ describe('Vulnerability Table', () => {
             fix: {
                 state: 'unknown'
             },
-            status: 'under_investigation',
             simplified_status: 'Pending Assessment',
             published: '2018-07-22T14:30:00Z',
             assessments: [],
@@ -204,7 +202,6 @@ describe('Vulnerability Table', () => {
             fix: {
                 state: 'unknown'
             },
-            status: 'fixed',
             simplified_status: 'Fixed',
             assessments: [
                 {
@@ -250,7 +247,6 @@ describe('Vulnerability Table', () => {
             pessimistic: new Iso8601Duration(undefined)
         },
         fix: { state: 'unknown' },
-        status: 'affected',
         simplified_status: 'Exploitable',
         assessments: [],
         published: '2024-01-01T00:00:00Z'
@@ -1613,7 +1609,6 @@ describe('Vulnerability Table', () => {
                     pessimistic: new Iso8601Duration('PT4H')
                 },
                 fix: { state: 'unknown' },
-                status: 'under_investigation',
                 simplified_status: 'Pending Assessment',
                 assessments: [],
                 variants: [],
@@ -1824,7 +1819,6 @@ describe('Vulnerability Table', () => {
                     pessimistic: new Iso8601Duration('PT4H')
                 },
                 fix: { state: 'unknown' },
-                status: 'under_investigation',
                 simplified_status: 'Pending Assessment',
                 assessments: [],
                 variants: [],
@@ -2175,7 +2169,6 @@ describe('More Filters dropdown', () => {
                 pessimistic: new Iso8601Duration(undefined)
             },
             fix: { state: 'unknown' },
-            status: 'affected',
             simplified_status: 'Exploitable',
             assessments: [],
             variants: [],
@@ -2214,7 +2207,6 @@ describe('More Filters dropdown', () => {
                 pessimistic: new Iso8601Duration(undefined)
             },
             fix: { state: 'unknown' },
-            status: 'under_investigation',
             simplified_status: 'Pending Assessment',
             assessments: [],
             variants: [],
@@ -2373,7 +2365,6 @@ describe('NVD timestamp columns', () => {
             pessimistic: new Iso8601Duration(undefined)
         },
         fix: { state: 'unknown' },
-        status: 'under_investigation',
         simplified_status: 'Pending Assessment',
         assessments: [],
         variants: [],

--- a/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
+++ b/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
@@ -161,7 +161,6 @@ describe('enrich_with_assessments', () => {
     ].map((v: any) => {
       return {
         ...v,
-        status: 'unknown',
         simplified_status: 'unknown',
         assessments: []
       };
@@ -202,7 +201,6 @@ describe('enrich_with_assessments', () => {
 
     // CVE-2021-1 should have latest assessment (most recent timestamp)
     const cve1 = enriched.find((v: any) => v.id === 'CVE-2021-1');
-    expect(cve1?.status).toBe('resolved');
     expect(cve1?.simplified_status).toBe('closed');
     expect(cve1?.assessments).toHaveLength(3);
     // Assessments should be sorted by timestamp
@@ -212,13 +210,11 @@ describe('enrich_with_assessments', () => {
 
     // CVE-2021-2 should have single assessment
     const cve2 = enriched.find((v: any) => v.id === 'CVE-2021-2');
-    expect(cve2?.status).toBe('affected');
     expect(cve2?.simplified_status).toBe('open');
     expect(cve2?.assessments).toHaveLength(1);
 
     // CVE-2021-3 should remain unchanged
     const cve3 = enriched.find((v: any) => v.id === 'CVE-2021-3');
-    expect(cve3?.status).toBe('unknown');
     expect(cve3?.simplified_status).toBe('unknown');
     expect(cve3?.assessments).toHaveLength(0);
   });
@@ -227,14 +223,13 @@ describe('enrich_with_assessments', () => {
     const vulns = [
       {
         ...rawVuln({ id: 'CVE-2021-1' }),
-        status: 'unknown',
         simplified_status: 'unknown',
         assessments: []
       }
     ];
 
     const enriched = Vulnerabilities.enrich_with_assessments(vulns, []);
-    expect(enriched[0].status).toBe('unknown');
+    expect(enriched[0].simplified_status).toBe('unknown');
     expect(enriched[0].assessments).toHaveLength(0);
   });
 
@@ -242,7 +237,6 @@ describe('enrich_with_assessments', () => {
     const vulns = [
       {
         ...rawVuln({ id: 'CVE-2021-1' }),
-        status: 'unknown',
         simplified_status: 'unknown',
         assessments: []
       }
@@ -250,7 +244,7 @@ describe('enrich_with_assessments', () => {
 
     // This simulates the case where no assessments exist for the vulnerability
     const enriched = Vulnerabilities.enrich_with_assessments(vulns, []);
-    expect(enriched[0].status).toBe('unknown');
+    expect(enriched[0].simplified_status).toBe('unknown');
   });
 });
 
@@ -259,13 +253,11 @@ describe('append_assessment', () => {
     const vulns = [
       {
         ...rawVuln({ id: 'CVE-2021-1' }),
-        status: 'unknown',
         simplified_status: 'unknown',
         assessments: []
       },
       {
         ...rawVuln({ id: 'CVE-2021-2' }),
-        status: 'unknown',
         simplified_status: 'unknown',
         assessments: []
       }
@@ -282,12 +274,11 @@ describe('append_assessment', () => {
     const result = Vulnerabilities.append_assessment(vulns, assessment);
 
     const cve1 = result.find((v: any) => v.id === 'CVE-2021-1');
-    expect(cve1?.status).toBe('investigating');
     expect(cve1?.simplified_status).toBe('open');
     expect(cve1?.assessments).toHaveLength(1);
 
     const cve2 = result.find((v: any) => v.id === 'CVE-2021-2');
-    expect(cve2?.status).toBe('unknown');
+    expect(cve2?.simplified_status).toBe('unknown');
     expect(cve2?.assessments).toHaveLength(0);
   });
 });
@@ -297,7 +288,6 @@ describe('append_cvss', () => {
     const vulns = [
       {
         ...rawVuln({ id: 'CVE-2021-1' }),
-        status: 'unknown',
         simplified_status: 'unknown',
         assessments: [],
         severity: {
@@ -330,7 +320,6 @@ describe('append_cvss', () => {
     const vulns = [
       {
         ...rawVuln({ id: 'CVE-2021-1' }),
-        status: 'unknown',
         simplified_status: 'unknown',
         assessments: [],
         severity: {
@@ -342,7 +331,6 @@ describe('append_cvss', () => {
       },
       {
         ...rawVuln({ id: 'CVE-2021-2' }),
-        status: 'unknown',
         simplified_status: 'unknown',
         assessments: [],
         severity: {
@@ -561,7 +549,6 @@ describe('isVulnerabilityActive', () => {
     epss: { score: undefined, percentile: undefined },
     effort: { optimistic: null as any, likely: null as any, pessimistic: null as any },
     fix: { state: 'unknown' },
-    status: simplified_status,
     simplified_status,
     assessments: [],
     status_summary,
@@ -621,10 +608,9 @@ describe('getStatusSortIndex', () => {
   });
 });
 
-describe('getLegacyStatusFromSummary via append_assessment', () => {
+describe('append_assessment via sort comparator', () => {
   const makeVuln = (id: string) => ({
     ...rawVuln({ id }),
-    status: 'unknown',
     simplified_status: 'unknown',
     assessments: [],
   });
@@ -649,17 +635,14 @@ describe('getLegacyStatusFromSummary via append_assessment', () => {
     expect(result[0].assessments[1].id).toBe('a1');
   });
 
-  test('getLegacyStatusFromSummary fallback: no matching dominant status', () => {
-    // enrich_with_assessments where all assessments have a different simplified_status
-    // than the computed dominant, triggering the fallback return
+  test('dominant status reflects highest-priority variant', () => {
+    // enrich_with_assessments with two variants: Fixed and Exploitable
+    // Exploitable has higher priority so it should be dominant
     const vuln = {
       ...rawVuln({ id: 'CVE-X' }),
-      status: 'unknown',
       simplified_status: 'unknown',
       assessments: [],
     };
-    // Use two different variants so dominant_status is Exploitable (highest priority)
-    // but we supply only non-matching assessments to trigger the loop fallback
     const assessments = [
       {
         vuln_id: 'CVE-X',
@@ -686,9 +669,6 @@ describe('getLegacyStatusFromSummary via append_assessment', () => {
     ] as any[];
 
     const enriched = Vulnerabilities.enrich_with_assessments([vuln as any], assessments);
-    // dominant_status should be Exploitable; getLegacyStatusFromSummary scans
-    // from the end to find the last assessment with simplified_status === 'Exploitable'
-    expect(enriched[0].status).toBe('affected');
     expect(enriched[0].simplified_status).toBe('Exploitable');
   });
 });

--- a/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
+++ b/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
@@ -27,7 +27,13 @@ jest.mock('ae-cvss-calculator', () => {
   };
 });
 
-import Vulnerabilities from '../../src/handlers/vulnerabilities';
+import Vulnerabilities, {
+  buildStatusSummary,
+  getTopStatusSummaryLabel,
+  isVulnerabilityActive,
+  getStatusSortIndex,
+  isActiveStatus,
+} from '../../src/handlers/vulnerabilities';
 
 // Utility to build raw vulnerability JSON objects returned by backend
 const rawVuln = (overrides: any = {}) => ({
@@ -398,5 +404,291 @@ describe('calculate_cvss_from_vector error handling', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
 
     consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('buildStatusSummary helpers', () => {
+  const makeAssessment = (simplified_status: string, timestamp: string, variant_id?: string) => ({
+    id: 'a',
+    vuln_id: 'CVE-1',
+    packages: [],
+    origin: 'sbom',
+    status: simplified_status,
+    simplified_status,
+    timestamp,
+    responses: [],
+    variant_id,
+  });
+
+  test('empty assessments returns unknown summary', () => {
+    const summary = buildStatusSummary([]);
+    expect(summary.dominant_status).toBe('unknown');
+    expect(summary.total_assessments).toBe(0);
+    expect(summary.has_active_status).toBe(false);
+  });
+
+  test('single assessment builds correct summary', () => {
+    const summary = buildStatusSummary([makeAssessment('Fixed', '2024-01-01T00:00:00')]);
+    expect(summary.dominant_status).toBe('Fixed');
+    expect(summary.total_assessments).toBe(1);
+    expect(summary.has_active_status).toBe(false);
+  });
+
+  test('multiple variants each contribute one slot', () => {
+    // v1 → Fixed, v2 → Exploitable; dominant_status should be Exploitable
+    const assessments = [
+      makeAssessment('Fixed', '2024-01-01T00:00:00', 'v1'),
+      makeAssessment('Exploitable', '2024-01-02T00:00:00', 'v2'),
+    ];
+    const summary = buildStatusSummary(assessments);
+    expect(summary.counts['Fixed']).toBe(1);
+    expect(summary.counts['Exploitable']).toBe(1);
+    expect(summary.dominant_status).toBe('Exploitable');
+    expect(summary.has_active_status).toBe(true);
+    // ordered should have 2 entries, triggering the sort comparator
+    expect(summary.ordered.length).toBe(2);
+  });
+
+  test('sort comparator uses count as tiebreaker', () => {
+    // v1 and v2 → Pending Assessment, v3 → Exploitable
+    const assessments = [
+      makeAssessment('Pending Assessment', '2024-01-01T00:00:00', 'v1'),
+      makeAssessment('Pending Assessment', '2024-01-01T00:00:00', 'v2'),
+      makeAssessment('Exploitable', '2024-01-01T00:00:00', 'v3'),
+    ];
+    const summary = buildStatusSummary(assessments);
+    // Exploitable has higher priority (lower index) so it's first despite lower count
+    expect(summary.dominant_status).toBe('Exploitable');
+    expect(summary.ordered[0].status).toBe('Exploitable');
+    expect(summary.ordered[1].status).toBe('Pending Assessment');
+  });
+
+  test('sort comparator uses localeCompare when priority and count tie', () => {
+    // Two unknown statuses from two variants, both non-standard
+    const assessments = [
+      makeAssessment('ZStatus', '2024-01-01T00:00:00', 'v1'),
+      makeAssessment('AStatus', '2024-01-01T00:00:00', 'v2'),
+    ];
+    const summary = buildStatusSummary(assessments);
+    // Both are equal priority and equal count → sorted alphabetically
+    expect(summary.ordered[0].status).toBe('AStatus');
+    expect(summary.ordered[1].status).toBe('ZStatus');
+  });
+
+  test('keeps latest assessment per variant', () => {
+    const assessments = [
+      makeAssessment('Pending Assessment', '2024-01-01T00:00:00', 'v1'),
+      makeAssessment('Fixed', '2024-01-02T00:00:00', 'v1'), // latest for v1
+    ];
+    const summary = buildStatusSummary(assessments);
+    expect(summary.dominant_status).toBe('Fixed');
+    expect(summary.counts['Fixed']).toBe(1);
+    expect(summary.counts['Pending Assessment']).toBeUndefined();
+  });
+
+  test('assessments without variant_id share one slot', () => {
+    const assessments = [
+      makeAssessment('Pending Assessment', '2024-01-01T00:00:00'),  // no variant
+      makeAssessment('Fixed', '2024-01-02T00:00:00'),               // no variant, later
+    ];
+    const summary = buildStatusSummary(assessments);
+    // Both share __no_variant__ → only Fixed (latest) counts
+    expect(summary.dominant_status).toBe('Fixed');
+    expect(Object.keys(summary.counts)).toHaveLength(1);
+  });
+});
+
+describe('getTopStatusSummaryLabel', () => {
+  test('returns all statuses when 2 or fewer', () => {
+    const summary = buildStatusSummary([
+      { id: 'a', vuln_id: 'CVE-1', packages: [], origin: '', status: 'Fixed', simplified_status: 'Fixed', timestamp: '2024-01-01T00:00:00', responses: [] }
+    ]);
+    expect(getTopStatusSummaryLabel(summary)).toBe('Fixed');
+  });
+
+  test('appends +N more when more than 2 entries', () => {
+    // Force a summary with 3 entries
+    const summary = {
+      counts: { 'Exploitable': 1, 'Pending Assessment': 1, 'Fixed': 1 },
+      ordered: [
+        { status: 'Exploitable', count: 1 },
+        { status: 'Pending Assessment', count: 1 },
+        { status: 'Fixed', count: 1 },
+      ],
+      total_assessments: 3,
+      dominant_status: 'Exploitable',
+      has_active_status: true,
+    };
+    const label = getTopStatusSummaryLabel(summary);
+    expect(label).toContain('+1 more');
+    expect(label).toContain('Exploitable');
+    expect(label).toContain('Pending Assessment');
+  });
+
+  test('custom maxItems parameter', () => {
+    const summary = {
+      counts: { 'A': 1, 'B': 1, 'C': 1, 'D': 1 },
+      ordered: [
+        { status: 'A', count: 1 },
+        { status: 'B', count: 1 },
+        { status: 'C', count: 1 },
+        { status: 'D', count: 1 },
+      ],
+      total_assessments: 4,
+      dominant_status: 'A',
+      has_active_status: false,
+    };
+    const label = getTopStatusSummaryLabel(summary, 3);
+    expect(label).toContain('+1 more');
+    expect(label).not.toContain('D');
+  });
+});
+
+describe('isVulnerabilityActive', () => {
+  const makeVuln = (simplified_status: string, status_summary?: any) => ({
+    id: 'CVE-1',
+    aliases: [],
+    related_vulnerabilities: [],
+    namespace: '',
+    found_by: [],
+    datasource: '',
+    packages: [],
+    packages_current: [],
+    variants: [],
+    urls: [],
+    texts: [],
+    severity: { severity: 'unknown', min_score: 0, max_score: 0, cvss: [] },
+    epss: { score: undefined, percentile: undefined },
+    effort: { optimistic: null as any, likely: null as any, pessimistic: null as any },
+    fix: { state: 'unknown' },
+    status: simplified_status,
+    simplified_status,
+    assessments: [],
+    status_summary,
+  });
+
+  test('returns false for Fixed', () => {
+    expect(isVulnerabilityActive(makeVuln('Fixed') as any)).toBe(false);
+  });
+
+  test('returns false for Not affected', () => {
+    expect(isVulnerabilityActive(makeVuln('Not affected') as any)).toBe(false);
+  });
+
+  test('returns false for unknown', () => {
+    expect(isVulnerabilityActive(makeVuln('unknown') as any)).toBe(false);
+  });
+
+  test('returns true for Exploitable', () => {
+    expect(isVulnerabilityActive(makeVuln('Exploitable') as any)).toBe(true);
+  });
+
+  test('returns true for Pending Assessment', () => {
+    expect(isVulnerabilityActive(makeVuln('Pending Assessment') as any)).toBe(true);
+  });
+
+  test('uses status_summary when present', () => {
+    const vuln = makeVuln('unknown', {
+      counts: { 'Exploitable': 1 },
+      ordered: [{ status: 'Exploitable', count: 1 }],
+      total_assessments: 1,
+      dominant_status: 'Exploitable',
+      has_active_status: true,
+    });
+    expect(isVulnerabilityActive(vuln as any)).toBe(true);
+  });
+});
+
+describe('isActiveStatus', () => {
+  test('Fixed is not active', () => expect(isActiveStatus('Fixed')).toBe(false));
+  test('Not affected is not active', () => expect(isActiveStatus('Not affected')).toBe(false));
+  test('unknown is not active', () => expect(isActiveStatus('unknown')).toBe(false));
+  test('Exploitable is active', () => expect(isActiveStatus('Exploitable')).toBe(true));
+  test('Pending Assessment is active', () => expect(isActiveStatus('Pending Assessment')).toBe(true));
+});
+
+describe('getStatusSortIndex', () => {
+  test('known statuses return expected index', () => {
+    expect(getStatusSortIndex('unknown')).toBe(0);
+    expect(getStatusSortIndex('Pending Assessment')).toBe(1);
+    expect(getStatusSortIndex('Exploitable')).toBe(2);
+    expect(getStatusSortIndex('Not affected')).toBe(3);
+    expect(getStatusSortIndex('Fixed')).toBe(4);
+  });
+
+  test('unknown status returns length of order array', () => {
+    expect(getStatusSortIndex('NonExistent')).toBe(5);
+  });
+});
+
+describe('getLegacyStatusFromSummary via append_assessment', () => {
+  const makeVuln = (id: string) => ({
+    ...rawVuln({ id }),
+    status: 'unknown',
+    simplified_status: 'unknown',
+    assessments: [],
+  });
+
+  test('append_assessment with two assessments triggers sort comparator', () => {
+    const vulns = [makeVuln('CVE-2021-1')];
+    const a1 = {
+      vuln_id: 'CVE-2021-1', status: 'fixed', simplified_status: 'Fixed',
+      timestamp: '2024-01-02T00:00:00', packages: [], responses: [], id: 'a1', origin: 'sbom',
+    } as any;
+    vulns[0].assessments = [a1];
+
+    const a2 = {
+      vuln_id: 'CVE-2021-1', status: 'affected', simplified_status: 'Exploitable',
+      timestamp: '2024-01-01T00:00:00', packages: [], responses: [], id: 'a2', origin: 'sbom',
+    } as any;
+
+    const result = Vulnerabilities.append_assessment(vulns as any, a2);
+    // a2 is earlier, a1 is later → sorted order [a2, a1] → latest is Fixed
+    expect(result[0].assessments).toHaveLength(2);
+    expect(result[0].assessments[0].id).toBe('a2'); // earlier first after sort
+    expect(result[0].assessments[1].id).toBe('a1');
+  });
+
+  test('getLegacyStatusFromSummary fallback: no matching dominant status', () => {
+    // enrich_with_assessments where all assessments have a different simplified_status
+    // than the computed dominant, triggering the fallback return
+    const vuln = {
+      ...rawVuln({ id: 'CVE-X' }),
+      status: 'unknown',
+      simplified_status: 'unknown',
+      assessments: [],
+    };
+    // Use two different variants so dominant_status is Exploitable (highest priority)
+    // but we supply only non-matching assessments to trigger the loop fallback
+    const assessments = [
+      {
+        vuln_id: 'CVE-X',
+        id: 'b1',
+        status: 'fixed',
+        simplified_status: 'Fixed',
+        timestamp: '2024-01-01T00:00:00',
+        packages: [],
+        responses: [],
+        variant_id: 'v1',
+        origin: 'sbom',
+      },
+      {
+        vuln_id: 'CVE-X',
+        id: 'b2',
+        status: 'affected',
+        simplified_status: 'Exploitable',
+        timestamp: '2024-01-01T00:00:00',
+        packages: [],
+        responses: [],
+        variant_id: 'v2',
+        origin: 'sbom',
+      },
+    ] as any[];
+
+    const enriched = Vulnerabilities.enrich_with_assessments([vuln as any], assessments);
+    // dominant_status should be Exploitable; getLegacyStatusFromSummary scans
+    // from the end to find the last assessment with simplified_status === 'Exploitable'
+    expect(enriched[0].status).toBe('affected');
+    expect(enriched[0].simplified_status).toBe('Exploitable');
   });
 });


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* summarize vulnerability statuses across current scope

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

- Open vulnerability tab.
- Pick vuln with multiple assessments affecting uneven set of packages in current project / variant scope.
- Verify Status column shows summary like `Fixed (2), Pending Assessment (1)` instead of single top status.
- Click status helper icon in table header. Verify tooltip explains scoped aggregation.
- Open Status filter. Select `Pending Assessment` or `Exploitable`. Verify row remains visible if summary contains such status, even when dominant status differs.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


