### PR TITLE
fix: Custom Time Estimates appear correctly in Review

### DIFF
--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -1111,6 +1111,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                         columns={teColumns as any}
                         data={timeEstimates.map(te => ({
                             ...te,
+                            id: `${te.vuln_id}::${te.variant_id ?? 'none'}`,
                             texts: vulnDescriptions[te.vuln_id] ?? [],
                         }))}
                         search={search}
@@ -1136,6 +1137,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                         columns={cvssColumns as any}
                         data={customCvss.map(c => ({
                             ...c,
+                            id: `${c.vuln_id}::${c.variant_id ?? 'none'}::${c.author}`,
                             texts: vulnDescriptions[c.vuln_id] ?? [],
                         }))}
                         search={search}

--- a/src/helpers/vuln_helpers.py
+++ b/src/helpers/vuln_helpers.py
@@ -75,7 +75,10 @@ def _apply_effort(record, variant_id, opt, lik, pes, log_prefix: str = ""):
             if variant_id is not None:
                 existing = TimeEstimate.get_by_finding_and_variant(finding.id, variant_id)
             else:
-                existing = finding.time_estimate
+                existing = next(
+                    (te for te in finding.time_estimates if te.variant_id is None),
+                    None,
+                )
             if existing is not None:
                 existing.update(optimistic=opt, likely=lik, pessimistic=pes)
             else:

--- a/src/models/finding.py
+++ b/src/models/finding.py
@@ -36,8 +36,8 @@ class Finding(Base):
         back_populates="finding", cascade="all, delete-orphan")
     assessments: Mapped[list["Assessment"]] = relationship(
         back_populates="finding", cascade="all, delete-orphan")
