### PR TITLE
fix: CVSS scope (scanner or custom)

### DIFF
--- a/src/bin/cmd_process.py
+++ b/src/bin/cmd_process.py
@@ -310,6 +310,7 @@ def _run_main() -> dict:
     latest_scan = ScanModel.get_latest()
     if latest_scan:
         assessCtrl.current_variant_id = latest_scan.variant_id
+        vulnCtrl.current_variant_id = latest_scan.variant_id
 
     # Wrap all ingestion + post-treatment inside batch_session so that the
     # hundreds/thousands of individual model commit() calls are deferred to a

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -7,6 +7,7 @@ import os
 import json
 import logging
 import typing
+import uuid
 import urllib.request
 import urllib.error
 from typing import Optional
@@ -40,7 +41,7 @@ def _batch_commit(done: int, total: int, label: str) -> None:
 
 def _persist_vuln_to_db(
         vuln: Vulnerability, pkg_id_cache=None, finding_cache=None,
-        db_record_cache=None, use_savepoint: bool = True) -> None:
+        db_record_cache=None, use_savepoint: bool = True, variant_id=None) -> None:
     """Silently persist a Vulnerability to the DB.
 
     Uses a SAVEPOINT so that a failure (e.g. IntegrityError) only rolls
@@ -54,12 +55,16 @@ def _persist_vuln_to_db(
     *db_record_cache* (``{vuln_id: record}``) avoids the ``get_by_id``
     SELECT for vulnerabilities already fetched in this session.
 
+    *variant_id* scopes persisted CVSS metrics to the variant currently
+    being processed (passed through to ``persist_from_transient``).
+
     Args:
         vuln: The vulnerability to persist
         pkg_id_cache: Optional cache of package IDs to avoid SELECT queries
         finding_cache: Optional cache of findings
         db_record_cache: Optional cache of DB Vulnerability records
         use_savepoint: If True (default), use SAVEPOINT. Set False in batch context.
+        variant_id: Optional variant UUID to scope persisted CVSS metrics.
     """
     try:
         from ..extensions import db
@@ -70,6 +75,7 @@ def _persist_vuln_to_db(
                     pkg_id_cache=pkg_id_cache,
                     finding_cache=finding_cache,
                     db_record_cache=db_record_cache,
+                    variant_id=variant_id,
                 )
         else:
             # Skip SAVEPOINT for better perf in bulk operations
@@ -78,6 +84,7 @@ def _persist_vuln_to_db(
                 pkg_id_cache=pkg_id_cache,
                 finding_cache=finding_cache,
                 db_record_cache=db_record_cache,
+                variant_id=variant_id,
             )
     except Exception as e:
         verbose(f"[_persist_vuln_to_db {vuln.id!r}] {e}")
@@ -112,6 +119,10 @@ class VulnerabilitiesController:
         observation for the new scan — preventing cross-variant observation leakage."""
         self._db_record_cache: dict = {}
         """Cache of {vuln_id: DB record} — avoids get_by_id SELECT in persist_from_transient."""
+        self.current_variant_id: uuid.UUID | None = None
+        """Variant UUID currently being processed. When set, persisted CVSS metrics
+        are scoped to this variant so scores from one project/variant don't leak
+        into another. Set by the process run from the latest scan's variant."""
         self.epss_api = EPSS_DB()
         self.nvd_api = NVD_DB()
         self._preload_cache()
@@ -135,7 +146,7 @@ class VulnerabilitiesController:
                 # Populate transient CVSS list from eager-loaded metrics
                 for m in (rec.metrics or []):
                     try:
-                        rec.register_cvss(CVSS(
+                        _cvss = CVSS(
                             m.version,
                             m.vector or "",
                             m.author or "unknown",
@@ -143,7 +154,12 @@ class VulnerabilitiesController:
                             0.0,
                             0.0,
                             m.origin or "scanner",
-                        ))
+                        )
+                        # Tag the CVSS with its source variant so that
+                        # persist_from_transient can skip custom scores that
+                        # belong to a different variant and must not be copied.
+                        _cvss.source_variant_id = m.variant_id
+                        rec.register_cvss(_cvss)
                     except Exception as e:
                         verbose(f"[VulnerabilitiesController._preload_cache register_cvss {rec.id!r}] {e}")
                 self.vulnerabilities[rec.id] = rec
