### PR TITLE
Optional initial bulk refresh

### DIFF
--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -30,7 +30,11 @@ def _launch_enrichment(app):
 
     Runs in its own thread so it doesn't block Flask request handlers
     (WAL journal mode allows concurrent reads).
+    Setting autoflush=False prevents every SELECT from triggering a flush
+    that would hold the write lock across slow HTTP calls.
     """
+    db.session.autoflush = False
+
     run_epss = os.getenv("INITIAL_REFRESH_EPSS", "true").lower() not in ("false", "0", "no")
     run_nvd = os.getenv("INITIAL_REFRESH_NVD", "false").lower() not in ("false", "0", "no")
 
@@ -55,7 +59,10 @@ def _launch_enrichment(app):
             )
 
             def _epss():
-                run_epss_refresh(app, cve_ids)
+                try:
+                    run_epss_refresh(app, cve_ids)
+                except Exception as exc:
+                    print(f"[enrichment/epss] Error during EPSS enrichment: {exc}", flush=True)
 
             threading.Thread(target=_epss, name="enrichment-epss", daemon=True).start()
         else:
@@ -70,7 +77,10 @@ def _launch_enrichment(app):
             )
 
             def _nvd():
-                run_nvd_refresh(app, cve_ids)
+                try:
+                    run_nvd_refresh(app, cve_ids)
+                except Exception as exc:
+                    print(f"[enrichment/nvd] Error during NVD enrichment: {exc}", flush=True)
 
             threading.Thread(target=_nvd, name="enrichment-nvd", daemon=True).start()
         else:

--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -10,7 +10,10 @@ from ..helpers.env_vars import get_bool_env
 from ..extensions import db, migrate, setup_write_serialization
 from ..routes import init_app
 from .. import models  # noqa: F401
-from .merger_ci import init_app as init_merger_cli, post_treatment
+from .merger_ci import init_app as init_merger_cli
+from ..controllers.refresh import run_epss_refresh, run_nvd_refresh
+from ..controllers.nvd_progress import NVDProgressTracker
+from ..controllers.epss_progress import EPSSProgressTracker
 import sys
 import os
 import threading
@@ -28,23 +31,50 @@ def _launch_enrichment(app):
     Runs in its own thread so it doesn't block Flask request handlers
     (WAL journal mode allows concurrent reads).
     """
-    def _enrich_epss():
-        with app.app_context():
-            # Disable autoflush: without this, every SELECT triggers a flush
-            # which acquires the write-lock and holds it across the slow HTTP
-            # calls until the next explicit commit().  With autoflush=False
-            # the lock is only held during commit() itself (milliseconds).
-            db.session.autoflush = False
-            try:
-                from ..controllers.packages import PackagesController
-                from ..controllers.vulnerabilities import VulnerabilitiesController
-                pkgCtrl = PackagesController()
-                vulnCtrl = VulnerabilitiesController(pkgCtrl)
-                post_treatment({"vulnerabilities": vulnCtrl, "packages": pkgCtrl})
-            except Exception as e:
-                print(f"[enrichment/epss] {e}", flush=True)
+    run_epss = os.getenv("INITIAL_REFRESH_EPSS", "true").lower() not in ("false", "0", "no")
+    run_nvd = os.getenv("INITIAL_REFRESH_NVD", "false").lower() not in ("false", "0", "no")
 
-    threading.Thread(target=_enrich_epss, name="enrichment-epss", daemon=True).start()
+    if not run_epss and not run_nvd:
+        return
+
+    cve_ids = db.session.execute(
+        db.select(models.Vulnerability.id).filter(
+            models.Vulnerability.id.like('CVE-%')
+        )
+    ).scalars().all()
+    if not cve_ids:
+        print("[enrichment] No CVE IDs found in DB, skipping enrichment", flush=True)
+        return
+
+    if run_epss:
+        print("[enrichment/epss] EPSS enrichment enabled by config", flush=True)
+        if EPSSProgressTracker.start_if_idle("bulk_epss_refresh"):
+            EPSSProgressTracker.update(
+                "bulk_epss_refresh", 0, len(cve_ids),
+                f"Starting EPSS enrichment: 0/{len(cve_ids)}",
+            )
+
+            def _epss():
+                run_epss_refresh(app, cve_ids)
+
+            threading.Thread(target=_epss, name="enrichment-epss", daemon=True).start()
+        else:
+            print("[enrichment/epss] Already in progress, skipping", flush=True)
+
+    if run_nvd:
+        print("[enrichment/nvd] NVD enrichment enabled by config", flush=True)
+        if NVDProgressTracker.start_if_idle("bulk_nvd_refresh"):
+            NVDProgressTracker.update(
+                "bulk_nvd_refresh", 0, len(cve_ids),
+                f"Starting NVD enrichment: 0/{len(cve_ids)}",
+            )
+
+            def _nvd():
+                run_nvd_refresh(app, cve_ids)
+
+            threading.Thread(target=_nvd, name="enrichment-nvd", daemon=True).start()
+        else:
+            print("[enrichment/nvd] Already in progress, skipping", flush=True)
 
 
 def create_app():

