### PR TITLE
fix: skip EPSS on CVEs already filled on web start

### DIFF
--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -300,13 +300,27 @@ class VulnerabilitiesController:
         # Only CVE-prefixed IDs exist in the EPSS database.
         all_cve_ids = [vid for vid in self.vulnerabilities if vid.startswith("CVE-")]
 
-        cve_vulns = {vid: self.vulnerabilities[vid] for vid in all_cve_ids}
+        # Skip CVEs whose EPSS score was already fetched in a previous run
+        # (``epss_fetched_at`` is set). The score is persisted in the DB at
+        # ingestion time, so re-fetching it from the FIRST.org API on every
+        # webapp start is redundant network/DB work.
+        cve_vulns = {
+            vid: self.vulnerabilities[vid]
+            for vid in all_cve_ids
+            if getattr(self.vulnerabilities[vid], "epss_fetched_at", None) is None
+        }
         skipped_non_cve = len(self.vulnerabilities) - len(all_cve_ids)
+        skipped_already_fetched = len(all_cve_ids) - len(cve_vulns)
 
         total = len(cve_vulns)
         msg = f"=== EPSS: starting enrichment for {total} CVEs"
+        extra = []
         if skipped_non_cve:
-            msg += f" ({skipped_non_cve} non-CVE IDs skipped)"
+            extra.append(f"{skipped_non_cve} non-CVE IDs skipped")
+        if skipped_already_fetched:
+            extra.append(f"{skipped_already_fetched} already enriched")
+        if extra:
+            msg += f" ({', '.join(extra)})"
         print(msg, flush=True)
 
         tracker = EPSSProgressTracker

--- a/tests/unit_tests/test_db_coverage.py
+++ b/tests/unit_tests/test_db_coverage.py
@@ -1155,6 +1155,34 @@ class TestVulnerabilitiesController:
         assert rec is not None
         assert float(rec.epss_score) == pytest.approx(0.42)
 
+    def test_fetch_epss_scores_skips_already_fetched(self, app, monkeypatch):
+        """fetch_epss_scores skips CVEs whose epss_fetched_at is already set."""
+        import datetime
+        from src.controllers.packages import PackagesController
+        from src.controllers.vulnerabilities import VulnerabilitiesController
+        from src.models.vulnerability import Vulnerability
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr("src.controllers.vulnerabilities.EPSS_DB", lambda: MagicMock())
+        rec = Vulnerability.create_record("CVE-2099-EPSS-SKIP")
+        rec.update_record(
+            epss_score=0.10,
+            epss_fetched_at=datetime.datetime.utcnow(),
+            commit=True,
+        )
+        pkgctrl = PackagesController()
+        ctrl = VulnerabilitiesController(pkgctrl)
+        ctrl.epss_api = MagicMock()
+        ctrl.epss_api.api_get_epss_batch.return_value = {
+            "CVE-2099-EPSS-SKIP": {"score": 0.99, "percentile": 99.0}
+        }
+        ctrl.fetch_epss_scores()
+        # The already-enriched CVE must not be re-fetched...
+        ctrl.epss_api.api_get_epss_batch.assert_not_called()
+        # ...and its stored score must be left untouched.
+        refreshed = Vulnerability.get_by_id("CVE-2099-EPSS-SKIP")
+        assert float(refreshed.epss_score) == pytest.approx(0.10)
+
     def test_fetch_ghsa_published_success(self):
         """_fetch_ghsa_published returns the published_at value on success (lines 279-280)."""
         import json


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

EPSS scores are fetched and persisted at SBOM ingestion. The webapp's first-start background enrichment re-fetched every CVE from the FIRST.org API on each restart and rewrote the DB.

Skip CVEs whose epss_fetched_at is already set so only new/unfetched CVEs are queried.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Start a new project. At first VulnScout start, the EPSS score isn't necessary fully fetch anymore