@@ -152,10 +168,12 @@ class VulnerabilitiesController:
                 # Cache the DB record so persist_from_transient skips get_by_id.
                 self._db_record_cache[rec.id] = rec
                 # Pre-populate Metrics._seen so from_cvss skips the SELECT
-                # for every metric that already exists in the DB.
+                # for every metric that already exists in the DB. The dedup key
+                # must match from_cvss exactly: (vuln_id, variant_id, version, score).
                 for m in (rec.metrics or []):
                     MetricsModel._seen.add((
                         rec.id,
+                        m.variant_id,
                         m.version,
                         float(m.score) if m.score is not None else None,
                     ))
@@ -213,12 +231,14 @@ class VulnerabilitiesController:
             known_pkgs = stored._persisted_packages
             if known_pkgs is None:
                 # First persist for this vuln
-                _persist_vuln_to_db(stored, use_savepoint=self.use_savepoints, **_caches)
+                _persist_vuln_to_db(stored, use_savepoint=self.use_savepoints,
+                                    variant_id=self.current_variant_id, **_caches)
                 stored._persisted_packages = set(stored.packages)
                 self._persisted_ids.add(canonical_id)
             elif (new_packages - known_pkgs) or merged:
                 # New packages or metadata may have changed — re-persist.
-                _persist_vuln_to_db(stored, use_savepoint=self.use_savepoints, **_caches)
+                _persist_vuln_to_db(stored, use_savepoint=self.use_savepoints,
+                                    variant_id=self.current_variant_id, **_caches)
                 stored._persisted_packages = set(stored.packages)
             # else: already persisted, nothing new — skip DB entirely
 