--- a/src/controllers/refresh.py
+++ b/src/controllers/refresh.py
@@ -1,0 +1,157 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Core EPSS and NVD refresh workers shared by startup enrichment and bulk refresh routes.
+
+Callers are responsible for calling the appropriate ProgressTracker.start_if_idle()
+before invoking a worker. Workers call complete() or error() when done.
+"""
+
+import datetime
+import os
+import re
+import time
+
+from ..extensions import db
+from ..models import Vulnerability
+from ..controllers.nvd_db import NVD_DB
+from ..controllers.nvd_apply import apply_nvd_update, apply_cvss_update
+from ..controllers.epss_db import EPSS_DB
+from ..controllers.nvd_progress import NVDProgressTracker
+from ..controllers.epss_progress import EPSSProgressTracker
+
+_EPSS_BATCH_SIZE = 100
+_NVD_COMMIT_EVERY = 50
+_MAX_CVE_IDS = 1000
+_CVE_RE = re.compile(r'^CVE-\d{4}-\d{4,}$')
+
+
+def _nvd_sleep_interval() -> float:
+    """Return seconds to sleep between NVD API calls based on key presence.
+
+    Without an API key: 5 req / 30 s → 6 s per call.
+    With an API key:   50 req / 30 s → 0.6 s per call.
+    """
+    return 0.6 if os.getenv("NVD_API_KEY") else 6.0
+
+
+def _safe_commit(label: str) -> None:
+    """Commit the current session; rollback and log on failure.
+
+    Always expunges all objects from the session after commit or rollback so
+    that the SQLAlchemy identity map does not accumulate loaded records across
+    many loop iterations.
+    """
+    try:
+        db.session.commit()
+    except Exception as exc:
+        print(f"[{label}] commit error: {exc}", flush=True)
+        db.session.rollback()
+    finally:
+        db.session.expunge_all()
+
+
+def run_epss_refresh(app, cve_ids: list) -> None:
+    """EPSS refresh worker. Caller must have called EPSSProgressTracker.start_if_idle()."""
+    total = len(cve_ids)
+    with app.app_context():
+        epss = EPSS_DB()
+        processed = 0
+        try:
+            chunks = [cve_ids[i:i + _EPSS_BATCH_SIZE] for i in range(0, total, _EPSS_BATCH_SIZE)]
+            for chunk in chunks:
+                if EPSSProgressTracker.is_cancelled():
+                    _safe_commit("bulk EPSS refresh cancel")
+                    EPSSProgressTracker.mark_cancelled()
+                    return
+
+                try:
+                    results = epss.api_get_epss_batch(chunk)
+                except Exception as exc:
+                    print(f"[bulk EPSS refresh] batch error: {exc}", flush=True)
+                    processed += len(chunk)
+                    EPSSProgressTracker.update(
+                        "bulk_epss_refresh", processed, total,
+                        f"EPSS refresh: {processed}/{total}",
+                    )
+                    continue
+
+                for cve_id in chunk:
+                    result = results.get(cve_id)
+                    if result:
+                        try:
+                            rec = db.session.get(Vulnerability, cve_id)
+                            if rec is not None:
+                                rec.update_record(
+                                    epss_score=result["score"],
+                                    epss_fetched_at=datetime.datetime.now(datetime.timezone.utc),
+                                    commit=False,
+                                )
+                        except Exception as exc:
+                            print(
+                                f"[bulk EPSS refresh] error updating {cve_id}: {exc}",
+                                flush=True,
+                            )
+                    processed += 1
+
+                _safe_commit("bulk EPSS refresh")
+                EPSSProgressTracker.update(
+                    "bulk_epss_refresh", processed, total,
+                    f"EPSS refresh: {processed}/{total}",
+                )
+
+            EPSSProgressTracker.complete()
+        except Exception as exc:
+            print(f"[bulk EPSS refresh] unhandled error: {exc}", flush=True)
+            EPSSProgressTracker.error(str(exc)[:200])
+
+
+def run_nvd_refresh(app, cve_ids: list) -> None:
+    """NVD refresh worker. Caller must have called NVDProgressTracker.start_if_idle()."""
+    total = len(cve_ids)
+    with app.app_context():
+        sleep_between = _nvd_sleep_interval()
+        nvd_api_key = os.getenv("NVD_API_KEY")
+        nvd = NVD_DB(nvd_api_key=nvd_api_key)
+        done = 0
+        try:
+            for cve_id in cve_ids:
+                if NVDProgressTracker.is_cancelled():
+                    _safe_commit("bulk NVD refresh cancel")
+                    NVDProgressTracker.mark_cancelled()
+                    return
+
+                try:
+                    now = datetime.datetime.now(datetime.timezone.utc)
+                    status_code, data = nvd.api_get_cve(cve_id, max_retries=2)
+                    if status_code == 200 and data.get("vulnerabilities"):
+                        cve = data["vulnerabilities"][0]["cve"]
+                        details = NVD_DB.extract_cve_details(cve)
+                        rec = db.session.get(Vulnerability, cve_id)
+                        if rec is not None:
+                            apply_nvd_update(rec, details, now)
+                            apply_cvss_update(rec, details, db)
+                    else:
+                        print(
+                            f"[bulk NVD refresh] {cve_id}: status={status_code}, "
+                            "skipping",
+                            flush=True,
+                        )
+                except Exception as exc:
+                    print(f"[bulk NVD refresh] error for {cve_id}: {exc}", flush=True)
+
+                done += 1
+                NVDProgressTracker.update(
+                    "bulk_nvd_refresh", done, total,
+                    f"NVD refresh: {done}/{total} ({cve_id})",
+                )
+                if done % _NVD_COMMIT_EVERY == 0:
+                    _safe_commit("bulk NVD refresh")
+                if done < total:
+                    time.sleep(sleep_between)
+
+            _safe_commit("bulk NVD refresh final")
+            NVDProgressTracker.complete()
+        except Exception as exc:
+            print(f"[bulk NVD refresh] unhandled error: {exc}", flush=True)
+            NVDProgressTracker.error(str(exc)[:200])

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -218,6 +218,8 @@ cmd_scan() {
     export DOCUMENT_URL="${DOCUMENT_URL:-}"
     export NVD_API_KEY="${NVD_API_KEY:-}"
     export REFRESH_REMOTE_DELAY="${REFRESH_REMOTE_DELAY:-48h}"
+    export INITIAL_REFRESH_NVD="${INITIAL_REFRESH_NVD:-false}"
+    export INITIAL_REFRESH_EPSS="${INITIAL_REFRESH_EPSS:-true}"
     export HTTP_PROXY="${HTTP_PROXY:-}"
     export HTTPS_PROXY="${HTTPS_PROXY:-}"
     export NO_PROXY="${NO_PROXY:-}"
@@ -544,6 +546,8 @@ SERVE_REQUESTED=false
 GRYPE_SCAN_REQUESTED=false
 NVD_SCAN_REQUESTED=false
 OSV_SCAN_REQUESTED=false
+INITIAL_REFRESH_NVD="${INITIAL_REFRESH_NVD:-false}"
+INITIAL_REFRESH_EPSS="${INITIAL_REFRESH_EPSS:-true}"
 REPORT_TEMPLATES=()
 EXPORT_FORMATS=()
 SCAN_REQUIRED=false
@@ -642,6 +646,18 @@ while [[ $# -gt 0 ]]; do
             NVD_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --perform-osv-scan)
             OSV_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
+        --initial-refresh-nvd)
+            if [[ "${2:-}" == "true" || "${2:-}" == "false" ]]; then
+                INITIAL_REFRESH_NVD="$2"; shift 2
+            else
+                INITIAL_REFRESH_NVD=true; shift
+            fi ;;
+        --initial-refresh-epss)
+            if [[ "${2:-}" == "true" || "${2:-}" == "false" ]]; then
+                INITIAL_REFRESH_EPSS="$2"; shift 2
+            else
+                INITIAL_REFRESH_EPSS=true; shift
+            fi ;;
         --clear-inputs)
             cmd_clear_inputs; shift ;;
         --delete-scan)

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -9,55 +9,20 @@ Progress is reported via the shared NVDProgressTracker / EPSSProgressTracker
 singletons, which are already polled by /api/nvd/progress and /api/epss/progress.
 """
 
-import datetime
-import os
-import re
 import threading
-import time
 
 from flask import jsonify, request
 
