### PR TITLE
Fix config.env persistence and MultiEdit status changes

### DIFF
--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -252,24 +252,31 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
             const data = await response.json().catch(() => ({}));
 
             if (data?.status === 'success' && Array.isArray(data?.assessments)) {
-                // Process successful assessments
+                // Group new assessments by vuln_id so we call patchVuln exactly
+                // once per distinct vuln.  Calling it once-per-assessment caused
+                // React to batch the setVulns calls and only keep the last one,
+                // leaving all other CVEs unchanged.
+                const newAssessmentsByVuln = new Map<string, Assessment[]>();
                 for (const assessmentData of data.assessments) {
                     const casted = asAssessment(assessmentData);
                     if (!Array.isArray(casted) && typeof casted === "object") {
                         appendAssessment(casted);
-
-                        // Update the vulnerability
-                        const vuln = vulnerabilities.find(v => v.id === casted.vuln_id);
-                        if (vuln) {
-                            const updatedAssessments = [...vuln.assessments, casted];
-                            const statusSummary = buildStatusSummary(updatedAssessments);
-                            patchVuln(casted.vuln_id, {
-                                ...vuln,
-                                assessments: updatedAssessments,
-                                simplified_status: statusSummary.dominant_status,
-                                status_summary: statusSummary,
-                            });
-                        }
+                        const list = newAssessmentsByVuln.get(casted.vuln_id) ?? [];
+                        list.push(casted);
+                        newAssessmentsByVuln.set(casted.vuln_id, list);
+                    }
+                }
+                for (const [vuln_id, newAssessments] of newAssessmentsByVuln.entries()) {
+                    const vuln = vulnerabilities.find(v => v.id === vuln_id);
+                    if (vuln) {
+                        const updatedAssessments = [...vuln.assessments, ...newAssessments];
+                        const statusSummary = buildStatusSummary(updatedAssessments);
+                        patchVuln(vuln_id, {
+                            ...vuln,
+                            assessments: updatedAssessments,
+                            simplified_status: statusSummary.dominant_status,
+                            status_summary: statusSummary,
+                        });
                     }
                 }
 

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import NavigationBar from "../components/NavigationBar";
 import MessageBanner from "../components/MessageBanner";
 import VersionDisplay from "../components/VersionDisplay";
@@ -38,6 +38,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
     const [selectorKey, setSelectorKey] = useState(0);
     const [pkgs, setPkgs] = useState<Package[]>([]);
     const [vulns, setVulns] = useState<Vulnerability[]>([]);
+    const vulnsRef = useRef<Vulnerability[]>([]);
     const [filterLabel, setFilterLabel] = useState<"Source" | "Severity" | "Status" | "Package" | undefined>(undefined);
     const [filterValue, setFilterValue] = useState<string | undefined>(undefined);
     const [bannerMessage, setBannerMessage] = useState<string>('');
@@ -156,17 +157,19 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         return null;
     }
 
+    // Keep vulnsRef in sync when vulns state is updated externally
+    // (e.g. after loadData or appendAssessment).
+    useEffect(() => { vulnsRef.current = vulns; }, [vulns]);
+
     function patchVuln(vulnId: string, replace_vuln: Vulnerability) {
-        const updatedVulns = vulns.map(vuln => {
-            if (vuln.id === vulnId) {
-                return replace_vuln;
-            }
-            return vuln;
-        });
-        setVulns(updatedVulns);
+        // Update the ref immediately so the next synchronous call to patchVuln
+        // (for a different CVE in the same multi-edit batch) reads the already-
+        // patched list rather than the stale closure value.
+        vulnsRef.current = vulnsRef.current.map(v => v.id === vulnId ? replace_vuln : v);
+        setVulns(vulnsRef.current);
 
         // Update packages with the new vulnerability data
-        setPkgs(Packages.enrich_with_vulns(pkgs, updatedVulns));
+        setPkgs(Packages.enrich_with_vulns(pkgs, vulnsRef.current));
     }
 
     // Update vulns state in-place after a Review tab edit or delete

--- a/vulnscout
+++ b/vulnscout
@@ -192,7 +192,7 @@ do_start() {
             -v "$VULNSCOUT_CACHE_DIR:/mnt/cache" \
             -v "$VULNSCOUT_OUTPUTS_DIR:/mnt/outputs" \
             "$DOCKER_IMAGE" \
-            -c "rm -rf /mnt/cache/config.env; chown -R ${uid}:${gid} /mnt/cache /mnt/outputs" \
+            -c "[ -f /mnt/cache/config.env ] && [ \"\$(stat -c %u /mnt/cache/config.env)\" = '0' ] && rm -f /mnt/cache/config.env; chown -R ${uid}:${gid} /mnt/cache /mnt/outputs" \
             2>/dev/null || true
     fi
     if [ ! -f "$VULNSCOUT_CONFIG_FILE" ]; then


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Fix config.env persistence 
* Fix MultiEdit status changes auto reload

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Fix config.env persistence 
Start VS, then change a setting and restart, the config.env content should stay unchanged

* Fix MultiEdit status changes auto reload
Go to the Vulnerabilities tab, pick multiple vulns then change the status, they should all move to the new status.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


