### PR TITLE
Bugfix: Prevent dev API URL from leaking

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,8 @@
 frontend/node_modules
 frontend/coverage
+frontend/.env*
+
+# Pre-compiled frontend assets — always rebuilt from source in the buildfront stage
+src/static
 
 __pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,13 @@ WORKDIR /frontend
 COPY frontend/package.json frontend/package-lock.json .
 RUN npm ci
 
-# Create build .env with API_URL set as blank. This way, fetch call are made to '/api/...' on same origin.
-RUN echo "VITE_API_URL=\"\"" > .env
-
 COPY frontend .
+
+# .env* files are excluded by .dockerignore so VITE_API_URL is never copied
+# from the developer's local environment. Create a production .env explicitly
+# so that all fetch calls go to '/api/...' on the same origin.
+RUN echo 'VITE_API_URL=' > .env
+
 RUN npm run build
 
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

Based on the issue: https://github.com/savoirfairelinux/vulnscout/issues/355

### Changes proposed in this pull request:

Move the VITE_API_URL="" write after "COPY frontend ." so it always
overrides any local .env that may contain a hardcoded dev API URL
(e.g. http://localhost:7275), fixing "TypeError: Failed to fetch" when
using a self-built image.

Two root causes allowed frontend/.env (VITE_API_URL=http://localhost:7275)
to be baked into the compiled JS bundle when building the image locally:

- src/static (pre-built host assets) was copied into the image via
   \"COPY src ./src\" before \"COPY --from=buildfront\" ran, leaving stale
   JS files with the hardcoded URL alongside the freshly built ones.

- frontend/.env was included in the build context, so \"COPY frontend .\"
   overwrote the blank .env written by the previous RUN step.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Run the command which should pass with this fix: 

```
docker build --no-cache -t vulnscout-test . && \
docker run --rm --entrypoint sh vulnscout-test \
  -c "grep -rl 'localhost:7275' /scan/src/static/ && echo FAIL || echo PASS"
```