-from ..models import Vulnerability
-from ..extensions import db
-from ..controllers.nvd_db import NVD_DB
-from ..controllers.nvd_apply import apply_nvd_update, apply_cvss_update
-from ..controllers.epss_db import EPSS_DB
+from ..controllers.refresh import (
+    run_epss_refresh,
+    run_nvd_refresh,
+    _MAX_CVE_IDS,
+    _CVE_RE,
+    _safe_commit,
+    _nvd_sleep_interval,
+)
 from ..controllers.nvd_progress import NVDProgressTracker
 from ..controllers.epss_progress import EPSSProgressTracker
-
-_EPSS_BATCH_SIZE = 100
-_NVD_COMMIT_EVERY = 50
-# HIGH: cap prevents unbounded background threads (no API key = 6 s/CVE × N seconds of work)
-_MAX_CVE_IDS = 1000
-# HIGH: only accept well-formed CVE identifiers to avoid wasting rate-limit quota
-_CVE_RE = re.compile(r'^CVE-\d{4}-\d{4,}$')
-
-
-def _nvd_sleep_interval() -> float:
-    """Return seconds to sleep between NVD API calls based on key presence.
-
-    Without an API key: 5 req / 30 s → 6 s per call.
-    With an API key:   50 req / 30 s → 0.6 s per call.
-
-    Reference: https://nvd.nist.gov/developers/start-here, section "Rate Limits"
-    """
-    return 0.6 if os.getenv("NVD_API_KEY") else 6.0
-
-
-def _safe_commit(label: str) -> None:
-    """Commit the current session; rollback and log on failure.
-
-    Always expunges all objects from the session after commit or rollback so
-    that the SQLAlchemy identity map does not accumulate loaded records across
-    many loop iterations (fix for unbounded session-cache growth).
-    """
-    try:
-        db.session.commit()
-    except Exception as exc:
-        print(f"[{label}] commit error: {exc}", flush=True)
-        db.session.rollback()
-    finally:
-        db.session.expunge_all()
 
 
 def init_app(app):
@@ -90,63 +55,14 @@ def init_app(app):
         NVDProgressTracker.update("bulk_nvd_refresh", 0, total, f"Starting bulk NVD refresh: 0/{total}")
 
         def _run():
-            with app.app_context():
-                sleep_between = _nvd_sleep_interval()
-                nvd_api_key = os.getenv("NVD_API_KEY")
-                nvd = NVD_DB(nvd_api_key=nvd_api_key)
-                done = 0
-                try:
-                    for cve_id in cve_ids:
-                        if NVDProgressTracker.is_cancelled():
-                            _safe_commit("bulk NVD refresh cancel")
-                            NVDProgressTracker.mark_cancelled()
-                            return
-
-                        try:
-                            now = datetime.datetime.now(datetime.timezone.utc)
-                            status_code, data = nvd.api_get_cve(cve_id, max_retries=2)
-                            if status_code == 200 and data.get("vulnerabilities"):
-                                cve = data["vulnerabilities"][0]["cve"]
-                                details = NVD_DB.extract_cve_details(cve)
-                                rec = db.session.get(Vulnerability, cve_id)
-                                if rec is not None:
-                                    apply_nvd_update(rec, details, now)
-                                    apply_cvss_update(rec, details, db)
-                            else:
-                                print(
-                                    f"[bulk NVD refresh] {cve_id}: status={status_code}, "
-                                    "skipping",
-                                    flush=True,
-                                )
-                        except Exception as exc:
-                            print(f"[bulk NVD refresh] error for {cve_id}: {exc}", flush=True)
-
-                        done += 1
-                        NVDProgressTracker.update(
-                            "bulk_nvd_refresh", done, total,
-                            f"NVD refresh: {done}/{total} ({cve_id})",
-                        )
-                        if done % _NVD_COMMIT_EVERY == 0:
-                            _safe_commit("bulk NVD refresh")
-                        if done < total:
-                            time.sleep(sleep_between)
-
-                    _safe_commit("bulk NVD refresh final")
-                    NVDProgressTracker.complete()
-                except Exception as exc:
-                    print(f"[bulk NVD refresh] unhandled error: {exc}", flush=True)
-                    NVDProgressTracker.error(str(exc)[:200])
+            run_nvd_refresh(app, cve_ids)
 
         threading.Thread(target=_run, name="bulk-nvd-refresh", daemon=True).start()
         return jsonify({"status": "started", "total": total}), 202
 
     @app.route('/api/vulnerabilities/cancel-nvd-refresh', methods=['POST'])
     def cancel_nvd_refresh():
-        """Request cancellation of an in-progress bulk NVD refresh.
-
-        Returns 200 when the cancellation was accepted (refresh was running).
-        Returns 409 when no bulk NVD refresh is currently in progress.
-        """
+        """Request cancellation of an in-progress bulk NVD refresh."""
         if NVDProgressTracker.cancel():
             return jsonify({"status": "cancelling"}), 200
         return jsonify({"error": "No bulk NVD refresh is currently in progress"}), 409
@@ -179,71 +95,14 @@ def init_app(app):
         EPSSProgressTracker.update("bulk_epss_refresh", 0, total, f"Starting bulk EPSS refresh: 0/{total}")
 
         def _run():
-            with app.app_context():
-                epss = EPSS_DB()
-                now = datetime.datetime.now(datetime.timezone.utc)
-                processed = 0
-                try:
-                    chunks = [
-                        cve_ids[i:i + _EPSS_BATCH_SIZE]
-                        for i in range(0, total, _EPSS_BATCH_SIZE)
-                    ]
-                    for chunk in chunks:
-                        if EPSSProgressTracker.is_cancelled():
-                            _safe_commit("bulk EPSS refresh cancel")
-                            EPSSProgressTracker.mark_cancelled()
-                            return
-
-                        try:
-                            results = epss.api_get_epss_batch(chunk)
-                        except Exception as exc:
-                            print(f"[bulk EPSS refresh] batch error: {exc}", flush=True)
-                            processed += len(chunk)
-                            EPSSProgressTracker.update(
-                                "bulk_epss_refresh", processed, total,
-                                f"EPSS refresh: {processed}/{total}",
-                            )
-                            continue
-
-                        for cve_id in chunk:
-                            result = results.get(cve_id)
-                            if result:
-                                try:
-                                    rec = db.session.get(Vulnerability, cve_id)
-                                    if rec is not None:
-                                        rec.update_record(
-                                            epss_score=result["score"],
-                                            epss_fetched_at=now,
-                                            commit=False,
-                                        )
-                                except Exception as exc:
-                                    print(
-                                        f"[bulk EPSS refresh] error updating {cve_id}: {exc}",
-                                        flush=True,
-                                    )
-                            processed += 1
-
-                        _safe_commit("bulk EPSS refresh")
-                        EPSSProgressTracker.update(
-                            "bulk_epss_refresh", processed, total,
-                            f"EPSS refresh: {processed}/{total}",
-                        )
-
-                    EPSSProgressTracker.complete()
-                except Exception as exc:
-                    print(f"[bulk EPSS refresh] unhandled error: {exc}", flush=True)
-                    EPSSProgressTracker.error(str(exc)[:200])
+            run_epss_refresh(app, cve_ids)
 
         threading.Thread(target=_run, name="bulk-epss-refresh", daemon=True).start()
         return jsonify({"status": "started", "total": total}), 202
 
     @app.route('/api/vulnerabilities/cancel-epss-refresh', methods=['POST'])
     def cancel_epss_refresh():
