### PR TITLE
bugfix: Fix nvd-refresh request

### DIFF
--- a/src/controllers/nvd_apply.py
+++ b/src/controllers/nvd_apply.py
@@ -20,6 +20,7 @@ def apply_cvss_update(rec, details: dict, db) -> None:
         db.select(Metrics).where(
             Metrics.vulnerability_id == rec.id,
             Metrics.version == cvss_version,
+            Metrics.variant_id.is_(None),
         )
     ).scalar_one_or_none()
     if existing is not None:

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -880,6 +880,7 @@ def init_app(app):
                 db.select(Metrics).where(
                     Metrics.vulnerability_id == rec.id,
                     Metrics.version == cvss_version,
+                    Metrics.variant_id.is_(None),
                 )
             ).scalar_one_or_none()
             if existing is not None:


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The migration l8a9b0c1d2e3 duplicated every global (variant_id=NULL) NVD Metrics row into N per-variant rows.

Both the inline nvd-refresh route and apply_cvss_update in nvd_apply.py then queried by (vulnerability_id, version) without a variant_id filter, returning multiple rows and causing scalar_one_or_none() to raise MultipleResultsFound

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Perform a vulnerability refresh (API nvd-refresh), shouldn't crash anymore.


