### PR TITLE
fix: report SPDX packages as "spdx3"

### DIFF
--- a/src/routes/_scan_helpers.py
+++ b/src/routes/_scan_helpers.py
@@ -34,6 +34,36 @@ def parse_uuid_or_400(value: str, label: str = "id"):
 
 
 # ---------------------------------------------------------------------------
+# Source / format naming
+# ---------------------------------------------------------------------------
+
+# Formats that are exclusively vulnerability scanners (never pure package BOMs)
+DEDICATED_SCANNER_FORMATS = frozenset({"grype", "yocto_cve_check"})
+
+# Mapping from SBOMDocument.format to the canonical source name exposed by the
+# API. This keeps package "sources" and vulnerability "found_by" consistent
+# (e.g. an SPDX document has format "spdx" but is surfaced as "spdx3").
+FORMAT_TO_FOUND_BY: dict[str, str] = {
+    "grype": "grype",
+    "spdx": "spdx3",
+    "cdx": "cyclonedx",
+    "openvex": "openvex",
+}
+
+# Mapping from Scan.scan_source to the canonical source name for tool scans
+TOOL_SOURCE_TO_FOUND_BY: dict[str, str] = {
+    "nvd": "nvd_cpe",
+    "osv": "osv",
+}
+
+
+def format_to_found_by(doc_format: str) -> str:
+    """Map an SBOMDocument.format to its canonical source name."""
+    return FORMAT_TO_FOUND_BY.get(doc_format, doc_format)
+
+
+
+# ---------------------------------------------------------------------------
 # Scan-trigger boilerplate
 # ---------------------------------------------------------------------------
 

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -14,7 +14,7 @@ from ..helpers.active_scans import (
     active_sbom_scan_ids_for_project,
 )
 from ._scan_queries import _packages_by_scan_ids, _package_rows
-from ._scan_helpers import parse_uuid_or_400
+from ._scan_helpers import parse_uuid_or_400, format_to_found_by
 
 
 def init_app(app):
@@ -154,7 +154,10 @@ def init_app(app):
                 if row.variant_name:
                     meta[key]["variants"].add(row.variant_name)
                 if row.doc_format:
-                    meta[key]["sources"].add(row.doc_format)
+                    # Map to the canonical source name so package "sources" stay
+                    # consistent with vulnerability "found_by" (e.g. an SPDX doc
+                    # has format "spdx" but is surfaced as "spdx3").
+                    meta[key]["sources"].add(format_to_found_by(row.doc_format))
                 if row.doc_source_name:
                     meta[key]["sbom_documents"].add(row.doc_source_name)
 

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -35,7 +35,12 @@ from ..helpers.vuln_helpers import (
     _validate_and_apply_cvss,
     _apply_effort,
 )
-from ._scan_helpers import parse_uuid_or_400
+from ._scan_helpers import (
+    parse_uuid_or_400,
+    DEDICATED_SCANNER_FORMATS,
+    FORMAT_TO_FOUND_BY,
+    TOOL_SOURCE_TO_FOUND_BY,
+)
 from ._scan_queries import VulnerabilityText, fetch_vulnerabilities_texts
 
 TIME_ESTIMATES_PATH = "/scan/outputs/time_estimates.json"
@@ -57,21 +62,13 @@ def _sbom_pkg_filter(pkg_ids):
 
 
 # Formats that are exclusively vulnerability scanners (never pure package BOMs)
-_DEDICATED_SCANNER_FORMATS = frozenset({"grype", "yocto_cve_check"})
+_DEDICATED_SCANNER_FORMATS = DEDICATED_SCANNER_FORMATS
 
 # Mapping from SBOMDocument.format to the found_by string exposed by the API
-_FORMAT_TO_FOUND_BY: dict[str, str] = {
-    "grype": "grype",
-    "spdx": "spdx3",
-    "cdx": "cyclonedx",
-    "openvex": "openvex",
-}
+_FORMAT_TO_FOUND_BY = FORMAT_TO_FOUND_BY
 
 # Mapping from Scan.scan_source to the found_by string for tool scans
-_TOOL_SOURCE_TO_FOUND_BY: dict[str, str] = {
-    "nvd": "nvd_cpe",
-    "osv": "osv",
-}
+_TOOL_SOURCE_TO_FOUND_BY = TOOL_SOURCE_TO_FOUND_BY
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Package "sources" were built from the raw SBOMDocument.format ("spdx"), while vulnerability "found_by" mapped the same document to "spdx3".

The frontend unioned the two, so an SPDX-sourced item showed up under both "spdx" and "SPDX3", which was a confusing duplicate.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Without this fix SBOM tab may display both "spdx" and "spdx3".

With this fix the "spdx" and "SPDX3" duplicate was removed: 

<img width="1830" height="776" alt="image" src="https://github.com/user-attachments/assets/6db32b59-5b38-47e4-892e-7123d0d7c821" />