-        """Request cancellation of an in-progress bulk EPSS refresh.
-
-        Returns 200 when the cancellation was accepted (refresh was running).
-        Returns 409 when no bulk EPSS refresh is currently in progress.
-        """
+        """Request cancellation of an in-progress bulk EPSS refresh."""
         if EPSSProgressTracker.cancel():
             return jsonify({"status": "cancelling"}), 200
         return jsonify({"error": "No bulk EPSS refresh is currently in progress"}), 409

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -18,8 +18,6 @@ from ..controllers.refresh import (
     run_nvd_refresh,
     _MAX_CVE_IDS,
     _CVE_RE,
-    _safe_commit,
-    _nvd_sleep_interval,
 )
 from ..controllers.nvd_progress import NVDProgressTracker
 from ..controllers.epss_progress import EPSSProgressTracker

--- a/tests/unit_tests/test_bulk_refresh.py
+++ b/tests/unit_tests/test_bulk_refresh.py
@@ -8,7 +8,7 @@ import os
 import pytest
 from unittest.mock import MagicMock, patch
 
-from src.routes.bulk_refresh import _nvd_sleep_interval, _safe_commit
+from src.controllers.refresh import _nvd_sleep_interval, _safe_commit
 from src.controllers.nvd_apply import apply_cvss_update
 from src.controllers.progress_tracker import ProgressTracker
 

--- a/tests/unit_tests/test_bulk_refresh.py
+++ b/tests/unit_tests/test_bulk_refresh.py
@@ -113,24 +113,24 @@ class TestApplyCvssUpdate:
 class TestSafeCommit:
 
     def test_commits_successfully(self):
-        with patch("src.routes.bulk_refresh.db") as mock_db:
+        with patch("src.controllers.refresh.db") as mock_db:
             _safe_commit("test")
             mock_db.session.commit.assert_called_once()
             mock_db.session.rollback.assert_not_called()
 
     def test_expunges_session_after_successful_commit(self):
-        with patch("src.routes.bulk_refresh.db") as mock_db:
+        with patch("src.controllers.refresh.db") as mock_db:
             _safe_commit("test")
             mock_db.session.expunge_all.assert_called_once()
 
     def test_rolls_back_on_commit_error(self):
-        with patch("src.routes.bulk_refresh.db") as mock_db:
+        with patch("src.controllers.refresh.db") as mock_db:
             mock_db.session.commit.side_effect = Exception("DB error")
             _safe_commit("test")
             mock_db.session.rollback.assert_called_once()
 
     def test_expunges_session_after_rollback(self):
-        with patch("src.routes.bulk_refresh.db") as mock_db:
+        with patch("src.controllers.refresh.db") as mock_db:
             mock_db.session.commit.side_effect = Exception("DB error")
             _safe_commit("test")
             mock_db.session.expunge_all.assert_called_once()