--- a/src/migrations/versions/n0c1d2e3f4a5_collapse_scanner_metrics_to_global.py
+++ b/src/migrations/versions/n0c1d2e3f4a5_collapse_scanner_metrics_to_global.py
@@ -1,0 +1,151 @@
+"""collapse scanner-origin metrics back to a single global (variant_id NULL) row
+
+Revision ``l8a9b0c1d2e3`` split legacy ``variant_id IS NULL`` CVSS rows into one
+copy per related variant. That was wrong for *standard* (scanner) data: a score
+coming from NVD/Grype/Yocto is identical for every variant, so it must be stored
+once globally (``variant_id IS NULL``) and never duplicated per variant. Only
+user-entered ``origin = 'custom'`` scores are variant-scoped.
+
+This migration re-collapses every scanner-origin (``origin <> 'custom'``)
+per-variant metric back to a single global row, deleting the duplicates. Custom
+rows are left untouched.
+
+Revision ID: n0c1d2e3f4a5
+Revises: 7cb28bf85fcc
+Create Date: 2026-06-10 00:00:00.000000
+"""
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'n0c1d2e3f4a5'
+down_revision = '7cb28bf85fcc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Scanner-origin rows that were wrongly scoped to a variant.
+    scoped_rows = conn.execute(
+        sa.text(
+            """
+            SELECT id, vulnerability_id, version, score, vector, author, origin
+            FROM metrics
+            WHERE variant_id IS NOT NULL
+              AND (origin IS NULL OR origin <> 'custom')
+            """
+        )
+    ).fetchall()
+
+    for row in scoped_rows:
+        params = {
+            "vulnerability_id": row.vulnerability_id,
+            "version": row.version,
+            "score": row.score,
+        }
+
+        # Is there already an equivalent global (variant_id IS NULL) row?
+        # Match on (vulnerability_id, version, score) only — the same criteria
+        # used by Metrics.from_cvss() at runtime — to avoid MultipleResultsFound
+        # when rows differ only in vector/author/origin.
+        # The `origin <> 'custom'` guard is redundant here (the outer query
+        # already filtered those out) but kept as a safety net.
+        global_exists = conn.execute(
+            sa.text(
+                """
+                SELECT 1
+                FROM metrics
+                WHERE variant_id IS NULL
+                  AND vulnerability_id = :vulnerability_id
+                  AND (version = :version OR (version IS NULL AND :version IS NULL))
+                  AND (score = :score OR (score IS NULL AND :score IS NULL))
+                  AND (origin IS NULL OR origin <> 'custom')
+                LIMIT 1
+                """
+            ),
+            params,
+        ).fetchone()
+
+        if not global_exists:
+            # Promote this row to global instead of inserting a brand new one.
+            conn.execute(
+                sa.text("UPDATE metrics SET variant_id = NULL WHERE id = :id"),
+                {"id": row.id},
+            )
+        else:
+            # A global row already covers this score: drop the scoped duplicate.
+            conn.execute(
+                sa.text("DELETE FROM metrics WHERE id = :id"),
+                {"id": row.id},
+            )
+
+
+def downgrade():
+    # Best-effort reverse: re-split each global scanner-origin row into one copy
+    # per variant that observes the vulnerability (mirrors l8a9b0c1d2e3). The
+    # original promoted row is removed once at least one per-variant copy exists.
+    conn = op.get_bind()
+
+    global_rows = conn.execute(
+        sa.text(
+            """
+            SELECT id, vulnerability_id, version, score, vector, author, origin
+            FROM metrics
+            WHERE variant_id IS NULL
+              AND (origin IS NULL OR origin <> 'custom')
+            """
+        )
+    ).fetchall()
+
+    for row in global_rows:
+        related_variants = conn.execute(
+            sa.text(
+                """
+                SELECT DISTINCT s.variant_id
+                FROM findings f
+                JOIN observations o ON o.finding_id = f.id
+                JOIN scans s ON s.id = o.scan_id
+                WHERE f.vulnerability_id = :vulnerability_id
+                  AND s.variant_id IS NOT NULL
+                """
+            ),
+            {"vulnerability_id": row.vulnerability_id},
+        ).fetchall()
+
+        if not related_variants:
+            continue
+
+        inserted_any = False
+        for variant_row in related_variants:
+            conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO metrics
+                        (id, vulnerability_id, variant_id, version, score, vector, author, origin)
+                    VALUES
+                        (:id, :vulnerability_id, :variant_id, :version, :score, :vector, :author, :origin)
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "vulnerability_id": row.vulnerability_id,
+                    "variant_id": variant_row.variant_id,
+                    "version": row.version,
+                    "score": row.score,
+                    "vector": row.vector,
+                    "author": row.author,
+                    "origin": row.origin,
+                },
+            )
+            inserted_any = True
+
+        if inserted_any:
+            conn.execute(
+                sa.text("DELETE FROM metrics WHERE id = :id"),
+                {"id": row.id},
+            )

--- a/src/models/cvss.py
+++ b/src/models/cvss.py
@@ -21,6 +21,10 @@ class CVSS:
         self.base_score = base_score
         self.exploitability_score = exploitability_score
         self.impact_score = impact_score
+        self.source_variant_id: object = None
+        """Set by VulnerabilitiesController._preload_cache to track which variant
+        this CVSS entry was loaded from.  Used by persist_from_transient to prevent
+        custom scores from one variant leaking into another."""
 
     def __str__(self) -> str:
         """Return a string representation of the CVSS score, using it's 3 scores as identifier."""

--- a/src/models/metrics.py
+++ b/src/models/metrics.py
@@ -150,11 +150,24 @@ class Metrics(Base):
     ) -> Optional["Metrics"]:
         """Create a :class:`Metrics` record from an in-memory :class:`CVSS` object.
 
-        If a matching record (same vulnerability_id + version + score) already exists it is
+        If a matching record (same vulnerability_id + variant_id + version + score) already exists it is
         returned unchanged when insert fallback is triggered; otherwise a new one is persisted.
         When the session dedup cache hits, ``None`` is returned to signal a no-op.
+
+        Scoping rule based on ``origin``:
+          * ``"custom"`` — user-entered override; stored scoped to *variant_id*
+            so it stays isolated per project/variant.
+          * anything else (``"scanner"`` and the like) — standard data shared by
+            every variant; forced to ``variant_id = NULL`` so it is stored once
+            and never duplicated across variants.
         """
         vid = vulnerability_id.upper()
