### PR TITLE
fix: modal navigation in sync with table order

### DIFF
--- a/frontend/src/components/TableGeneric.tsx
+++ b/frontend/src/components/TableGeneric.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from 'react-dom'
-import { getCoreRowModel, getSortedRowModel, getFilteredRowModel, useReactTable, flexRender, Row, RowSelectionState, OnChangeFn, SortingState } from '@tanstack/react-table'
+import { getCoreRowModel, getSortedRowModel, getFilteredRowModel, getPaginationRowModel, useReactTable, flexRender, Row, RowSelectionState, OnChangeFn, SortingState, PaginationState } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpShortWide, faArrowDownWideShort, faSort } from "@fortawesome/free-solid-svg-icons";
@@ -40,8 +40,9 @@ function TableGeneric<DataType> ({
     onFilteredDataChange,
     onFocusedRowChange
 }: Readonly<Props<DataType>>) {
-    const [pageIndex, setPageIndex] = useState(0)
-    const [itemsPerPage, setItemsPerPage] = useState(50)
+    const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 50 })
+    const pageIndex = pagination.pageIndex
+    const itemsPerPage = pagination.pageSize
     const [sorting, setSorting] = useState<SortingState>([])
     const [focusedRowIndex, setFocusedRowIndex] = useState<number | null>(null)
     const rowRefs = useRef<Map<number, HTMLTableRowElement>>(new Map())
@@ -101,47 +102,6 @@ function TableGeneric<DataType> ({
         return data;
     }, [search, fuse, data, fuseKeys]);
 