--- a/tests/unit_tests/test_refresh.py
+++ b/tests/unit_tests/test_refresh.py
@@ -1,0 +1,259 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture
+def mock_app():
+    """Minimal Flask app mock with a working app_context."""
+    app = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=None)
+    ctx.__exit__ = MagicMock(return_value=False)
+    app.app_context.return_value = ctx
+    return app
+
+
+class TestNvdSleepInterval:
+
+    def test_returns_six_seconds_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("NVD_API_KEY", raising=False)
+        from src.controllers.refresh import _nvd_sleep_interval
+        assert _nvd_sleep_interval() == pytest.approx(6.0)
+
+    def test_returns_point_six_with_api_key(self, monkeypatch):
+        monkeypatch.setenv("NVD_API_KEY", "abc123")
+        from src.controllers.refresh import _nvd_sleep_interval
+        assert _nvd_sleep_interval() == pytest.approx(0.6)
+
+
+class TestSafeCommit:
+
+    def test_commits_successfully(self):
+        with patch("src.controllers.refresh.db") as mock_db:
+            from src.controllers.refresh import _safe_commit
+            _safe_commit("test")
+            mock_db.session.commit.assert_called_once()
+            mock_db.session.rollback.assert_not_called()
+
+    def test_expunges_session_after_successful_commit(self):
+        with patch("src.controllers.refresh.db") as mock_db:
+            from src.controllers.refresh import _safe_commit
+            _safe_commit("test")
+            mock_db.session.expunge_all.assert_called_once()
+
+    def test_rolls_back_on_commit_error(self):
+        with patch("src.controllers.refresh.db") as mock_db:
+            mock_db.session.commit.side_effect = Exception("DB error")
+            from src.controllers.refresh import _safe_commit
+            _safe_commit("test")
+            mock_db.session.rollback.assert_called_once()
+
+    def test_expunges_session_after_rollback(self):
+        with patch("src.controllers.refresh.db") as mock_db:
+            mock_db.session.commit.side_effect = Exception("DB error")
+            from src.controllers.refresh import _safe_commit
+            _safe_commit("test")
+            mock_db.session.expunge_all.assert_called_once()
+
+
+class TestRunEpssRefresh:
+    """Tests for run_epss_refresh worker."""
+
+    def test_calls_complete_when_empty_list(self, mock_app):
+        """complete() is called even when cve_ids is empty (no batches)."""
+        with patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.EPSS_DB"), \
+             patch("src.controllers.refresh.db"):
+            MockTracker.is_cancelled.return_value = False
+            from src.controllers.refresh import run_epss_refresh
+            run_epss_refresh(mock_app, [])
+        MockTracker.complete.assert_called_once()
+
+    def test_updates_record_when_epss_data_returned(self, mock_app):
+        """update_record is called when EPSS API returns a score."""
+        mock_rec = MagicMock()
+        cve_id = "CVE-2024-00001"
+        with patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db") as mock_db:
+            MockTracker.is_cancelled.return_value = False
+            MockEPSS.return_value.api_get_epss_batch.return_value = {cve_id: {"score": 0.42}}
+            mock_db.session.get.return_value = mock_rec
+            from src.controllers.refresh import run_epss_refresh
+            run_epss_refresh(mock_app, [cve_id])
+        mock_rec.update_record.assert_called_once()
+
+    def test_skips_update_when_no_epss_result(self, mock_app):
+        """update_record is not called when EPSS returns no data."""
+        mock_rec = MagicMock()
+        cve_id = "CVE-2024-00001"
+        with patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db") as mock_db:
+            MockTracker.is_cancelled.return_value = False
+            MockEPSS.return_value.api_get_epss_batch.return_value = {}
+            mock_db.session.get.return_value = mock_rec
+            from src.controllers.refresh import run_epss_refresh
+            run_epss_refresh(mock_app, [cve_id])
+        mock_rec.update_record.assert_not_called()
+
+    def test_calls_mark_cancelled_when_cancelled(self, mock_app):
+        """mark_cancelled() is called when the tracker signals cancellation."""
+        cve_ids = [f"CVE-2024-{i:05d}" for i in range(150)]  # 2 chunks
+        chunk_count = {"n": 0}
+
+        def fake_is_cancelled():
+            chunk_count["n"] += 1
+            return chunk_count["n"] > 1
+
+        with patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh._safe_commit"), \
+             patch("src.controllers.refresh.db"):
+            MockTracker.is_cancelled.side_effect = fake_is_cancelled
+            MockEPSS.return_value.api_get_epss_batch.return_value = {}
+            from src.controllers.refresh import run_epss_refresh
+            run_epss_refresh(mock_app, cve_ids)
+        MockTracker.mark_cancelled.assert_called_once()
+        MockTracker.complete.assert_not_called()
+
+    def test_calls_error_on_outer_exception(self, mock_app):
+        """error() is called when an unhandled exception occurs."""
+        with patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db"):
+            MockTracker.is_cancelled.return_value = False
+            MockEPSS.return_value.api_get_epss_batch.return_value = {}
+            MockTracker.complete.side_effect = RuntimeError("tracker failure")
+            from src.controllers.refresh import run_epss_refresh
+            run_epss_refresh(mock_app, ["CVE-2024-00001"])
+        MockTracker.error.assert_called_once()
+
+    def test_batches_into_chunks_of_batch_size(self, mock_app):
+        """api_get_epss_batch is called twice for 150 CVEs (batch size 100)."""
+        cve_ids = [f"CVE-2024-{i:05d}" for i in range(150)]
+        with patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db"):
+            MockTracker.is_cancelled.return_value = False
+            MockEPSS.return_value.api_get_epss_batch.return_value = {}
+            from src.controllers.refresh import run_epss_refresh
+            run_epss_refresh(mock_app, cve_ids)
+        assert MockEPSS.return_value.api_get_epss_batch.call_count == 2
+
+
+class TestRunNvdRefresh:
+    """Tests for run_nvd_refresh worker."""
+
+    def test_calls_complete_when_empty_list(self, mock_app):
+        """complete() is called even when cve_ids is empty."""
+        with patch("src.controllers.refresh.NVDProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.NVD_DB"), \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"):
+            MockTracker.is_cancelled.return_value = False
+            from src.controllers.refresh import run_nvd_refresh
+            run_nvd_refresh(mock_app, [])
+        MockTracker.complete.assert_called_once()
+
+    def test_applies_update_on_200_response(self, mock_app):
+        """apply_nvd_update and apply_cvss_update are called on a 200 response."""
+        from unittest.mock import ANY
+        cve_id = "CVE-2024-00001"
+        mock_rec = MagicMock()
+        mock_details = {"base_score": 7.5}
+        with patch("src.controllers.refresh.NVDProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.apply_nvd_update") as mock_apply, \
+             patch("src.controllers.refresh.apply_cvss_update") as mock_cvss, \
+             patch("src.controllers.refresh.db") as mock_db, \
+             patch("src.controllers.refresh.time.sleep"):
+            MockTracker.is_cancelled.return_value = False
+            MockNVD.return_value.api_get_cve.return_value = (
+                200, {"vulnerabilities": [{"cve": {}}]}
+            )
+            MockNVD.extract_cve_details.return_value = mock_details
+            mock_db.session.get.return_value = mock_rec
+            from src.controllers.refresh import run_nvd_refresh
+            run_nvd_refresh(mock_app, [cve_id])
+        mock_apply.assert_called_once_with(mock_rec, mock_details, ANY)
+        mock_cvss.assert_called_once_with(mock_rec, mock_details, mock_db)
+
+    def test_skips_update_on_non_200(self, mock_app):
+        """apply_nvd_update is not called when API returns non-200."""
+        with patch("src.controllers.refresh.NVDProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.apply_nvd_update") as mock_apply, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"):
+            MockTracker.is_cancelled.return_value = False
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            from src.controllers.refresh import run_nvd_refresh
+            run_nvd_refresh(mock_app, ["CVE-2024-00001"])
+        mock_apply.assert_not_called()
+
+    def test_calls_mark_cancelled_when_cancelled(self, mock_app):
+        """mark_cancelled() is called and loop exits when tracker signals cancellation."""
+        cve_ids = ["CVE-2024-00001", "CVE-2024-00002"]
+        call_count = {"n": 0}
+
+        def fake_is_cancelled():
+            call_count["n"] += 1
+            return call_count["n"] > 1
+
+        with patch("src.controllers.refresh.NVDProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh._safe_commit"), \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"):
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            MockTracker.is_cancelled.side_effect = fake_is_cancelled
+            from src.controllers.refresh import run_nvd_refresh
+            run_nvd_refresh(mock_app, cve_ids)
+        MockTracker.mark_cancelled.assert_called_once()
+        MockTracker.complete.assert_not_called()
+
+    def test_continues_after_per_cve_exception(self, mock_app):
+        """Loop continues and complete() is called even when one CVE raises."""
+        def fake_api(cve_id, **kw):
+            if cve_id == "CVE-2024-00001":
+                raise RuntimeError("transient error")
+            return (404, {})
+
+        with patch("src.controllers.refresh.NVDProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"):
+            MockTracker.is_cancelled.return_value = False
+            MockNVD.return_value.api_get_cve.side_effect = fake_api
+            from src.controllers.refresh import run_nvd_refresh
+            run_nvd_refresh(mock_app, ["CVE-2024-00001", "CVE-2024-00002"])
+        MockTracker.complete.assert_called_once()
+
+    def test_sleeps_between_cves_but_not_after_last(self, mock_app):
+        """time.sleep is called N-1 times for N CVEs."""
+        with patch("src.controllers.refresh.NVDProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep") as mock_sleep:
+            MockTracker.is_cancelled.return_value = False
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            from src.controllers.refresh import run_nvd_refresh
+            run_nvd_refresh(mock_app, ["CVE-2024-00001", "CVE-2024-00002"])
+        assert mock_sleep.call_count == 1
+
+    def test_calls_error_on_outer_exception(self, mock_app):
+        """error() is called when an unhandled exception occurs."""
+        with patch("src.controllers.refresh.NVDProgressTracker") as MockTracker, \
+             patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"):
+            MockTracker.is_cancelled.return_value = False
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            MockTracker.complete.side_effect = RuntimeError("tracker failure")
+            from src.controllers.refresh import run_nvd_refresh
+            run_nvd_refresh(mock_app, ["CVE-2024-00001"])
+        MockTracker.error.assert_called_once()

