### PR TITLE
fix: rank top vulnerabilities by severity label

### DIFF
--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -13,6 +13,41 @@ import { useMemo, useState, useCallback } from "react";
 
         ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, PointElement, LineElement, BarElement, LogarithmicScale);
 
+        // Rank active vulnerabilities for the "Most critical unfixed" table.
+        // Sort by the displayed severity label first (so the ranking always
+        // matches the Severity column even after an nvd-refresh changes a
+        // vulnerability's severity), then preserve the incoming order as a
+        // tiebreaker so vulnerabilities of equal severity keep the same order
+        // as the Vulnerability tab (which sorts by severity label and leaves
+        // the backend CVE-id order within each severity).
+        function rankTopVulns(vulnerabilities: Vulnerability[]) {
+            return [...vulnerabilities]
+                .filter((vuln) => isVulnerabilityActive(vuln))
+                .map((vuln, index) => {
+                    return {
+                        id: index + 1,
+                        rank: 0,
+                        cve: vuln.id,
+                        package: vuln.packages_current.join(", "),
+                        severity: vuln.severity.severity,
+                        texts: vuln.texts,
+                        original: vuln,
+                    };
+                })
+                .sort((a, b) => {
+                    const severityDiff =
+                        SEVERITY_ORDER.indexOf(b.severity.toUpperCase())
+                        - SEVERITY_ORDER.indexOf(a.severity.toUpperCase());
+                    if (severityDiff !== 0) return severityDiff;
+                    return a.id - b.id;
+                })
+                .slice(0, 5)
+                .map((vuln, idx) => ({
+                    ...vuln,
+                    rank: idx + 1,
+                }));
+        }
+
         type Props = {
             packages: Package[];
             vulnerabilities: Vulnerability[];
@@ -183,28 +218,7 @@ const vulnColumns = useMemo(
               className="bg-slate-800 hover:bg-slate-700 px-2 rounded-lg"
               onClick={() => {
                 // Get the current TopVulns list and find the index
-                const currentTopVulns = [...vulnerabilities]
-                  .map((v, index) => {
-                    const maxCvss = v.severity.cvss?.length
-                      ? Math.max(...v.severity.cvss.map((cvss) => cvss.base_score || 0))
-                      : 0;
-                    return {
-                      id: index + 1,
-                      rank: 0,
-                      cve: v.id,
-                      package: v.packages_current.join(", "),
-                      severity: v.severity.severity,
-                      maxCvss,
-                      texts: v.texts,
-                      original: v,
-                    };
-                  })
-                  .sort((a, b) => b.maxCvss - a.maxCvss)
-                  .slice(0, 5)
-                  .map((v, idx) => ({
-                    ...v,
-                    rank: idx + 1,
-                  }));
+                const currentTopVulns = rankTopVulns(vulnerabilities);
 
                 const index = currentTopVulns.findIndex(item => item.original.id === vuln.id);
                 setModalVuln(vuln);
@@ -433,29 +447,7 @@ const packageColumns = [
   }, [vulnerabilities]);
 
   const TopVulns = useMemo(() => {
-    return [...vulnerabilities]
-      .filter((vuln) => isVulnerabilityActive(vuln))
-      .map((vuln, index) => {
-        const maxCvss = vuln.severity.cvss?.length
-          ? Math.max(...vuln.severity.cvss.map((cvss) => cvss.base_score || 0))
-          : 0;
-        return {
-          id: index + 1,
-          rank: 0,
-          cve: vuln.id,
-          package: vuln.packages_current.join(", "),
-          severity: vuln.severity.severity,
-          maxCvss,
-          texts: vuln.texts,
-          original: vuln,
-        };
-      })
-      .sort((a, b) => b.maxCvss - a.maxCvss)
-      .slice(0, 5)
-      .map((vuln, idx) => ({
-        ...vuln,
-        rank: idx + 1,
-        }));
+    return rankTopVulns(vulnerabilities);
     }, [vulnerabilities]);
 
     const handleModalNavigation = (newIndex: number) => {

--- a/frontend/tests/unit_tests/test_metrics_tables_and_ui.tsx
+++ b/frontend/tests/unit_tests/test_metrics_tables_and_ui.tsx
@@ -270,6 +270,51 @@ describe('Metrics — TopVulns and topVulnerablePackages', () => {
         expect(vulnTableRows.length).toBeLessThanOrEqual(5);
     });
 
+    test('TopVulns ranks by severity label, not a stale CVSS score', async () => {
+        // Reproduces the bug where an nvd-refresh lowered a vulnerability to
+        // "medium" but a stale high CVSS score kept it ranked above criticals.
+        const medium = makeVuln('CVE-MEDIUM', [makeAssessment('var-1', 'Exploitable')], ['pkgM@1.0'], 'medium', 9.8);
+        medium.simplified_status = 'Exploitable';
+        medium.status_summary = { counts: { 'Exploitable': 1 }, ordered: [{ status: 'Exploitable', count: 1 }], total_assessments: 1, dominant_status: 'Exploitable', has_active_status: true };
+
+        const critical = makeVuln('CVE-CRITICAL', [makeAssessment('var-1', 'Exploitable')], ['pkgC@1.0'], 'critical', 9.0);
+        critical.simplified_status = 'Exploitable';
+        critical.status_summary = { counts: { 'Exploitable': 1 }, ordered: [{ status: 'Exploitable', count: 1 }], total_assessments: 1, dominant_status: 'Exploitable', has_active_status: true };
+
+        render(<Metrics {...DEFAULT_PROPS} vulnerabilities={[medium, critical]} />);
+        await waitForRender();
+        const tables = screen.getAllByTestId('mock-table');
+        const vulnTableRows = tables[0].querySelectorAll('[data-testid="mock-table-row"]');
+        const rowTexts = Array.from(vulnTableRows).map(r => r.textContent);
+        // The critical vulnerability must rank above the medium one despite its
+        // lower CVSS score.
+        expect(rowTexts[0]).toContain('CVE-CRITICAL');
+        expect(rowTexts[1]).toContain('CVE-MEDIUM');
+    });
+
+    test('TopVulns keeps incoming order for equal-severity vulns (matches Vulnerability tab)', async () => {
+        // Within the same severity, the ranking must follow the same order as
+        // the Vulnerability tab (which keeps the backend CVE-id order within a
+        // severity) instead of re-sorting by the raw CVSS score.
+        const first = makeVuln('CVE-2000-0001', [makeAssessment('var-1', 'Exploitable')], ['pkg1@1.0'], 'critical', 9.0);
+        first.simplified_status = 'Exploitable';
+        first.status_summary = { counts: { 'Exploitable': 1 }, ordered: [{ status: 'Exploitable', count: 1 }], total_assessments: 1, dominant_status: 'Exploitable', has_active_status: true };
+
+        const second = makeVuln('CVE-2000-0002', [makeAssessment('var-1', 'Exploitable')], ['pkg2@1.0'], 'critical', 10.0);
+        second.simplified_status = 'Exploitable';
+        second.status_summary = { counts: { 'Exploitable': 1 }, ordered: [{ status: 'Exploitable', count: 1 }], total_assessments: 1, dominant_status: 'Exploitable', has_active_status: true };
+
+        // `second` has the higher CVSS score but comes later in the incoming
+        // order; the incoming order must win.
+        render(<Metrics {...DEFAULT_PROPS} vulnerabilities={[first, second]} />);
+        await waitForRender();
+        const tables = screen.getAllByTestId('mock-table');
+        const vulnTableRows = tables[0].querySelectorAll('[data-testid="mock-table-row"]');
+        const rowTexts = Array.from(vulnTableRows).map(r => r.textContent);
+        expect(rowTexts[0]).toContain('CVE-2000-0001');
+        expect(rowTexts[1]).toContain('CVE-2000-0002');
+    });
+
     test('topVulnerablePackages aggregates by package name', async () => {
         const vuln1 = makeVuln('CVE-A', [makeAssessment('var-1', 'Exploitable')], ['openssl@3.0', 'zlib@1.2'], 'HIGH', 8.0);
         const vuln2 = makeVuln('CVE-B', [makeAssessment('var-1', 'Exploitable')], ['openssl@3.0'], 'HIGH', 7.0);


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The "Most critical unfixed vulnerabilities" list sorted by the raw max CVSS score while displaying the severity label.

Extract the ranking into a shared rankTopVulns()
helper used by both the TopVulns list and the Edit button, which also fixes a latent bug where the Edit button's inline copy skipped the isVulnerabilityActive filter and caused modal-navigation index mismatches.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Take a CVE which a a severity score which changes with a refresh (e.g. CVE-1999-0656). Then refresh it

Without this fix: 

<img width="891" height="861" alt="image" src="https://github.com/user-attachments/assets/aff1d3e1-7cbe-4d43-8426-d4942226a071" />


With this fix: 

<img width="1830" height="776" alt="image" src="https://github.com/user-attachments/assets/5f8e8c34-bd3c-42fb-acd9-f5950fd24497" />