+
+        # Standard (scanner) metrics are global: never scope them to a variant,
+        # otherwise the same NVD/Grype score would be stored once per variant.
+        origin = getattr(cvss, "origin", None)
+        if origin != "custom":
+            variant_id = None
 
         dedup_key = (
             vid,
@@ -182,7 +195,7 @@ class Metrics(Base):
                     score=cvss.base_score,
                     vector=cvss.vector_string,
                     author=cvss.author,
-                    origin=getattr(cvss, "origin", None),
+                    origin=origin,
                 )
                 db.session.add(record)
                 db.session.flush()

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -623,6 +623,7 @@ class Vulnerability(Base):
         pkg_id_cache: dict | None = None,
         finding_cache: dict | None = None,
         db_record_cache: dict | None = None,
+        variant_id=None,
     ) -> "Vulnerability":
         """Upsert a DB record from an in-memory Vulnerability (with transient attrs).
 
@@ -636,6 +637,11 @@ class Vulnerability(Base):
 
         *db_record_cache* (``{vuln_id: Vulnerability_record}``) avoids the
         ``get_by_id`` SELECT for vulnerabilities already fetched this session.
+
+        *variant_id* scopes persisted CVSS metrics to the variant currently
+        being processed so that scores from one project/variant do not leak
+        into another.  When ``None`` (e.g. legacy callers) metrics are stored
+        unscoped, matching the historical behaviour.
         """
 
         if pkg_id_cache is None:
@@ -728,7 +734,16 @@ class Vulnerability(Base):
         # wraps the whole persist_from_transient in one.
         for cvss_obj in vuln.severity_cvss:
             try:
-                Metrics.from_cvss(cvss_obj, record.id)
+                # Skip custom CVSS that were loaded from a *different* variant.
+                # They carry a ``source_variant_id`` tag set by
+                # VulnerabilitiesController._preload_cache; persisting them
+                # with the current variant_id would copy scores across variants.
+                cvss_origin = getattr(cvss_obj, "origin", None)
+                if cvss_origin == "custom":
+                    src_vid = getattr(cvss_obj, "source_variant_id", None)
+                    if src_vid is not None and src_vid != variant_id:
+                        continue
+                Metrics.from_cvss(cvss_obj, record.id, variant_id=variant_id)
             except Exception as e:
                 verbose(f"[Vulnerability.persist_from_transient CVSS {record.id!r}] {e}")
 

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -152,8 +152,13 @@ def _variant_scoped_metrics_and_effort_overrides(
     overrides: dict[str, _ScopedOverrides] = {}
     for r in records:
         metric_bucket = metrics_by_vuln.get(r.id, {"scoped": [], "fallback": []})
-        selected_metrics = metric_bucket["scoped"] or metric_bucket["fallback"]
+        # CVSS is a union: global (scanner, variant_id IS NULL) scores are
+        # standard data shown for every variant, plus this variant's own
+        # custom scores. Custom scores add to — they don't hide — scanner data.
+        selected_metrics = metric_bucket["fallback"] + metric_bucket["scoped"]
 
+        # Effort is a single value per vuln: a variant-scoped estimate overrides
+        # the global one, falling back to global when none is set.
         chosen_effort = effort_by_vuln.get(r.id) or fallback_effort_by_vuln.get(r.id)
         overrides[str(r.id)] = _ScopedOverrides(selected_metrics, chosen_effort or _Effort(None, None, None))
 
@@ -453,14 +458,50 @@ def init_app(app):
                     .order_by(Vulnerability.id)
                 ).scalars().all())
 