--- a/tests/unit_tests/test_webapp_coverage_boost.py
+++ b/tests/unit_tests/test_webapp_coverage_boost.py
@@ -23,18 +23,30 @@ class _InlineThread:
         self._target()
 
 
+def _make_fake_db(cve_ids):
+    """Build a minimal fake db object whose session.execute() chain returns cve_ids."""
+    mock_scalars = SimpleNamespace(all=lambda: cve_ids)
+    mock_result = SimpleNamespace(scalars=lambda: mock_scalars)
+    fake_session = SimpleNamespace(autoflush=True, execute=lambda *a, **kw: mock_result)
+    fake_db = SimpleNamespace(session=fake_session, select=lambda *a, **kw: SimpleNamespace(
+        filter=lambda *a, **kw: None
+    ))
+    return fake_db, fake_session
+
+
 def test_launch_enrichment_executes_epss(monkeypatch):
     calls: list[str] = []
 
-    fake_session = SimpleNamespace(autoflush=True)
-    fake_db = SimpleNamespace(session=fake_session)
+    fake_db, fake_session = _make_fake_db(["CVE-2024-1234", "CVE-2024-5678"])
 
-    def _record_post_treatment(_controllers):
+    def _record_run_epss_refresh(_app, _cve_ids):
         calls.append("epss")
 
     monkeypatch.setattr(webapp_mod, "db", fake_db)
     monkeypatch.setattr(webapp_mod.threading, "Thread", _InlineThread)
-    monkeypatch.setattr(webapp_mod, "post_treatment", _record_post_treatment)
+    monkeypatch.setattr(webapp_mod, "run_epss_refresh", _record_run_epss_refresh)
+    monkeypatch.setattr(webapp_mod.EPSSProgressTracker, "start_if_idle", staticmethod(lambda *a: True))
+    monkeypatch.setattr(webapp_mod.EPSSProgressTracker, "update", staticmethod(lambda *a, **kw: None))
 
     app = Flask(__name__)
     webapp_mod._launch_enrichment(app)
@@ -44,15 +56,16 @@ def test_launch_enrichment_executes_epss(monkeypatch):
 
 
 def test_launch_enrichment_catches_and_logs_failures(monkeypatch, capsys):
-    fake_session = SimpleNamespace(autoflush=True)
-    fake_db = SimpleNamespace(session=fake_session)
+    fake_db, fake_session = _make_fake_db(["CVE-2024-1234"])
 
-    def _raise_in_post_treatment(_controllers):
+    def _raise_in_run_epss_refresh(_app, _cve_ids):
         raise RuntimeError("epss failure")
 
     monkeypatch.setattr(webapp_mod, "db", fake_db)
     monkeypatch.setattr(webapp_mod.threading, "Thread", _InlineThread)
-    monkeypatch.setattr(webapp_mod, "post_treatment", _raise_in_post_treatment)
+    monkeypatch.setattr(webapp_mod, "run_epss_refresh", _raise_in_run_epss_refresh)
+    monkeypatch.setattr(webapp_mod.EPSSProgressTracker, "start_if_idle", staticmethod(lambda *a: True))
+    monkeypatch.setattr(webapp_mod.EPSSProgressTracker, "update", staticmethod(lambda *a, **kw: None))
 
     app = Flask(__name__)
     webapp_mod._launch_enrichment(app)

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -317,12 +317,12 @@ class TestBulkNvdRefreshBackground:
         mock_rec = MagicMock()
         mock_details = {"base_score": 7.5, "cvss_version": "3.1", "cvss_vector": "CVSS:3.1/X"}
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
-             patch("src.routes.bulk_refresh.apply_cvss_update") as mock_cvss, \
-             patch("src.routes.bulk_refresh.db") as mock_db, \
-             patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.apply_nvd_update") as mock_apply, \
+             patch("src.controllers.refresh.apply_cvss_update") as mock_cvss, \
+             patch("src.controllers.refresh.db") as mock_db, \
+             patch("src.controllers.refresh.time.sleep"), \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (
                 200, {"vulnerabilities": [{"cve": {}}]}
@@ -338,11 +338,11 @@ class TestBulkNvdRefreshBackground:
         """_run() skips the update and logs when API returns a non-200 status."""
         target = self._capture_target(client, [existing_cve_id])
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.apply_nvd_update") as mock_apply, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"), \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             target()
@@ -353,11 +353,11 @@ class TestBulkNvdRefreshBackground:
         """_run() skips update when 200 but vulnerabilities list is empty."""
         target = self._capture_target(client, [existing_cve_id])
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.apply_nvd_update") as mock_apply, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"), \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (200, {"vulnerabilities": []})
             target()
@@ -368,11 +368,11 @@ class TestBulkNvdRefreshBackground:
         """_run() skips apply_nvd_update when the vulnerability is absent from the local DB."""
         target = self._capture_target(client, [existing_cve_id])
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
-             patch("src.routes.bulk_refresh.db") as mock_db, \
-             patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.apply_nvd_update") as mock_apply, \
+             patch("src.controllers.refresh.db") as mock_db, \
+             patch("src.controllers.refresh.time.sleep"), \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (
                 200, {"vulnerabilities": [{"cve": {}}]}
@@ -394,11 +394,11 @@ class TestBulkNvdRefreshBackground:
                 raise RuntimeError("transient API error")
             return (404, {})
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh.apply_nvd_update") as mock_apply, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.apply_nvd_update") as mock_apply, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"), \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.side_effect = fake_get_cve
             target()
