### PR TITLE
fix: refresh CVSS gauges after saving custom score

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -1,6 +1,6 @@
 import type { Vulnerability } from "../handlers/vulnerabilities";
 import type { CVSS } from "../handlers/vulnerabilities";
-import { asCVSS, buildStatusSummary } from "../handlers/vulnerabilities";
+import Vulnerabilities, { asCVSS, buildStatusSummary } from "../handlers/vulnerabilities";
 import type { Assessment } from "../handlers/assessments";
 import { asAssessment } from "../handlers/assessments";
 import { escape } from "lodash-es";
@@ -830,10 +830,24 @@ type VariantScopedSnapshot = {
                 : data?.severity?.cvss;
 
             if (Array.isArray(updatedSeverity) && variantId) {
-                // Only update the local vuln object when viewing a specific variant.
-                // In all-variants mode the snapshot refresh below handles the display.
-                vuln.severity.cvss = updatedSeverity;
-                patchVuln(vuln.id, vuln);
+                // Only use the response severity directly when viewing a specific
+                // variant: the PATCH response is already variant-scoped.
+                const updatedVuln = { ...vuln, severity: { ...vuln.severity, cvss: updatedSeverity } };
+                patchVuln(vuln.id, updatedVuln);
+            } else if (!variantId) {
+                // All-variants mode: the PATCH response is variant-scoped, so it
+                // can't populate the union gauge view. Re-fetch the vulnerability
+                // in the current (project) scope so the CVSS gauges reflect the new
+                // custom score immediately, mirroring a page reload.
+                try {
+                    const refreshedCvss = await Vulnerabilities.fetchScopedCvss(vuln.id, projectId);
+                    if (refreshedCvss) {
+                        const updatedVuln = { ...vuln, severity: { ...vuln.severity, cvss: refreshedCvss } };
+                        patchVuln(vuln.id, updatedVuln);
+                    }
+                } catch (e) {
+                    console.error("Failed to refresh vulnerability after CVSS save:", e);
+                }
             }
 
             // Refresh per-variant snapshots immediately so the panel reflects the
@@ -1137,7 +1151,7 @@ type VariantScopedSnapshot = {
                                     {vuln.severity.cvss.map((cvss) => (
                                     <div
                                         key={encodeURIComponent(
-                                        `${cvss.author}-${cvss.version}-${cvss.base_score}`
+                                        `${cvss.variant_id ?? 'global'}-${cvss.author}-${cvss.version}-${cvss.base_score}`
                                         )}
                                         className="bg-gray-800 p-2 rounded-xl min-w-[216px]"
                                     >

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -281,6 +281,25 @@ class Vulnerabilities {
         return data.flatMap(asVulnerability);
     }
 
+    // Re-fetch a single vulnerability in the given (project) scope and return
+    // its CVSS list. Used after saving a custom score in all-variants mode,
+    // where the PATCH response is variant-scoped and cannot populate the union
+    // gauges. Returns null when the request fails or the payload is invalid.
+    static async fetchScopedCvss(vulnId: string, projectId?: string): Promise<CVSS[] | null> {
+        const url = new URL(
+            import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vulnId)}`,
+            window.location.href,
+        );
+        if (projectId) url.searchParams.set('project_id', projectId);
+        const response = await fetch(url.toString(), { mode: 'cors' });
+        if (!response.ok) return null;
+        const refreshedVuln = asVulnerability(await response.json());
+        if (!Array.isArray(refreshedVuln) && Array.isArray(refreshedVuln.severity?.cvss)) {
+            return refreshedVuln.severity.cvss;
+        }
+        return null;
+    }
+
     static enrich_with_assessments(vulns: Vulnerability[], assessments: Assessment[]): Vulnerability[] {
         const assessments_per_vuln = assessments.reduce((acc, assessment: Assessment) => {
             if (!acc[assessment.vuln_id]) {

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -402,6 +402,83 @@ describe('Vulnerability Modal', () => {
         expect(successBanner).toBeInTheDocument();
     });
 
+    test('custom CVSS in all-variants mode re-fetches the union scope to refresh gauges', async () => {
+        // In all-variants mode the PATCH response is variant-scoped and cannot
+        // populate the union CVSS gauges, so the modal re-fetches the
+        // vulnerability in the current (project) scope. This guards that
+        // refresh path (commit "fix CVSS refresh").
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+
+        const closeCb = jest.fn();
+        const patchVuln = jest.fn();
+        const appendCVSS = jest.fn().mockReturnValue({
+            author: 'tester',
+            version: '3.1',
+            base_score: 7.5,
+            origin: 'custom',
+        });
+
+        // PATCH response: variant-scoped, only the custom score.
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve({
+                    id: 'CVE-2010-1234',
+                    severity: { cvss: [{ author: 'tester', version: '3.1', base_score: 7.5, origin: 'custom' }] }
+                })
+            } as Response)
+        );
+
+        // Re-fetch (union scope): scanner score + custom score.
+        const refetchUnion = [
+            { author: 'nvd', version: '3.1', base_score: 3.0, origin: 'scanner' },
+            { author: 'tester', version: '3.1', base_score: 7.5, origin: 'custom' },
+        ];
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve({
+                    id: 'CVE-2010-1234',
+                    severity: { cvss: refetchUnion }
+                })
+            } as Response)
+        );
+
+        const vulnCopy = { ...vulnerability, severity: { ...vulnerability.severity, cvss: [] } };
+
+        render(<VulnModal vuln={vulnCopy} onClose={closeCb} appendAssessment={() => {}} appendCVSS={appendCVSS} patchVuln={patchVuln} isEditing={true} projectId="proj-1" />);
+
+        const user = userEvent.setup();
+        await user.click(await screen.getByRole('button', { name: /add custom cvss vector/i }));
+        const vectorInput = await screen.getByPlaceholderText(/CVSS:3\.1/i);
+        await user.type(vectorInput, 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
+        await user.click(await screen.getByRole('button', { name: /^add$/i }));
+
+        // A re-fetch in project scope must have been issued.
+        await waitFor(() => {
+            const calledRefetch = fetchMock.mock.calls.some(call => {
+                const url = String(call[0]);
+                return url.includes('/api/vulnerabilities/CVE-2010-1234') && url.includes('project_id=proj-1');
+            });
+            expect(calledRefetch).toBe(true);
+        });
+
+        // patchVuln must be called with the union cvss from the re-fetch, not
+        // the single variant-scoped score from the PATCH response.
+        await waitFor(() => {
+            expect(patchVuln).toHaveBeenCalled();
+            const lastCall = patchVuln.mock.calls[patchVuln.mock.calls.length - 1];
+            expect(lastCall[1].severity.cvss).toHaveLength(2);
+        });
+
+        const successBanner = await screen.findByText(/successfully added custom cvss/i);
+        expect(successBanner).toBeInTheDocument();
+    });
+
     test('ESC key closes modal without unsaved changes', async () => {
         const closeCb = jest.fn();
         render(<VulnModal vuln={vulnerability} onClose={closeCb} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -491,9 +491,11 @@ def init_app(app):
                 _custom_metric_keys: dict[str, set] = {}
                 for m in metric_rows:
                     if m.variant_id is not None:
-                        # Dedupe identical custom metrics across the project's
-                        # variants so the same score isn't listed once per variant.
+                        # Keep one custom metric per variant so each variant's
+                        # score gets its own gauge, while still collapsing exact
+                        # duplicates within the same variant.
                         key = (
+                            m.variant_id,
                             m.version,
                             float(m.score) if m.score is not None else None,
                             m.vector,


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

When a custom CVSS score is saved from the vulnerability modal while viewing all variants, the PATCH response is variant-scoped and cannot populate the union CVSS gauge view. 

As a result the gauges did not reflect the newly added score until the modal was reopened or the page reloaded.

Re-fetch the vulnerability in the current (project) scope after a successful save so the gauges update immediately, mirroring a reload. The variant-scoped path is unchanged since its PATCH response already carries the correct data.

Add a VulnModal test covering the all-variants re-fetch path, asserting the project-scoped request is issued and patchVuln receives the union CVSS list rather than the single variant-scoped score.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Enter a custom CVSS score (e.g. `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`), and now the UI doesn't require to press F5 to appear properly

With this fix: 

<img width="1825" height="810" alt="image" src="https://github.com/user-attachments/assets/e261dd68-0907-4059-924f-3be125c5a797" />