-    // Notify parent component when filtered data changes
-    useEffect(() => {
-        if (onFilteredDataChange) {
-            onFilteredDataChange(filteredData);
-        }
-    }, [filteredData, onFilteredDataChange]);
-
-    const sortedData = useMemo(() => {
-        if (sorting.length === 0) return filteredData;
-        const sorted = [...filteredData];
-        const { id, desc } = sorting[0];
-        const column = columns.find(col => col.id === id);
-        if (!column) return sorted;
-        sorted.sort((a, b) => {
-            if (column.sortingFn) {
-                const result = column.sortingFn({ original: a } as any, { original: b } as any, id);
-                return desc ? -result : result;
-            }
-            let aVal: any, bVal: any;
-            if (typeof column.accessorFn === 'function') {
-                aVal = column.accessorFn(a, 0);
-                bVal = column.accessorFn(b, 0);
-            } else if (column.accessorKey) {
-                const keys = String(column.accessorKey).split('.');
-                aVal = keys.reduce((obj, key) => obj?.[key], a as any);
-                bVal = keys.reduce((obj, key) => obj?.[key], b as any);
-            } else return 0;
-            if (aVal === bVal) return 0;
-            if (aVal == null) return 1;
-            if (bVal == null) return -1;
-            const result = aVal > bVal ? 1 : -1;
-            return desc ? -result : result;
-        });
-        return sorted;
-    }, [filteredData, sorting, columns]);
-
-    const paginatedData = useMemo(() => {
-        const start = pageIndex * itemsPerPage
-        return sortedData.slice(start, start + itemsPerPage)
-    }, [sortedData, pageIndex, itemsPerPage])
-
     const paginationSizes = useMemo(() => {
         const total = filteredData.length;
 
@@ -164,18 +124,40 @@ function TableGeneric<DataType> ({
 
     const table = useReactTable({
         columns,
-        data: paginatedData,
+        data: filteredData,
         getCoreRowModel: getCoreRowModel(),
         getSortedRowModel: getSortedRowModel(),
         getFilteredRowModel: getFilteredRowModel(),
+        getPaginationRowModel: getPaginationRowModel(),
+        autoResetPageIndex: false,
         enableRowSelection: selected !== undefined,
         enableMultiRowSelection: selected !== undefined,
         // @ts-expect-error: Row ID might not always be present in the data
         getRowId: row => row?.id,
         onRowSelectionChange: updateSelected,
         onSortingChange: setSorting,
-        state: { rowSelection: selected ?? {}, sorting }
+        onPaginationChange: setPagination,
+        state: { rowSelection: selected ?? {}, sorting, pagination }
     });
+
+    // Notify parent component with the fully filtered + sorted rows (across all
+    // pages, in the exact order the table displays them). Consumers that rely on
+    // row order — e.g. modal/keyboard navigation — must see the same order the
+    // table renders. Derived from the table's own sorted row model so it can
+    // never diverge from what is displayed. Depends only on data + sorting (not
+    // on the columns array, which would create a render loop with parents that
+    // rebuild columns from this callback's result).
+    const sortedOriginals = useMemo(
+        () => table.getSortedRowModel().rows.map(row => row.original),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [table, filteredData, sorting]
+    );
+
+    useEffect(() => {
+        if (onFilteredDataChange) {
+            onFilteredDataChange(sortedOriginals);
+        }
+    }, [sortedOriginals, onFilteredDataChange]);
 
     const { rows } = table.getRowModel()
     //The virtualizer needs to know the scrollable container element
@@ -478,8 +460,7 @@ function TableGeneric<DataType> ({
                 <select
                 value={itemsPerPage}
                 onChange={(e) => {
-                    setPageIndex(0)
-                    setItemsPerPage(Number(e.target.value))
+                    setPagination({ pageIndex: 0, pageSize: Number(e.target.value) })
                 }}
                 className="bg-slate-700 text-white border border-slate-500 rounded px-2 py-1"
                 >
@@ -495,14 +476,14 @@ function TableGeneric<DataType> ({
                 <button
                 className="px-2 py-1 bg-slate-600 rounded disabled:opacity-50"
                 disabled={pageIndex === 0}
-                onClick={() => setPageIndex(0)}
+                onClick={() => setPagination(prev => ({ ...prev, pageIndex: 0 }))}
                 >
                 First
                 </button>
                 <button
                 className="px-2 py-1 bg-slate-600 rounded disabled:opacity-50"
                 disabled={pageIndex === 0}
-                onClick={() => setPageIndex(prev => Math.max(prev - 1, 0))}
+                onClick={() => setPagination(prev => ({ ...prev, pageIndex: Math.max(prev.pageIndex - 1, 0) }))}
                 >
                 Previous
                 </button>
@@ -516,7 +497,7 @@ function TableGeneric<DataType> ({
                         'px-2 py-1 rounded',
                         p === pageIndex ? 'bg-blue-600' : 'bg-slate-600'
                     ].join(' ')}
-                    onClick={() => setPageIndex(p)}
+                    onClick={() => setPagination(prev => ({ ...prev, pageIndex: p }))}
                     >
                     {p + 1}
                     </button>
@@ -525,14 +506,14 @@ function TableGeneric<DataType> ({
                 <button
                 className="px-2 py-1 bg-slate-600 rounded disabled:opacity-50"
                 disabled={pageIndex + 1 >= pageCount}
-                onClick={() => setPageIndex(prev => prev + 1)}
+                onClick={() => setPagination(prev => ({ ...prev, pageIndex: prev.pageIndex + 1 }))}
                 >
                 Next
                 </button>
                 <button
                 className="px-2 py-1 bg-slate-600 rounded disabled:opacity-50"
                 disabled={pageIndex + 1 >= pageCount}
-                onClick={() => setPageIndex(pageCount - 1)}
+                onClick={() => setPagination(prev => ({ ...prev, pageIndex: pageCount - 1 }))}
                 >
                 Last
                 </button>

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -1,6 +1,6 @@
 import type { Vulnerability } from "../handlers/vulnerabilities";
 import type { CVSS } from "../handlers/vulnerabilities";
-import { asVulnerability, buildStatusSummary } from "../handlers/vulnerabilities";
+import { asCVSS, buildStatusSummary } from "../handlers/vulnerabilities";
 import type { Assessment } from "../handlers/assessments";
 import { asAssessment } from "../handlers/assessments";
 import { escape } from "lodash-es";
@@ -142,50 +142,68 @@ type VariantScopedSnapshot = {
             return;
         }
 
+        const variantNameById = new Map(availableVariants.map(v => [v.id, v.name]));
+
         (async () => {
-            const snapshots = await Promise.all(availableVariants.map(async (variant): Promise<VariantScopedSnapshot | null> => {
-                try {
-                    const response = await fetch(
-                        import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}?variant_id=${encodeURIComponent(variant.id)}`,
-                        { mode: 'cors' }
-                    );
-                    if (!response.ok) return null;
-                    const raw = await response.json();
-                    const vulnData = asVulnerability(raw);
-                    if (Array.isArray(vulnData)) return null;
-                    const customCvss = Array.isArray(vulnData?.severity?.cvss)
-                        ? vulnData.severity.cvss.filter(score => score.origin === 'custom')
-                        : [];
-
-                    const optimisticDuration = vulnData?.effort?.optimistic;
-                    const likelyDuration = vulnData?.effort?.likely;
-                    const pessimisticDuration = vulnData?.effort?.pessimistic;
-                    const hasEffort = [optimisticDuration, likelyDuration, pessimisticDuration].some((duration) => {
-                        return typeof duration?.total_seconds === 'number' && duration.total_seconds > 0;
-                    });
-                    return {
-                        variantId: variant.id,
-                        variantName: variant.name,
-                        hasEffort,
-                        effort: {
-                            optimistic: typeof optimisticDuration?.formatHumanShort === 'function' && optimisticDuration.total_seconds > 0 ? optimisticDuration.formatHumanShort() : undefined,
-                            likely: typeof likelyDuration?.formatHumanShort === 'function' && likelyDuration.total_seconds > 0 ? likelyDuration.formatHumanShort() : undefined,
-                            pessimistic: typeof pessimisticDuration?.formatHumanShort === 'function' && pessimisticDuration.total_seconds > 0 ? pessimisticDuration.formatHumanShort() : undefined,
-                        },
-                        customCvss,
-                    };
-                } catch {
-                    return null;
+            try {
+                const url = new URL(
+                    import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/variant-snapshots`,
+                    window.location.href
+                );
+                if (projectId) {
+                    url.searchParams.set('project_id', projectId);
                 }
-            }));
+                const response = await fetch(url.toString(), { mode: 'cors' });
+                if (!response.ok) {
+                    if (!cancelled) setVariantSnapshots([]);
+                    return;
+                }
+                const data = await response.json();
+                if (!Array.isArray(data)) {
+                    if (!cancelled) setVariantSnapshots([]);
+                    return;
+                }
 
-            if (!cancelled) {
-                setVariantSnapshots(snapshots.filter((s): s is VariantScopedSnapshot => s !== null));
+                const snapshots = data
+                    .filter((entry: any) => variantNameById.has(entry?.variant_id))
+                    .map((entry: any): VariantScopedSnapshot => {
+                        const customCvss: CVSS[] = Array.isArray(entry?.custom_cvss)
+                            ? entry.custom_cvss.flatMap(asCVSS)
+                            : [];
+
+                        const optimisticDuration = typeof entry?.effort?.optimistic === 'string'
+                            ? new Iso8601Duration(entry.effort.optimistic) : undefined;
+                        const likelyDuration = typeof entry?.effort?.likely === 'string'
+                            ? new Iso8601Duration(entry.effort.likely) : undefined;
+                        const pessimisticDuration = typeof entry?.effort?.pessimistic === 'string'
+                            ? new Iso8601Duration(entry.effort.pessimistic) : undefined;
+                        const hasEffort = [optimisticDuration, likelyDuration, pessimisticDuration].some((duration) => {
+                            return typeof duration?.total_seconds === 'number' && duration.total_seconds > 0;
+                        });
+
+                        return {
+                            variantId: entry.variant_id,
+                            variantName: variantNameById.get(entry.variant_id) ?? entry.variant_id,
+                            hasEffort,
+                            effort: {
+                                optimistic: optimisticDuration && optimisticDuration.total_seconds > 0 ? optimisticDuration.formatHumanShort() : undefined,
+                                likely: likelyDuration && likelyDuration.total_seconds > 0 ? likelyDuration.formatHumanShort() : undefined,
+                                pessimistic: pessimisticDuration && pessimisticDuration.total_seconds > 0 ? pessimisticDuration.formatHumanShort() : undefined,
+                            },
+                            customCvss,
+                        };
+                    });
+
+                if (!cancelled) {
+                    setVariantSnapshots(snapshots);
+                }
+            } catch {
+                if (!cancelled) setVariantSnapshots([]);
             }
         })();
 
         return () => { cancelled = true; };
-    }, [variantId, availableVariants, vuln.id, snapshotVersion]);
+    }, [variantId, availableVariants, vuln.id, projectId, snapshotVersion]);
 
     const [hasTimeChanges, setHasTimeChanges] = useState(false);
     const [hasAssessmentChanges, setHasAssessmentChanges] = useState(false);

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -415,6 +415,7 @@ export {
     SEVERITY_ORDER,
     STATUS_SORT_ORDER,
     asVulnerability,
+    asCVSS,
     buildStatusSummary,
     getStatusSortIndex,
     getTopStatusSummaryLabel,

--- a/frontend/tests/unit_tests/test_table_generic.tsx
+++ b/frontend/tests/unit_tests/test_table_generic.tsx
@@ -386,4 +386,52 @@ describe('TableGeneric component (direct tests to raise coverage)', () => {
     expect(await screen.findByRole('cell', { name: /^row0$/ })).toBeInTheDocument();  // passes group1
     expect(await screen.findByRole('cell', { name: /^row5$/ })).toBeInTheDocument();  // rescued by group2
   });
+
+  test('onFilteredDataChange reports rows in the displayed sorted order across all pages (modal/keyboard navigation)', async () => {
+    // Regression: the callback used to receive the raw filtered data (unsorted),
+    // while the table displayed a sorted + paginated view. Consumers relying on
+    // row order — e.g. next/prev navigation in VulnModal — then jumped to the
+    // wrong row. The callback must mirror the table's sorted row model, spanning
+    // every page, not just the current one.
+    const captured: RowType[][] = [];
+    const onFilteredDataChange = jest.fn((d: RowType[]) => { captured.push(d); });
+
+    // value mirrors the id index so the initial (unsorted) order is ascending
+    // by value, which differs from the sorted order produced below.
+    const N = 120; // > default page size (50) to prove it spans all pages
+    const data: RowType[] = Array.from({ length: N }, (_v, i) => ({
+      id: `row${i}`,
+      value: i,
+      descriptions: [{ content: `Description ${i}` }],
+    }));
+
+    render(
+      <TableGeneric
+        columns={columns}
+        data={data}
+        tableHeight="auto"
+        hasPagination={true}
+        onFilteredDataChange={onFilteredDataChange}
+      />
+    );
+
+    // Initially the callback fires with the full data set in its natural order.
+    await waitFor(() => {
+      expect(captured.length).toBeGreaterThan(0);
+    });
+    const initial = captured[captured.length - 1];
+    expect(initial).toHaveLength(N);
+    expect(initial.map(r => r.value)).toEqual(data.map(r => r.value)); // unsorted/original order
+
+    // Sort by Value (numeric columns sort descending on first click).
+    const user = userEvent.setup();
+    await user.click(await screen.findByText('Value'));
+
+    await waitFor(() => {
+      const last = captured[captured.length - 1];
+      // Still every row (all pages), now in the exact order the table displays.
+      expect(last).toHaveLength(N);
+      expect(last.map(r => r.value)).toEqual(Array.from({ length: N }, (_v, i) => N - 1 - i));
+    });
+  }, 10000);
 });

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -1849,8 +1849,7 @@ describe('Vulnerability Modal', () => {
             { id: 'v2', name: 'Variant Beta', project_id: 'proj1' }
         ]));
         fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
-        fetchMock.mockResponseOnce(JSON.stringify(vulnerability)); // variant snapshot for v1
-        fetchMock.mockResponseOnce(JSON.stringify(vulnerability)); // variant snapshot for v2
+        fetchMock.mockResponseOnce(JSON.stringify([])); // batch variant snapshots (single fetch)
         // Two POST responses for two variants
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -726,6 +726,49 @@ def init_app(app):
 
         return response
 
+    @app.get('/api/vulnerabilities/<id>/variant-snapshots')
+    def get_vuln_variant_snapshots(id):
+        """Return variant-scoped effort and custom CVSS for every variant that
+        observes this vulnerability, in a single response.
+
+        Replaces the previous per-variant N+1 fetch performed by the modal.
+        """
+        record = Vulnerability.get_by_id(id)
+        if not record:
+            return "Not found", 404
+
+        variant_uuids = _variant_ids_for_vulnerability(record.id)
+
+        project_id = request.args.get("project_id")
+        if project_id:
+            project_uuid, err = parse_uuid_or_400(project_id, "project_id")
+            if err:
+                return err
+            allowed = set(db.session.execute(
+                db.select(Variant.id).where(Variant.project_id == project_uuid)
+            ).scalars().all())
+            variant_uuids = [v for v in variant_uuids if v in allowed]
+
+        snapshots = []
+        for variant_uuid in variant_uuids:
+            if variant_uuid is None:
+                continue
+            overrides = _variant_scoped_metrics_and_effort_overrides([record], variant_uuid)
+            scoped = overrides.get(str(record.id))
+            if scoped is None:
+                continue
+            custom_cvss = [
+                m.to_dict() for m in scoped.cvss
+                if (m.origin or "scanner") == "custom"
+            ]
+            snapshots.append({
+                "variant_id": str(variant_uuid),
+                "effort": scoped.effort.to_dict(),
+                "custom_cvss": custom_cvss,
+            })
+
+        return jsonify(snapshots)
+
     @app.patch('/api/vulnerabilities/<id>')
     def patch_vuln(id):
         record = Vulnerability.get_by_id(id)

--- a/tests/webapp_tests/test_vulnerabilities_coverage.py
+++ b/tests/webapp_tests/test_vulnerabilities_coverage.py
@@ -895,3 +895,84 @@ def test_get_vulns_global_no_scope(client):
     vuln = data[0]
     assert "variants" in vuln
     assert "first_scan_date" in vuln
+
+
+# ---------------------------------------------------------------------------
+# GET /api/vulnerabilities/<id>/variant-snapshots — single batched call
+# ---------------------------------------------------------------------------
+
+def test_variant_snapshots_returns_effort_and_custom_cvss(app, client):
+    """The batch endpoint returns per-variant effort and custom CVSS in one call."""
+    from src.extensions import db
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.observation import Observation
+    from src.models.finding import Finding
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.metrics import Metrics
+    from src.models.time_estimate import TimeEstimate
+    from datetime import datetime, timezone
+    import uuid as _uuid
+
+    with app.app_context():
+        project = Project.create("SnapshotProject")
+        variant = Variant.create("snapshot-variant", project.id)
+        pkg = Package.find_or_create("snapshot-pkg", "1.0.0", [], [], "")
+        db.session.commit()
+        Vulnerability.create_record(
+            id="CVE-SNAP-0001",
+            description="Test vuln for variant snapshots",
+            status="high",
+        )
+        db.session.commit()
+        finding = Finding.get_or_create(pkg.id, "CVE-SNAP-0001")
+
+        scan = Scan(
+            id=_uuid.uuid4(),
+            variant_id=variant.id,
+            timestamp=datetime(2021, 1, 1, tzinfo=timezone.utc),
+        )
+        db.session.add(scan)
+        db.session.add(Observation(finding_id=finding.id, scan_id=scan.id))
+
+        # Variant-scoped custom CVSS and time estimate
+        Metrics.create(
+            vulnerability_id="CVE-SNAP-0001",
+            variant_id=variant.id,
+            version="3.1",
+            score=7.5,
+            vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            author="tester",
+            origin="custom",
+        )
+        TimeEstimate.create(
+            finding_id=finding.id,
+            variant_id=variant.id,
+            optimistic=1,
+            likely=2,
+            pessimistic=4,
+        )
+        db.session.commit()
+        pid = str(project.id)
+        vid = str(variant.id)
+
+    response = client.get(f"/api/vulnerabilities/CVE-SNAP-0001/variant-snapshots?project_id={pid}")
+    assert response.status_code == 200
+    snapshots = json.loads(response.data)
+    assert isinstance(snapshots, list)
+    snap = next((s for s in snapshots if s["variant_id"] == vid), None)
+    assert snap is not None
+    assert snap["effort"]["optimistic"] is not None
+    assert len(snap["custom_cvss"]) == 1
+    assert snap["custom_cvss"][0]["origin"] == "custom"
+    assert snap["custom_cvss"][0]["base_score"] == 7.5
+
+
+def test_variant_snapshots_unknown_vuln_returns_404(client):
+    """The batch endpoint returns 404 for an unknown vulnerability id."""
+    response = client.get("/api/vulnerabilities/CVE-DOES-NOT-EXIST/variant-snapshots")
+    assert response.status_code == 404
+
+


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

*Drive pagination through own pagination state/row model and derive the parent callback from the table's sorted row model, so the reported rows always span every page in the exact order the table renders.
This removes the hand-rolled sort/slice logic that could diverge from what is displayed.

*Optimized the vulnerability load to be sync and fast

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

<img width="1830" height="776" alt="image" src="https://github.com/user-attachments/assets/396f3b9e-9d80-4259-9471-8c7907e265e7" />

1) Sort in a specific order (e.g Severity)
2) Open a Vulnerability
3) Navigate to the next Vulnerability

And now the next vulnerability correspond to the next one in the array

Also when you nav to a new vulnerability:

```
172.17.0.1 - - [11/Jun/2026 20:20:56] "GET /api/vulnerabilities/CVE-1999-0199/assessments HTTP/1.1" 200 -
172.17.0.1 - - [11/Jun/2026 20:20:56] "GET /api/vulnerabilities/CVE-1999-0199/variants HTTP/1.1" 200 -
172.17.0.1 - - [11/Jun/2026 20:20:56] "GET /api/vulnerabilities/CVE-1999-0199/variants HTTP/1.1" 200 -
172.17.0.1 - - [11/Jun/2026 20:20:56] "GET /api/vulnerabilities/CVE-1999-0199/assessments HTTP/1.1" 200 -
172.17.0.1 - - [11/Jun/2026 20:20:56] "GET /api/vulnerabilities/CVE-1999-0199?variant_id=6698f14c-c7d7-4493-8bd5-5cf73cce2b2f HTTP/1.1" 200 -
```