-    time_estimate: Mapped[Optional["TimeEstimate"]] = relationship(
-        back_populates="finding", uselist=False, cascade="all, delete-orphan")
+    time_estimates: Mapped[list["TimeEstimate"]] = relationship(
+        back_populates="finding", cascade="all, delete-orphan")
 
     def __repr__(self) -> str:
         return (

--- a/src/models/time_estimate.py
+++ b/src/models/time_estimate.py
@@ -18,7 +18,7 @@ class TimeEstimate(Base):
     likely = db.Column(db.Integer, nullable=True)
     pessimistic = db.Column(db.Integer, nullable=True)
 
-    finding = db.relationship("Finding", back_populates="time_estimate")
+    finding = db.relationship("Finding", back_populates="time_estimates")
     variant = db.relationship("Variant", back_populates="time_estimates")
 
     def __repr__(self) -> str:

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -284,7 +284,12 @@ class Vulnerability(Base):
         if not any(effort_dict.values()) and not self.effort_variant_loaded:
             try:
                 for f in (self.findings or []):
-                    te = f.time_estimate
+                    estimates = f.time_estimates or []
+                    # Prefer the unscoped (variant-less) estimate as the global
+                    # effort; fall back to any available estimate.
+                    te = next((t for t in estimates if t.variant_id is None), None)
+                    if te is None and estimates:
+                        te = estimates[0]
                     if te is not None:
                         def _h(v):
                             if v is None:

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -358,20 +358,18 @@ def init_app(app):
         else:
             vuln_texts = {}
 
-        vuln_map: dict[str, dict] = {}
+        # Key by (vuln_id, variant_id) so each variant keeps its own estimate
+        # instead of variants overwriting each other for the same vulnerability.
+        vuln_map: dict[tuple[str, str | None], dict] = {}
         for te in all_te:
             vid = te.finding.vulnerability_id
-            current = vuln_map.get(vid)
-            is_scoped = te.variant_id is not None
-            # Prefer variant-scoped entries over unscoped ones for the same vuln
-            if current is not None and current.get("variant_id") and not is_scoped:
-                continue
+            scoped_variant = str(te.variant_id) if te.variant_id else None
             opt = te.optimistic or 0
             lik = te.likely or 0
             pes = te.pessimistic or 0
-            vuln_map[vid] = {
+            vuln_map[(vid, scoped_variant)] = {
                 "vuln_id": vid,
-                "variant_id": str(te.variant_id) if te.variant_id else None,
+                "variant_id": scoped_variant,
                 "optimistic": opt,
                 "likely": lik,
                 "pessimistic": pes,
@@ -381,7 +379,15 @@ def init_app(app):
                 "vuln_texts": list(map(VulnerabilityText.to_dict, vuln_texts.get(vid, []))),
             }
 
-        return sorted(vuln_map.values(), key=lambda x: x["vuln_id"])
+        # Prefer variant-scoped entries: when a vuln has at least one
+        # variant-scoped estimate, drop its unscoped (variant-less) entry.
+        vulns_with_scoped = {vid for (vid, variant) in vuln_map if variant is not None}
+        result = [
+            entry for (vid, variant), entry in vuln_map.items()
+            if variant is not None or vid not in vulns_with_scoped
+        ]
+
+        return sorted(result, key=lambda x: (x["vuln_id"], x["variant_id"] or ""))
 
     @app.route('/api/assessments/review/custom-cvss')
     def review_custom_cvss():

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -310,7 +310,7 @@ def init_app(app):
             _scope_project = None
             opts = (
                 selectinload(Vulnerability.findings).selectinload(Finding.package),
-                selectinload(Vulnerability.findings).selectinload(Finding.time_estimate),
+                selectinload(Vulnerability.findings).selectinload(Finding.time_estimates),
                 selectinload(Vulnerability.metrics),
             )
 
@@ -385,7 +385,7 @@ def init_app(app):
                     select(Vulnerability)
                     .options(
                         selectinload(Vulnerability.findings).selectinload(Finding.package),
-                        selectinload(Vulnerability.findings).selectinload(Finding.time_estimate),
+                        selectinload(Vulnerability.findings).selectinload(Finding.time_estimates),
                         selectinload(Vulnerability.metrics),
                     )
                     .join(Finding, Vulnerability.id == Finding.vulnerability_id)

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -738,6 +738,94 @@ def test_review_time_estimates_by_project(client):
     assert isinstance(json.loads(resp.data), list)
 
 
+def test_review_time_estimates_one_row_per_variant(app, client):
+    """Each variant with its own estimate yields a distinct row (not merged)."""
+    from src.extensions import db
+    from src.models.finding import Finding
+    from src.models.variant import Variant
+    from src.models.time_estimate import TimeEstimate
+
+    second_variant_id = uuid.UUID("22222222-2222-2222-2222-222222222223")
+    with app.app_context():
+        # Add a second variant in the same project.
+        db.session.add(Variant(
+            id=second_variant_id,
+            name="second",
+            project_id=PROJECT_UUID,
+        ))
+        finding = Finding.get_by_vulnerability("CVE-2020-35492")[0]
+        # One estimate per variant on the same finding.
+        TimeEstimate.create(finding_id=finding.id, variant_id=VARIANT_UUID,
+                            optimistic=5, likely=5, pessimistic=5)
+        TimeEstimate.create(finding_id=finding.id, variant_id=second_variant_id,
+                            optimistic=8, likely=8, pessimistic=8)
+        db.session.commit()
+
+    resp = client.get(f"/api/assessments/review/time-estimates?project_id={PROJECT_UUID}")
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    rows = [e for e in data if e["vuln_id"] == "CVE-2020-35492"]
+    assert len(rows) == 2
+    variants = {e["variant_id"] for e in rows}
+    assert str(VARIANT_UUID) in variants
+    assert str(second_variant_id) in variants
+    by_variant = {e["variant_id"]: e for e in rows}
+    assert by_variant[str(VARIANT_UUID)]["optimistic"] == 5
+    assert by_variant[str(second_variant_id)]["optimistic"] == 8
+
+
+def test_review_time_estimates_matches_export_via_patch_flow(app, client):
+    """Reproduce the real UI flow: set effort per variant through PATCH, then
+    verify the review endpoint AND the export endpoint both expose one entry
+    per variant (project scope and unscoped)."""
+    from src.extensions import db
+    from src.models.variant import Variant
+
+    second_variant_id = uuid.UUID("22222222-2222-2222-2222-222222222224")
+    with app.app_context():
+        db.session.add(Variant(
+            id=second_variant_id,
+            name="second-patch",
+            project_id=PROJECT_UUID,
+        ))
+        db.session.commit()
+
+    # Set a different estimate for each variant exactly like the web UI does.
+    r1 = client.patch("/api/vulnerabilities/CVE-2020-35492", json={
+        "variant_id": str(VARIANT_UUID),
+        "effort": {"optimistic": "PT5H", "likely": "PT5H", "pessimistic": "PT5H"},
+    })
+    assert r1.status_code == 200
+    r2 = client.patch("/api/vulnerabilities/CVE-2020-35492", json={
+        "variant_id": str(second_variant_id),
+        "effort": {"optimistic": "PT8H", "likely": "PT8H", "pessimistic": "PT8H"},
+    })
+    assert r2.status_code == 200
+
+    # Review endpoint (project scope) → two distinct rows.
+    resp = client.get(f"/api/assessments/review/time-estimates?project_id={PROJECT_UUID}")
+    assert resp.status_code == 200
+    rows = [e for e in json.loads(resp.data) if e["vuln_id"] == "CVE-2020-35492"]
+    by_variant = {e["variant_id"]: e for e in rows}
+    assert by_variant.get(str(VARIANT_UUID), {}).get("optimistic") == 5
+    assert by_variant.get(str(second_variant_id), {}).get("optimistic") == 8
+    assert len(rows) == 2
+
+    # Review endpoint (no scope / all variants) → still two rows.
+    resp_all = client.get("/api/assessments/review/time-estimates")
+    assert resp_all.status_code == 200
+    rows_all = [e for e in json.loads(resp_all.data) if e["vuln_id"] == "CVE-2020-35492"]
+    assert len({e["variant_id"] for e in rows_all}) == 2
+
+    # Export endpoint (project scope) → two time-estimate entries, matching.
+    exp = client.get(f"/api/assessments/review/export-custom-data?project_id={PROJECT_UUID}")
+    assert exp.status_code == 200
+    exported = json.loads(exp.data)["time_estimates"]
+    exp_rows = [e for e in exported if e["vuln_id"] == "CVE-2020-35492"]
+    assert len(exp_rows) == 2
+
+
+
 # ── GET /api/assessments/review/custom-cvss ──────────────────────────────
 
 def test_review_custom_cvss_empty(client):


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* fix: list one review time-estimate row per variant

The review time-estimates endpoint keyed its result map by vuln_id alone,
so when several variants had their own estimate for the same vulnerability
they overwrote each other and only one row was returned.

* model fix : allow multiple time estimates per finding

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Create a project with two variants, or more, add a time estimate per variant. 

The Review tab now display all time estimate properly: 

<img width="1825" height="810" alt="image" src="https://github.com/user-attachments/assets/3d58d2a9-a47b-4c4e-9d89-e22f45c86b86" />

