### PR TITLE
Support CPE referenceType as full URI in SPDX parsing

### DIFF
--- a/src/views/fast_spdx.py
+++ b/src/views/fast_spdx.py
@@ -46,7 +46,7 @@ class FastSPDX ():
                 purl = _get_field(external_ref, ["referenceLocator"])
                 if isinstance(purl, str):
                     package.add_purl(purl)
-            elif ref_type == "cpe23Type":
+            elif ref_type in ("cpe23Type", "http://spdx.org/rdf/references/cpe23Type"):
                 cpe = _get_field(external_ref, ["referenceLocator"])
                 if isinstance(cpe, str):
                     package.add_cpe(cpe)

--- a/src/views/spdx.py
+++ b/src/views/spdx.py
@@ -110,7 +110,7 @@ class SPDX:
             for external_ref in package.external_references:
                 if external_ref.reference_type == "purl":
                     pkg.add_purl(external_ref.locator)
-                elif external_ref.reference_type == "cpe23Type":
+                elif external_ref.reference_type in ("cpe23Type", "http://spdx.org/rdf/references/cpe23Type"):
                     pkg.add_cpe(external_ref.locator)
 
             pkg.generate_generic_cpe()

--- a/tests/integration_tests/test_fastsdpx_parsing.py
+++ b/tests/integration_tests/test_fastsdpx_parsing.py
@@ -170,6 +170,42 @@ def test_parse_cpe23type_externalrefs(spdx_parser):
     assert "pkg:deb/ubuntu/libtasn1-6@4.13-2?arch=arm64" in pkg.purl
 
 
+def test_parse_cpe23type_uri_reference_type(spdx_parser):
+    """referenceType given as full URI 'http://spdx.org/rdf/references/cpe23Type' must be accepted."""
+    spdx_parser.parse_from_dict({
+        "spdxVersion": "SPDX-2.2",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "test",
+        "creationInfo": {"created": "2026-05-10T05:32:45Z", "creators": ["Tool: OpenEmbedded"]},
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://example.com/test",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-linux-kernel",
+                "name": "linux-jammy-nvidia-tegra",
+                "versionInfo": "5.15.148+git",
+                "filesAnalyzed": False,
+                "downloadLocation": "NOASSERTION",
+                "externalRefs": [
+                    {
+                        "referenceCategory": "SECURITY",
+                        "referenceType": "http://spdx.org/rdf/references/cpe23Type",
+                        "referenceLocator": "cpe:2.3:*:*:linux_kernel:5.15.148:*:*:*:*:*:*:*"
+                    }
+                ]
+            }
+        ]
+    })
+
+    pkg = spdx_parser.packagesCtrl.get("linux-jammy-nvidia-tegra@5.15.148")
+    assert pkg is not None
+
+    # URI-form referenceType CPE must be extracted
+    assert "cpe:2.3:*:*:linux_kernel:5.15.148:*:*:*:*:*:*:*" in pkg.cpe
+    # Must be first (before generic fallback)
+    assert pkg.cpe[0] == "cpe:2.3:*:*:linux_kernel:5.15.148:*:*:*:*:*:*:*"
+
+
 def test_parse_no_cpe23type_still_gets_generic(spdx_parser):
     """Packages without cpe23Type externalRefs must still receive the generic CPE fallback."""
     spdx_parser.parse_from_dict({

--- a/tests/integration_tests/test_spdx_parsing.py
+++ b/tests/integration_tests/test_spdx_parsing.py
@@ -209,6 +209,42 @@ def test_parse_cpe23type_externalrefs(spdx_parser):
     assert "pkg:deb/ubuntu/libtasn1-6@4.13-2?arch=arm64" in pkg.purl
 
 
+def test_parse_cpe23type_uri_reference_type(spdx_parser):
+    """referenceType as full URI 'http://spdx.org/rdf/references/cpe23Type' (SPDX 2.2) must be accepted."""
+    spdx_parser.load_from_dict({
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "test",
+        "spdxVersion": "SPDX-2.2",
+        "creationInfo": {"created": "2022-11-03T07:10:10Z", "creators": ["Tool: test"]},
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://example.com/test",
+        "packages": [
+            {
+                "SPDXID": "SPDXRef-linux-kernel",
+                "name": "linux-jammy-nvidia-tegra",
+                "versionInfo": "5.15.148+git",
+                "filesAnalyzed": False,
+                "downloadLocation": "NOASSERTION",
+                "externalRefs": [
+                    {
+                        "referenceCategory": "SECURITY",
+                        "referenceType": "http://spdx.org/rdf/references/cpe23Type",
+                        "referenceLocator": "cpe:2.3:*:*:linux_kernel:5.15.148:*:*:*:*:*:*:*"
+                    }
+                ]
+            }
+        ]
+    })
+    spdx_parser.parse_and_merge()
+
+    # spdx_tools normalizes "5.15.148+git" → "5.15.148"
+    pkg = spdx_parser.packagesCtrl.get("linux-jammy-nvidia-tegra@5.15.148")
+    assert pkg is not None
+
+    assert "cpe:2.3:*:*:linux_kernel:5.15.148:*:*:*:*:*:*:*" in pkg.cpe
+    assert pkg.cpe[0] == "cpe:2.3:*:*:linux_kernel:5.15.148:*:*:*:*:*:*:*"
+
+
 def test_parse_no_cpe23type_still_gets_generic(spdx_parser):
     """Packages without cpe23Type externalRefs must still receive the generic CPE fallback."""
     spdx_parser.load_from_dict({


### PR DESCRIPTION
### Changes proposed in this pull request:

* Add support for the full URI in the CPE referenceType that SPDX 2.2 is using.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Use a file in which `http://spdx.org/rdf/references/cpe23Type` is used in the reference type and start VulnScout.

### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [x] Added necessary reviewers