@@ -410,11 +410,11 @@ class TestBulkNvdRefreshBackground:
         cve_ids = [f"CVE-2024-{i:05d}" for i in range(50)]
         target = self._capture_target(client, cve_ids)
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh._safe_commit") as mock_commit, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh._safe_commit") as mock_commit, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"), \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             target()
@@ -427,10 +427,10 @@ class TestBulkNvdRefreshBackground:
         cve_ids = ["CVE-2024-00001", "CVE-2024-00002"]
         target = self._capture_target(client, cve_ids)
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.time.sleep") as mock_sleep, \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep") as mock_sleep, \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             target()
@@ -441,10 +441,10 @@ class TestBulkNvdRefreshBackground:
         """_run() calls NVDProgressTracker.complete() after all CVEs are processed."""
         target = self._capture_target(client, [existing_cve_id])
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"), \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             target()
@@ -455,10 +455,10 @@ class TestBulkNvdRefreshBackground:
         """_run() calls NVDProgressTracker.error() when an unhandled exception occurs."""
         target = self._capture_target(client, [existing_cve_id])
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"), \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             # complete() is inside the outer try, so making it raise triggers the outer except
@@ -495,9 +495,9 @@ class TestBulkEpssRefreshBackground:
         target = self._capture_target(client, [existing_cve_id])
         mock_rec = MagicMock()
 
-        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
-             patch("src.routes.bulk_refresh.db") as mock_db, \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db") as mock_db, \
+             patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {
                 existing_cve_id: {"score": 0.42}
@@ -512,9 +512,9 @@ class TestBulkEpssRefreshBackground:
         target = self._capture_target(client, [existing_cve_id])
         mock_rec = MagicMock()
 
-        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
-             patch("src.routes.bulk_refresh.db") as mock_db, \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db") as mock_db, \
+             patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {}
             mock_db.session.get.return_value = mock_rec
@@ -526,9 +526,9 @@ class TestBulkEpssRefreshBackground:
         """_run() skips update_record when the vulnerability is absent from the local DB."""
         target = self._capture_target(client, [existing_cve_id])
 
-        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
-             patch("src.routes.bulk_refresh.db") as mock_db, \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db") as mock_db, \
+             patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {
                 existing_cve_id: {"score": 0.5}
@@ -541,9 +541,9 @@ class TestBulkEpssRefreshBackground:
         """_run() continues processing after api_get_epss_batch raises."""
         target = self._capture_target(client, [existing_cve_id])
 
-        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.side_effect = Exception("API timeout")
             target()
@@ -556,9 +556,9 @@ class TestBulkEpssRefreshBackground:
         mock_rec = MagicMock()
         mock_rec.update_record.side_effect = Exception("DB constraint")
 
-        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
-             patch("src.routes.bulk_refresh.db") as mock_db, \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db") as mock_db, \
+             patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {
                 existing_cve_id: {"score": 0.3}
@@ -573,9 +573,9 @@ class TestBulkEpssRefreshBackground:
         cve_ids = [f"CVE-2024-{i:05d}" for i in range(150)]
         target = self._capture_target(client, cve_ids)
 
-        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {}
             target()
@@ -586,9 +586,9 @@ class TestBulkEpssRefreshBackground:
         """_run() calls EPSSProgressTracker.complete() after successful processing."""
         target = self._capture_target(client, [existing_cve_id])
 
-        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {}
             target()
@@ -599,9 +599,9 @@ class TestBulkEpssRefreshBackground:
         """_run() calls EPSSProgressTracker.error() on an unhandled outer exception."""
         target = self._capture_target(client, [existing_cve_id])
 
-        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             MockEPSS.return_value.api_get_epss_batch.return_value = {}
             # complete() is inside the outer try, so making it raise triggers the outer except
@@ -697,11 +697,11 @@ class TestBulkNvdRefreshCancellation:
             # Cancel after first iteration
             return call_count["n"] > 1
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh._safe_commit") as mock_commit, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh._safe_commit") as mock_commit, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"), \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockNVD.return_value.api_get_cve.return_value = (404, {})
             MockTracker.is_cancelled.side_effect = fake_is_cancelled
             target()
@@ -726,11 +726,11 @@ class TestBulkNvdRefreshCancellation:
         def fake_is_cancelled():
             return api_call_count["n"] >= cancel_after
 
-        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh._safe_commit"), \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.time.sleep"), \
-             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.NVD_DB") as MockNVD, \
+             patch("src.controllers.refresh._safe_commit"), \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.time.sleep"), \
+             patch("src.controllers.refresh.NVDProgressTracker") as MockTracker:
             MockNVD.return_value.api_get_cve.side_effect = fake_api_get
             MockTracker.is_cancelled.side_effect = fake_is_cancelled
             target()
@@ -756,10 +756,10 @@ class TestBulkEpssRefreshCancellation:
             chunk_count["n"] += 1
             return chunk_count["n"] > 1
 
-        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
-             patch("src.routes.bulk_refresh._safe_commit") as mock_commit, \
-             patch("src.routes.bulk_refresh.db"), \
-             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+        with patch("src.controllers.refresh.EPSS_DB") as MockEPSS, \
+             patch("src.controllers.refresh._safe_commit") as mock_commit, \
+             patch("src.controllers.refresh.db"), \
+             patch("src.controllers.refresh.EPSSProgressTracker") as MockTracker:
             MockEPSS.return_value.api_get_epss_batch.return_value = {}
             MockTracker.is_cancelled.side_effect = fake_is_cancelled
             target()