-                # Bulk-load metrics per vulnerability
+                # Variants that belong to this project — used to scope custom
+                # CVSS/effort so overrides from other projects don't leak in.
+                # Standard (scanner) metrics live globally (variant_id IS NULL)
+                # and are shown for every project.
+                project_variant_ids = [v.id for v in Variant.get_by_project(project_uuid)]
+                if project_variant_ids:
+                    _metric_var_filter = db.or_(
+                        Metrics.variant_id.in_(project_variant_ids),
+                        Metrics.variant_id.is_(None),
+                    )
+                else:
+                    _metric_var_filter = Metrics.variant_id.is_(None)
+
+                # Bulk-load metrics per vulnerability: global scanner rows plus
+                # this project's custom rows.
                 metric_rows = db.session.execute(
                     db.select(Metrics)
-                    .where(Metrics.vulnerability_id.in_(vuln_ids_subq))
+                    .where(Metrics.vulnerability_id.in_(vuln_ids_subq), _metric_var_filter)
                 ).scalars().all()
-                metrics_by_vuln: dict[str, list] = {}
+                _global_metrics: dict[str, list] = {}
+                _custom_metrics: dict[str, list] = {}
+                _custom_metric_keys: dict[str, set] = {}
                 for m in metric_rows:
-                    metrics_by_vuln.setdefault(m.vulnerability_id, []).append(m)
+                    if m.variant_id is not None:
+                        # Dedupe identical custom metrics across the project's
+                        # variants so the same score isn't listed once per variant.
+                        key = (
+                            m.version,
+                            float(m.score) if m.score is not None else None,
+                            m.vector,
+                            m.author,
+                            m.origin,
+                        )
+                        seen = _custom_metric_keys.setdefault(m.vulnerability_id, set())
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        _custom_metrics.setdefault(m.vulnerability_id, []).append(m)
+                    else:
+                        _global_metrics.setdefault(m.vulnerability_id, []).append(m)
+                # Union: global scanner data + project custom overrides.
+                metrics_by_vuln: dict[str, list] = {}
+                for vid in set(_global_metrics) | set(_custom_metrics):
+                    metrics_by_vuln[vid] = _global_metrics.get(vid, []) + _custom_metrics.get(vid, [])
 
                 # Bulk-load packages per vulnerability, expanding to all same-name+version
                 # supplier variants so that Grype-linked packages (no supplier) also surface
@@ -478,21 +519,38 @@ def init_app(app):
                     sid = f"{pname}@{pver}::{psup}" if psup else f"{pname}@{pver}"
                     pkgs_by_vuln.setdefault(vid, []).append(sid)
 
-                # Bulk-load effort (time estimates) per vulnerability
+                # Bulk-load effort (time estimates) per vulnerability, scoped to
+                # this project's variants (plus global NULL rows). Project-scoped
+                # estimates take precedence over global ones.
+                if project_variant_ids:
+                    _te_var_filter = db.or_(
+                        TimeEstimate.variant_id.in_(project_variant_ids),
+                        TimeEstimate.variant_id.is_(None),
+                    )
+                else:
+                    _te_var_filter = TimeEstimate.variant_id.is_(None)
                 te_rows = db.session.execute(
                     db.select(
                         Finding.vulnerability_id,
+                        TimeEstimate.variant_id,
                         TimeEstimate.optimistic,
                         TimeEstimate.likely,
                         TimeEstimate.pessimistic,
                     )
                     .join(Finding, TimeEstimate.finding_id == Finding.id)
-                    .where(Finding.vulnerability_id.in_(vuln_ids_subq))
+                    .where(Finding.vulnerability_id.in_(vuln_ids_subq), _te_var_filter)
                 ).all()
                 effort_by_vuln: dict[str, tuple] = {}
-                for vid, opti, like, pess in te_rows:
+                _fallback_effort_by_vuln: dict[str, tuple] = {}
+                for vid, te_variant_id, opti, like, pess in te_rows:
+                    if te_variant_id is not None:
+                        if vid not in effort_by_vuln:
+                            effort_by_vuln[vid] = (opti, like, pess)
+                    elif vid not in _fallback_effort_by_vuln:
+                        _fallback_effort_by_vuln[vid] = (opti, like, pess)
+                for vid, fallback in _fallback_effort_by_vuln.items():
                     if vid not in effort_by_vuln:
-                        effort_by_vuln[vid] = (opti, like, pess)
+                        effort_by_vuln[vid] = fallback
 
                 # Pre-populate transient fields so to_dict() won't lazy-load findings
                 for r in records:

--- a/tests/unit_tests/test_new_db_models.py
+++ b/tests/unit_tests/test_new_db_models.py
@@ -768,7 +768,7 @@ class TestMetricsModelExtra:
         assert not any(m.id == m2.id for m in results)
 
     def test_from_cvss_with_variant_id(self, app, vuln, variant):
-        """from_cvss() with variant_id parameter creates scoped metrics."""
+        """from_cvss() scopes custom-origin metrics to the given variant."""
         from src.models.cvss import CVSS
         cvss = CVSS(
             version="3.1",
@@ -777,10 +777,27 @@ class TestMetricsModelExtra:
             base_score=7.5,
             exploitability_score=3.9,
             impact_score=3.6,
+            origin="custom",
         )
         Metrics._seen = set()
         m = Metrics.from_cvss(cvss, vuln.id, variant_id=variant.id)
         assert m.variant_id == variant.id
+        assert m.vulnerability_id == vuln.id
+
+    def test_from_cvss_scanner_origin_is_global(self, app, vuln, variant):
+        """from_cvss() forces scanner-origin metrics to variant_id NULL."""
+        from src.models.cvss import CVSS
+        cvss = CVSS(
+            version="3.1",
+            vector_string="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:L",
+            author="NVD",
+            base_score=7.6,
+            exploitability_score=3.9,
+            impact_score=3.6,
+        )
+        Metrics._seen = set()
+        m = Metrics.from_cvss(cvss, vuln.id, variant_id=variant.id)
+        assert m.variant_id is None
         assert m.vulnerability_id == vuln.id
 
     def test_get_by_id_with_string_uuid(self, app, metrics):
@@ -808,8 +825,10 @@ class TestMetricsModelExtra:
             exploitability_score=0.0,
             impact_score=0.0,
         )
-        # Clear _seen so from_cvss attempts the INSERT path
-        Metrics._seen.discard((vuln.id, cvss.version, float(cvss.base_score)))
+        # Clear _seen so from_cvss attempts the INSERT path. The dedup key must
+        # match from_cvss exactly: (vuln_id, variant_id, version, score). Scanner
+        # origin (the default here) is stored globally, so variant_id is None.
+        Metrics._seen.discard((vuln.id.upper(), None, cvss.version, float(cvss.base_score)))
         # Mock session.flush() to raise IntegrityError, forcing the SELECT fallback
         with mock_patch.object(_db.session, "flush", side_effect=IntegrityError("stmt", {}, None)):
             result = Metrics.from_cvss(cvss, vuln.id)


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

*Standard scanner scores (NVD/Grype/Yocto) are identical for every variant, so storing them per variant duplicated each score N times and leaked other variants' scores into a project view. 
*Custom user scores, in contrast, must stay isolated per variant.

### Changes proposed in this pull request:

* Metrics.from_cvss now forces variant_id=NULL for any non-custom origin and keeps custom scores variant-scoped. 
* The list/detail endpoints return the union of global scanner rows plus the current variant/project's custom rows (deduped). 
* A migration re-collapses previously per-variant scanner rows back to a single global row. Tests updated to the new contract.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Load multiples projects with multiples variants and the CVSS overlap won't appear anymore


With this fix: 

<img width="1769" height="368" alt="image" src="https://github.com/user-attachments/assets/6911f4a0-8a79-47d9-b92f-ef6254ff247c" />

Without this fix: 

<img width="1769" height="368" alt="image" src="https://github.com/user-attachments/assets/8ba8d3d6-b991-45b0-9e41-ca6f7a7f05cc" />