--- a/tests/webapp_tests/test_launch_enrichment.py
+++ b/tests/webapp_tests/test_launch_enrichment.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the revised _launch_enrichment in webapp.py."""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from src.bin.webapp import create_app
+from tests.webapp_tests import write_demo_files, setup_demo_db
+
+
+@pytest.fixture()
+def init_files(tmp_path):
+    files = {
+        "status": tmp_path / "status.txt",
+        "packages": tmp_path / "packages-merged.json",
+        "vulnerabilities": tmp_path / "vulnerabilities-merged.json",
+        "assessments": tmp_path / "assessments-merged.json",
+        "openvex": tmp_path / "openvex.json",
+        "time_estimates": tmp_path / "time_estimates.json",
+    }
+    write_demo_files(files)
+    return files
+
+
+@pytest.fixture()
+def app(init_files):
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": init_files["status"],
+            "OPENVEX_FILE": init_files["openvex"],
+        })
+        setup_demo_db(application)
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture(autouse=True)
+def reset_trackers():
+    from src.controllers.nvd_progress import NVDProgressTracker
+    from src.controllers.epss_progress import EPSSProgressTracker
+    NVDProgressTracker.complete()
+    EPSSProgressTracker.complete()
+    yield
+    NVDProgressTracker.complete()
+    EPSSProgressTracker.complete()
+
+
+class TestLaunchEnrichment:
+
+    def test_epss_thread_spawned_when_enabled_and_cves_exist(self, app, monkeypatch):
+        """A thread is spawned for EPSS when INITIAL_REFRESH_EPSS=true and CVEs are in the DB."""
+        monkeypatch.setenv("INITIAL_REFRESH_EPSS", "true")
+        monkeypatch.setenv("INITIAL_REFRESH_NVD", "false")
+
+        from src.bin.webapp import _launch_enrichment
+        with patch("src.bin.webapp.threading.Thread") as MockThread, \
+             patch("src.bin.webapp.EPSSProgressTracker") as MockEPSS, \
+             patch("src.bin.webapp.NVDProgressTracker"):
+            MockThread.return_value = MagicMock()
+            MockEPSS.start_if_idle.return_value = True
+
+            with app.app_context():
+                _launch_enrichment(app)
+
+        assert MockThread.return_value.start.call_count == 1
+
+    def test_nvd_thread_spawned_when_enabled_and_cves_exist(self, app, monkeypatch):
+        """A thread is spawned for NVD when INITIAL_REFRESH_NVD=true and CVEs are in the DB."""
+        monkeypatch.setenv("INITIAL_REFRESH_EPSS", "false")
+        monkeypatch.setenv("INITIAL_REFRESH_NVD", "true")
+
+        from src.bin.webapp import _launch_enrichment
+        with patch("src.bin.webapp.threading.Thread") as MockThread, \
+             patch("src.bin.webapp.NVDProgressTracker") as MockNVD, \
+             patch("src.bin.webapp.EPSSProgressTracker"):
+            MockThread.return_value = MagicMock()
+            MockNVD.start_if_idle.return_value = True
+
+            with app.app_context():
+                _launch_enrichment(app)
+
+        assert MockThread.return_value.start.call_count == 1
+
+    def test_no_thread_spawned_when_both_disabled(self, app, monkeypatch):
+        """No threads are spawned when both flags are false."""
+        monkeypatch.setenv("INITIAL_REFRESH_EPSS", "false")
+        monkeypatch.setenv("INITIAL_REFRESH_NVD", "false")
+
+        from src.bin.webapp import _launch_enrichment
+        with patch("src.bin.webapp.threading.Thread") as MockThread:
+            with app.app_context():
+                _launch_enrichment(app)
+
+        MockThread.assert_not_called()
+
+    def test_no_thread_spawned_when_epss_already_running(self, app, monkeypatch):
+        """No EPSS thread is spawned when EPSSProgressTracker is already in progress."""
+        monkeypatch.setenv("INITIAL_REFRESH_EPSS", "true")
+        monkeypatch.setenv("INITIAL_REFRESH_NVD", "false")
+
+        from src.bin.webapp import _launch_enrichment
+        with patch("src.bin.webapp.threading.Thread") as MockThread, \
+             patch("src.bin.webapp.EPSSProgressTracker") as MockEPSS:
+            MockEPSS.start_if_idle.return_value = False
+
+            with app.app_context():
+                _launch_enrichment(app)
+
+        MockThread.assert_not_called()
+
+    def test_no_thread_spawned_when_no_cves_in_db(self, app, monkeypatch):
+        """No threads are spawned when the DB has no CVE-format vulnerabilities."""
+        monkeypatch.setenv("INITIAL_REFRESH_EPSS", "true")
+        monkeypatch.setenv("INITIAL_REFRESH_NVD", "false")
+
+        from src.bin.webapp import _launch_enrichment
+        from src.extensions import db
+
+        with patch("src.bin.webapp.threading.Thread") as MockThread, \
+             patch("src.bin.webapp.EPSSProgressTracker"):
+            with app.app_context():
+                with patch("src.bin.webapp.db") as mock_db:
+                    mock_db.select = db.select
+                    mock_db.session.execute.return_value.scalars.return_value.all.return_value = []
+                    _launch_enrichment(app)
+
+        MockThread.assert_not_called()
+
+    def test_no_thread_spawned_when_nvd_already_running(self, app, monkeypatch):
+        """No NVD thread is spawned when NVDProgressTracker is already in progress."""
+        monkeypatch.setenv("INITIAL_REFRESH_EPSS", "false")
+        monkeypatch.setenv("INITIAL_REFRESH_NVD", "true")
+
+        from src.bin.webapp import _launch_enrichment
+        with patch("src.bin.webapp.threading.Thread") as MockThread, \
+             patch("src.bin.webapp.NVDProgressTracker") as MockNVD, \
+             patch("src.bin.webapp.EPSSProgressTracker"):
+            MockNVD.start_if_idle.return_value = False
+
+            with app.app_context():
+                _launch_enrichment(app)
+
+        MockThread.assert_not_called()

--- a/vulnscout
+++ b/vulnscout
@@ -66,6 +66,8 @@ Input commands (can be chained, triggers scan automatically):
   --perform-grype-scan            Run Grype on the current DB content (after merging any added inputs)
   --perform-nvd-scan              Run an NVD CPE-based vulnerability scan
   --perform-osv-scan              Run an OSV PURL-based vulnerability scan
+  --initial-refresh-nvd [true|false]  Enable/disable NVD background enrichment at startup (default: false)
+  --initial-refresh-epss [true|false] Enable/disable EPSS background enrichment at startup (default: true)
 
 Scan & output commands:
   --match-condition <expr>        Run vulnerability scan
@@ -314,6 +316,20 @@ parse_and_run() {
                 ensure_running; PENDING_ARGS+=(--perform-nvd-scan); shift ;;
             perform-osv-scan|--perform-osv-scan)
                 ensure_running; PENDING_ARGS+=(--perform-osv-scan); shift ;;
+            initial-refresh-nvd|--initial-refresh-nvd)
+                ensure_running
+                if [[ "${2:-}" == "true" || "${2:-}" == "false" ]]; then
+                    PENDING_ARGS+=(--initial-refresh-nvd "$2"); shift 2
+                else
+                    PENDING_ARGS+=(--initial-refresh-nvd); shift
+                fi ;;
+            initial-refresh-epss|--initial-refresh-epss)
+                ensure_running
+                if [[ "${2:-}" == "true" || "${2:-}" == "false" ]]; then
+                    PENDING_ARGS+=(--initial-refresh-epss "$2"); shift 2
+                else
+                    PENDING_ARGS+=(--initial-refresh-epss); shift
+                fi ;;
             export-spdx|--export-spdx)
                 ensure_running; EXPORT_ARGS+=(--export-spdx); shift ;;
             export-cdx|--export-cdx)


### PR DESCRIPTION
### Changes proposed in this pull request:

This PR introduces optional bulk refresh for NVD and EPSS. The UI-triggered refresh and the initial refresh now use the same logic.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Use the files in #343 and run the following command with the flag value of your choice:
```
   ./vulnscout --dev \
      --add-spdx example/spdx2/test-nvd-refresh-stale.spdx.json \
      --add-grype example/spdx2/test-nvd-refresh-stale.grype.json \
      --initial-refresh-epss <true|false> \
      --initial-refresh-nvd <true|false> \
      --serve
```
Then, observe the initial refresh behaviour with different flag values.

### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [x] Added necessary reviewers


