### PR TITLE
Support sbom-cve-check scans

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -846,12 +846,12 @@ Same response shape as Grype status. `total` is the number of unique PURLs to qu
 ### Trigger sbom-cve-check Scan
 
 ```
-POST /api/variants/<variant_id>/scc-scan
+POST /api/variants/<variant_id>/sbom-cve-check-scan
 ```
 
-Runs a fully offline CVE scan powered by the sbom-cve-check engine. For every active package, the engine looks up candidate advisories from locally-cloned NVD-FKIE and CVEList V5 databases, applies product-name aliasing, evaluates version ranges locally, and records findings as a tool scan. No network calls are made during matching.
+Runs a CVE scan powered by the sbom-cve-check engine. For every active package, the engine looks up candidate advisories from locally-cloned NVD-FKIE and CVEList V5 databases, applies product-name aliasing, evaluates version ranges locally, and records findings as a tool scan. No network calls are made during matching.
 
-The databases must be present at `SCC_DATABASES_DIR` inside the container (default: `/scc_databases`, mounted from the host path `$VULNSCOUT_SCC_DB_DIR` or `~/.cache/sbom_cve_check/databases`). Set `SCC_AUTO_UPDATE=1` to let the engine clone or update them on startup.
+The databases must be present at `SBOM_CVE_CHECK_DATABASES_DIR` inside the container (default: `/sbom_cve_check_databases`, mounted from the host path `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` or `~/.cache/sbom_cve_check/databases`). Set `sbom_cve_check_AUTO_UPDATE=1` to let the engine clone or update them on startup.
 
 **Response:** `202 Accepted`
 ```json
@@ -863,7 +863,7 @@ The databases must be present at `SCC_DATABASES_DIR` inside the container (defau
 ### Check sbom-cve-check Scan Status
 
 ```
-GET /api/variants/<variant_id>/scc-scan/status
+GET /api/variants/<variant_id>/sbom-cve-check-scan/status
 ```
 
 Same response shape as Grype status. `total` is the number of active packages being scanned, `done_count` advances per package.

--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -843,6 +843,45 @@ GET /api/variants/<variant_id>/osv-scan/status
 
 Same response shape as Grype status. `total` is the number of unique PURLs to query.
 
+### Trigger sbom-cve-check Scan
+
+```
+POST /api/variants/<variant_id>/scc-scan
+```
+
+Runs a fully offline CVE scan powered by the sbom-cve-check engine. For every active package, the engine looks up candidate advisories from locally-cloned NVD-FKIE and CVEList V5 databases, applies product-name aliasing, evaluates version ranges locally, and records findings as a tool scan. No network calls are made during matching.
+
+The databases must be present at `SCC_DATABASES_DIR` inside the container (default: `/scc_databases`, mounted from the host path `$VULNSCOUT_SCC_DB_DIR` or `~/.cache/sbom_cve_check/databases`). Set `SCC_AUTO_UPDATE=1` to let the engine clone or update them on startup.
+
+**Response:** `202 Accepted`
+```json
+{ "status": "started", "variant_id": "..." }
+```
+
+`total` is the number of active packages to scan. Progress is reported per package.
+
+### Check sbom-cve-check Scan Status
+
+```
+GET /api/variants/<variant_id>/scc-scan/status
+```
+
+Same response shape as Grype status. `total` is the number of active packages being scanned, `done_count` advances per package.
+
+**Response:**
+```json
+{
+  "status": "running",
+  "error": null,
+  "progress": "42/120 packages",
+  "logs": ["Resolved 120 active packages", "Index ready — scanning packages", "[1/120] busybox@1.35.0 → 3 vuln(s): CVE-2022-28391, ..."],
+  "total": 120,
+  "done_count": 42
+}
+```
+
+Status values: `"idle"` (no scan started), `"running"`, `"done"`, `"error"`.
+
 ---
 
 ## SBOM Upload

--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -851,7 +851,7 @@ POST /api/variants/<variant_id>/sbom-cve-check-scan
 
 Runs a CVE scan powered by the sbom-cve-check engine. For every active package, the engine looks up candidate advisories from locally-cloned NVD-FKIE and CVEList V5 databases, applies product-name aliasing, evaluates version ranges locally, and records findings as a tool scan. No network calls are made during matching.
 
-The databases must be present at `SBOM_CVE_CHECK_DATABASES_DIR` inside the container (default: `/sbom_cve_check_databases`, mounted from the host path `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` or `~/.cache/sbom_cve_check/databases`). Set `sbom_cve_check_AUTO_UPDATE=1` to let the engine clone or update them on startup.
+The databases live at `SBOM_CVE_CHECK_DATABASES_DIR` inside the container (default: `/cache/vulnscout/sbom_cve_check_databases`, inside the cache volume next to `vulnscout.db`). Set `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` on the host to use a shared clone mounted at `/sbom_cve_check_databases` instead. Set `SBOM_CVE_CHECK_AUTO_UPDATE=1` to let the engine clone the databases on first use and fetch fresh advisories before every scan.
 
 **Response:** `202 Accepted`
 ```json

--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -46,6 +46,9 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 | `--add-cdx <path>` | Add a CycloneDX file |
 | `--add-grype <path>` | Add a Grype results file (`.grype.json`) |
 | `--perform-grype-scan` | Export current DB as CycloneDX, run Grype on it, and merge results back |
+| `--perform-nvd-scan` | Run an NVD CPE-based vulnerability scan |
+| `--perform-osv-scan` | Run an OSV PURL-based vulnerability scan |
+| `--perform-scc-scan` | Run a fully offline CVE scan using local sbom-cve-check databases |
 | `--clear-inputs` | Remove all staged input files |
 
 ### Scan & Output Commands
@@ -108,6 +111,9 @@ When multiple flags are provided in a single invocation, the entrypoint processe
    - Web server started in background (if `--serve`)
    - Input files merged into the database
    - Grype scan (if `--perform-grype-scan`)
+   - NVD CPE scan (if `--perform-nvd-scan`)
+   - OSV PURL scan (if `--perform-osv-scan`)
+   - sbom-cve-check offline scan (if `--perform-scc-scan`)
    - Vulnerability processing (NVD enrichment, EPSS scoring)
    - Input files cleaned up after processing
 3. **Reports** — Templates specified with `--report` are generated
@@ -130,6 +136,7 @@ The following paths inside the container are relevant:
 | `/scan/src/views/templates/` | Built-in report templates |
 | `/cache/vulnscout/vulnscout.db` | SQLite database |
 | `/etc/vulnscout/config.env` | Persistent configuration file |
+| `/scc_databases/` | Mount point for the local sbom-cve-check advisory database clones (host path: `$VULNSCOUT_SCC_DB_DIR`, default: `~/.cache/sbom_cve_check/databases`) |
 | `/scan/status.txt` | Scan progress status (used by the web UI) |
 
 ---
@@ -161,6 +168,16 @@ docker exec vulnscout /scan/src/entrypoint.sh \
   --report all_assessments.adoc \
   --export-spdx --export-cdx
 ```
+
+**Run a fully offline sbom-cve-check scan:**
+```bash
+docker exec vulnscout /scan/src/entrypoint.sh \
+  --project demo --variant x86 \
+  --add-spdx /scan/inputs/sbom.spdx.json \
+  --perform-scc-scan
+```
+
+> The container must have the sbom-cve-check databases mounted at `/scc_databases` (see the `VULNSCOUT_SCC_DB_DIR` note below). The databases are cloned automatically on first use when `SCC_AUTO_UPDATE=1` is set in the environment.
 
 **Set persistent configuration:**
 ```bash

--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -136,7 +136,7 @@ The following paths inside the container are relevant:
 | `/scan/src/views/templates/` | Built-in report templates |
 | `/cache/vulnscout/vulnscout.db` | SQLite database |
 | `/etc/vulnscout/config.env` | Persistent configuration file |
-| `/sbom_cve_check_databases/` | Mount point for the local sbom-cve-check advisory database clones (host path: `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR`, default: `~/.cache/sbom_cve_check/databases`) |
+| `/cache/vulnscout/sbom_cve_check_databases/` | Local sbom-cve-check advisory database clones (NVD-FKIE + CVEList), stored inside the cache volume next to `vulnscout.db`. Override the host path with `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` (then mounted at `/sbom_cve_check_databases`) |
 | `/scan/status.txt` | Scan progress status (used by the web UI) |
 
 ---
@@ -177,7 +177,7 @@ docker exec vulnscout /scan/src/entrypoint.sh \
   --perform-sbom-cve-check-scan
 ```
 
-> The container must have the sbom-cve-check databases mounted at `/sbom_cve_check_databases` (see the `VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` note below). The databases are cloned automatically on first use when `SBOM_CVE_CHECK_AUTO_UPDATE=1` is set in the environment.
+> By default the sbom-cve-check databases live in `/cache/vulnscout/sbom_cve_check_databases` (inside the cache volume, next to `vulnscout.db`); set `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` to use a shared host clone mounted at `/sbom_cve_check_databases` instead. With `SBOM_CVE_CHECK_AUTO_UPDATE=1` the databases are cloned automatically on first use and refreshed before every scan.
 
 **Set persistent configuration:**
 ```bash

--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -48,7 +48,7 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 | `--perform-grype-scan` | Export current DB as CycloneDX, run Grype on it, and merge results back |
 | `--perform-nvd-scan` | Run an NVD CPE-based vulnerability scan |
 | `--perform-osv-scan` | Run an OSV PURL-based vulnerability scan |
-| `--perform-scc-scan` | Run a fully offline CVE scan using local sbom-cve-check databases |
+| `--perform-sbom-cve-check-scan` | Run a CVE scan using local sbom-cve-check databases |
 | `--clear-inputs` | Remove all staged input files |
 
 ### Scan & Output Commands
@@ -113,7 +113,7 @@ When multiple flags are provided in a single invocation, the entrypoint processe
    - Grype scan (if `--perform-grype-scan`)
    - NVD CPE scan (if `--perform-nvd-scan`)
    - OSV PURL scan (if `--perform-osv-scan`)
-   - sbom-cve-check offline scan (if `--perform-scc-scan`)
+   - sbom-cve-check scan (if `--perform-sbom-cve-check-scan`)
    - Vulnerability processing (NVD enrichment, EPSS scoring)
    - Input files cleaned up after processing
 3. **Reports** — Templates specified with `--report` are generated
@@ -136,7 +136,7 @@ The following paths inside the container are relevant:
 | `/scan/src/views/templates/` | Built-in report templates |
 | `/cache/vulnscout/vulnscout.db` | SQLite database |
 | `/etc/vulnscout/config.env` | Persistent configuration file |
-| `/scc_databases/` | Mount point for the local sbom-cve-check advisory database clones (host path: `$VULNSCOUT_SCC_DB_DIR`, default: `~/.cache/sbom_cve_check/databases`) |
+| `/sbom_cve_check_databases/` | Mount point for the local sbom-cve-check advisory database clones (host path: `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR`, default: `~/.cache/sbom_cve_check/databases`) |
 | `/scan/status.txt` | Scan progress status (used by the web UI) |
 
 ---
@@ -169,15 +169,15 @@ docker exec vulnscout /scan/src/entrypoint.sh \
   --export-spdx --export-cdx
 ```
 
-**Run a fully offline sbom-cve-check scan:**
+**Run a sbom-cve-check scan:**
 ```bash
 docker exec vulnscout /scan/src/entrypoint.sh \
   --project demo --variant x86 \
   --add-spdx /scan/inputs/sbom.spdx.json \
-  --perform-scc-scan
+  --perform-sbom-cve-check-scan
 ```
 
-> The container must have the sbom-cve-check databases mounted at `/scc_databases` (see the `VULNSCOUT_SCC_DB_DIR` note below). The databases are cloned automatically on first use when `SCC_AUTO_UPDATE=1` is set in the environment.
+> The container must have the sbom-cve-check databases mounted at `/sbom_cve_check_databases` (see the `VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` note below). The databases are cloned automatically on first use when `SBOM_CVE_CHECK_AUTO_UPDATE=1` is set in the environment.
 
 **Set persistent configuration:**
 ```bash

--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -185,6 +185,24 @@ This can be chained with other inputs to scan newly added files immediately:
 
 ---
 
+## Performing an sbom-cve-check Scan
+
+The `--perform-scc-scan` flag runs a fully offline CVE scan powered by [sbom-cve-check](https://github.com/savoirfairelinux/sbom-cve-check). Unlike the NVD and OSV scanners, and once the databases are synced, this scan never makes network calls during analysis,it queries locally-cloned advisory databases (NVD-FKIE JSON feeds and CVEList V5).
+
+```bash
+./vulnscout --project demo --variant x86 --perform-scc-scan
+```
+
+The scan can be chained with other inputs:
+
+```bash
+./vulnscout --project demo \
+  --add-spdx example/spdx3/core-image-minimal-qemux86-64.rootfs.spdx.json \
+  --perform-scc-scan
+```
+
+---
+
 ## Non-Interactive Mode (CI / Automation)
 
 For CI pipelines or automated scans, use the `--match-condition` argument instead of the web UI:

--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -187,10 +187,10 @@ This can be chained with other inputs to scan newly added files immediately:
 
 ## Performing an sbom-cve-check Scan
 
-The `--perform-scc-scan` flag runs a fully offline CVE scan powered by [sbom-cve-check](https://github.com/savoirfairelinux/sbom-cve-check). Unlike the NVD and OSV scanners, and once the databases are synced, this scan never makes network calls during analysis,it queries locally-cloned advisory databases (NVD-FKIE JSON feeds and CVEList V5).
+The `--perform-sbom-cve-check-scan` flag runs a CVE scan powered by [sbom-cve-check](https://github.com/savoirfairelinux/sbom-cve-check). Unlike the NVD and OSV scanners, and once the databases are synced, this scan never makes network calls during analysis,it queries locally-cloned advisory databases (NVD-FKIE JSON feeds and CVEList V5).
 
 ```bash
-./vulnscout --project demo --variant x86 --perform-scc-scan
+./vulnscout --project demo --variant x86 --perform-sbom-cve-check-scan
 ```
 
 The scan can be chained with other inputs:
@@ -198,7 +198,7 @@ The scan can be chained with other inputs:
 ```bash
 ./vulnscout --project demo \
   --add-spdx example/spdx3/core-image-minimal-qemux86-64.rootfs.spdx.json \
-  --perform-scc-scan
+  --perform-sbom-cve-check-scan
 ```
 
 ---

--- a/frontend/src/handlers/scanStateManager.ts
+++ b/frontend/src/handlers/scanStateManager.ts
@@ -280,6 +280,7 @@ export class ScanStateManager {
                             status: "error",
                             error: status.error ?? `${this.label} scan failed`,
                             progress: null,
+                            logs: status.logs ?? current.logs,
                         });
                         anyChanged = true;
                         anyJustFinished = true;
@@ -295,10 +296,10 @@ export class ScanStateManager {
                         });
                         anyChanged = true;
                         anyJustFinished = true;
-                    } else if (status.status === "running" && status.progress) {
+                    } else if (status.status === "running") {
                         this.states.set(vid, {
                             ...current,
-                            progress: status.progress,
+                            progress: status.progress ?? current.progress,
                             logs: status.logs ?? current.logs,
                             total: status.total ?? current.total,
                             doneCount: status.done_count ?? current.doneCount,

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -270,9 +270,9 @@ class ScansHandler {
         return await response.json();
     }
 
-    static async triggerSccScan(variantId: string): Promise<{ ok: boolean; error?: string }> {
+    static async triggerSbomCveCheckScan(variantId: string): Promise<{ ok: boolean; error?: string }> {
         const response = await fetch(
-            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/scc-scan`,
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/sbom-cve-check-scan`,
             { method: 'POST', mode: 'cors' }
         );
         if (response.ok || response.status === 202) return { ok: true };
@@ -280,9 +280,9 @@ class ScansHandler {
         return { ok: false, error: data?.error ?? `HTTP ${response.status}` };
     }
 
-    static async getSccScanStatus(variantId: string): Promise<{ status: string; error?: string | null; progress?: string | null; logs?: string[]; total?: number; done_count?: number }> {
+    static async getSbomCveCheckScanStatus(variantId: string): Promise<{ status: string; error?: string | null; progress?: string | null; logs?: string[]; total?: number; done_count?: number }> {
         const response = await fetch(
-            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/scc-scan/status`,
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/sbom-cve-check-scan/status`,
             { mode: 'cors' }
         );
         if (!response.ok) return { status: 'unknown' };

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -270,6 +270,25 @@ class ScansHandler {
         return await response.json();
     }
 
+    static async triggerSccScan(variantId: string): Promise<{ ok: boolean; error?: string }> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/scc-scan`,
+            { method: 'POST', mode: 'cors' }
+        );
+        if (response.ok || response.status === 202) return { ok: true };
+        const data = await response.json().catch(() => ({}));
+        return { ok: false, error: data?.error ?? `HTTP ${response.status}` };
+    }
+
+    static async getSccScanStatus(variantId: string): Promise<{ status: string; error?: string | null; progress?: string | null; logs?: string[]; total?: number; done_count?: number }> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/scc-scan/status`,
+            { mode: 'cors' }
+        );
+        if (!response.ok) return { status: 'unknown' };
+        return await response.json();
+    }
+
     static async deleteScan(scanId: string): Promise<{ ok: boolean; error?: string; orphaned_findings_removed?: number }> {
         const response = await fetch(
             import.meta.env.VITE_API_URL + `/api/scans/${encodeURIComponent(scanId)}`,

--- a/frontend/src/handlers/sccScanState.ts
+++ b/frontend/src/handlers/sccScanState.ts
@@ -1,5 +1,5 @@
 /**
- * SCC (sbom-cve-check) scan state — per-variant progress tracking.
+ * sbom-cve-check scan state — per-variant progress tracking.
  *
  * Thin wrapper around the generic ScanStateManager.
  * Lives at module scope so state survives component unmounts.
@@ -10,8 +10,8 @@ import { ScanStateManager } from "./scanStateManager";
 export type { ScanEntryState as SccState, ScanManagerSnapshot } from "./scanStateManager";
 
 const manager = new ScanStateManager(
-    (vid) => ScansHandler.triggerSccScan(vid),
-    (vid) => ScansHandler.getSccScanStatus(vid),
+    (vid) => ScansHandler.triggerSbomCveCheckScan(vid),
+    (vid) => ScansHandler.getSbomCveCheckScanStatus(vid),
     "sbom-cve-check",
 );
 

--- a/frontend/src/handlers/sccScanState.ts
+++ b/frontend/src/handlers/sccScanState.ts
@@ -1,0 +1,23 @@
+/**
+ * SCC (sbom-cve-check) scan state — per-variant progress tracking.
+ *
+ * Thin wrapper around the generic ScanStateManager.
+ * Lives at module scope so state survives component unmounts.
+ */
+
+import ScansHandler from "./scans";
+import { ScanStateManager } from "./scanStateManager";
+export type { ScanEntryState as SccState, ScanManagerSnapshot } from "./scanStateManager";
+
+const manager = new ScanStateManager(
+    (vid) => ScansHandler.triggerSccScan(vid),
+    (vid) => ScansHandler.getSccScanStatus(vid),
+    "sbom-cve-check",
+);
+
+export const subscribe = manager.subscribe;
+export const getSnapshot = manager.getSnapshot;
+export const setOnDone = manager.setOnDone;
+export const triggerScan = manager.triggerScan;
+export const dismiss = manager.dismiss;
+export const dismissAll = manager.dismissAll;

--- a/frontend/src/helpers/sourceNames.ts
+++ b/frontend/src/helpers/sourceNames.ts
@@ -7,7 +7,9 @@ export const SOURCE_DISPLAY_NAMES: Record<string, string> = {
     cyclonedx: 'CycloneDx',
     spdx3: 'SPDX3',
     nvd_cpe: 'NVD CPE',
+    nvd: 'NVD CPE',
     osv: 'OSV',
+    scc: 'sbom-cve-check',
 };
 
 /** Reverse mapping: display name → backend key. */

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1528,7 +1528,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                         { key: 'grype', label: 'Grype', icon: faBug, color: 'purple' },
                                         { key: 'nvd', label: 'NVD CPE', icon: faShieldHalved, color: 'orange' },
                                         { key: 'osv', label: 'OSV', icon: faLeaf, color: 'green' },
-                                        { key: 'scc', label: 'sbom-cve-check (offline)', icon: faCrosshairs, color: 'sky' },
+                                        { key: 'scc', label: 'sbom-cve-check', icon: faCrosshairs, color: 'sky' },
                                     ] as const).map(({ key, label, icon, color }) => (
                                         <label
                                             key={key}

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -17,6 +17,13 @@ import {
     triggerScan as osvTriggerScan,
     dismiss as osvDismiss,
 } from "../handlers/osvScanState";
+import {
+    subscribe as sccSubscribe,
+    getSnapshot as sccGetSnapshot,
+    setOnDone as sccSetOnDone,
+    triggerScan as sccTriggerScan,
+    dismiss as sccDismiss,
+} from "../handlers/sccScanState";
 import type { ScanManagerSnapshot } from "../handlers/scanStateManager";
 import ScanProgressPanel from "../components/ScanProgressPanel";
 import { useDocUrl } from "../helpers/useDocUrl";
@@ -1096,6 +1103,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     const [showGrype, setShowGrype] = useState(true);
     const [showOsv, setShowOsv] = useState(true);
     const [showNvd, setShowNvd] = useState(true);
+    const [showScc, setShowScc] = useState(true);
 
     // Export state
     const [exportMenuScanId, setExportMenuScanId] = useState<string | null>(null);
@@ -1109,7 +1117,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     const [scanMenuOpen, setScanMenuOpen] = useState(false);
     const [allVariants, setAllVariants] = useState<Variant[]>([]);
     const [selectedVariantIds, setSelectedVariantIds] = useState<Set<string>>(new Set());
-    const [selectedScanTypes, setSelectedScanTypes] = useState<Set<string>>(new Set(['grype', 'nvd', 'osv']));
+    const [selectedScanTypes, setSelectedScanTypes] = useState<Set<string>>(new Set(['grype', 'nvd', 'osv', 'scc']));
     const scanMenuRef = useRef<HTMLDivElement>(null);
 
     // Global Grype scan state — survives tab switches (per-variant)
@@ -1123,6 +1131,10 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     // Global OSV scan state — survives tab switches (per-variant)
     const osvEntries: ScanManagerSnapshot = useSyncExternalStore(osvSubscribe, osvGetSnapshot);
     const osvRunning = osvEntries.some(e => e.status === "running");
+
+    // Global SCC scan state — survives tab switches (per-variant)
+    const sccEntries: ScanManagerSnapshot = useSyncExternalStore(sccSubscribe, sccGetSnapshot);
+    const sccRunning = sccEntries.some(e => e.status === "running");
 
     const refreshScans = useCallback(() => {
         ScansHandler.list(variantId, projectId)
@@ -1195,11 +1207,17 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         return () => osvSetOnDone(null);
     }, [refreshScans, onScanComplete]);
 
+    useEffect(() => {
+        sccSetOnDone(() => { refreshScans(); onScanComplete?.(); });
+        return () => sccSetOnDone(null);
+    }, [refreshScans, onScanComplete]);
+
     // If a scan finished while we were away, refresh the list on mount
     useEffect(() => {
         if (grypeEntries.some(e => e.status === 'done')) refreshScans();
         if (nvdEntries.some(e => e.status === 'done')) refreshScans();
         if (osvEntries.some(e => e.status === 'done')) refreshScans();
+        if (sccEntries.some(e => e.status === 'done')) refreshScans();
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -1284,6 +1302,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         if (selectedScanTypes.has('grype')) promises.push(triggerScan(variants));
         if (selectedScanTypes.has('nvd')) promises.push(nvdTriggerScan(variants));
         if (selectedScanTypes.has('osv')) promises.push(osvTriggerScan(variants));
+        if (selectedScanTypes.has('scc')) promises.push(sccTriggerScan(variants));
         await Promise.all(promises);
     }
 
@@ -1303,7 +1322,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
 
     // Build the scan-trigger button (always visible when there are variant(s) to scan)
     const canTriggerScan = effectiveVariantIds.length > 0 || variantId;
-    const allRunning = grypeRunning || nvdRunning || osvRunning;
+    const allRunning = grypeRunning || nvdRunning || osvRunning || sccRunning;
 
     // Filter out "empty" scans (no changes) when toggle is active
     const displayedScans = hideEmptyScans
@@ -1331,6 +1350,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         if (src === 'grype' && !showGrype) return false;
         if (src === 'osv' && !showOsv) return false;
         if (src === 'nvd' && !showNvd) return false;
+        if (src === 'scc' && !showScc) return false;
         return true;
     });
 
@@ -1357,6 +1377,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         grype: "bg-purple-400",
         osv: "bg-green-400",
         nvd: "bg-orange-400",
+        scc: "bg-sky-400",
     };
 
     // Column sizing — single lane
@@ -1417,6 +1438,17 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
             >
                 <FontAwesomeIcon icon={faShieldHalved} />
                 NVD
+            </button>
+            <button
+                onClick={() => setShowScc(v => !v)}
+                className={[
+                    "py-1 px-2 rounded flex items-center gap-1 text-xs font-semibold transition-colors",
+                    showScc ? "bg-sky-600 text-white" : "bg-sky-900/60 text-sky-400 line-through",
+                ].join(' ')}
+                title={showScc ? "sbom-cve-check scans visible" : "sbom-cve-check scans hidden"}
+            >
+                <FontAwesomeIcon icon={faCrosshairs} />
+                sbom-cve-check
             </button>
 
             {/* Right side: doc link + export + scan menu */}
@@ -1496,6 +1528,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                         { key: 'grype', label: 'Grype', icon: faBug, color: 'purple' },
                                         { key: 'nvd', label: 'NVD CPE', icon: faShieldHalved, color: 'orange' },
                                         { key: 'osv', label: 'OSV', icon: faLeaf, color: 'green' },
+                                        { key: 'scc', label: 'sbom-cve-check (offline)', icon: faCrosshairs, color: 'sky' },
                                     ] as const).map(({ key, label, icon, color }) => (
                                         <label
                                             key={key}
@@ -1575,6 +1608,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     const grypeColors = { border: "border-purple-700/60", headerBg: "bg-purple-900/40", iconText: "text-purple-400", titleText: "text-purple-200", subtitleText: "text-purple-300/80", bar: "bg-purple-500" };
     const nvdColors = { border: "border-orange-700/60", headerBg: "bg-orange-900/40", iconText: "text-orange-400", titleText: "text-orange-200", subtitleText: "text-orange-300/80", bar: "bg-orange-500" };
     const osvColors = { border: "border-green-700/60", headerBg: "bg-green-900/40", iconText: "text-green-400", titleText: "text-green-200", subtitleText: "text-green-300/80", bar: "bg-green-500" };
+    const sccColors = { border: "border-sky-700/60", headerBg: "bg-sky-900/40", iconText: "text-sky-400", titleText: "text-sky-200", subtitleText: "text-sky-300/80", bar: "bg-sky-500" };
 
     const progressPanels = (
         <>
@@ -1594,6 +1628,12 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                 .filter(e => e.status === "running" || e.status === "done" || (e.status === "error" && e.logs.length > 0))
                 .map(entry => (
                     <ScanProgressPanel key={`osv-${entry.variantId}`} entry={entry} label="OSV Scan" icon={faLeaf} colors={osvColors} onDismiss={() => osvDismiss(entry.variantId)} />
+                ))
+            }
+            {sccEntries
+                .filter(e => e.status === "running" || e.status === "done" || (e.status === "error" && e.logs.length > 0))
+                .map(entry => (
+                    <ScanProgressPanel key={`scc-${entry.variantId}`} entry={entry} label="sbom-cve-check Scan" icon={faCrosshairs} colors={sccColors} onDismiss={() => sccDismiss(entry.variantId)} />
                 ))
             }
         </>
@@ -1774,6 +1814,17 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                         <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300">
                                             <FontAwesomeIcon icon={faShieldHalved} className="mr-1" />
                                             NVD CPE Scan
+                                        </span>
+                                        </>
+                                    ) : (scan.scan_type || 'sbom') === 'tool' && scan.scan_source === 'scc' ? (
+                                        <>
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300">
+                                            <FontAwesomeIcon icon={faCrosshairs} className="mr-1" />
+                                            Vulnerability Scan
+                                        </span>
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+                                            <FontAwesomeIcon icon={faBook} className="mr-1" />
+                                            sbom-cve-check Scan
                                         </span>
                                         </>
                                     ) : (scan.scan_type || 'sbom') === 'tool' ? (

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,4 @@ uuid7==0.1.0
 Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.1.0
 psycopg2-binary==2.9.9
+sbom_cve_check==1.3.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,3 +18,4 @@ uuid7==0.1.0
 sphinx==9.1.0
 myst-parser==5.0.0
 sphinx-rtd-theme==3.1.0
+sbom_cve_check==1.3.1

--- a/src/bin/cmd_vuln_scan.py
+++ b/src/bin/cmd_vuln_scan.py
@@ -352,7 +352,7 @@ def osv_scan_command(project: str, variant: str | None) -> None:
 
 
 # ---------------------------------------------------------------------------
-# scc-scan: local NVD-FKIE + CVEList engine with version-range evaluation
+# sbom-cve-check-scan: local NVD-FKIE + CVEList engine with version-range evaluation
 # ---------------------------------------------------------------------------
 
 # OpenVEX status → human-readable simplified label (mirrors Assessment model).
@@ -392,7 +392,7 @@ def _scc_cvss_version(metric) -> str:
 
 
 class _SccBulkWriter:
-    """Buffered bulk persister for scc-scan findings.
+    """Buffered bulk persister for sbom-cve-check-scan findings.
 
     The previous implementation persisted every engine finding with its own
     ``get_or_create`` round-trips (vuln SELECT, finding SELECT + savepoint INSERT,
@@ -675,19 +675,19 @@ class _SccBulkWriter:
         return found
 
 
-@click.command("scc-scan")
+@click.command("sbom-cve-check-scan")
 @click.option("--project", "-p", required=True, help="Project name.")
 @click.option("--variant", "-v", default=None,
               help=f"Variant name (defaults to '{DEFAULT_VARIANT_NAME}').")
 @with_appcontext
-def scc_scan_command(project: str, variant: str | None) -> None:
+def sbom_cve_check_scan_command(project: str, variant: str | None) -> None:
     """Run a local CVE-database scan (NVD-FKIE + CVEList V5) with version-range evaluation.
 
     Unlike the live ``nvd-scan`` / ``osv-scan`` paths, this command matches every
     active package against locally-cloned advisory databases, applies product-name
     aliasing and semantic version-range analysis, and records the engine's VEX
     verdict.  It detects vulnerabilities the CPE/PURL API scans miss (notably the
-    Linux kernel) and works fully offline against the existing clones.
+    Linux kernel) and works against the existing clones.
 
     Every verdict is recorded — including ``not_affected`` and ``fixed`` — so the
     full VEX picture is captured.  A new assessment is written only when the

--- a/src/bin/cmd_vuln_scan.py
+++ b/src/bin/cmd_vuln_scan.py
@@ -10,13 +10,17 @@ from ..models.observation import Observation
 from ..models.vulnerability import Vulnerability as VulnModel
 from ..models.metrics import Metrics as MetricsModel
 from ..models.cvss import CVSS
-from ..models.assessment import Assessment
+from ..models.assessment import Assessment, STATUS_TO_SIMPLIFIED
 from ..models.package import Package
 from ..extensions import db as _db
+from ..extensions import write_lock as _write_lock
 from ..helpers.active_scans import active_sbom_scan_ids_for_variant, active_package_ids_for_scans
 from ._common import DEFAULT_VARIANT_NAME, resolve_project_variant
 import click
 import os
+import uuid
+from datetime import datetime, timezone
+from sqlalchemy import inspect as sa_inspect
 from flask.cli import with_appcontext
 
 
@@ -343,5 +347,371 @@ def osv_scan_command(project: str, variant: str | None) -> None:
     _db.session.commit()
     click.echo(
         f"✓ Scan complete — found {len(vulns_found)} unique vulnerabilities "
+        f"across {total_pkgs} packages"
+    )
+
+
+# ---------------------------------------------------------------------------
+# scc-scan: local NVD-FKIE + CVEList engine with version-range evaluation
+# ---------------------------------------------------------------------------
+
+# OpenVEX status → human-readable simplified label (mirrors Assessment model).
+def _simplified_label(status: str | None) -> str:
+    """Canonical simplified label for a status, collapsing OpenVEX/CDX synonyms.
+
+    Both an engine OpenVEX verdict (``affected``) and a CDX-VEX status carrying
+    the same meaning (``exploitable``) map to the same label (``Exploitable``),
+    so a finding's recorded state can be compared regardless of which vocabulary
+    produced it.
+    """
+    return STATUS_TO_SIMPLIFIED.get(status or "", "Pending Assessment")
+
+
+def _ts_key(ts) -> str:
+    """Normalise a timestamp (str, datetime or None) to a comparable string."""
+    if ts is None:
+        return ""
+    if isinstance(ts, str):
+        return ts
+    try:
+        return ts.isoformat()
+    except Exception:
+        return str(ts)
+
+
+def _scc_cvss_version(metric) -> str:
+    """Render an engine ``CvssMetric.cvss_ver`` tuple as a ``"major.minor"`` string."""
+    value = getattr(metric.cvss_ver, "value", (0, 0))
+    try:
+        major, minor = value
+    except (TypeError, ValueError):
+        return ""
+    if not major:
+        return ""
+    return f"{major}.{minor}"
+
+
+class _SccBulkWriter:
+    """Buffered bulk persister for scc-scan findings.
+
+    The previous implementation persisted every engine finding with its own
+    ``get_or_create`` round-trips (vuln SELECT, finding SELECT + savepoint INSERT,
+    observation INSERT, assessment SELECT + INSERT) and committed once per
+    package.  A Yocto kernel recipe expands into hundreds of ``kernel-module-*``
+    sub-packages that each carry the full ``linux_kernel`` CVE set, so the scan
+    produced millions of findings and the row-at-a-time persistence dominated the
+    runtime (hours).
+
+    This writer instead accumulates plain row dictionaries and flushes them with
+    ``bulk_insert_mappings`` in foreign-key order (vulnerabilities → metrics →
+    findings → observations → assessments), committing once per chunk.  Duplicate
+    work is avoided in memory:
+
+    * ``(package_id, cve)`` pairs that already have a finding (from a prior
+      nvd/osv scan) are pre-loaded so existing findings are reused, never
+      re-inserted;
+    * a fresh scan owns brand-new finding UUIDs, so newly created findings are
+      globally unique and need no run-internal dedup tracking (kept out of the
+      in-memory index to bound memory on the kernel explosion);
+    * metrics are inserted only alongside a newly created vulnerability, deduped
+      by ``(version, score)``;
+    * an assessment is recorded only when the engine verdict changes a finding's
+      most recent state: every finding's latest assessment (for this variant) is
+      pre-loaded as a simplified label, and a new assessment is appended only
+      when the engine's verdict maps to a different label (a finding with no
+      prior assessment always counts as a change).  Every verdict the engine
+      emits is considered — ``affected``, ``under_investigation``,
+      ``not_affected`` and ``fixed`` — so the full VEX state is captured;
+    * ``found_by`` is a transient (non-persisted) attribute, so dropping the
+      per-vuln ``add_found_by``/enrichment updates changes nothing on disk.
+    """
+
+    FLUSH_THRESHOLD = 5000
+    _SELECT_CHUNK = 500
+
+    def __init__(self, scan_id, variant_uuid, packages):
+        self._scan_id = scan_id
+        self._variant_uuid = variant_uuid
+        self.cves_found: set[str] = set()
+
+        # Confirmed-present (existing or already-inserted) vulnerability ids.
+        self._known_vuln_ids: set[str] = set()
+        # cve_id -> (vuln_row, [metric_row, ...]) awaiting existence resolution.
+        self._pending_vulns: dict[str, tuple[dict, list[dict]]] = {}
+
+        # Pre-loaded existing findings, plus the simplified status (and its
+        # timestamp key) of each finding's most recent assessment for this
+        # variant.  This lets a re-scan record a fresh assessment only when the
+        # engine verdict actually changes the finding's state.
+        self._finding_index: dict[tuple, uuid.UUID] = {}
+        self._last_simplified: dict[uuid.UUID, str] = {}
+        self._last_ts: dict[uuid.UUID, str] = {}
+
+        # Row buffers for the current chunk.
+        self._vuln_rows: list[dict] = []
+        self._metric_rows: list[dict] = []
+        self._finding_rows: list[dict] = []
+        self._obs_rows: list[dict] = []
+        self._assess_rows: list[dict] = []
+        self._buffered_findings = 0
+
+        self._preload(packages)
+
+    # ------------------------------------------------------------------
+    # Pre-loading
+    # ------------------------------------------------------------------
+
+    def _preload(self, packages) -> None:
+        """Load existing findings and each one's most recent assessment status."""
+        pkg_ids = [pkg.id for pkg in packages]
+        for i in range(0, len(pkg_ids), self._SELECT_CHUNK):
+            chunk = pkg_ids[i:i + self._SELECT_CHUNK]
+            rows = _db.session.execute(
+                _db.select(
+                    FindingModel.id,
+                    FindingModel.package_id,
+                    FindingModel.vulnerability_id,
+                ).where(FindingModel.package_id.in_(chunk))
+            ).all()
+            for fid, package_id, vuln_id in rows:
+                self._finding_index[(package_id, vuln_id.upper())] = fid
+
+        # For every pre-existing finding remember the simplified status of its
+        # most recent assessment for this variant, so the writer only records a
+        # new assessment when the engine verdict changes that state.
+        finding_ids = list(self._finding_index.values())
+        for i in range(0, len(finding_ids), self._SELECT_CHUNK):
+            chunk = finding_ids[i:i + self._SELECT_CHUNK]
+            rows = _db.session.execute(
+                _db.select(
+                    Assessment.finding_id,
+                    Assessment.status,
+                    Assessment.timestamp,
+                ).where(
+                    Assessment.finding_id.in_(chunk),
+                    Assessment.variant_id == self._variant_uuid,
+                )
+            ).all()
+            for fid, status, ts in rows:
+                ts_key = _ts_key(ts)
+                if ts_key >= self._last_ts.get(fid, ""):
+                    self._last_ts[fid] = ts_key
+                    self._last_simplified[fid] = _simplified_label(status)
+
+    # ------------------------------------------------------------------
+    # Row building
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_vuln(cve_id: str, computed) -> tuple[dict, list[dict]]:
+        publish_date = (
+            computed.date_published.date() if computed.date_published is not None else None
+        )
+        links = sorted({ref.url for ref in computed.external_refs if getattr(ref, "url", None)})
+        nvd_last_modified = (
+            computed.date_modified.isoformat() if computed.date_modified is not None else None
+        )
+        vuln_row = {
+            "id": cve_id,
+            "description": computed.description,
+            "publish_date": publish_date,
+            "links": links or None,
+            "nvd_last_modified": nvd_last_modified,
+        }
+
+        metric_rows: list[dict] = []
+        seen_metric: set[tuple] = set()
+        for metric in computed.cvss_metrics:
+            if metric.score is None:
+                continue
+            version = _scc_cvss_version(metric)
+            score = float(metric.score)
+            dk = (version, score)
+            if dk in seen_metric:
+                continue
+            seen_metric.add(dk)
+            metric_rows.append({
+                "id": uuid.uuid4(),
+                "vulnerability_id": cve_id,
+                "variant_id": None,
+                "version": version,
+                "score": score,
+                "vector": metric.vector_str or "",
+                "author": metric.source or "sbom-cve-check",
+                "origin": None,
+            })
+        return vuln_row, metric_rows
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def add(self, pkg, computed, status, seen_keys: set) -> str | None:
+        """Queue one engine finding for bulk insertion.
+
+        Returns the CVE id when the finding was queued, or ``None`` if it was a
+        duplicate already handled for this package in the current run.
+        """
+        cve_id = str(computed.identifier).upper()
+        key = (pkg.id, cve_id)
+        if key in seen_keys:
+            return None
+        seen_keys.add(key)
+        self.cves_found.add(cve_id)
+
+        # Ensure the vulnerability exists (or is queued) before its finding.
+        if cve_id not in self._known_vuln_ids and cve_id not in self._pending_vulns:
+            self._pending_vulns[cve_id] = self._build_vuln(cve_id, computed)
+
+        finding_id = self._finding_index.get(key)
+        is_new_finding = finding_id is None
+        if is_new_finding:
+            finding_id = uuid.uuid4()
+            self._finding_rows.append({
+                "id": finding_id,
+                "package_id": pkg.id,
+                "vulnerability_id": cve_id,
+            })
+            self._buffered_findings += 1
+
+        # The scan is freshly created, so every finding gets one observation.
+        self._obs_rows.append({
+            "id": uuid.uuid4(),
+            "finding_id": finding_id,
+            "scan_id": self._scan_id,
+        })
+
+        # Only record an initial "Pending Assessment" for brand-new findings
+        # (not already in the pool).  Pre-existing findings keep whatever
+        # assessment they already have, even if they have none yet.
+        assert finding_id is not None
+        if is_new_finding:
+            self._last_simplified[finding_id] = "Pending Assessment"
+            self._assess_rows.append({
+                "id": uuid.uuid4(),
+                "status": "under_investigation",
+                "simplified_status": "Pending Assessment",
+                "finding_id": finding_id,
+                "variant_id": self._variant_uuid,
+                "origin": "scc",
+                "status_notes": None,
+                "timestamp": datetime.now(timezone.utc),
+                "responses": [],
+            })
+
+        return cve_id
+
+    def maybe_flush(self) -> None:
+        if self._buffered_findings >= self.FLUSH_THRESHOLD:
+            self.flush()
+
+    def flush(self) -> None:
+        """Resolve pending vulnerabilities and bulk-insert the buffered chunk."""
+        if self._pending_vulns:
+            pending_ids = list(self._pending_vulns.keys())
+            existing = self._existing_vuln_ids(pending_ids)
+            for cid in pending_ids:
+                vuln_row, metric_rows = self._pending_vulns.pop(cid)
+                self._known_vuln_ids.add(cid)
+                if cid in existing:
+                    continue
+                self._vuln_rows.append(vuln_row)
+                self._metric_rows.extend(metric_rows)
+
+        if not (self._vuln_rows or self._metric_rows or self._finding_rows
+                or self._obs_rows or self._assess_rows):
+            return
+
+        # Insert in foreign-key dependency order.  Bulk operations bypass the
+        # before_flush write-lock hook, so serialise explicitly for SQLite.
+        with _write_lock():
+            if self._vuln_rows:
+                _db.session.bulk_insert_mappings(sa_inspect(VulnModel), self._vuln_rows)
+            if self._metric_rows:
+                _db.session.bulk_insert_mappings(sa_inspect(MetricsModel), self._metric_rows)
+            if self._finding_rows:
+                _db.session.bulk_insert_mappings(sa_inspect(FindingModel), self._finding_rows)
+            if self._obs_rows:
+                _db.session.bulk_insert_mappings(sa_inspect(Observation), self._obs_rows)
+            if self._assess_rows:
+                _db.session.bulk_insert_mappings(sa_inspect(Assessment), self._assess_rows)
+            _db.session.commit()
+
+        self._vuln_rows.clear()
+        self._metric_rows.clear()
+        self._finding_rows.clear()
+        self._obs_rows.clear()
+        self._assess_rows.clear()
+        self._buffered_findings = 0
+
+    def _existing_vuln_ids(self, ids: list[str]) -> set[str]:
+        found: set[str] = set()
+        for i in range(0, len(ids), self._SELECT_CHUNK):
+            chunk = [x.upper() for x in ids[i:i + self._SELECT_CHUNK]]
+            rows = _db.session.execute(
+                _db.select(VulnModel.id).where(VulnModel.id.in_(chunk))
+            ).all()
+            found.update(r[0] for r in rows)
+        return found
+
+
+@click.command("scc-scan")
+@click.option("--project", "-p", required=True, help="Project name.")
+@click.option("--variant", "-v", default=None,
+              help=f"Variant name (defaults to '{DEFAULT_VARIANT_NAME}').")
+@with_appcontext
+def scc_scan_command(project: str, variant: str | None) -> None:
+    """Run a local CVE-database scan (NVD-FKIE + CVEList V5) with version-range evaluation.
+
+    Unlike the live ``nvd-scan`` / ``osv-scan`` paths, this command matches every
+    active package against locally-cloned advisory databases, applies product-name
+    aliasing and semantic version-range analysis, and records the engine's VEX
+    verdict.  It detects vulnerabilities the CPE/PURL API scans miss (notably the
+    Linux kernel) and works fully offline against the existing clones.
+
+    Every verdict is recorded — including ``not_affected`` and ``fixed`` — so the
+    full VEX picture is captured.  A new assessment is written only when the
+    verdict changes a finding's most recent state.
+    """
+    from ..controllers.scc_engine import get_engine
+
+    project_obj, variant_obj = resolve_project_variant(project, variant, create=True)
+    variant_uuid = variant_obj.id
+
+    packages = _resolve_active_packages(variant_uuid)
+    click.echo(f"Resolved {len(packages)} active packages")
+
+    click.echo("Loading local CVE databases (NVD-FKIE + CVEList) and building index…")
+    engine = get_engine()
+    click.echo("Index ready — scanning packages")
+
+    scan = _create_tool_scan(variant_uuid, "scc")
+    total_pkgs = len(packages)
+    writer = _SccBulkWriter(scan.id, variant_uuid, packages)
+
+    for idx, pkg in enumerate(packages, 1):
+        pkg_label = f"{pkg.name}@{pkg.version}" if pkg.name else str(pkg.id)
+        persisted_ids: list[str] = []
+        seen_keys: set = set()
+        try:
+            for computed, status in engine.applicable_vulns(pkg):
+                cve_id = writer.add(pkg, computed, status, seen_keys)
+                if cve_id is not None:
+                    persisted_ids.append(cve_id)
+        except Exception as e:
+            click.echo(
+                f"[{idx}/{total_pkgs}] ERROR {pkg_label}: {str(e)[:200]}",
+                err=True,
+            )
+            continue
+
+        _echo_query_results(idx, total_pkgs, pkg_label, persisted_ids,
+                            "vuln(s)", "no vulnerabilities")
+        # Flush in large bulk-inserted chunks to bound memory/transaction size.
+        writer.maybe_flush()
+
+    writer.flush()
+    click.echo(
+        f"✓ Scan complete — found {len(writer.cves_found)} unique vulnerabilities "
         f"across {total_pkgs} packages"
     )

--- a/src/bin/cmd_vuln_scan.py
+++ b/src/bin/cmd_vuln_scan.py
@@ -434,6 +434,11 @@ class _SccBulkWriter:
         self._variant_uuid = variant_uuid
         self.cves_found: set[str] = set()
 
+        # CVE ids already observed in this variant across any previous scan.
+        self._variant_existing_cves: set[str] = set()
+        # CVE ids first seen in this run for this variant.
+        self._variant_new_cves: set[str] = set()
+
         # Confirmed-present (existing or already-inserted) vulnerability ids.
         self._known_vuln_ids: set[str] = set()
         # cve_id -> (vuln_row, [metric_row, ...]) awaiting existence resolution.
@@ -475,6 +480,20 @@ class _SccBulkWriter:
             ).all()
             for fid, package_id, vuln_id in rows:
                 self._finding_index[(package_id, vuln_id.upper())] = fid
+
+        # CVEs already present in this variant (via any finding observed by any
+        # scan tied to the variant). Pending assessment must only be added for
+        # truly new CVEs, not for existing CVEs appearing on additional packages.
+        existing_variant_cves = _db.session.execute(
+            _db.select(FindingModel.vulnerability_id)
+            .join(Observation, Observation.finding_id == FindingModel.id)
+            .join(ScanModel, ScanModel.id == Observation.scan_id)
+            .where(ScanModel.variant_id == self._variant_uuid)
+            .distinct()
+        ).all()
+        self._variant_existing_cves = {
+            vuln_id.upper() for (vuln_id,) in existing_variant_cves if vuln_id
+        }
 
         # For every pre-existing finding remember the simplified status of its
         # most recent assessment for this variant, so the writer only records a
@@ -581,11 +600,12 @@ class _SccBulkWriter:
             "scan_id": self._scan_id,
         })
 
-        # Only record an initial "Pending Assessment" for brand-new findings
-        # (not already in the pool).  Pre-existing findings keep whatever
-        # assessment they already have, even if they have none yet.
+        # Only record an initial "Pending Assessment" for brand-new CVEs in the
+        # variant. Existing CVEs must not be modified, even if this scan creates
+        # a new finding for a different package.
         assert finding_id is not None
-        if is_new_finding:
+        if is_new_finding and cve_id not in self._variant_existing_cves and cve_id not in self._variant_new_cves:
+            self._variant_new_cves.add(cve_id)
             self._last_simplified[finding_id] = "Pending Assessment"
             self._assess_rows.append({
                 "id": uuid.uuid4(),

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -37,7 +37,7 @@ from .cmd_scans import (
     list_scans_command,
     delete_scan_command,
 )
-from .cmd_vuln_scan import nvd_scan_command, osv_scan_command, scc_scan_command
+from .cmd_vuln_scan import nvd_scan_command, osv_scan_command, sbom_cve_check_scan_command
 
 
 def init_app(app) -> None:
@@ -53,7 +53,7 @@ def init_app(app) -> None:
     app.cli.add_command(delete_scan_command)
     app.cli.add_command(nvd_scan_command)
     app.cli.add_command(osv_scan_command)
-    app.cli.add_command(scc_scan_command)
+    app.cli.add_command(sbom_cve_check_scan_command)
 
 
 def main() -> ControllersCache:

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -37,7 +37,7 @@ from .cmd_scans import (
     list_scans_command,
     delete_scan_command,
 )
-from .cmd_vuln_scan import nvd_scan_command, osv_scan_command
+from .cmd_vuln_scan import nvd_scan_command, osv_scan_command, scc_scan_command
 
 
 def init_app(app) -> None:
@@ -53,6 +53,7 @@ def init_app(app) -> None:
     app.cli.add_command(delete_scan_command)
     app.cli.add_command(nvd_scan_command)
     app.cli.add_command(osv_scan_command)
+    app.cli.add_command(scc_scan_command)
 
 
 def main() -> ControllersCache:

--- a/src/controllers/__init__.py
+++ b/src/controllers/__init__.py
@@ -11,6 +11,7 @@ from .variants import VariantController
 from .vulnerabilities import VulnerabilitiesController
 
 from .cache import ControllersCache
+from . import scc_engine
 
 __all__ = [
     "AssessmentsController",

--- a/src/controllers/scc_adapter.py
+++ b/src/controllers/scc_adapter.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+"""Adapters exposing VulnScout :class:`Package` objects to the sbom-cve-check engine.
+
+The sbom-cve-check matching engine consumes :class:`~sbom_cve_check.sbom.component.Component`
+and :class:`~sbom_cve_check.sbom.component.CompBuild` objects.  Rather than reproduce the
+yocto/SPDX scaffolding the engine normally builds from an SBOM, we wrap VulnScout's own
+``Package`` model directly.  Each ``Package`` becomes a single-component ``CompBuild`` whose
+identifiers are derived from the package CPEs, PURLs and bare name — maximising matches across
+ecosystems (OS packages via canonical CPE, pypi/npm via PURL/generic-CPE name).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from packageurl import PackageURL
+
+from sbom_cve_check.sbom.component import CompBuild, Component, CompType
+from sbom_cve_check.vuln.comp_id import CompId
+
+
+def _comp_ids_for_package(name: str, version: str, cpes: Iterable[str],
+                          purls: Iterable[str]) -> set[CompId]:
+    """Build the set of component identifiers used to match a package.
+
+    Identifiers are collected from three sources so that a single package can be
+    matched whichever way an advisory references it:
+
+    * every CPE → :meth:`CompId.build_from_cpe` (carries vendor + canonical product)
+    * every PURL package name → ``CompId(name=...)``
+    * the bare package name → ``CompId(name=...)``
+    """
+    ids: set[CompId] = set()
+
+    for cpe in cpes:
+        if not cpe:
+            continue
+        try:
+            cid = CompId.build_from_cpe(cpe)
+        except Exception:
+            cid = None
+        if cid is not None:
+            ids.add(cid)
+
+    for purl in purls:
+        if not purl:
+            continue
+        try:
+            pname = PackageURL.from_string(purl).name
+        except Exception:
+            pname = None
+        if pname:
+            ids.add(CompId(name=pname.lower()))
+
+    if name:
+        ids.add(CompId(name=name.lower()))
+
+    return ids
+
+
+class VsComponent(Component):
+    """Wrap a single VulnScout :class:`Package` as an engine ``Component``."""
+
+    def __init__(self, name: str, version: str, identifiers: set[CompId],
+                 cpes: tuple[str, ...], purls: tuple[str, ...]) -> None:
+        self._name = name
+        self._version = version
+        self._identifiers = identifiers
+        self._cpes = cpes
+        self._purls = purls
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def version(self) -> str | None:
+        return self._version or None
+
+    @property
+    def pkg_version(self) -> str | None:
+        return self._version or None
+
+    @property
+    def supplier(self) -> str | None:
+        return None
+
+    @property
+    def comp_type(self) -> CompType | None:
+        return None
+
+    @property
+    def identifiers(self) -> set[CompId]:
+        return self._identifiers
+
+    @property
+    def purls(self) -> set[str]:
+        return set(self._purls)
+
+
+class VsCompBuild(CompBuild):
+    """Wrap a single VulnScout :class:`Package` as an engine ``CompBuild``.
+
+    A package maps to exactly one build holding one component, sharing the same
+    version and identifiers (the invariant the engine expects).  Compiled-source
+    refinement (kernel per-file trimming) is intentionally disabled: VulnScout's
+    portable SBOM does not carry recipe source-file lists, so an empty set is
+    returned, which makes the engine fall back to pure version-range evaluation.
+    """
+
+    def __init__(self, name: str, version: str, identifiers: set[CompId],
+                 cpes: tuple[str, ...], purls: tuple[str, ...]) -> None:
+        super().__init__()
+        self._build_name = name
+        self._version = version
+        self._identifiers = tuple(sorted(identifiers))
+        self._component = VsComponent(name, version, identifiers, cpes, purls)
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    @property
+    def identifiers(self) -> tuple[CompId, ...]:
+        return self._identifiers
+
+    @property
+    def components(self) -> Iterable[Component]:
+        return [self._component]
+
+    @property
+    def build_name(self) -> str | None:
+        return self._build_name
+
+    def _get_compiled_sources(self) -> set[str]:
+        return set()
+
+
+def build_comp_build(pkg) -> VsCompBuild | None:
+    """Create a :class:`VsCompBuild` from a VulnScout ``Package``.
+
+    Returns ``None`` when the package carries neither a usable version nor any
+    identifier the engine could match against.
+    """
+    name = (pkg.name or "").strip()
+    version = (pkg.version or "").strip()
+    cpes = tuple(pkg.cpe or [])
+    purls = tuple(pkg.purl or [])
+
+    identifiers = _comp_ids_for_package(name, version, cpes, purls)
+    if not identifiers or not version:
+        return None
+
+    return VsCompBuild(name, version, identifiers, cpes, purls)

--- a/src/controllers/scc_engine.py
+++ b/src/controllers/scc_engine.py
@@ -11,17 +11,21 @@ the lifetime of the process.
 Configuration (environment variables):
 
 * ``SBOM_CVE_CHECK_DATABASES_DIR`` — directory holding the ``nvd-fkie`` and ``cvelist`` git
-  clones.  Defaults to ``$XDG_CACHE_HOME/sbom_cve_check/databases`` (i.e.
-  ``~/.cache/sbom_cve_check/databases``).
+  clones.  Defaults to a ``sbom_cve_check_databases`` sub-directory of the VulnScout
+  cache directory (``$VULNSCOUT_CACHE_DIR/sbom_cve_check_databases``, i.e.
+  ``/cache/vulnscout/sbom_cve_check_databases`` inside the container), so the advisory
+  clones live next to ``vulnscout.db`` instead of in a separate XDG cache tree.
 * ``SBOM_CVE_CHECK_GIT_FETCH_DEPTH`` — git fetch/clone depth (default ``1``: shallow clone).
-* ``SBOM_CVE_CHECK_AUTO_UPDATE`` — ``"1"``/``"true"`` to allow the engine to fetch fresh
-  advisories on startup, anything else disables network updates (default
-  disabled, so scans run against the existing clones).
+* ``SBOM_CVE_CHECK_AUTO_UPDATE`` — ``"1"``/``"true"`` to let the engine clone/fetch fresh
+  advisories (default ``"1"``).  The databases are refreshed before *every* scan so each
+  run uses up-to-date advisories.  Set to ``"0"`` to run in offline mode against
+  already-cloned databases.
 """
 
 from __future__ import annotations
 
 import functools
+import logging
 import os
 import pathlib
 import threading
@@ -35,6 +39,8 @@ from sbom_cve_check.products.products import init_products_database
 from sbom_cve_check.vuln.cna import init_cna_database
 
 from .scc_adapter import build_comp_build
+
+_logger = logging.getLogger(__name__)
 
 _ENGINE_LOCK = threading.Lock()
 _ENGINE: "SccEngine | None" = None
@@ -80,12 +86,17 @@ def _install_cpe_parse_caches() -> None:
 
 
 def _databases_dir() -> pathlib.Path:
-    """Resolve the directory holding the local advisory git clones."""
+    """Resolve the directory holding the local advisory git clones.
+
+    Defaults to a ``sbom_cve_check_databases`` sub-directory of the VulnScout cache
+    directory so the NVD-FKIE and CVEList clones sit next to ``vulnscout.db`` instead
+    of in a separate ``~/.cache/sbom_cve_check`` tree.
+    """
     env = os.getenv("SBOM_CVE_CHECK_DATABASES_DIR")
     if env and env.strip():
         return pathlib.Path(env).expanduser().resolve()
-    cache = os.getenv("XDG_CACHE_HOME") or "~/.cache"
-    return pathlib.Path(cache).expanduser().joinpath("sbom_cve_check", "databases").resolve()
+    cache = os.getenv("VULNSCOUT_CACHE_DIR") or "/cache/vulnscout"
+    return pathlib.Path(cache).expanduser().joinpath("sbom_cve_check_databases").resolve()
 
 
 def _truthy(value: str | None) -> bool:
@@ -125,6 +136,11 @@ class SccEngine:
     def __init__(self, databases_dir: pathlib.Path, fetch_depth: int,
                  auto_update: bool) -> None:
         self._databases_dir = databases_dir
+        self._fetch_depth = fetch_depth
+        self._auto_update = auto_update
+        # Serialises per-scan database refreshes so two concurrent scans never
+        # fetch / rebuild the index at the same time.
+        self._refresh_lock = threading.Lock()
         self._manager = VulnDbManager()
 
         nvd_dir = databases_dir.joinpath("nvd-fkie")
@@ -133,9 +149,14 @@ class SccEngine:
             if not path.is_dir() and not auto_update:
                 raise RuntimeError(
                     f"Vulnerability database '{label}' not found at {path}. "
-                    "Clone it (or set SBOM_CVE_CHECK_AUTO_UPDATE=1 to let the engine clone it) "
-                    "before running sbom-cve-check-scan."
+                    "Clone it before running sbom-cve-check-scan, or set "
+                    "SBOM_CVE_CHECK_AUTO_UPDATE=1 to let the engine clone it automatically."
                 )
+
+        # When network updates are allowed the clones may not exist yet; make sure
+        # the parent directory is present so git can create them on first fetch.
+        if auto_update:
+            databases_dir.mkdir(parents=True, exist_ok=True)
 
         # Let git read the clones even when the process uid differs from the
         # clone owner, otherwise the engine bypasses its on-disk index cache and
@@ -211,6 +232,70 @@ class SccEngine:
                 if getattr(db.get_vuln, "__wrapped__", None) is not None:
                     continue
                 db.get_vuln = functools.lru_cache(maxsize=65_536)(db.get_vuln)
+
+    def _git_databases(self) -> list:
+        """Return the underlying ``GitDatabase`` objects of every managed DB."""
+        result: list = []
+        databases = getattr(self._manager, "_databases", None)
+        if not databases:
+            return result
+        for dbs in databases.values():
+            for db in dbs:
+                git_db = getattr(db, "git_database", None)
+                if git_db is not None:
+                    result.append(git_db)
+        return result
+
+    def _clear_caches(self) -> None:
+        """Drop every per-scan cache so a refreshed index is never served stale data."""
+        self._applicable_cache.clear()
+        self._verdict_cache.clear()
+        databases = getattr(self._manager, "_databases", None)
+        if databases:
+            for dbs in databases.values():
+                for db in dbs:
+                    clear = getattr(getattr(db, "get_vuln", None), "cache_clear", None)
+                    if callable(clear):
+                        clear()
+
+    def refresh_databases(self) -> bool:
+        """Fetch fresh advisories for each git database before a scan.
+
+        Called once per scan (see :func:`get_engine`).  The process-wide engine is
+        built once and reused, so without this the NVD-FKIE / CVEList clones would
+        only ever be fetched at construction (the first scan of the process).  When
+        ``SBOM_CVE_CHECK_AUTO_UPDATE`` is enabled this force-fetches every clone so
+        each scan runs against up-to-date databases; when it is disabled it is a
+        no-op (offline mode, scans run against the existing clones).
+
+        The expensive in-memory index is only rebuilt when a clone actually advanced
+        to a new commit, in which case the per-scan caches are dropped as well so no
+        stale verdict survives.  Network / git failures are logged and swallowed so a
+        transient fetch error never aborts an otherwise-runnable scan.
+
+        :return: ``True`` if any clone advanced and the index was rebuilt.
+        """
+        if not self._auto_update:
+            return False
+        with self._refresh_lock:
+            changed = False
+            for git_db in self._git_databases():
+                before = git_db.get_date_last_commit()
+                try:
+                    git_db.update(force_update=True)
+                except Exception as exc:  # noqa: BLE001 - never abort a scan on fetch error
+                    _logger.warning(
+                        "sbom-cve-check database refresh failed (using existing clone): %s",
+                        exc,
+                    )
+                    continue
+                after = git_db.get_date_last_commit()
+                if before != after:
+                    changed = True
+            if changed:
+                self._manager.create_index()
+                self._clear_caches()
+            return changed
 
     @staticmethod
     def _vex_status_str(computed: ComputedVulnInfo) -> str:
@@ -292,10 +377,15 @@ class SccEngine:
 
 
 def get_engine() -> SccEngine:
-    """Return the process-wide indexed engine, building it on first use."""
+    """Return the process-wide indexed engine, building it on first use.
+
+    The engine is expensive to build and is cached for the lifetime of the
+    process.  Because that one build would otherwise be the only time the advisory
+    clones are fetched, every call refreshes the databases before returning (a
+    no-op unless ``SBOM_CVE_CHECK_AUTO_UPDATE`` is enabled) so each scan — the
+    first included — runs against up-to-date advisories.
+    """
     global _ENGINE
-    if _ENGINE is not None:
-        return _ENGINE
     with _ENGINE_LOCK:
         if _ENGINE is None:
             depth_env = os.getenv("SBOM_CVE_CHECK_GIT_FETCH_DEPTH")
@@ -308,6 +398,7 @@ def get_engine() -> SccEngine:
                 fetch_depth=fetch_depth,
                 auto_update=_truthy(os.getenv("SBOM_CVE_CHECK_AUTO_UPDATE")),
             )
+    _ENGINE.refresh_databases()
     return _ENGINE
 
 

--- a/src/controllers/scc_engine.py
+++ b/src/controllers/scc_engine.py
@@ -77,7 +77,7 @@ def _install_cpe_parse_caches() -> None:
                 return cached(arg)
             return func(arg)
 
-        wrapper.cache_clear = cached.cache_clear
+        wrapper.cache_clear = cached.cache_clear  # type: ignore[attr-defined]
         return wrapper
 
     Cpe23.parse = staticmethod(_string_keyed(Cpe23.parse, 200_000))  # type: ignore[method-assign]

--- a/src/controllers/scc_engine.py
+++ b/src/controllers/scc_engine.py
@@ -10,13 +10,13 @@ the lifetime of the process.
 
 Configuration (environment variables):
 
-* ``SCC_DATABASES_DIR`` — directory holding the ``nvd-fkie`` and ``cvelist`` git
+* ``SBOM_CVE_CHECK_DATABASES_DIR`` — directory holding the ``nvd-fkie`` and ``cvelist`` git
   clones.  Defaults to ``$XDG_CACHE_HOME/sbom_cve_check/databases`` (i.e.
   ``~/.cache/sbom_cve_check/databases``).
-* ``SCC_GIT_FETCH_DEPTH`` — git fetch/clone depth (default ``1``: shallow clone).
-* ``SCC_AUTO_UPDATE`` — ``"1"``/``"true"`` to allow the engine to fetch fresh
+* ``SBOM_CVE_CHECK_GIT_FETCH_DEPTH`` — git fetch/clone depth (default ``1``: shallow clone).
+* ``SBOM_CVE_CHECK_AUTO_UPDATE`` — ``"1"``/``"true"`` to allow the engine to fetch fresh
   advisories on startup, anything else disables network updates (default
-  disabled, so scans run fully offline against the existing clones).
+  disabled, so scans run against the existing clones).
 """
 
 from __future__ import annotations
@@ -81,7 +81,7 @@ def _install_cpe_parse_caches() -> None:
 
 def _databases_dir() -> pathlib.Path:
     """Resolve the directory holding the local advisory git clones."""
-    env = os.getenv("SCC_DATABASES_DIR")
+    env = os.getenv("SBOM_CVE_CHECK_DATABASES_DIR")
     if env and env.strip():
         return pathlib.Path(env).expanduser().resolve()
     cache = os.getenv("XDG_CACHE_HOME") or "~/.cache"
@@ -133,8 +133,8 @@ class SccEngine:
             if not path.is_dir() and not auto_update:
                 raise RuntimeError(
                     f"Vulnerability database '{label}' not found at {path}. "
-                    "Clone it (or set SCC_AUTO_UPDATE=1 to let the engine clone it) "
-                    "before running scc-scan."
+                    "Clone it (or set SBOM_CVE_CHECK_AUTO_UPDATE=1 to let the engine clone it) "
+                    "before running sbom-cve-check-scan."
                 )
 
         # Let git read the clones even when the process uid differs from the
@@ -298,7 +298,7 @@ def get_engine() -> SccEngine:
         return _ENGINE
     with _ENGINE_LOCK:
         if _ENGINE is None:
-            depth_env = os.getenv("SCC_GIT_FETCH_DEPTH")
+            depth_env = os.getenv("SBOM_CVE_CHECK_GIT_FETCH_DEPTH")
             try:
                 fetch_depth = int(depth_env) if depth_env else 1
             except ValueError:
@@ -306,7 +306,7 @@ def get_engine() -> SccEngine:
             _ENGINE = SccEngine(
                 databases_dir=_databases_dir(),
                 fetch_depth=fetch_depth,
-                auto_update=_truthy(os.getenv("SCC_AUTO_UPDATE")),
+                auto_update=_truthy(os.getenv("SBOM_CVE_CHECK_AUTO_UPDATE")),
             )
     return _ENGINE
 

--- a/src/controllers/scc_engine.py
+++ b/src/controllers/scc_engine.py
@@ -1,0 +1,318 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+"""Thin wrapper around the sbom-cve-check matching engine.
+
+Builds and caches an indexed :class:`~sbom_cve_check.database.manager.VulnDbManager`
+backed by local NVD-FKIE + CVEList V5 git databases, with the products-alias and
+CNA-role tables initialised.  The indexed manager is expensive to build (it reads
+hundreds of thousands of advisory JSON files), so a single instance is cached for
+the lifetime of the process.
+
+Configuration (environment variables):
+
+* ``SCC_DATABASES_DIR`` — directory holding the ``nvd-fkie`` and ``cvelist`` git
+  clones.  Defaults to ``$XDG_CACHE_HOME/sbom_cve_check/databases`` (i.e.
+  ``~/.cache/sbom_cve_check/databases``).
+* ``SCC_GIT_FETCH_DEPTH`` — git fetch/clone depth (default ``1``: shallow clone).
+* ``SCC_AUTO_UPDATE`` — ``"1"``/``"true"`` to allow the engine to fetch fresh
+  advisories on startup, anything else disables network updates (default
+  disabled, so scans run fully offline against the existing clones).
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import pathlib
+import threading
+from collections.abc import Generator
+
+from sbom_cve_check.analysis.computed_vuln import ComputedVulnInfo
+from sbom_cve_check.database.db_git import GitDatabase
+from sbom_cve_check.database.locking import init_global_databases_lock
+from sbom_cve_check.database.manager import DatabasesConfigData, VulnDbManager
+from sbom_cve_check.products.products import init_products_database
+from sbom_cve_check.vuln.cna import init_cna_database
+
+from .scc_adapter import build_comp_build
+
+_ENGINE_LOCK = threading.Lock()
+_ENGINE: "SccEngine | None" = None
+_PURE_CACHES_INSTALLED = False
+
+
+def _install_cpe_parse_caches() -> None:
+    """Memoize the pure CPE-parsing helpers the engine calls repeatedly.
+
+    ``VulnDbManager.get_applicable_vulns`` re-parses every CPE string of every
+    candidate CVE, for every package it evaluates.  The same CPE strings recur
+    across the thousands of packages in a Yocto image (most visibly the many
+    sub-packages a single recipe expands into, e.g. ``busybox`` ->
+    ``busybox-syslog`` / ``busybox-udhcpc`` ...), so the same strings are parsed
+    tens of thousands of times per scan.  ``Cpe23.parse`` and
+    ``CompId.build_from_cpe`` are pure functions of a string argument and return
+    immutable objects, so memoizing them collapses that quadratic re-parsing
+    into a one-off cost (profiling attributes the majority of per-package time
+    to these two calls).  Only string/``None`` inputs are cached; ``Cpe23``
+    instances pass straight through, so behaviour is unchanged.
+    """
+    global _PURE_CACHES_INSTALLED
+    if _PURE_CACHES_INSTALLED:
+        return
+    from sbom_cve_check.vuln.cpe import Cpe23
+    from sbom_cve_check.vuln.comp_id import CompId
+
+    def _string_keyed(func, maxsize):
+        cached = functools.lru_cache(maxsize=maxsize)(func)
+
+        @functools.wraps(func)
+        def wrapper(arg=None):
+            if arg is None or isinstance(arg, str):
+                return cached(arg)
+            return func(arg)
+
+        wrapper.cache_clear = cached.cache_clear
+        return wrapper
+
+    Cpe23.parse = staticmethod(_string_keyed(Cpe23.parse, 200_000))  # type: ignore[method-assign]
+    CompId.build_from_cpe = staticmethod(_string_keyed(CompId.build_from_cpe, 200_000))  # type: ignore[method-assign]
+    _PURE_CACHES_INSTALLED = True
+
+
+def _databases_dir() -> pathlib.Path:
+    """Resolve the directory holding the local advisory git clones."""
+    env = os.getenv("SCC_DATABASES_DIR")
+    if env and env.strip():
+        return pathlib.Path(env).expanduser().resolve()
+    cache = os.getenv("XDG_CACHE_HOME") or "~/.cache"
+    return pathlib.Path(cache).expanduser().joinpath("sbom_cve_check", "databases").resolve()
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _trust_git_directories(paths: list[pathlib.Path]) -> None:
+    """Mark the local advisory git clones as safe for git to read.
+
+    The clones are frequently owned by a different uid than the running process
+    (e.g. a container running as root over volume-mounted, builder-owned
+    databases).  Git's "dubious ownership" protection then makes ``git rev-parse``
+    fail, which silently defeats sbom-cve-check's commit-keyed index cache: with
+    no resolvable HEAD it rebuilds the whole index from hundreds of thousands of
+    advisory files on every scan (minutes) instead of loading the cached index
+    (about a second).
+
+    Adding the directories to git's ``safe.directory`` list via the
+    ``GIT_CONFIG_*`` environment variables (process-scoped, no files written)
+    restores the cache fast-path.  Existing ``GIT_CONFIG_*`` entries are
+    preserved.
+    """
+    try:
+        count = int(os.environ.get("GIT_CONFIG_COUNT", "0"))
+    except ValueError:
+        count = 0
+    for path in paths:
+        os.environ[f"GIT_CONFIG_KEY_{count}"] = "safe.directory"
+        os.environ[f"GIT_CONFIG_VALUE_{count}"] = str(path)
+        count += 1
+    os.environ["GIT_CONFIG_COUNT"] = str(count)
+
+
+class SccEngine:
+    """Indexed sbom-cve-check engine ready to match VulnScout packages."""
+
+    def __init__(self, databases_dir: pathlib.Path, fetch_depth: int,
+                 auto_update: bool) -> None:
+        self._databases_dir = databases_dir
+        self._manager = VulnDbManager()
+
+        nvd_dir = databases_dir.joinpath("nvd-fkie")
+        cvelist_dir = databases_dir.joinpath("cvelist")
+        for label, path in (("nvd-fkie", nvd_dir), ("cvelist", cvelist_dir)):
+            if not path.is_dir() and not auto_update:
+                raise RuntimeError(
+                    f"Vulnerability database '{label}' not found at {path}. "
+                    "Clone it (or set SCC_AUTO_UPDATE=1 to let the engine clone it) "
+                    "before running scc-scan."
+                )
+
+        # Let git read the clones even when the process uid differs from the
+        # clone owner, otherwise the engine bypasses its on-disk index cache and
+        # rebuilds the whole index from every advisory file on each scan.
+        _trust_git_directories([databases_dir, nvd_dir, cvelist_dir])
+
+        # The git databases grab the global lock at construction time, so it must
+        # be initialised first.  An empty config list makes it fall back to
+        # SBOM_CVE_CHECK_DATABASES_DIR, which we point at our databases dir.
+        os.environ.setdefault("SBOM_CVE_CHECK_DATABASES_DIR", str(databases_dir))
+        init_global_databases_lock([])
+
+        # Disable network fetches unless the operator explicitly opts in, so a
+        # scan against an already-cloned DB never reaches out to the network.
+        GitDatabase.DISABLE_AUTO_UPDATES_GLOBALLY = not auto_update
+
+        db_sections = {
+            "nvd-fkie": {
+                "type": "cve-db-nvd-fkie",
+                "path": str(nvd_dir),
+                "git_fetch_depth": fetch_depth,
+            },
+            "cvelist": {
+                "type": "cve-db-cvelist",
+                "path": str(cvelist_dir),
+                "git_fetch_depth": fetch_depth,
+            },
+        }
+        self._manager.add_databases_from_configs(
+            [DatabasesConfigData(databases_dir, db_sections)]
+        )
+
+        # Products alias table (vendor/product canonicalisation, e.g.
+        # linux-yocto -> linux_kernel) and CNA-role table (needed for accurate
+        # version-range scoping, including the Linux-kernel CNA special-case).
+        init_products_database([], load_defaults=True)
+        init_cna_database([])
+
+        # Memoize the pure CPE-parsing helpers before any matching runs.
+        _install_cpe_parse_caches()
+
+        # Build the in-memory index (parallel across databases).  Expensive.
+        self._manager.create_index()
+
+        # Memoize per-CVE record reads so each advisory JSON file is opened and
+        # parsed at most once per engine lifetime instead of once per
+        # (package x candidate-CVE).  The same popular CVEs (curl, glibc,
+        # openssl, the kernel ...) are candidates for nearly every package, so
+        # without this the scan re-reads the same files thousands of times.
+        self._install_get_vuln_caches()
+
+        # Cache the applicable-vulnerability computation keyed on the matching
+        # signature of a package (see :meth:`applicable_vulns`).
+        self._applicable_cache: dict[
+            tuple[frozenset, str | None],
+            list[tuple[tuple, ...]],
+        ] = {}
+        # Cache the per-CVE version verdict (affected / not_affected / fixed /
+        # under_investigation) under the same signature, so the costly
+        # version-range evaluation runs once per signature instead of once per
+        # sibling package.
+        self._verdict_cache: dict[
+            tuple[frozenset, str | None], dict[str, str]
+        ] = {}
+
+    def _install_get_vuln_caches(self) -> None:
+        """Wrap every database's ``get_vuln`` with a bounded per-record cache."""
+        databases = getattr(self._manager, "_databases", None)
+        if not databases:
+            return
+        for dbs in databases.values():
+            for db in dbs:
+                if getattr(db.get_vuln, "__wrapped__", None) is not None:
+                    continue
+                db.get_vuln = functools.lru_cache(maxsize=65_536)(db.get_vuln)
+
+    @staticmethod
+    def _vex_status_str(computed: ComputedVulnInfo) -> str:
+        """Map an engine VEX assessment to a VulnScout OpenVEX status string.
+
+        Triggers the engine's (expensive) version-range evaluation via
+        ``computed.vex_assessment``.
+        """
+        from sbom_cve_check.vuln.vex import VexStatus
+
+        status = computed.vex_assessment.status
+        if status == VexStatus.AFFECTED:
+            return "affected"
+        if status == VexStatus.NOT_AFFECTED:
+            return "not_affected"
+        if status == VexStatus.FIXED:
+            return "fixed"
+        return "under_investigation"
+
+    def applicable_vulns(
+        self, pkg
+    ) -> Generator[tuple[ComputedVulnInfo, str], None, None]:
+        """Yield ``(ComputedVulnInfo, status)`` for every applicable vuln of a package.
+
+        ``status`` is the OpenVEX verdict string (``affected`` /
+        ``not_affected`` / ``fixed`` / ``under_investigation``).
+
+        Many packages in a Yocto image share an identical *matching* signature
+        even though they are distinct packages.  The clearest case is the kernel:
+        a single recipe expands into the ``linux-*`` package plus hundreds of
+        ``kernel-module-*`` sub-packages, and every one of them carries the same
+        ``linux_kernel`` / ``linux`` CPE at the same version.  The kernel's
+        product name resolves to tens of thousands of candidate CVEs, so without
+        caching each of those hundreds of sub-packages re-evaluates the very same
+        ~16k advisories and re-runs the very same version-range verdicts — the
+        dominant cost of a full scan.
+
+        Both the applicable-vulnerability set and the per-CVE version verdict are
+        pure functions of the package's *index-relevant* identifiers and version:
+        an identifier whose product name is absent from the index can neither
+        pull a candidate CVE nor loosely match one (the index and the loose-match
+        check are both derived from each advisory's applicable component names),
+        so it is dropped from the signature.  Packages sharing a signature
+        therefore share both heavy computations; only the cheap per-package
+        :class:`ComputedVulnInfo` wrappers (which carry the correct component for
+        reporting) are rebuilt, so results are unchanged.
+        """
+        comp_build = build_comp_build(pkg)
+        if comp_build is None:
+            return
+
+        index = self._manager._index_comp_vuln
+        relevant_ids = frozenset(
+            cid for cid in comp_build.ids_for_matching() if cid.name in index
+        )
+        key = (relevant_ids, comp_build.version)
+
+        entry_groups = self._applicable_cache.get(key)
+        if entry_groups is None:
+            entry_groups = [
+                computed._vuln_db_entries
+                for computed in self._manager.get_applicable_vulns(comp_build)
+            ]
+            # Bound memory across long-lived engines handling many scans.
+            if len(self._applicable_cache) >= 50_000:
+                self._applicable_cache.clear()
+                self._verdict_cache.clear()
+            self._applicable_cache[key] = entry_groups
+
+        verdicts = self._verdict_cache.setdefault(key, {})
+        for entries in entry_groups:
+            computed = ComputedVulnInfo(comp_build, entries)
+            cve_id = str(computed.identifier)
+            status = verdicts.get(cve_id)
+            if status is None:
+                status = self._vex_status_str(computed)
+                verdicts[cve_id] = status
+            yield computed, status
+
+
+def get_engine() -> SccEngine:
+    """Return the process-wide indexed engine, building it on first use."""
+    global _ENGINE
+    if _ENGINE is not None:
+        return _ENGINE
+    with _ENGINE_LOCK:
+        if _ENGINE is None:
+            depth_env = os.getenv("SCC_GIT_FETCH_DEPTH")
+            try:
+                fetch_depth = int(depth_env) if depth_env else 1
+            except ValueError:
+                fetch_depth = 1
+            _ENGINE = SccEngine(
+                databases_dir=_databases_dir(),
+                fetch_depth=fetch_depth,
+                auto_update=_truthy(os.getenv("SCC_AUTO_UPDATE")),
+            )
+    return _ENGINE
+
+
+def reset_engine() -> None:
+    """Drop the cached engine (used by tests to force a rebuild)."""
+    global _ENGINE
+    with _ENGINE_LOCK:
+        _ENGINE = None

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -20,11 +20,17 @@ if [ -f "$CONFIG_FILE" ]; then
     . "$CONFIG_FILE"
 fi
 
-# The launcher always mounts the host sbom-cve-check databases at /sbom_cve_check_databases.
-# Default SBOM_CVE_CHECK_DATABASES_DIR to that mount point so the engine finds them
-# without requiring an explicit env var; config.env (sourced above) may
-# still override this.
-export SBOM_CVE_CHECK_DATABASES_DIR="${SBOM_CVE_CHECK_DATABASES_DIR:-/sbom_cve_check_databases}"
+# The sbom-cve-check advisory databases live inside the VulnScout cache directory
+# (mounted at /cache/vulnscout), in a sbom_cve_check_databases sub-folder next to
+# vulnscout.db.  Default SBOM_CVE_CHECK_DATABASES_DIR to that location so the engine
+# finds (and, with SBOM_CVE_CHECK_AUTO_UPDATE=1, clones) them without an explicit env
+# var; config.env (sourced above) or an explicit override may still change this.
+export SBOM_CVE_CHECK_DATABASES_DIR="${SBOM_CVE_CHECK_DATABASES_DIR:-/cache/vulnscout/sbom_cve_check_databases}"
+mkdir -p "$SBOM_CVE_CHECK_DATABASES_DIR" 2>/dev/null || true
+# Auto-update is on by default: the engine will clone/fetch the NVD-FKIE and CVEList
+# databases on first use and keep them current.  Set SBOM_CVE_CHECK_AUTO_UPDATE=0 to
+# run in offline mode against an already-cloned database.
+export SBOM_CVE_CHECK_AUTO_UPDATE="${SBOM_CVE_CHECK_AUTO_UPDATE:-1}"
 
 show_help() {
     cat <<EOF

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -20,11 +20,11 @@ if [ -f "$CONFIG_FILE" ]; then
     . "$CONFIG_FILE"
 fi
 
-# The launcher always mounts the host SCC databases at /scc_databases.
-# Default SCC_DATABASES_DIR to that mount point so the engine finds them
+# The launcher always mounts the host sbom-cve-check databases at /sbom_cve_check_databases.
+# Default SBOM_CVE_CHECK_DATABASES_DIR to that mount point so the engine finds them
 # without requiring an explicit env var; config.env (sourced above) may
 # still override this.
-export SCC_DATABASES_DIR="${SCC_DATABASES_DIR:-/scc_databases}"
+export SBOM_CVE_CHECK_DATABASES_DIR="${SBOM_CVE_CHECK_DATABASES_DIR:-/sbom_cve_check_databases}"
 
 show_help() {
     cat <<EOF
@@ -44,7 +44,7 @@ Input commands:
   --perform-grype-scan      Perform a Grype scan on the added inputs
   --perform-nvd-scan        Run an NVD CPE-based vulnerability scan
   --perform-osv-scan        Run an OSV PURL-based vulnerability scan
-  --perform-scc-scan        Run a local sbom-cve-check vulnerability scan
+  --perform-sbom-cve-check-scan  Run a sbom-cve-check vulnerability scan
 
 Scan & output commands:
   --serve                   Run scan then start interactive web UI (port 7275)
@@ -311,7 +311,7 @@ cmd_scan() {
     local _cmd_scan_exit=0
     [[ -n "${MATCH_CONDITION:-}" ]]       && has_condition=true
 
-    if [[ "$has_inputs" == "true" ]] || [[ "$has_condition" == "true" ]] || [[ "${GRYPE_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${NVD_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${OSV_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${SCC_SCAN_REQUESTED:-false}" == "true" ]]; then
+    if [[ "$has_inputs" == "true" ]] || [[ "$has_condition" == "true" ]] || [[ "${GRYPE_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${NVD_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${OSV_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${SBOM_CVE_CHECK_SCAN_REQUESTED:-false}" == "true" ]]; then
         if [[ "$has_inputs" == "true" ]]; then
             if [[ "${INTERACTIVE_MODE}" == "true" ]]; then
                 set_status "1" "Merging inputs and processing vulnerabilities"
@@ -357,10 +357,10 @@ cmd_scan() {
                 --project "$PROJECT_NAME" --variant "$VARIANT_NAME")
         fi
 
-        # If an SCC scan was requested, run it synchronously via the flask CLI.
-        if [[ "${SCC_SCAN_REQUESTED:-false}" == "true" ]]; then
+        # If an sbom-cve-check scan was requested, run it synchronously via the flask CLI.
+        if [[ "${SBOM_CVE_CHECK_SCAN_REQUESTED:-false}" == "true" ]]; then
             echo "Running sbom-cve-check scan for project '$PROJECT_NAME' variant '$VARIANT_NAME'..."
-            (cd "$BASE_DIR" && flask --app src.bin.webapp scc-scan \
+            (cd "$BASE_DIR" && flask --app src.bin.webapp sbom-cve-check-scan \
                 --project "$PROJECT_NAME" --variant "$VARIANT_NAME")
         fi
 
@@ -562,7 +562,7 @@ SERVE_REQUESTED=false
 GRYPE_SCAN_REQUESTED=false
 NVD_SCAN_REQUESTED=false
 OSV_SCAN_REQUESTED=false
-SCC_SCAN_REQUESTED=false
+SBOM_CVE_CHECK_SCAN_REQUESTED=false
 REPORT_TEMPLATES=()
 EXPORT_FORMATS=()
 SCAN_REQUIRED=false
@@ -661,8 +661,8 @@ while [[ $# -gt 0 ]]; do
             NVD_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --perform-osv-scan)
             OSV_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
-        --perform-scc-scan)
-            SCC_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
+        --perform-sbom-cve-check-scan)
+            SBOM_CVE_CHECK_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --clear-inputs)
             cmd_clear_inputs; shift ;;
         --delete-scan)

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -20,6 +20,12 @@ if [ -f "$CONFIG_FILE" ]; then
     . "$CONFIG_FILE"
 fi
 
+# The launcher always mounts the host SCC databases at /scc_databases.
+# Default SCC_DATABASES_DIR to that mount point so the engine finds them
+# without requiring an explicit env var; config.env (sourced above) may
+# still override this.
+export SCC_DATABASES_DIR="${SCC_DATABASES_DIR:-/scc_databases}"
+
 show_help() {
     cat <<EOF
 VulnScout Entrypoint
@@ -38,6 +44,7 @@ Input commands:
   --perform-grype-scan      Perform a Grype scan on the added inputs
   --perform-nvd-scan        Run an NVD CPE-based vulnerability scan
   --perform-osv-scan        Run an OSV PURL-based vulnerability scan
+  --perform-scc-scan        Run a local sbom-cve-check vulnerability scan
 
 Scan & output commands:
   --serve                   Run scan then start interactive web UI (port 7275)
@@ -304,7 +311,7 @@ cmd_scan() {
     local _cmd_scan_exit=0
     [[ -n "${MATCH_CONDITION:-}" ]]       && has_condition=true
 
-    if [[ "$has_inputs" == "true" ]] || [[ "$has_condition" == "true" ]] || [[ "${GRYPE_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${NVD_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${OSV_SCAN_REQUESTED:-false}" == "true" ]]; then
+    if [[ "$has_inputs" == "true" ]] || [[ "$has_condition" == "true" ]] || [[ "${GRYPE_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${NVD_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${OSV_SCAN_REQUESTED:-false}" == "true" ]] || [[ "${SCC_SCAN_REQUESTED:-false}" == "true" ]]; then
         if [[ "$has_inputs" == "true" ]]; then
             if [[ "${INTERACTIVE_MODE}" == "true" ]]; then
                 set_status "1" "Merging inputs and processing vulnerabilities"
@@ -347,6 +354,13 @@ cmd_scan() {
         if [[ "${OSV_SCAN_REQUESTED:-false}" == "true" ]]; then
             echo "Running OSV scan for project '$PROJECT_NAME' variant '$VARIANT_NAME'..."
             (cd "$BASE_DIR" && flask --app src.bin.webapp osv-scan \
+                --project "$PROJECT_NAME" --variant "$VARIANT_NAME")
+        fi
+
+        # If an SCC scan was requested, run it synchronously via the flask CLI.
+        if [[ "${SCC_SCAN_REQUESTED:-false}" == "true" ]]; then
+            echo "Running sbom-cve-check scan for project '$PROJECT_NAME' variant '$VARIANT_NAME'..."
+            (cd "$BASE_DIR" && flask --app src.bin.webapp scc-scan \
                 --project "$PROJECT_NAME" --variant "$VARIANT_NAME")
         fi
 
@@ -548,6 +562,7 @@ SERVE_REQUESTED=false
 GRYPE_SCAN_REQUESTED=false
 NVD_SCAN_REQUESTED=false
 OSV_SCAN_REQUESTED=false
+SCC_SCAN_REQUESTED=false
 REPORT_TEMPLATES=()
 EXPORT_FORMATS=()
 SCAN_REQUIRED=false
@@ -646,6 +661,8 @@ while [[ $# -gt 0 ]]; do
             NVD_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --perform-osv-scan)
             OSV_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
+        --perform-scc-scan)
+            SCC_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --clear-inputs)
             cmd_clear_inputs; shift ;;
         --delete-scan)

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -143,6 +143,34 @@ def setup_write_serialization(session_factory: object) -> None:
 
 
 @contextmanager
+def write_lock() -> Generator[None, None, None]:
+    """Hold the priority write lock for a block of manual/bulk writes.
+
+    The ``before_flush`` listener only serialises unit-of-work flushes; bulk
+    operations (``bulk_insert_mappings`` / ``executemany``) bypass it and would
+    otherwise collide with concurrent SQLite writers (enrichment threads,
+    request handlers).  Wrapping a bulk-insert-then-commit block in this context
+    manager serialises it the same way a normal flush would.
+
+    No-op when write serialisation is inactive (non-SQLite engines) or when the
+    current thread already holds the lock (reentrant).  The ``after_commit`` /
+    ``after_soft_rollback`` listeners release the lock at commit/rollback time;
+    the ``finally`` here is an idempotent safety net.
+    """
+    if not _write_serialization_initialized or getattr(_write_lock_state, "held", False):
+        yield
+        return
+    _db_write_lock.acquire()
+    _write_lock_state.held = True
+    try:
+        yield
+    finally:
+        if getattr(_write_lock_state, "held", False):
+            _write_lock_state.held = False
+            _db_write_lock.release()
+
+
+@contextmanager
 def batch_session() -> Generator[object, None, None]:
     """Context manager that defers all ``db.session.commit()`` calls to a single
     commit at the end of the block.  Inside the block every ``commit()`` is

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -728,33 +728,32 @@ def init_app(app: Flask) -> None:
         return scan_status_response(variant_id, _osv_scans_in_progress)
 
     # ------------------------------------------------------------------
-    # SCC (sbom-cve-check) Scan — local NVD-FKIE + CVEList with VEX
+    # sbom-cve-check Scan — local NVD-FKIE + CVEList with VEX
     # ------------------------------------------------------------------
 
-    _scc_scans_in_progress: dict = {}
+    _sbom_cve_check_scans_in_progress: dict = {}
 
-    @app.route('/api/variants/<variant_id>/scc-scan', methods=['POST'])
-    def trigger_scc_scan(variant_id):
+    @app.route('/api/variants/<variant_id>/sbom-cve-check-scan', methods=['POST'])
+    def trigger_sbom_cve_check_scan(variant_id):
         """Trigger a local CVE-database scan (NVD-FKIE + CVEList V5) for the given variant.
 
         Matches every active package against locally-cloned advisory databases,
         applies product-name aliasing and semantic version-range analysis, and
-        records each engine VEX verdict.  Works fully offline once the databases
-        are cloned.
+        records each engine VEX verdict.  Works once the databases are cloned.
         """
         variant_uuid, variant, err = validate_trigger(
-            variant_id, _scc_scans_in_progress, "sbom-cve-check scan")
+            variant_id, _sbom_cve_check_scans_in_progress, "sbom-cve-check scan")
         if err is not None:
             return err
 
         vid_str = str(variant_uuid)
-        init_progress(_scc_scans_in_progress, vid_str)
+        init_progress(_sbom_cve_check_scans_in_progress, vid_str)
 
-        def _run_scc_scan():
+        def _run_sbom_cve_check_scan():
             with app.app_context():
-                _do_scc_scan(vid_str, variant_uuid)
+                _do_sbom_cve_check_scan(vid_str, variant_uuid)
 
-        def _do_scc_scan(vid_str, variant_uuid):
+        def _do_sbom_cve_check_scan(vid_str, variant_uuid):
             try:
                 from ..controllers.scc_engine import get_engine
                 from ..bin.cmd_vuln_scan import (
@@ -762,17 +761,17 @@ def init_app(app: Flask) -> None:
                 )
 
                 # 1. Resolve active packages
-                _scc_scans_in_progress[vid_str]["logs"].append(
+                _sbom_cve_check_scans_in_progress[vid_str]["logs"].append(
                     "Resolving active packages…"
                 )
                 packages, pkg_err = resolve_active_packages(
-                    variant_uuid, _scc_scans_in_progress, vid_str)
+                    variant_uuid, _sbom_cve_check_scans_in_progress, vid_str)
                 if pkg_err:
                     return
 
                 total_pkgs = len(packages)
-                _scc_scans_in_progress[vid_str]["total"] = total_pkgs
-                _scc_scans_in_progress[vid_str]["logs"].append(
+                _sbom_cve_check_scans_in_progress[vid_str]["total"] = total_pkgs
+                _sbom_cve_check_scans_in_progress[vid_str]["logs"].append(
                     f"Resolved {total_pkgs} active packages"
                 )
 
@@ -791,7 +790,7 @@ def init_app(app: Flask) -> None:
                         self._logs.append(self.format(record))
 
                 _forwarder = _SccLogForwarder(
-                    _scc_scans_in_progress[vid_str]["logs"]
+                    _sbom_cve_check_scans_in_progress[vid_str]["logs"]
                 )
                 _forwarder.setFormatter(logging.Formatter("%(message)s"))
                 _scc_logger = logging.getLogger("sbom_cve_check")
@@ -799,12 +798,12 @@ def init_app(app: Flask) -> None:
                 try:
                     engine = get_engine()
                 except Exception as e:
-                    set_error(_scc_scans_in_progress, vid_str,
+                    set_error(_sbom_cve_check_scans_in_progress, vid_str,
                               f"Failed to load CVE databases: {str(e)[:300]}")
                     return
                 finally:
                     _scc_logger.removeHandler(_forwarder)
-                _scc_scans_in_progress[vid_str]["logs"].append(
+                _sbom_cve_check_scans_in_progress[vid_str]["logs"].append(
                     "Index ready — scanning packages"
                 )
 
@@ -821,7 +820,7 @@ def init_app(app: Flask) -> None:
                     pkg_label = (
                         f"{pkg.name}@{pkg.version}" if pkg.name else str(pkg.id)
                     )
-                    _scc_scans_in_progress[vid_str]["progress"] = (
+                    _sbom_cve_check_scans_in_progress[vid_str]["progress"] = (
                         f"{idx}/{total_pkgs} packages"
                     )
 
@@ -837,9 +836,9 @@ def init_app(app: Flask) -> None:
                             f"[{idx}/{total_pkgs}] ERROR "
                             f"{pkg_label}: {str(e)[:200]}"
                         )
-                        _scc_scans_in_progress[vid_str]["logs"].append(log_entry)
-                        _scc_scans_in_progress[vid_str]["done_count"] = idx
-                        print(f"[SCC Scan] Error scanning {pkg_label}: {e}", flush=True)
+                        _sbom_cve_check_scans_in_progress[vid_str]["logs"].append(log_entry)
+                        _sbom_cve_check_scans_in_progress[vid_str]["done_count"] = idx
+                        print(f"[sbom-cve-check Scan] Error scanning {pkg_label}: {e}", flush=True)
                         continue
 
                     if persisted_ids:
@@ -853,8 +852,8 @@ def init_app(app: Flask) -> None:
                         log_entry = (
                             f"[{idx}/{total_pkgs}] {pkg_label} → no vulnerabilities"
                         )
-                    _scc_scans_in_progress[vid_str]["logs"].append(log_entry)
-                    _scc_scans_in_progress[vid_str]["done_count"] = idx
+                    _sbom_cve_check_scans_in_progress[vid_str]["logs"].append(log_entry)
+                    _sbom_cve_check_scans_in_progress[vid_str]["done_count"] = idx
 
                     # Flush in large bulk-inserted chunks to bound transaction size.
                     writer.maybe_flush()
@@ -862,12 +861,12 @@ def init_app(app: Flask) -> None:
                 writer.flush()
                 cves_found = writer.cves_found
 
-                done_logs = _scc_scans_in_progress[vid_str].get("logs", [])
+                done_logs = _sbom_cve_check_scans_in_progress[vid_str].get("logs", [])
                 done_logs.append(
                     f"✓ Scan complete — found {len(cves_found)} "
                     f"unique vulnerabilities across {total_pkgs} packages"
                 )
-                _scc_scans_in_progress[vid_str] = {
+                _sbom_cve_check_scans_in_progress[vid_str] = {
                     "status": "done",
                     "error": None,
                     "progress": (
@@ -881,18 +880,18 @@ def init_app(app: Flask) -> None:
 
             except Exception as e:
                 db.session.rollback()
-                set_error(_scc_scans_in_progress, vid_str, str(e)[:500])
+                set_error(_sbom_cve_check_scans_in_progress, vid_str, str(e)[:500])
 
         thread = threading.Thread(
-            target=_run_scc_scan,
-            name=f"scc-scan-{vid_str}",
+            target=_run_sbom_cve_check_scan,
+            name=f"sbom-cve-check-scan-{vid_str}",
             daemon=True,
         )
         thread.start()
 
         return jsonify({"status": "started", "variant_id": vid_str}), 202
 
-    @app.route('/api/variants/<variant_id>/scc-scan/status')
-    def scc_scan_status(variant_id):
-        """Check the status of a running SCC scan for the given variant."""
-        return scan_status_response(variant_id, _scc_scans_in_progress)
+    @app.route('/api/variants/<variant_id>/sbom-cve-check-scan/status')
+    def sbom_cve_check_scan_status(variant_id):
+        """Check the status of a running sbom-cve-check scan for the given variant."""
+        return scan_status_response(variant_id, _sbom_cve_check_scans_in_progress)

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -734,7 +734,7 @@ def init_app(app: Flask) -> None:
     _sbom_cve_check_scans_in_progress: dict = {}
 
     @app.route('/api/variants/<variant_id>/sbom-cve-check-scan', methods=['POST'])
-    def trigger_sbom_cve_check_scan(variant_id):
+    def trigger_sbom_cve_check_scan(variant_id: str) -> ResponseReturnValue:
         """Trigger a local CVE-database scan (NVD-FKIE + CVEList V5) for the given variant.
 
         Matches every active package against locally-cloned advisory databases,
@@ -745,15 +745,17 @@ def init_app(app: Flask) -> None:
             variant_id, _sbom_cve_check_scans_in_progress, "sbom-cve-check scan")
         if err is not None:
             return err
+        if variant_uuid is None:
+            return jsonify({"error": "Internal error"}), 500
 
         vid_str = str(variant_uuid)
         init_progress(_sbom_cve_check_scans_in_progress, vid_str)
 
-        def _run_sbom_cve_check_scan():
+        def _run_sbom_cve_check_scan() -> None:
             with app.app_context():
                 _do_sbom_cve_check_scan(vid_str, variant_uuid)
 
-        def _do_sbom_cve_check_scan(vid_str, variant_uuid):
+        def _do_sbom_cve_check_scan(vid_str: str, variant_uuid: uuid.UUID) -> None:
             try:
                 from ..controllers.scc_engine import get_engine
                 from ..bin.cmd_vuln_scan import (
@@ -898,6 +900,6 @@ def init_app(app: Flask) -> None:
         return jsonify({"status": "started", "variant_id": vid_str}), 202
 
     @app.route('/api/variants/<variant_id>/sbom-cve-check-scan/status')
-    def sbom_cve_check_scan_status(variant_id):
+    def sbom_cve_check_scan_status(variant_id: str) -> ResponseReturnValue:
         """Check the status of a running sbom-cve-check scan for the given variant."""
         return scan_status_response(variant_id, _sbom_cve_check_scans_in_progress)

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -726,3 +726,173 @@ def init_app(app: Flask) -> None:
     def osv_scan_status(variant_id: str) -> ResponseReturnValue:
         """Check the status of a running OSV scan for the given variant."""
         return scan_status_response(variant_id, _osv_scans_in_progress)
+
+    # ------------------------------------------------------------------
+    # SCC (sbom-cve-check) Scan — local NVD-FKIE + CVEList with VEX
+    # ------------------------------------------------------------------
+
+    _scc_scans_in_progress: dict = {}
+
+    @app.route('/api/variants/<variant_id>/scc-scan', methods=['POST'])
+    def trigger_scc_scan(variant_id):
+        """Trigger a local CVE-database scan (NVD-FKIE + CVEList V5) for the given variant.
+
+        Matches every active package against locally-cloned advisory databases,
+        applies product-name aliasing and semantic version-range analysis, and
+        records each engine VEX verdict.  Works fully offline once the databases
+        are cloned.
+        """
+        variant_uuid, variant, err = validate_trigger(
+            variant_id, _scc_scans_in_progress, "sbom-cve-check scan")
+        if err is not None:
+            return err
+
+        vid_str = str(variant_uuid)
+        init_progress(_scc_scans_in_progress, vid_str)
+
+        def _run_scc_scan():
+            with app.app_context():
+                _do_scc_scan(vid_str, variant_uuid)
+
+        def _do_scc_scan(vid_str, variant_uuid):
+            try:
+                from ..controllers.scc_engine import get_engine
+                from ..bin.cmd_vuln_scan import (
+                    _SccBulkWriter,
+                )
+
+                # 1. Resolve active packages
+                _scc_scans_in_progress[vid_str]["logs"].append(
+                    "Resolving active packages…"
+                )
+                packages, pkg_err = resolve_active_packages(
+                    variant_uuid, _scc_scans_in_progress, vid_str)
+                if pkg_err:
+                    return
+
+                total_pkgs = len(packages)
+                _scc_scans_in_progress[vid_str]["total"] = total_pkgs
+                _scc_scans_in_progress[vid_str]["logs"].append(
+                    f"Resolved {total_pkgs} active packages"
+                )
+
+                # 2. Load (or reuse cached) engine index — expensive on first call.
+                # Forward sbom_cve_check library log records (git clone/fetch
+                # progress, indexing steps) directly into the scan log so the
+                # UI shows live progress instead of a frozen spinner.
+                import logging
+
+                class _SccLogForwarder(logging.Handler):
+                    def __init__(self, logs: list) -> None:
+                        super().__init__(logging.INFO)
+                        self._logs = logs
+
+                    def emit(self, record: logging.LogRecord) -> None:
+                        self._logs.append(self.format(record))
+
+                _forwarder = _SccLogForwarder(
+                    _scc_scans_in_progress[vid_str]["logs"]
+                )
+                _forwarder.setFormatter(logging.Formatter("%(message)s"))
+                _scc_logger = logging.getLogger("sbom_cve_check")
+                _scc_logger.addHandler(_forwarder)
+                try:
+                    engine = get_engine()
+                except Exception as e:
+                    set_error(_scc_scans_in_progress, vid_str,
+                              f"Failed to load CVE databases: {str(e)[:300]}")
+                    return
+                finally:
+                    _scc_logger.removeHandler(_forwarder)
+                _scc_scans_in_progress[vid_str]["logs"].append(
+                    "Index ready — scanning packages"
+                )
+
+                # 3. Create a tool scan
+                scan = Scan.create(
+                    description="empty description",
+                    variant_id=variant_uuid,
+                    scan_type="tool",
+                    scan_source="scc",
+                )
+                writer = _SccBulkWriter(scan.id, variant_uuid, packages)
+
+                for idx, pkg in enumerate(packages, 1):
+                    pkg_label = (
+                        f"{pkg.name}@{pkg.version}" if pkg.name else str(pkg.id)
+                    )
+                    _scc_scans_in_progress[vid_str]["progress"] = (
+                        f"{idx}/{total_pkgs} packages"
+                    )
+
+                    persisted_ids: list = []
+                    seen_keys: set = set()
+                    try:
+                        for computed, status in engine.applicable_vulns(pkg):
+                            cve_id = writer.add(pkg, computed, status, seen_keys)
+                            if cve_id is not None:
+                                persisted_ids.append(cve_id)
+                    except Exception as e:
+                        log_entry = (
+                            f"[{idx}/{total_pkgs}] ERROR "
+                            f"{pkg_label}: {str(e)[:200]}"
+                        )
+                        _scc_scans_in_progress[vid_str]["logs"].append(log_entry)
+                        _scc_scans_in_progress[vid_str]["done_count"] = idx
+                        print(f"[SCC Scan] Error scanning {pkg_label}: {e}", flush=True)
+                        continue
+
+                    if persisted_ids:
+                        ids_str = ', '.join(persisted_ids[:10])
+                        ellip = '…' if len(persisted_ids) > 10 else ''
+                        log_entry = (
+                            f"[{idx}/{total_pkgs}] {pkg_label} → "
+                            f"{len(persisted_ids)} vuln(s): {ids_str}{ellip}"
+                        )
+                    else:
+                        log_entry = (
+                            f"[{idx}/{total_pkgs}] {pkg_label} → no vulnerabilities"
+                        )
+                    _scc_scans_in_progress[vid_str]["logs"].append(log_entry)
+                    _scc_scans_in_progress[vid_str]["done_count"] = idx
+
+                    # Flush in large bulk-inserted chunks to bound transaction size.
+                    writer.maybe_flush()
+
+                writer.flush()
+                cves_found = writer.cves_found
+
+                done_logs = _scc_scans_in_progress[vid_str].get("logs", [])
+                done_logs.append(
+                    f"✓ Scan complete — found {len(cves_found)} "
+                    f"unique vulnerabilities across {total_pkgs} packages"
+                )
+                _scc_scans_in_progress[vid_str] = {
+                    "status": "done",
+                    "error": None,
+                    "progress": (
+                        f"Found {len(cves_found)} vulnerabilities "
+                        f"across {total_pkgs} packages"
+                    ),
+                    "logs": done_logs,
+                    "total": total_pkgs,
+                    "done_count": total_pkgs,
+                }
+
+            except Exception as e:
+                db.session.rollback()
+                set_error(_scc_scans_in_progress, vid_str, str(e)[:500])
+
+        thread = threading.Thread(
+            target=_run_scc_scan,
+            name=f"scc-scan-{vid_str}",
+            daemon=True,
+        )
+        thread.start()
+
+        return jsonify({"status": "started", "variant_id": vid_str}), 202
+
+    @app.route('/api/variants/<variant_id>/scc-scan/status')
+    def scc_scan_status(variant_id):
+        """Check the status of a running SCC scan for the given variant."""
+        return scan_status_response(variant_id, _scc_scans_in_progress)

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -795,6 +795,11 @@ def init_app(app: Flask) -> None:
                 _forwarder.setFormatter(logging.Formatter("%(message)s"))
                 _scc_logger = logging.getLogger("sbom_cve_check")
                 _scc_logger.addHandler(_forwarder)
+                _scc_prev_level = _scc_logger.level
+                _scc_logger.setLevel(logging.INFO)
+                _sbom_cve_check_scans_in_progress[vid_str]["logs"].append(
+                    "Loading CVE databases — this might take several minutes on first run…"
+                )
                 try:
                     engine = get_engine()
                 except Exception as e:
@@ -803,6 +808,7 @@ def init_app(app: Flask) -> None:
                     return
                 finally:
                     _scc_logger.removeHandler(_forwarder)
+                    _scc_logger.setLevel(_scc_prev_level)
                 _sbom_cve_check_scans_in_progress[vid_str]["logs"].append(
                     "Index ready — scanning packages"
                 )

--- a/tests/unit_tests/test_assessment_io.py
+++ b/tests/unit_tests/test_assessment_io.py
@@ -1,0 +1,427 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for assessment_io.py helper functions."""
+
+import io
+import json
+import os
+import tarfile
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src.helpers.assessment_io import (
+    is_openvex_doc,
+    sanitize_variant_name,
+    _get_vuln_info,
+    import_archive_bytes,
+    import_directory,
+    build_variant_by_name_map,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_openvex_doc() tests
+# ---------------------------------------------------------------------------
+
+class TestIsOpenvexDoc:
+    """Test is_openvex_doc validator."""
+
+    def test_valid_openvex_doc(self):
+        """GIVEN a valid OpenVEX document WHEN validated THEN return True."""
+        doc = {
+            "@context": "https://openvex.dev/ns/v0.2.0",
+            "statements": [],
+        }
+        assert is_openvex_doc(doc) is True
+
+    def test_openvex_doc_with_url_list(self):
+        """GIVEN a valid OpenVEX document with list context WHEN validated THEN return True."""
+        doc = {
+            "@context": ["https://openvex.dev/ns/v0.2.0"],
+            "statements": [],
+        }
+        assert is_openvex_doc(doc) is True
+
+    def test_non_dict_input(self):
+        """GIVEN a non-dict input WHEN validated THEN return False."""
+        assert is_openvex_doc("not a dict") is False
+        assert is_openvex_doc([]) is False
+        assert is_openvex_doc(None) is False
+        assert is_openvex_doc(42) is False
+
+    def test_missing_context(self):
+        """GIVEN a dict without @context WHEN validated THEN return False."""
+        doc = {"statements": []}
+        assert is_openvex_doc(doc) is False
+
+    def test_missing_statements(self):
+        """GIVEN a dict without statements key WHEN validated THEN return False."""
+        doc = {"@context": "https://openvex.dev/ns/v0.2.0"}
+        assert is_openvex_doc(doc) is False
+
+    def test_statements_not_list(self):
+        """GIVEN a doc with non-list statements WHEN validated THEN return False."""
+        doc = {
+            "@context": "https://openvex.dev/ns/v0.2.0",
+            "statements": "not a list",
+        }
+        assert is_openvex_doc(doc) is False
+
+    def test_context_without_openvex(self):
+        """GIVEN a doc with @context missing 'openvex' WHEN validated THEN return False."""
+        doc = {
+            "@context": "https://example.com/ns/v1.0",
+            "statements": [],
+        }
+        assert is_openvex_doc(doc) is False
+
+    def test_empty_context_string(self):
+        """GIVEN a doc with empty @context WHEN validated THEN return False."""
+        doc = {
+            "@context": "",
+            "statements": [],
+        }
+        assert is_openvex_doc(doc) is False
+
+
+# ---------------------------------------------------------------------------
+# sanitize_variant_name() tests
+# ---------------------------------------------------------------------------
+
+class TestSanitizeVariantName:
+    """Test sanitize_variant_name function."""
+
+    def test_forward_slash_replaced(self):
+        """GIVEN a name with forward slashes WHEN sanitized THEN slashes become underscores."""
+        assert sanitize_variant_name("my/variant") == "my_variant"
+        assert sanitize_variant_name("/root/path") == "_root_path"
+
+    def test_backslash_replaced(self):
+        """GIVEN a name with backslashes WHEN sanitized THEN backslashes become underscores."""
+        assert sanitize_variant_name("my\\variant") == "my_variant"
+        assert sanitize_variant_name("\\root\\path") == "_root_path"
+
+    def test_both_slashes_replaced(self):
+        """GIVEN a name with both forward and backslashes WHEN sanitized THEN both become underscores."""
+        assert sanitize_variant_name("my/variant\\name") == "my_variant_name"
+
+    def test_normal_name_unchanged(self):
+        """GIVEN a normal variant name WHEN sanitized THEN it remains unchanged."""
+        assert sanitize_variant_name("my-variant-1.0") == "my-variant-1.0"
+        assert sanitize_variant_name("variant_name") == "variant_name"
+        assert sanitize_variant_name("VariantName") == "VariantName"
+
+    def test_empty_string(self):
+        """GIVEN an empty string WHEN sanitized THEN it remains empty."""
+        assert sanitize_variant_name("") == ""
+
+    def test_only_slashes(self):
+        """GIVEN a string with only slashes WHEN sanitized THEN all become underscores."""
+        assert sanitize_variant_name("/") == "_"
+        assert sanitize_variant_name("\\") == "_"
+        assert sanitize_variant_name("///") == "___"
+
+
+# ---------------------------------------------------------------------------
+# _get_vuln_info() tests
+# ---------------------------------------------------------------------------
+
+class TestGetVulnInfo:
+    """Test _get_vuln_info helper."""
+
+    def test_vuln_not_in_cache(self):
+        """GIVEN a vuln_id not in cache WHEN fetched THEN db is queried and cache updated."""
+        cache = {}
+        
+        # Mock the Vulnerability model
+        mock_vuln = mock.MagicMock()
+        mock_vuln.description = "Test CVE description"
+        mock_vuln.aliases = ["ALIAS-1", "ALIAS-2"]
+        mock_vuln.urls = ["https://example.com/cve"]
+        mock_vuln.links = None
+        
+        with mock.patch(
+            "src.models.vulnerability.Vulnerability.get_by_id",
+            return_value=mock_vuln
+        ):
+            result = _get_vuln_info("CVE-2021-1234", cache)
+        
+        assert result["description"] == "Test CVE description"
+        assert result["aliases"] == ["ALIAS-1", "ALIAS-2"]
+        assert result["url"] == "https://example.com/cve"
+        assert "CVE-2021-1234" in cache
+
+    def test_vuln_not_found_cve(self):
+        """GIVEN a CVE that doesn't exist WHEN fetched THEN return empty strings."""
+        cache = {}
+        with mock.patch(
+            "src.models.vulnerability.Vulnerability.get_by_id",
+            return_value=None
+        ):
+            result = _get_vuln_info("CVE-2021-9999", cache)
+        
+        assert result["description"] == ""
+        assert result["aliases"] == []
+        assert result["url"] == ""
+
+    def test_vuln_not_found_ghsa(self):
+        """GIVEN a GHSA that doesn't exist WHEN fetched THEN return empty strings."""
+        cache = {}
+        with mock.patch(
+            "src.models.vulnerability.Vulnerability.get_by_id",
+            return_value=None
+        ):
+            result = _get_vuln_info("GHSA-xxxx-yyyy-zzzz", cache)
+        
+        assert result["description"] == ""
+        assert result["aliases"] == []
+        assert result["url"] == ""
+
+    def test_vuln_not_found_unknown_type(self):
+        """GIVEN an unknown vuln ID that doesn't exist WHEN fetched THEN no URL."""
+        cache = {}
+        with mock.patch(
+            "src.models.vulnerability.Vulnerability.get_by_id",
+            return_value=None
+        ):
+            result = _get_vuln_info("UNKNOWN-2021-1234", cache)
+        
+        assert result["description"] == ""
+        assert result["aliases"] == []
+        assert result["url"] == ""
+
+    def test_vuln_with_links_fallback(self):
+        """GIVEN a vuln with links instead of urls WHEN fetched THEN use links."""
+        cache = {}
+        
+        mock_vuln = mock.MagicMock()
+        mock_vuln.description = "Test vulnerability"
+        mock_vuln.aliases = None
+        mock_vuln.urls = None
+        mock_vuln.links = ["https://example.com/link"]
+        
+        with mock.patch(
+            "src.models.vulnerability.Vulnerability.get_by_id",
+            return_value=mock_vuln
+        ):
+            result = _get_vuln_info("CVE-2021-1234", cache)
+        
+        assert result["url"] == "https://example.com/link"
+        assert result["aliases"] == []
+
+    def test_vuln_cached_on_second_call(self):
+        """GIVEN a cached vuln WHEN fetched again THEN db is not queried."""
+        with mock.patch(
+            "src.models.vulnerability.Vulnerability.get_by_id",
+            return_value=None
+        ) as mock_get:
+            cache = {"CVE-2021-1234": None}
+            result = _get_vuln_info("CVE-2021-1234", cache)
+        
+            # Should not call get_by_id since it's in cache
+            mock_get.assert_not_called()
+            assert result["url"] == ""
+
+
+# ---------------------------------------------------------------------------
+# import_archive_bytes() tests
+# ---------------------------------------------------------------------------
+
+class TestImportArchiveBytes:
+    """Test import_archive_bytes function."""
+
+    def test_invalid_tar_gz_bytes(self):
+        """GIVEN invalid tar.gz bytes WHEN imported THEN raise ValueError."""
+        invalid_bytes = b"this is not a tar file"
+        variant_by_name = {}
+        
+        with pytest.raises(ValueError, match="Unable to open tar.gz archive"):
+            import_archive_bytes(invalid_bytes, variant_by_name)
+
+    def test_tar_with_no_json_files(self):
+        """GIVEN a tar.gz with no JSON files WHEN imported THEN skip them."""
+        # Create a tar archive with non-JSON files
+        tar_buffer = io.BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode='w:gz') as tar:
+            # Add non-JSON files
+            info = tarfile.TarInfo(name="readme.txt")
+            info.size = 5
+            tar.addfile(info, io.BytesIO(b"hello"))
+        
+        variant_by_name = {}
+        created, errors, skipped, variant_files_found = import_archive_bytes(
+            tar_buffer.getvalue(),
+            variant_by_name
+        )
+        
+        assert variant_files_found == 0
+        assert created == []
+        assert errors == []
+
+    def test_tar_with_missing_variant(self):
+        """GIVEN a tar with JSON for unknown variant WHEN imported THEN add error."""
+        tar_buffer = io.BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode='w:gz') as tar:
+            doc = {"@context": "https://openvex.dev/ns/v0.2.0", "statements": []}
+            json_bytes = json.dumps(doc).encode()
+            info = tarfile.TarInfo(name="unknown_variant.json")
+            info.size = len(json_bytes)
+            tar.addfile(info, io.BytesIO(json_bytes))
+        
+        variant_by_name = {}
+        created, errors, skipped, variant_files_found = import_archive_bytes(
+            tar_buffer.getvalue(),
+            variant_by_name
+        )
+        
+        assert variant_files_found == 0
+        assert len(errors) == 1
+        assert "No variant found" in errors[0]["error"]
+
+    def test_tar_with_directory_member(self):
+        """GIVEN a tar with directory entries WHEN imported THEN skip them."""
+        tar_buffer = io.BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode='w:gz') as tar:
+            # Add a directory
+            info = tarfile.TarInfo(name="subdir/")
+            info.type = tarfile.DIRTYPE
+            tar.addfile(info)
+        
+        variant_by_name = {}
+        created, errors, skipped, variant_files_found = import_archive_bytes(
+            tar_buffer.getvalue(),
+            variant_by_name
+        )
+        
+        assert variant_files_found == 0
+
+
+# ---------------------------------------------------------------------------
+# import_directory() tests
+# ---------------------------------------------------------------------------
+
+class TestImportDirectory:
+    """Test import_directory function."""
+
+    def test_empty_directory(self):
+        """GIVEN a directory with no JSON files WHEN imported THEN raise ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            variant_by_name = {}
+            
+            with pytest.raises(ValueError, match="No .json files found"):
+                import_directory(tmpdir, variant_by_name)
+
+    def test_directory_with_non_json_files(self):
+        """GIVEN a directory with only non-JSON files WHEN imported THEN raise ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a non-JSON file
+            with open(os.path.join(tmpdir, "readme.txt"), "w") as f:
+                f.write("hello")
+            
+            variant_by_name = {}
+            
+            with pytest.raises(ValueError, match="No .json files found"):
+                import_directory(tmpdir, variant_by_name)
+
+    def test_directory_with_unknown_variant(self):
+        """GIVEN a directory with JSON for unknown variant WHEN imported THEN add error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a valid JSON file
+            doc = {"@context": "https://openvex.dev/ns/v0.2.0", "statements": []}
+            json_path = os.path.join(tmpdir, "unknown_variant.json")
+            with open(json_path, "w") as f:
+                json.dump(doc, f)
+            
+            variant_by_name = {}
+            created, errors, skipped, variant_files_found = import_directory(
+                tmpdir,
+                variant_by_name
+            )
+            
+            assert variant_files_found == 0
+            assert len(errors) == 1
+            assert "No variant found" in errors[0]["error"]
+
+    def test_directory_sorted_by_filename(self):
+        """GIVEN a directory with multiple JSON files WHEN imported THEN files are processed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create multiple JSON files with different names
+            for name in ["zebra.json", "apple.json", "monkey.json"]:
+                doc = {"@context": "https://openvex.dev/ns/v0.2.0", "statements": []}
+                json_path = os.path.join(tmpdir, name)
+                with open(json_path, "w") as f:
+                    json.dump(doc, f)
+            
+            variant_by_name = {}
+            
+            # All 3 files should produce errors for missing variants
+            created, errors, skipped, variant_files_found = import_directory(
+                tmpdir,
+                variant_by_name
+            )
+            
+            # All 3 files should produce errors for missing variants
+            assert len(errors) == 3
+
+
+# ---------------------------------------------------------------------------
+# build_variant_by_name_map() tests
+# ---------------------------------------------------------------------------
+
+class TestBuildVariantByNameMap:
+    """Test build_variant_by_name_map function."""
+
+    def test_returns_dict(self):
+        """GIVEN a project_id WHEN building map THEN return dict."""
+        mock_variant = mock.MagicMock()
+        mock_variant.name = "test-variant"
+        mock_variant.id = "test-id"
+        
+        with mock.patch(
+            "src.models.variant.Variant.get_by_project",
+            return_value=[mock_variant]
+        ):
+            import uuid
+            project_id = uuid.uuid4()
+            result = build_variant_by_name_map(project_id)
+        
+        assert isinstance(result, dict)
+        assert "test-variant" in result
+
+    def test_includes_sanitized_name(self):
+        """GIVEN a variant with special characters WHEN building map THEN include both names."""
+        mock_variant = mock.MagicMock()
+        mock_variant.name = "my/variant"
+        mock_variant.id = "test-id"
+        
+        with mock.patch(
+            "src.models.variant.Variant.get_by_project",
+            return_value=[mock_variant]
+        ):
+            import uuid
+            project_id = uuid.uuid4()
+            result = build_variant_by_name_map(project_id)
+        
+        # Should have both the original and sanitized names
+        assert "my/variant" in result
+        assert "my_variant" in result
+
+    def test_all_variants_when_no_project_id(self):
+        """GIVEN no project_id WHEN building map THEN fetch all variants."""
+        mock_variant = mock.MagicMock()
+        mock_variant.name = "global-variant"
+        mock_variant.id = "test-id"
+        
+        with mock.patch(
+            "src.models.variant.Variant.get_all",
+            return_value=[mock_variant]
+        ):
+            result = build_variant_by_name_map(None)
+        
+        assert "global-variant" in result

--- a/tests/unit_tests/test_coverage_supplement.py
+++ b/tests/unit_tests/test_coverage_supplement.py
@@ -218,67 +218,350 @@ class TestEpssProgressTrackerError:
 
 
 # ===========================================================================
-# SBOMObservation — __repr__ (line 39) and create with commit=True (line 67)
+# _common.py — error branches (lines 33-34, 68-69, 73-74)
+# ===========================================================================
+
+class TestCommonHelperErrors:
+    """Cover the SystemExit error branches in _common.py."""
+
+    def test_resolve_project_not_found_exits(self, app):
+        with app.app_context():
+            from src.bin._common import resolve_project
+            with pytest.raises(SystemExit):
+                resolve_project("NoSuchProject_XYZ")
+
+    def test_resolve_project_found_returns_object(self, app):
+        from src.models.project import Project
+        with app.app_context():
+            Project.create("ResolveProjectOK")
+            from src.bin._common import resolve_project
+            result = resolve_project("ResolveProjectOK")
+            assert result is not None
+
+    def test_resolve_project_variant_project_not_found_exits(self, app):
+        with app.app_context():
+            from src.bin._common import resolve_project_variant
+            with pytest.raises(SystemExit):
+                resolve_project_variant("NoSuchProject_XYZ", "default", create=False)
+
+    def test_resolve_project_variant_variant_not_found_exits(self, app):
+        from src.models.project import Project
+        with app.app_context():
+            project = Project.create("VariantMissingProject")
+            from src.bin._common import resolve_project_variant
+            with pytest.raises(SystemExit):
+                resolve_project_variant("VariantMissingProject", "no-such-variant", create=False)
+
+    def test_resolve_project_variant_create_true(self, app):
+        """create=True path (lines 63-64) — creates missing project and variant."""
+        with app.app_context():
+            from src.bin._common import resolve_project_variant
+            proj, var = resolve_project_variant("AutoCreatedProj", "AutoVar", create=True)
+            assert proj is not None
+            assert var is not None
+
+    def test_resolve_project_variant_existing(self, app):
+        """Successful non-create path returns existing objects (lines 75-77)."""
+        from src.models.project import Project
+        from src.models.variant import Variant
+        with app.app_context():
+            project = Project.create("ExistingResolveProj")
+            Variant.create("ExistingResolveVar", project.id)
+            from src.bin._common import resolve_project_variant
+            proj, var = resolve_project_variant("ExistingResolveProj", "ExistingResolveVar", create=False)
+            assert proj.name == "ExistingResolveProj"
+            assert var.name == "ExistingResolveVar"
+
+
+# ===========================================================================
+# cmd_export.py — scope resolution warning branches (lines 45-58)
+# ===========================================================================
+
+class TestCmdExportScopeBranches:
+    """Cover the project/variant warning branches in export_command."""
+
+    def test_export_project_not_found_warns(self, app, tmp_path):
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "export", "--format", "spdx2", "--output-dir", str(tmp_path),
+            "--project", "NonExistentProject_XYZ",
+        ])
+        assert result.exit_code == 0
+        assert "not found" in result.output
+
+    def test_export_variant_not_found_warns_and_uses_project_scope(self, app, tmp_path):
+        from src.models.project import Project
+        from src.models.variant import Variant
+        with app.app_context():
+            project = Project.create("ExportScopeProj")
+            variant = Variant.create("ExportScopeVar", project.id)
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "export", "--format", "spdx2", "--output-dir", str(tmp_path),
+            "--project", "ExportScopeProj",
+            "--variant", "NonExistentVariant_XYZ",
+        ])
+        assert result.exit_code == 0
+        assert "not found" in result.output
+
+    def test_export_with_project_and_variant_scoped(self, app, tmp_path):
+        from src.models.project import Project
+        from src.models.variant import Variant
+        with app.app_context():
+            project = Project.create("ExportScopeProjV")
+            variant = Variant.create("ExportScopeVarV", project.id)
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "export", "--format", "spdx2", "--output-dir", str(tmp_path),
+            "--project", "ExportScopeProjV",
+            "--variant", "ExportScopeVarV",
+        ])
+        assert result.exit_code == 0
+
+    def test_export_with_project_only_uses_project_scope(self, app, tmp_path):
+        from src.models.project import Project
+        from src.models.variant import Variant
+        with app.app_context():
+            project = Project.create("ExportScopeProjOnly")
+            variant = Variant.create("ExportScopeVarOnly", project.id)
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "export", "--format", "spdx2", "--output-dir", str(tmp_path),
+            "--project", "ExportScopeProjOnly",
+        ])
+        assert result.exit_code == 0
+
+
+# ===========================================================================
+# merger_ci.py — main() and __name__ == "__main__" (lines 66, 70)
+# ===========================================================================
+
+class TestMergerCiMain:
+    """Cover the main() function in merger_ci.py."""
+
+    def test_main_calls_run_main(self, app):
+        from unittest.mock import patch, MagicMock
+        fake_cache = MagicMock()
+        with app.app_context():
+            with patch("src.bin.merger_ci._run_main", return_value=fake_cache) as mock_run:
+                from src.bin.merger_ci import main
+                result = main()
+        mock_run.assert_called_once()
+        assert result is fake_cache
+
+
+# ===========================================================================
+# grype_vulns.py — _normalize_artifact_name fallback & description warning
+# ===========================================================================
+
+class TestGrypeVulnsNormalize:
+    """Cover uncovered branches in GrypeVulns static helpers."""
+
+    def test_normalize_name_with_slash_no_purl_returns_last_segment(self):
+        """Lines 68-72: fallback path when name has '/' and purl is absent."""
+        from src.views.grype_vulns import GrypeVulns
+        result = GrypeVulns._normalize_artifact_name("openssl/openssl-foo")
+        assert result == "openssl-foo"
+
+    def test_normalize_name_with_slash_purl_empty_falls_through(self):
+        """Lines 68-72: purl present but yields empty purl_name → fallback."""
+        from src.views.grype_vulns import GrypeVulns
+        # A purl where path_part after stripping ends up empty forces fallback
+        result = GrypeVulns._normalize_artifact_name("namespace/pkg-name", purl=None)
+        assert result == "pkg-name"
+
+    def test_parse_vulnerability_non_string_description_warns(self, app):
+        """Line 140: description present but not a string triggers logger.warning."""
+        from src.controllers.cache import ControllersCache
+        from src.views.grype_vulns import GrypeVulns
+        with app.app_context():
+            cache = ControllersCache()
+            g = GrypeVulns(cache)
+            vuln = g.parse_vulnerability_section({
+                "id": "CVE-2023-9999",
+                "severity": "HIGH",
+                "description": 99,   # not a str, not None → line 140
+                "urls": [],
+                "cvss": [],
+                "fix": {},
+                "relatedVulnerabilities": [],
+            })
+        assert vuln is not None
+        assert vuln.description is None  # non-string desc is skipped, remains None
+
+
+# ===========================================================================
+# SBOMObservation — __repr__ and commit=False path
 # ===========================================================================
 
 class TestSBOMObservation:
     def test_repr(self, app):
-        """Call repr() on a bare SBOMObservation instance — covers __repr__ body."""
-        from src.models.sbom_observation import SBOMObservation
-        obs = SBOMObservation(
-            vulnerability_id="CVE-9999-REPR",
-            sbom_document_id=uuid.uuid4(),
-            key="test-key",
-            description="test-desc",
-        )
-        r = repr(obs)
-        assert "SBOMObservation" in r
-        assert "CVE-9999-REPR" in r
-
-    def test_create_commit_true(self, app, db_vuln):
-        """Call SBOMObservation.create() with default commit=True — covers db.session.commit() branch."""
-        from src.models.sbom_observation import SBOMObservation
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
         from src.models.sbom_document import SBOMDocument
+        from src.models.vulnerability import Vulnerability
+        from src.models.sbom_observation import SBOMObservation
+        with app.app_context():
+            proj = Project.create("obs-repr-proj")
+            var = Variant.create("main", proj.id)
+            scan = Scan.create("obs-repr-scan", var.id)
+            doc = SBOMDocument.create("/obs/test.spdx", "src", scan.id)
+            vuln = Vulnerability.create_record("CVE-2099-OBS1")
+            obs = SBOMObservation.create(vuln.id, doc.id, "yocto description", "some text")
+            r = repr(obs)
+            assert "SBOMObservation" in r
 
-        proj = Project.create("obs-create-proj")
-        variant = Variant.create("main", proj.id)
-        scan = Scan.create("obs-create-scan", variant.id)
-        doc = SBOMDocument.create("/obs/create.spdx", "test-source", scan.id)
-        obs = SBOMObservation.create(
-            vulnerability_id=db_vuln.id,
-            sbom_document_id=doc.id,
-            key="cve-check",
-            description="test description",
-        )
-        assert obs.id is not None
-        assert obs.vulnerability_id == db_vuln.id
+    def test_create_commit_false(self, app):
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.sbom_document import SBOMDocument
+        from src.models.vulnerability import Vulnerability
+        from src.models.sbom_observation import SBOMObservation
+        from src.extensions import db
+        with app.app_context():
+            proj = Project.create("obs-flush-proj")
+            var = Variant.create("main", proj.id)
+            scan = Scan.create("obs-flush-scan", var.id)
+            doc = SBOMDocument.create("/obs/flush.spdx", "src", scan.id)
+            vuln = Vulnerability.create_record("CVE-2099-OBS2")
+            obs = SBOMObservation.create(vuln.id, doc.id, "key", "desc", commit=False)
+            db.session.commit()
+            assert obs.id is not None
 
 
 # ===========================================================================
-# SBOMDocument — get_by_path (lines 63-66)
+# SBOMDocument.get_by_path — None return when no match / result when match
 # ===========================================================================
 
 class TestSBOMDocumentGetByPath:
-    def test_get_by_path_existing(self, app):
-        """get_by_path returns the most-recently-created document for a given path."""
+    def test_get_by_path_returns_none_when_not_found(self, app):
         from src.models.sbom_document import SBOMDocument
+        with app.app_context():
+            result = SBOMDocument.get_by_path("/nonexistent/path.spdx")
+            assert result is None
+
+    def test_get_by_path_returns_document_when_found(self, app):
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
-
-        proj = Project.create("doc-path-proj")
-        variant = Variant.create("main", proj.id)
-        scan = Scan.create("doc-path-scan", variant.id)
-        doc = SBOMDocument.create("/unique/path/test.spdx", "src", scan.id)
-        found = SBOMDocument.get_by_path("/unique/path/test.spdx")
-        assert found is not None
-        assert found.id == doc.id
-
-    def test_get_by_path_missing(self, app):
-        """get_by_path returns None when no document matches the path."""
         from src.models.sbom_document import SBOMDocument
-        result = SBOMDocument.get_by_path("/nonexistent/path.spdx")
-        assert result is None
+        with app.app_context():
+            proj = Project.create("getbypath-proj")
+            var = Variant.create("main", proj.id)
+            scan = Scan.create("getbypath-scan", var.id)
+            doc = SBOMDocument.create("/sbom/found.spdx", "src", scan.id)
+            result = SBOMDocument.get_by_path("/sbom/found.spdx")
+            assert result is not None
+            assert result.id == doc.id
+
+
+# ===========================================================================
+# Assessment.add_package — Package instance path (lines 235-238)
+# ===========================================================================
+
+class TestAssessmentAddPackageInstance:
+    def test_add_package_with_package_instance(self, app, db_package):
+        from src.models.assessment import Assessment
+        with app.app_context():
+            dto = Assessment.new_dto("CVE-2099-ADDPKG")
+            result = dto.add_package(db_package)
+            assert result is True
+            assert db_package.string_id in dto.packages
+
+
+# ===========================================================================
+# Assessment.from_vuln_assessment — sets origin to "sbom" when not already set
+# ===========================================================================
+
+class TestAssessmentFromVulnAssessmentOrigin:
+    def test_sets_origin_to_sbom_on_update(self, app, db_package, db_vuln, db_finding):
+        from src.models.assessment import Assessment
+        with app.app_context():
+            # Create existing assessment with origin != "sbom"
+            existing = Assessment.create(
+                status="under_investigation",
+                finding_id=db_finding.id,
+            )
+            existing.origin = "scanner"
+            from src.extensions import db
+            db.session.flush()
+
+            dto = Assessment.new_dto(db_vuln.id, [db_package.string_id])
+            dto.id = existing.id
+            dto.set_status("affected")
+            updated = Assessment.from_vuln_assessment(dto, finding_id=db_finding.id)
+            assert updated.origin == "sbom"
+
+
+# ===========================================================================
+# vuln_helpers.apply_cvss — sets default origin when missing
+# ===========================================================================
+
+class TestApplyCvssDefaultOrigin:
+    def test_apply_cvss_sets_default_origin(self, app, db_vuln):
+        from src.helpers.vuln_helpers import validate_and_apply_cvss
+        with app.app_context():
+            cvss_dict = {
+                "base_score": 5.0,
+                "vector_string": "AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+                "version": "3.1",
+                "author": "scanner",
+                # "origin" intentionally absent → line 72: new_cvss["origin"] = "scanner"
+            }
+            result = validate_and_apply_cvss(cvss_dict, db_vuln.id, None)
+            assert result is None
+
+
+# ===========================================================================
+# Finding.get_or_create — race-condition except path (finding.py lines 139-141)
+# ===========================================================================
+
+class TestFindingGetOrCreateRace:
+    """Cover the except block in Finding.get_or_create.
+
+    The except branch is hit when a concurrent writer inserts the same
+    (package, vulnerability) row between our initial SELECT (which returned
+    None) and our own INSERT (which then collides on the UniqueConstraint).
+    We simulate this by patching get_by_package_and_vulnerability to return
+    None on the first call while the row already exists in the DB, so the
+    nested INSERT raises IntegrityError and the recovery re-query returns it.
+    """
+
+    def test_race_condition_except_path(self, app, db_package, db_vuln):
+        from unittest.mock import patch
+        from src.models.finding import Finding
+
+        # Row already in DB — the recovery SELECT will find it.
+        pre_existing = Finding.create(db_package.id, db_vuln.id)
+
+        call_count = [0]
+        original = Finding.get_by_package_and_vulnerability
+
+        def patched(pkg_id, vuln_id):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return None  # pretend the row is absent (race window)
+            return original(pkg_id, vuln_id)
+
+        with patch.object(Finding, "get_by_package_and_vulnerability", patched):
+            result = Finding.get_or_create(db_package.id, db_vuln.id)
+
+        assert result.id == pre_existing.id
+        assert call_count[0] == 2  # initial miss + recovery
+
+
+# ===========================================================================
+# Iso8601Duration.try_parse — unsupported-type path (line 210)
+# ===========================================================================
+
+class TestIso8601DurationTryParseUnsupported:
+    """Cover the ValueError branch in Iso8601Duration.try_parse."""
+
+    def test_try_parse_float_raises_value_error(self):
+        from src.models.iso8601_duration import Iso8601Duration
+
+        with pytest.raises(ValueError, match="Can only compare"):
+            Iso8601Duration.try_parse(3.14)
+

--- a/tests/unit_tests/test_coverage_supplement.py
+++ b/tests/unit_tests/test_coverage_supplement.py
@@ -565,3 +565,342 @@ class TestIso8601DurationTryParseUnsupported:
         with pytest.raises(ValueError, match="Can only compare"):
             Iso8601Duration.try_parse(3.14)
 
+
+# ===========================================================================
+# ControllersCache — unused cached_property accessors (cache.py lines 48, 52, 56, 72)
+# ===========================================================================
+
+class TestControllersCacheProperties:
+    """Access the four cached_property paths not exercised by any other test."""
+
+    def test_conditions_parser_property(self):
+        from src.controllers.cache import ControllersCache
+        cache = ControllersCache()
+        assert cache.conditions_parser is not None
+
+    def test_finding_property(self):
+        from src.controllers.cache import ControllersCache
+        cache = ControllersCache()
+        assert cache.finding is not None
+
+    def test_metrics_property(self):
+        from src.controllers.cache import ControllersCache
+        cache = ControllersCache()
+        assert cache.metrics is not None
+
+    def test_time_estimate_property(self):
+        from src.controllers.cache import ControllersCache
+        cache = ControllersCache()
+        assert cache.time_estimate is not None
+
+
+# ===========================================================================
+# normalize_timestamp_for_sort — all branches (datetime_utils.py lines 35, 37-40)
+# ===========================================================================
+
+class TestNormalizeTimestampForSort:
+
+    def test_none_returns_datetime_min(self):
+        from src.helpers.datetime_utils import normalize_timestamp_for_sort
+        from datetime import datetime, timezone
+        result = normalize_timestamp_for_sort(None)
+        assert result == datetime.min.replace(tzinfo=timezone.utc)
+
+    def test_valid_iso_string_is_parsed(self):
+        from src.helpers.datetime_utils import normalize_timestamp_for_sort
+        from datetime import datetime, timezone
+        result = normalize_timestamp_for_sort("2024-01-15T10:00:00+00:00")
+        assert result == datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+
+    def test_invalid_string_returns_datetime_min(self):
+        from src.helpers.datetime_utils import normalize_timestamp_for_sort
+        from datetime import datetime, timezone
+        result = normalize_timestamp_for_sort("not-a-date")
+        assert result == datetime.min.replace(tzinfo=timezone.utc)
+
+    def test_naive_datetime_gets_utc_attached(self):
+        from src.helpers.datetime_utils import normalize_timestamp_for_sort
+        from datetime import datetime, timezone
+        naive = datetime(2024, 6, 1, 12, 0, 0)
+        result = normalize_timestamp_for_sort(naive)
+        assert result.tzinfo == timezone.utc
+        assert result.year == 2024
+
+
+# ===========================================================================
+# ConditionParser.eval — dead-code None guard (conditions_parser.py line 136)
+# ===========================================================================
+
+class TestConditionParserNullParsed:
+    """Cover the ``if parsed is None`` guard by forcing parse_string to return None."""
+
+    def test_eval_raises_when_parsed_is_none(self):
+        from unittest.mock import MagicMock, patch
+        from src.controllers.conditions_parser import ConditionParser
+        cp = ConditionParser()
+        fake_result = MagicMock()
+        fake_result.asList.return_value = None
+        with patch.object(cp, "parse_string", return_value=fake_result):
+            with pytest.raises(ValueError, match="Failed to parse"):
+                cp.evaluate("anything", {})
+
+
+# ===========================================================================
+# apply_effort — exception branch (vuln_helpers.py lines 105-106)
+# ===========================================================================
+
+class TestApplyEffortExceptionBranch:
+    """Cover the except block in apply_effort by making findings raise."""
+
+    def test_exception_is_swallowed(self):
+        from src.helpers.vuln_helpers import apply_effort, Effort
+
+        class _BrokenRecord:
+            @property
+            def findings(self):
+                raise RuntimeError("db exploded")
+
+        effort = Effort(optimistic=1, likely=2, pessimistic=4)
+        # Must not raise — the except block swallows the error.
+        apply_effort(_BrokenRecord(), None, effort)
+
+
+# ===========================================================================
+# _scan_helpers.validate_trigger — internal-error 500 branch (line 67)
+# ===========================================================================
+
+class TestValidateTriggerInternalError:
+    """Cover the defensive ``variant_uuid is None`` branch (line 67).
+
+    ``parse_uuid_or_400`` never returns ``(None, None)`` in practice, so this
+    branch is dead code that requires a patch to reach.
+    """
+
+    def test_none_uuid_returns_500(self, app):
+        from unittest.mock import patch
+        with app.app_context():
+            from src.routes._scan_helpers import validate_trigger
+            with patch("src.routes._scan_helpers.parse_uuid_or_400", return_value=(None, None)):
+                _, _, err = validate_trigger("anything", {}, "test-scan")
+        assert err is not None
+        assert err[1] == 500
+
+
+# ===========================================================================
+# SBOMPackage.get_or_create — exception fallback path (lines 82-83)
+# ===========================================================================
+
+class TestSBOMPackageGetOrCreateException:
+    """Cover the except branch of get_or_create (race-condition recovery)."""
+
+    def test_create_exception_falls_back_to_get(self, app):
+        from unittest.mock import patch
+        from src.models.sbom_package import SBOMPackage
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.sbom_document import SBOMDocument
+        from src.models.package import Package
+
+        with app.app_context():
+            proj = Project.create("sbom-race-proj")
+            var = Variant.create("main", proj.id)
+            scan = Scan.create("race-scan", var.id)
+            doc = SBOMDocument.create("/race/test.spdx", "src", scan.id)
+            pkg = Package.create("race-lib", "1.0.0")
+
+            # Pre-create the association so the recovery get() finds it.
+            pre = SBOMPackage.create(doc.id, pkg.id)
+
+            # Patch SBOMPackage.create to simulate a concurrent-insert error.
+            with patch.object(SBOMPackage, "get", side_effect=[None, pre]):
+                with patch.object(SBOMPackage, "create", side_effect=Exception("unique constraint")):
+                    result = SBOMPackage.get_or_create(doc.id, pkg.id)
+
+            assert result.package_id == pkg.id
+
+
+# ===========================================================================
+# SPDX3.output_as_json — vuln-not-in-vuln_to_ref continue branch (line 183)
+# ===========================================================================
+
+class TestSpdx3VulnNotInRefContinue:
+    """Cover the ``continue`` on line 183 of spdx3.py.
+
+    The third loop in output_as_json skips a vulnerability when it has no
+    entry in vuln_to_ref.  This happens when the vulnerabilities dict returns
+    an extra entry in the third pass that was absent during the second pass.
+    """
+
+    def test_vuln_absent_from_vuln_to_ref_is_skipped(self):
+        from unittest.mock import MagicMock, PropertyMock
+        from src.views.spdx3 import SPDX3
+        from src.controllers import ControllersCache
+
+        ctrl = ControllersCache()
+        ctrl.packages = MagicMock()
+        ctrl.packages.__iter__ = MagicMock(return_value=iter([]))
+
+        # Loop 2 (building elements): sees nothing → vuln_to_ref stays empty.
+        # Loop 3 (building relationships): sees ghost vuln → hits the ``continue``.
+        ghost_vuln = MagicMock()
+        ghost_vuln.packages = []
+
+        call_count = [0]
+
+        def _items_side_effect():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return {}.items()  # second loop: empty
+            return {"CVE-GHOST-1": ghost_vuln}.items()  # third loop: ghost
+
+        mock_vulns = MagicMock()
+        mock_vulns.items.side_effect = _items_side_effect
+        ctrl.vulnerabilities = MagicMock()
+        type(ctrl.vulnerabilities).vulnerabilities = PropertyMock(return_value=mock_vulns)
+
+        view = SPDX3(ctrl)
+        output = view.output_as_json()
+        # Ghost vuln has no ref → continue executed; JSON still returns.
+        assert "@graph" in output
+
+
+# ===========================================================================
+# openvex.py line 118 — stmt["vulnerability"] is None → reset to {}
+# ===========================================================================
+
+class TestOpenVexVulnerabilityNullReset:
+    def test_vulnerability_none_resets_to_empty_dict(self):
+        """openvex.py line 118: when to_openvex_dict returns a dict with
+        vulnerability=None and the vuln lookup returns a vuln object, the
+        None value is replaced with {}."""
+        from unittest.mock import MagicMock
+        from src.views.openvex import OpenVex
+        from src.controllers import ControllersCache
+
+        fake_assess = MagicMock()
+        fake_assess.vuln_id = "CVE-2024-NULL"
+        fake_assess.to_openvex_dict.return_value = {
+            "vulnerability": None,
+            "status": "affected",
+        }
+        fake_assess.packages = []
+
+        fake_vuln = MagicMock()
+        fake_vuln.description = ""
+        fake_vuln.aliases = ["CVE-2024-NULL"]
+        fake_vuln.datasource = "nvd"
+        fake_vuln.found_by = []
+
+        ctrl = ControllersCache()
+        ctrl.packages = MagicMock()
+        ctrl.vulnerabilities = MagicMock()
+        ctrl.vulnerabilities.get = MagicMock(return_value=fake_vuln)
+        ctrl.assessments = MagicMock()
+        ctrl.assessments.get_all = MagicMock(return_value=[fake_assess])
+
+        view = OpenVex(ctrl)
+        result = view.to_dict()
+        stmt = result["statements"][0]
+        # After the reset, aliases should be set on the now-empty dict.
+        assert stmt["vulnerability"]["aliases"] == ["CVE-2024-NULL"]
+
+
+# ===========================================================================
+# fast_spdx3.py lines 491-493, 495 — dedup: compatible existing assessment
+# ===========================================================================
+
+class TestFastSpdx3DedupCompatibleAssessment:
+    def test_compatible_existing_skips_add(self):
+        """fast_spdx3.py lines 491-495: when a compatible existing assessment
+        is found for the (vuln, pkg) pair, add() is not called."""
+        from unittest.mock import MagicMock
+        from src.views.fast_spdx3 import FastSPDX3
+        from src.controllers import ControllersCache
+
+        ctrl = ControllersCache()
+        view = FastSPDX3(ctrl)
+
+        pkg_uri = "http://example.com/pkg/foo@1.0"
+        pkg_id = "foo@1.0"
+        view.uri_to_package[pkg_uri] = pkg_id
+
+        existing = MagicMock()
+        existing.is_compatible_status.return_value = True
+
+        view.assessmentsCtrl = MagicMock()
+        view.assessmentsCtrl.warm_packages = MagicMock()
+        view.assessmentsCtrl.gets_by_vuln_pkg = MagicMock(return_value=[existing])
+        view.assessmentsCtrl.add = MagicMock()
+
+        spdx_dict = {
+            "@graph": [
+                {
+                    "type": "security_VexAffectedVulnAssessmentRelationship",
+                    "from": "https://nvd.nist.gov/vuln/detail/CVE-2024-9999",
+                    "to": [pkg_uri],
+                    "relationshipType": "doesNotAffect",
+                }
+            ]
+        }
+        view.process_vex_relationships(spdx_dict)
+
+        existing.is_compatible_status.assert_called_once()
+        view.assessmentsCtrl.add.assert_not_called()
+
+
+# ===========================================================================
+# spdx.py line 87  — load_from_file: parse succeeds but returns falsy
+# spdx.py lines 103-104 — merge_components: supplier attribute access fails
+# ===========================================================================
+
+class TestSpdxLoadFromFileInvalidResult:
+    def test_falsy_parse_result_raises(self, tmp_path):
+        """spdx.py line 87: when parse_file returns None/falsy, raise
+        Exception('Invalid SPDX file')."""
+        from unittest.mock import patch
+        from src.views.spdx import SPDX
+        from src.controllers import ControllersCache
+
+        dummy = tmp_path / "dummy.spdx.json"
+        dummy.write_text("{}")
+
+        ctrl = ControllersCache()
+        view = SPDX(ctrl)
+
+        with patch("src.views.spdx.parse_file", return_value=None):
+            with pytest.raises(Exception, match="Invalid SPDX file"):
+                view.load_from_file(str(dummy))
+
+
+class TestSpdxMergeSupplierAccessError:
+    def test_supplier_attribute_error_calls_verbose(self):
+        """spdx.py lines 103-104: when accessing package.supplier raises,
+        the except block calls verbose and the package is still added."""
+        from unittest.mock import MagicMock, patch
+        from src.views.spdx import SPDX
+        from src.controllers import ControllersCache
+
+        bad_pkg = MagicMock()
+        bad_pkg.name = "bad-pkg"
+        bad_pkg.version = "1.0"
+        bad_pkg.supplier = MagicMock()
+        # Make isinstance check pass but attribute access fail
+        bad_pkg.supplier.__class__ = object  # not SpdxNoAssertion
+        type(bad_pkg.supplier).actor_type = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+        bad_pkg.license_declared = None
+        bad_pkg.external_references = []
+
+        doc = MagicMock()
+        doc.packages = [bad_pkg]
+
+        ctrl = ControllersCache()
+        view = SPDX(ctrl)
+        view.sbom = doc
+
+        with patch("src.views.spdx.verbose") as mock_verbose:
+            view.merge_components_into_controller()
+
+        mock_verbose.assert_called_once()
+        assert "bad-pkg" in mock_verbose.call_args[0][0]
+

--- a/tests/unit_tests/test_openvex_output.py
+++ b/tests/unit_tests/test_openvex_output.py
@@ -79,3 +79,35 @@ def test_openvex_empty_slug_uses_hash_fallback():
     at_id = result["statements"][0]["products"][0]["@id"]
     assert at_id != "pkg:generic/foo@1.0"   # must NOT collide with no-supplier case
     assert "supplier-" in at_id             # hash-based fallback
+
+
+def test_openvex_with_vuln_description_and_http_datasource():
+    """Line 118+: when vulnerabilitiesCtrl.get returns a vuln the description
+    and @id are embedded in the statement."""
+    pkg = _make_pkg("bar", "2.0")
+    assess = _make_assessment("CVE-2024-VD", pkg)
+
+    fake_vuln = MagicMock()
+    fake_vuln.description = "A serious flaw"
+    fake_vuln.aliases = ["CVE-2024-VD"]
+    fake_vuln.datasource = "https://nvd.nist.gov/vuln/detail/CVE-2024-VD"
+    fake_vuln.found_by = ["grype", "openvex"]
+
+    ctrl = ControllersCache()
+    ctrl.packages = MagicMock()
+    ctrl.packages.get = MagicMock(side_effect=lambda pid: next(
+        (p for p in [pkg] if p.string_id == pid), None
+    ))
+    ctrl.vulnerabilities = MagicMock()
+    ctrl.vulnerabilities.get = MagicMock(return_value=fake_vuln)
+    ctrl.assessments = MagicMock()
+    ctrl.assessments.get_all = MagicMock(return_value=[assess])
+
+    view = OpenVex(ctrl)
+    result = view.to_dict()
+    stmt = result["statements"][0]
+    assert stmt["vulnerability"]["description"] == "A serious flaw"
+    assert stmt["vulnerability"]["@id"] == "https://nvd.nist.gov/vuln/detail/CVE-2024-VD"
+    # strict_export=False → scanners key present, "openvex" filtered out
+    assert "grype" in stmt["scanners"]
+    assert "openvex" not in stmt["scanners"]

--- a/tests/unit_tests/test_scc_adapter.py
+++ b/tests/unit_tests/test_scc_adapter.py
@@ -1,0 +1,294 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for src/controllers/scc_adapter.py.
+
+All tests are pure in-process: they exercise the adapter helpers with real
+sbom_cve_check types but no database connection.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sbom_cve_check.vuln.comp_id import CompId
+
+from src.controllers.scc_adapter import (
+    _comp_ids_for_package,
+    VsComponent,
+    VsCompBuild,
+    build_comp_build,
+)
+
+
+# ---------------------------------------------------------------------------
+# _comp_ids_for_package
+# ---------------------------------------------------------------------------
+
+class TestCompIdsForPackage:
+
+    def test_empty_inputs_returns_name_only(self):
+        ids = _comp_ids_for_package("curl", "8.0", [], [])
+        assert CompId(name="curl") in ids
+
+    def test_valid_cpe_adds_comp_id(self):
+        ids = _comp_ids_for_package(
+            "openssl", "1.1.1",
+            ["cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"],
+            [],
+        )
+        # The CPE-derived CompId and the bare-name CompId must both be present.
+        assert CompId(name="openssl") in ids
+        # At least two identifiers: vendor-qualified + bare name.
+        assert len(ids) >= 2
+
+    def test_empty_cpe_string_skipped(self):
+        ids = _comp_ids_for_package("bash", "5.0", ["", "  "], [])
+        # Only the bare-name CompId from the empty/blank CPE strings.
+        assert CompId(name="bash") in ids
+        assert all(c.name == "bash" for c in ids)
+
+    def test_invalid_cpe_skipped_gracefully(self):
+        # build_from_cpe returns None for a bad CPE string; we verify no crash
+        # and only the bare-name identifier is present.
+        ids = _comp_ids_for_package("tool", "1.0", ["not-a-valid-cpe"], [])
+        assert CompId(name="tool") in ids
+
+    def test_build_from_cpe_exception_caught(self, monkeypatch):
+        """If CompId.build_from_cpe raises (e.g. internal error), the exception
+        is silently caught and the CPE is skipped."""
+        from sbom_cve_check.vuln.comp_id import CompId as RealCompId
+        monkeypatch.setattr(
+            RealCompId, "build_from_cpe",
+            staticmethod(lambda _cpe: (_ for _ in ()).throw(RuntimeError("forced error"))),
+        )
+        # Should not raise; the bare-name id is still added.
+        ids = _comp_ids_for_package("pkg", "1.0", ["cpe:2.3:a:a:b:1:*:*:*:*:*:*:*"], [])
+        assert CompId(name="pkg") in ids
+
+    def test_valid_purl_adds_name(self):
+        ids = _comp_ids_for_package(
+            "requests", "2.28.0",
+            [],
+            ["pkg:pypi/requests@2.28.0"],
+        )
+        assert CompId(name="requests") in ids
+
+    def test_empty_purl_skipped(self):
+        ids = _comp_ids_for_package("lib", "1.0", [], ["", "  "])
+        # Only the bare name.
+        assert all(c.name == "lib" for c in ids)
+
+    def test_invalid_purl_skipped_gracefully(self):
+        ids = _comp_ids_for_package("lib", "1.0", [], ["not-a-purl"])
+        assert CompId(name="lib") in ids
+
+    def test_purl_with_no_name_skipped(self):
+        # Craft a PURL whose parsed name is empty-string / None.
+        # We patch PackageURL.from_string to return an object with name="".
+        from unittest.mock import patch, MagicMock
+        fake_purl = MagicMock()
+        fake_purl.name = ""
+        with patch("src.controllers.scc_adapter.PackageURL.from_string", return_value=fake_purl):
+            ids = _comp_ids_for_package("mylib", "2.0", [], ["pkg:pypi/mylib@2.0"])
+        assert CompId(name="mylib") in ids
+        # No empty-name CompId was added.
+        assert not any(c.name == "" for c in ids)
+
+    def test_multiple_cpes_and_purls(self):
+        ids = _comp_ids_for_package(
+            "curl", "8.0",
+            [
+                "cpe:2.3:a:haxx:curl:8.0:*:*:*:*:*:*:*",
+                "cpe:2.3:a:curl:curl:8.0:*:*:*:*:*:*:*",
+            ],
+            ["pkg:pypi/curl@8.0", "pkg:npm/curl@8.0"],
+        )
+        assert CompId(name="curl") in ids
+        assert len(ids) >= 2
+
+    def test_empty_name_does_not_add_blank_id(self):
+        ids = _comp_ids_for_package("", "1.0", [], [])
+        # Empty string name: the `if name:` guard prevents adding a blank id.
+        assert len(ids) == 0
+
+
+# ---------------------------------------------------------------------------
+# VsComponent
+# ---------------------------------------------------------------------------
+
+class TestVsComponent:
+
+    def _make(self, name="curl", version="8.0", cpes=(), purls=()):
+        ids = {CompId(name=name)}
+        return VsComponent(name, version, ids, tuple(cpes), tuple(purls))
+
+    def test_name_property(self):
+        comp = self._make("openssl", "1.1.1")
+        assert comp.name == "openssl"
+
+    def test_version_property(self):
+        comp = self._make("curl", "8.0")
+        assert comp.version == "8.0"
+
+    def test_version_property_empty_returns_none(self):
+        comp = self._make("curl", "")
+        assert comp.version is None
+
+    def test_pkg_version_property(self):
+        comp = self._make("curl", "8.0")
+        assert comp.pkg_version == "8.0"
+
+    def test_pkg_version_empty_returns_none(self):
+        comp = self._make("curl", "")
+        assert comp.pkg_version is None
+
+    def test_supplier_is_none(self):
+        comp = self._make()
+        assert comp.supplier is None
+
+    def test_comp_type_is_none(self):
+        comp = self._make()
+        assert comp.comp_type is None
+
+    def test_identifiers_property(self):
+        ids = {CompId(name="openssl")}
+        comp = VsComponent("openssl", "1.0", ids, (), ())
+        assert comp.identifiers is ids
+
+    def test_purls_property(self):
+        comp = VsComponent(
+            "curl", "8.0",
+            {CompId(name="curl")},
+            (),
+            ("pkg:pypi/curl@8.0",),
+        )
+        assert comp.purls == {"pkg:pypi/curl@8.0"}
+
+    def test_purls_empty(self):
+        comp = self._make()
+        assert comp.purls == set()
+
+
+# ---------------------------------------------------------------------------
+# VsCompBuild
+# ---------------------------------------------------------------------------
+
+class TestVsCompBuild:
+
+    def _make(self, name="openssl", version="1.1.1", cpes=(), purls=()):
+        ids = {CompId(name=name)}
+        return VsCompBuild(name, version, ids, tuple(cpes), tuple(purls))
+
+    def test_version_property(self):
+        cb = self._make("curl", "8.0")
+        assert cb.version == "8.0"
+
+    def test_identifiers_property_is_tuple(self):
+        cb = self._make()
+        assert isinstance(cb.identifiers, tuple)
+        assert len(cb.identifiers) >= 1
+
+    def test_components_contains_vs_component(self):
+        cb = self._make("bash", "5.2")
+        comps = list(cb.components)
+        assert len(comps) == 1
+        assert isinstance(comps[0], VsComponent)
+        assert comps[0].name == "bash"
+
+    def test_build_name_property(self):
+        cb = self._make("glibc", "2.38")
+        assert cb.build_name == "glibc"
+
+    def test_get_compiled_sources_empty(self):
+        cb = self._make()
+        # VulnScout SBOMs don't carry source-file lists; must return empty set
+        # so the engine falls back to pure version-range evaluation.
+        assert cb._get_compiled_sources() == set()
+
+    def test_identifiers_are_sorted(self):
+        ids = {CompId(name="z"), CompId(name="a"), CompId(name="m")}
+        cb = VsCompBuild("pkg", "1.0", ids, (), ())
+        names = [c.name for c in cb.identifiers]
+        assert names == sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# build_comp_build
+# ---------------------------------------------------------------------------
+
+class TestBuildCompBuild:
+
+    def _pkg(self, name="openssl", version="1.1.1", cpe=None, purl=None):
+        pkg = MagicMock()
+        pkg.name = name
+        pkg.version = version
+        pkg.cpe = cpe or []
+        pkg.purl = purl or []
+        return pkg
+
+    def test_valid_package_returns_vscompbuild(self):
+        pkg = self._pkg(
+            "openssl", "1.1.1",
+            cpe=["cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"],
+        )
+        result = build_comp_build(pkg)
+        assert isinstance(result, VsCompBuild)
+        assert result.version == "1.1.1"
+
+    def test_empty_version_returns_none(self):
+        pkg = self._pkg("curl", "")
+        assert build_comp_build(pkg) is None
+
+    def test_none_version_returns_none(self):
+        pkg = self._pkg("curl", None)
+        assert build_comp_build(pkg) is None
+
+    def test_whitespace_version_returns_none(self):
+        pkg = self._pkg("curl", "   ")
+        assert build_comp_build(pkg) is None
+
+    def test_no_identifiers_returns_none(self):
+        # A package with empty name and no CPE/PURL has no identifiers.
+        pkg = self._pkg(name="", version="1.0", cpe=[], purl=[])
+        assert build_comp_build(pkg) is None
+
+    def test_purl_only_package(self):
+        pkg = self._pkg(
+            "requests", "2.28.0",
+            cpe=[],
+            purl=["pkg:pypi/requests@2.28.0"],
+        )
+        result = build_comp_build(pkg)
+        assert isinstance(result, VsCompBuild)
+
+    def test_name_and_version_only(self):
+        # A bare name + version should yield a CompBuild with a name CompId.
+        pkg = self._pkg("curl", "8.0", cpe=[], purl=[])
+        result = build_comp_build(pkg)
+        assert isinstance(result, VsCompBuild)
+        assert CompId(name="curl") in set(result.identifiers)
+
+    def test_strips_whitespace_from_name_and_version(self):
+        pkg = self._pkg("  openssl  ", "  1.1.1  ")
+        result = build_comp_build(pkg)
+        assert result is not None
+        assert result.version == "1.1.1"
+
+    def test_invalid_cpe_skipped_gracefully(self):
+        # Even with a bad CPE the bare-name identifier keeps the result valid.
+        pkg = self._pkg("lib", "2.0", cpe=["garbage-cpe"])
+        result = build_comp_build(pkg)
+        assert isinstance(result, VsCompBuild)
+
+    def test_ids_for_matching_works(self):
+        pkg = self._pkg(
+            "openssl", "1.1.1",
+            cpe=["cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"],
+        )
+        cb = build_comp_build(pkg)
+        ids = list(cb.ids_for_matching())
+        names = [c.name for c in ids]
+        assert "openssl" in names

--- a/tests/unit_tests/test_scc_engine_utils.py
+++ b/tests/unit_tests/test_scc_engine_utils.py
@@ -700,6 +700,17 @@ class TestRefreshDatabases:
         assert engine.refresh_databases() is False
         engine._manager.create_index.assert_not_called()
 
+    def test_no_databases_returns_false_without_fetch(self, tmp_path):
+        # _manager._databases is {} (falsy) so _git_databases() returns [] immediately.
+        engine = _make_mock_engine(tmp_path, auto_update=True)
+        engine._manager.create_index.reset_mock()
+        # Do NOT call _attach_git_dbs — leave _databases as the empty dict set by _make_mock_engine.
+
+        changed = engine.refresh_databases()
+
+        assert changed is False
+        engine._manager.create_index.assert_not_called()
+
 
 class TestGetEngineRefresh:
 

--- a/tests/unit_tests/test_scc_engine_utils.py
+++ b/tests/unit_tests/test_scc_engine_utils.py
@@ -41,31 +41,31 @@ class TestDatabasesDir:
 
     def test_uses_env_var_when_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", str(tmp_path))
-        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.delenv("VULNSCOUT_CACHE_DIR", raising=False)
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
         assert result == tmp_path.expanduser().resolve()
 
-    def test_uses_xdg_cache_home_when_env_set(self, monkeypatch, tmp_path):
+    def test_uses_vulnscout_cache_dir_when_env_set(self, monkeypatch, tmp_path):
         monkeypatch.delenv("SBOM_CVE_CHECK_DATABASES_DIR", raising=False)
-        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+        monkeypatch.setenv("VULNSCOUT_CACHE_DIR", str(tmp_path))
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
-        assert result == tmp_path.joinpath("sbom_cve_check", "databases").resolve()
+        assert result == tmp_path.joinpath("sbom_cve_check_databases").resolve()
 
-    def test_falls_back_to_home_cache(self, monkeypatch):
+    def test_falls_back_to_cache_vulnscout(self, monkeypatch):
         monkeypatch.delenv("SBOM_CVE_CHECK_DATABASES_DIR", raising=False)
-        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.delenv("VULNSCOUT_CACHE_DIR", raising=False)
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
-        assert "sbom_cve_check" in str(result)
+        assert str(result).endswith("/cache/vulnscout/sbom_cve_check_databases")
 
     def test_blank_env_var_falls_back(self, monkeypatch):
         monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", "   ")
-        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.delenv("VULNSCOUT_CACHE_DIR", raising=False)
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
-        assert "sbom_cve_check" in str(result)
+        assert "sbom_cve_check_databases" in str(result)
 
 
 class TestTrustGitDirectories:
@@ -536,6 +536,7 @@ class TestGetAndResetEngine:
             self._manager = mock_mgr
             self._applicable_cache = {}
             self._verdict_cache = {}
+            self._auto_update = auto_update
 
         with patch("src.controllers.scc_engine.VulnDbManager", return_value=mock_mgr), \
              patch("src.controllers.scc_engine.init_global_databases_lock"), \
@@ -569,6 +570,7 @@ class TestGetAndResetEngine:
             self._manager = mock_mgr
             self._applicable_cache = {}
             self._verdict_cache = {}
+            self._auto_update = auto_update
 
         with patch("src.controllers.scc_engine.VulnDbManager", return_value=mock_mgr), \
              patch("src.controllers.scc_engine.init_global_databases_lock"), \
@@ -608,3 +610,128 @@ class TestGetAndResetEngine:
             reset_engine()
             import src.controllers.scc_engine as mod
             assert mod._ENGINE is None
+
+
+class _FakeGitDb:
+    """Minimal stand-in for sbom_cve_check's GitDatabase used in refresh tests."""
+
+    def __init__(self, commits):
+        # ``commits`` is the sequence of values returned by successive
+        # get_date_last_commit() calls (before/after each update).
+        self._commits = list(commits)
+        self._idx = 0
+        self.update_calls = []
+        self.raise_on_update = False
+
+    def get_date_last_commit(self):
+        value = self._commits[min(self._idx, len(self._commits) - 1)]
+        self._idx += 1
+        return value
+
+    def update(self, force_update):
+        self.update_calls.append(force_update)
+        if self.raise_on_update:
+            raise RuntimeError("network down")
+
+
+def _attach_git_dbs(engine, git_dbs):
+    """Wire fake git databases into the engine's manager."""
+    wrappers = []
+    for git_db in git_dbs:
+        wrapper = MagicMock()
+        wrapper.git_database = git_db
+        wrappers.append(wrapper)
+    engine._manager._databases = {0: wrappers}
+    return engine
+
+
+class TestRefreshDatabases:
+
+    def test_noop_when_auto_update_disabled(self, tmp_path):
+        engine = _make_mock_engine(tmp_path, auto_update=False)
+        engine._manager.create_index.reset_mock()
+        git_db = _FakeGitDb(["sha-a", "sha-a"])
+        _attach_git_dbs(engine, [git_db])
+
+        assert engine.refresh_databases() is False
+        # No fetch attempted in offline mode.
+        assert git_db.update_calls == []
+        engine._manager.create_index.assert_not_called()
+
+    def test_force_fetches_each_db_without_commit_change(self, tmp_path):
+        engine = _make_mock_engine(tmp_path, auto_update=True)
+        engine._manager.create_index.reset_mock()
+        git_a = _FakeGitDb(["sha-a", "sha-a"])
+        git_b = _FakeGitDb(["sha-b", "sha-b"])
+        _attach_git_dbs(engine, [git_a, git_b])
+
+        changed = engine.refresh_databases()
+
+        assert changed is False
+        assert git_a.update_calls == [True]
+        assert git_b.update_calls == [True]
+        # Unchanged commits → index is not rebuilt.
+        engine._manager.create_index.assert_not_called()
+
+    def test_rebuilds_index_and_clears_caches_on_commit_change(self, tmp_path):
+        engine = _make_mock_engine(tmp_path, auto_update=True)
+        engine._manager.create_index.reset_mock()
+        git_db = _FakeGitDb(["sha-old", "sha-new"])
+        _attach_git_dbs(engine, [git_db])
+
+        engine._applicable_cache[("k",)] = ["x"]
+        engine._verdict_cache[("k",)] = {"CVE-1": "affected"}
+
+        changed = engine.refresh_databases()
+
+        assert changed is True
+        engine._manager.create_index.assert_called_once()
+        assert engine._applicable_cache == {}
+        assert engine._verdict_cache == {}
+
+    def test_swallows_fetch_errors(self, tmp_path):
+        engine = _make_mock_engine(tmp_path, auto_update=True)
+        engine._manager.create_index.reset_mock()
+        git_db = _FakeGitDb(["sha-a", "sha-a"])
+        git_db.raise_on_update = True
+        _attach_git_dbs(engine, [git_db])
+
+        # A failing fetch must not raise and must not rebuild the index.
+        assert engine.refresh_databases() is False
+        engine._manager.create_index.assert_not_called()
+
+
+class TestGetEngineRefresh:
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        import src.controllers.scc_engine as mod
+        mod._ENGINE = None
+        yield
+        mod._ENGINE = None
+
+    def test_refreshes_on_every_call(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", str(tmp_path))
+        monkeypatch.delenv("SBOM_CVE_CHECK_GIT_FETCH_DEPTH", raising=False)
+        monkeypatch.delenv("SBOM_CVE_CHECK_AUTO_UPDATE", raising=False)
+
+        (tmp_path / "nvd-fkie").mkdir()
+        (tmp_path / "cvelist").mkdir()
+
+        mock_mgr = MagicMock()
+        mock_mgr._databases = {}
+
+        with patch("src.controllers.scc_engine.VulnDbManager", return_value=mock_mgr), \
+             patch("src.controllers.scc_engine.init_global_databases_lock"), \
+             patch("src.controllers.scc_engine.GitDatabase"), \
+             patch("src.controllers.scc_engine.init_products_database"), \
+             patch("src.controllers.scc_engine.init_cna_database"), \
+             patch("src.controllers.scc_engine._install_cpe_parse_caches"), \
+             patch("src.controllers.scc_engine.SccEngine.refresh_databases") as refresh:
+            from src.controllers.scc_engine import get_engine
+            get_engine()
+            # First scan: built then refreshed so even the first scan is fresh.
+            refresh.assert_called_once()
+            get_engine()
+            # Cached engine reused → refreshed again before the next scan.
+            assert refresh.call_count == 2

--- a/tests/unit_tests/test_scc_engine_utils.py
+++ b/tests/unit_tests/test_scc_engine_utils.py
@@ -40,28 +40,28 @@ class TestTruthy:
 class TestDatabasesDir:
 
     def test_uses_env_var_when_set(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("SCC_DATABASES_DIR", str(tmp_path))
+        monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", str(tmp_path))
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
         assert result == tmp_path.expanduser().resolve()
 
     def test_uses_xdg_cache_home_when_env_set(self, monkeypatch, tmp_path):
-        monkeypatch.delenv("SCC_DATABASES_DIR", raising=False)
+        monkeypatch.delenv("SBOM_CVE_CHECK_DATABASES_DIR", raising=False)
         monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
         assert result == tmp_path.joinpath("sbom_cve_check", "databases").resolve()
 
     def test_falls_back_to_home_cache(self, monkeypatch):
-        monkeypatch.delenv("SCC_DATABASES_DIR", raising=False)
+        monkeypatch.delenv("SBOM_CVE_CHECK_DATABASES_DIR", raising=False)
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
         assert "sbom_cve_check" in str(result)
 
     def test_blank_env_var_falls_back(self, monkeypatch):
-        monkeypatch.setenv("SCC_DATABASES_DIR", "   ")
+        monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", "   ")
         monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
@@ -490,9 +490,9 @@ class TestGetAndResetEngine:
         mod._ENGINE = None
 
     def test_get_engine_creates_once(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("SCC_DATABASES_DIR", str(tmp_path))
-        monkeypatch.delenv("SCC_GIT_FETCH_DEPTH", raising=False)
-        monkeypatch.delenv("SCC_AUTO_UPDATE", raising=False)
+        monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", str(tmp_path))
+        monkeypatch.delenv("SBOM_CVE_CHECK_GIT_FETCH_DEPTH", raising=False)
+        monkeypatch.delenv("SBOM_CVE_CHECK_AUTO_UPDATE", raising=False)
 
         nvd = tmp_path / "nvd-fkie"
         nvd.mkdir()
@@ -515,9 +515,9 @@ class TestGetAndResetEngine:
         assert e1 is e2  # cached — not rebuilt on second call
 
     def test_get_engine_respects_fetch_depth_env(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("SCC_DATABASES_DIR", str(tmp_path))
-        monkeypatch.setenv("SCC_GIT_FETCH_DEPTH", "5")
-        monkeypatch.delenv("SCC_AUTO_UPDATE", raising=False)
+        monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", str(tmp_path))
+        monkeypatch.setenv("SBOM_CVE_CHECK_GIT_FETCH_DEPTH", "5")
+        monkeypatch.delenv("SBOM_CVE_CHECK_AUTO_UPDATE", raising=False)
 
         nvd = tmp_path / "nvd-fkie"
         nvd.mkdir()
@@ -550,9 +550,9 @@ class TestGetAndResetEngine:
         assert captured["fetch_depth"] == 5
 
     def test_get_engine_invalid_depth_defaults_to_1(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("SCC_DATABASES_DIR", str(tmp_path))
-        monkeypatch.setenv("SCC_GIT_FETCH_DEPTH", "notanint")
-        monkeypatch.delenv("SCC_AUTO_UPDATE", raising=False)
+        monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", str(tmp_path))
+        monkeypatch.setenv("SBOM_CVE_CHECK_GIT_FETCH_DEPTH", "notanint")
+        monkeypatch.delenv("SBOM_CVE_CHECK_AUTO_UPDATE", raising=False)
 
         nvd = tmp_path / "nvd-fkie"
         nvd.mkdir()
@@ -583,9 +583,9 @@ class TestGetAndResetEngine:
         assert captured["fetch_depth"] == 1
 
     def test_reset_engine_clears_cache(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("SCC_DATABASES_DIR", str(tmp_path))
-        monkeypatch.delenv("SCC_GIT_FETCH_DEPTH", raising=False)
-        monkeypatch.delenv("SCC_AUTO_UPDATE", raising=False)
+        monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", str(tmp_path))
+        monkeypatch.delenv("SBOM_CVE_CHECK_GIT_FETCH_DEPTH", raising=False)
+        monkeypatch.delenv("SBOM_CVE_CHECK_AUTO_UPDATE", raising=False)
 
         nvd = tmp_path / "nvd-fkie"
         nvd.mkdir()

--- a/tests/unit_tests/test_scc_engine_utils.py
+++ b/tests/unit_tests/test_scc_engine_utils.py
@@ -1,0 +1,610 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unit tests for src/controllers/scc_engine.py.
+
+The tests cover all helper functions and the SccEngine class methods without
+requiring real advisory git clones.  Heavy external dependencies (VulnDbManager,
+GitDatabase, init_*) are replaced with lightweight fakes via monkeypatching.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from sbom_cve_check.vuln.comp_id import CompId
+from sbom_cve_check.vuln.vex import VexStatus
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+class TestTruthy:
+
+    def test_true_values(self):
+        from src.controllers.scc_engine import _truthy
+        for val in ("1", "true", "TRUE", "yes", "YES", "on", "ON", "  true  "):
+            assert _truthy(val) is True, f"Expected True for {val!r}"
+
+    def test_false_values(self):
+        from src.controllers.scc_engine import _truthy
+        for val in ("0", "false", "no", "off", "", None, "anything-else"):
+            assert _truthy(val) is False, f"Expected False for {val!r}"
+
+
+class TestDatabasesDir:
+
+    def test_uses_env_var_when_set(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("SCC_DATABASES_DIR", str(tmp_path))
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        from src.controllers import scc_engine as mod
+        result = mod._databases_dir()
+        assert result == tmp_path.expanduser().resolve()
+
+    def test_uses_xdg_cache_home_when_env_set(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("SCC_DATABASES_DIR", raising=False)
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+        from src.controllers import scc_engine as mod
+        result = mod._databases_dir()
+        assert result == tmp_path.joinpath("sbom_cve_check", "databases").resolve()
+
+    def test_falls_back_to_home_cache(self, monkeypatch):
+        monkeypatch.delenv("SCC_DATABASES_DIR", raising=False)
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        from src.controllers import scc_engine as mod
+        result = mod._databases_dir()
+        assert "sbom_cve_check" in str(result)
+
+    def test_blank_env_var_falls_back(self, monkeypatch):
+        monkeypatch.setenv("SCC_DATABASES_DIR", "   ")
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        from src.controllers import scc_engine as mod
+        result = mod._databases_dir()
+        assert "sbom_cve_check" in str(result)
+
+
+class TestTrustGitDirectories:
+
+    def test_sets_git_config_env_vars(self, monkeypatch):
+        # Remove any existing GIT_CONFIG_* vars.
+        for key in list(os.environ.keys()):
+            if key.startswith("GIT_CONFIG"):
+                monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GIT_CONFIG_COUNT", "0")
+
+        from src.controllers import scc_engine as mod
+        paths = [pathlib.Path("/a"), pathlib.Path("/b")]
+        mod._trust_git_directories(paths)
+
+        assert os.environ["GIT_CONFIG_COUNT"] == "2"
+        assert os.environ["GIT_CONFIG_KEY_0"] == "safe.directory"
+        assert os.environ["GIT_CONFIG_VALUE_0"] == "/a"
+        assert os.environ["GIT_CONFIG_KEY_1"] == "safe.directory"
+        assert os.environ["GIT_CONFIG_VALUE_1"] == "/b"
+
+    def test_preserves_existing_count(self, monkeypatch):
+        for key in list(os.environ.keys()):
+            if key.startswith("GIT_CONFIG"):
+                monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GIT_CONFIG_COUNT", "3")
+
+        from src.controllers import scc_engine as mod
+        mod._trust_git_directories([pathlib.Path("/x")])
+
+        assert os.environ["GIT_CONFIG_COUNT"] == "4"
+        assert os.environ["GIT_CONFIG_KEY_3"] == "safe.directory"
+        assert os.environ["GIT_CONFIG_VALUE_3"] == "/x"
+
+    def test_invalid_count_treated_as_zero(self, monkeypatch):
+        for key in list(os.environ.keys()):
+            if key.startswith("GIT_CONFIG"):
+                monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GIT_CONFIG_COUNT", "notanumber")
+
+        from src.controllers import scc_engine as mod
+        mod._trust_git_directories([pathlib.Path("/y")])
+
+        assert os.environ["GIT_CONFIG_KEY_0"] == "safe.directory"
+
+    def test_empty_list_keeps_count(self, monkeypatch):
+        for key in list(os.environ.keys()):
+            if key.startswith("GIT_CONFIG"):
+                monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("GIT_CONFIG_COUNT", "2")
+
+        from src.controllers import scc_engine as mod
+        mod._trust_git_directories([])
+
+        assert os.environ["GIT_CONFIG_COUNT"] == "2"
+
+
+class TestInstallCpeParserCaches:
+
+    def test_is_idempotent(self, monkeypatch):
+        """Calling the function twice must not crash and must set the flag."""
+        import src.controllers.scc_engine as mod
+        # Reset the flag so the first call runs the full install path.
+        monkeypatch.setattr(mod, "_PURE_CACHES_INSTALLED", False)
+        mod._install_cpe_parse_caches()
+        assert mod._PURE_CACHES_INSTALLED is True
+        # Second call: flag is True, should be a no-op.
+        mod._install_cpe_parse_caches()
+        assert mod._PURE_CACHES_INSTALLED is True
+
+    def test_already_installed_returns_early(self, monkeypatch):
+        import src.controllers.scc_engine as mod
+        monkeypatch.setattr(mod, "_PURE_CACHES_INSTALLED", True)
+        # Should return without importing or reassigning anything.
+        mod._install_cpe_parse_caches()
+        assert mod._PURE_CACHES_INSTALLED is True
+
+    def test_wrapper_string_arg_uses_cache(self, monkeypatch):
+        """After cache installation, calling Cpe23.parse with a string hits
+        the cached branch (lines 70-71 inside the wrapper)."""
+        import src.controllers.scc_engine as mod
+        from sbom_cve_check.vuln.cpe import Cpe23
+
+        monkeypatch.setattr(mod, "_PURE_CACHES_INSTALLED", False)
+        mod._install_cpe_parse_caches()
+
+        cpe_str = "cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"
+        result = Cpe23.parse(cpe_str)
+        # Cached second call — still returns a valid result.
+        result2 = Cpe23.parse(cpe_str)
+        assert result == result2
+
+    def test_wrapper_none_arg_uses_cache(self, monkeypatch):
+        """Calling the wrapper with None hits the cached branch."""
+        import src.controllers.scc_engine as mod
+        from sbom_cve_check.vuln.cpe import Cpe23
+
+        monkeypatch.setattr(mod, "_PURE_CACHES_INSTALLED", False)
+        mod._install_cpe_parse_caches()
+        # None passes through the string/None branch (line 71).
+        result = Cpe23.parse(None)
+        assert result is None
+
+    def test_wrapper_non_string_arg_passes_through(self, monkeypatch):
+        """Calling the wrapper with a Cpe23 instance hits the pass-through
+        branch (line 72: ``return func(arg)``) before the original function
+        handles it (which may itself raise)."""
+        import src.controllers.scc_engine as mod
+        from sbom_cve_check.vuln.cpe import Cpe23
+
+        monkeypatch.setattr(mod, "_PURE_CACHES_INSTALLED", False)
+        mod._install_cpe_parse_caches()
+
+        # Parse a string to get a real Cpe23 instance.
+        cpe_str = "cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"
+        cpe_obj = Cpe23.parse(cpe_str)
+        # Call parse with the Cpe23 object → non-str, non-None → line 72
+        # (``return func(arg)``).  The original Cpe23.parse doesn't accept a
+        # Cpe23 instance so it raises; we just need line 72 to execute.
+        with pytest.raises(Exception):
+            Cpe23.parse(cpe_obj)
+
+
+# ---------------------------------------------------------------------------
+# SccEngine – constructed with mocked dependencies
+# ---------------------------------------------------------------------------
+
+def _make_mock_engine(tmp_path, auto_update=False):
+    """Return a SccEngine with all external I/O mocked out."""
+    nvd_dir = tmp_path / "nvd-fkie"
+    nvd_dir.mkdir()
+    cvelist_dir = tmp_path / "cvelist"
+    cvelist_dir.mkdir()
+
+    mock_mgr = MagicMock()
+    mock_mgr._databases = {}
+
+    with patch("src.controllers.scc_engine.VulnDbManager", return_value=mock_mgr), \
+         patch("src.controllers.scc_engine.init_global_databases_lock"), \
+         patch("src.controllers.scc_engine.GitDatabase"), \
+         patch("src.controllers.scc_engine.init_products_database"), \
+         patch("src.controllers.scc_engine.init_cna_database"), \
+         patch("src.controllers.scc_engine._install_cpe_parse_caches"):
+        from src.controllers.scc_engine import SccEngine
+        engine = SccEngine(tmp_path, 1, auto_update)
+
+    engine._manager = mock_mgr
+    return engine
+
+
+class TestSccEngineInit:
+
+    def test_creates_manager_and_indexes(self, tmp_path):
+        engine = _make_mock_engine(tmp_path)
+        # create_index must have been called once.
+        engine._manager.create_index.assert_called_once()
+
+    def test_raises_when_dir_missing_and_no_auto_update(self, tmp_path):
+        # Neither nvd-fkie nor cvelist directories exist.
+        mock_mgr = MagicMock()
+        with patch("src.controllers.scc_engine.VulnDbManager", return_value=mock_mgr), \
+             patch("src.controllers.scc_engine.init_global_databases_lock"), \
+             patch("src.controllers.scc_engine.GitDatabase"), \
+             patch("src.controllers.scc_engine.init_products_database"), \
+             patch("src.controllers.scc_engine.init_cna_database"), \
+             patch("src.controllers.scc_engine._install_cpe_parse_caches"):
+            from src.controllers.scc_engine import SccEngine
+            with pytest.raises(RuntimeError, match="nvd-fkie"):
+                SccEngine(tmp_path, 1, auto_update=False)
+
+    def test_no_error_when_auto_update_even_if_dirs_missing(self, tmp_path):
+        mock_mgr = MagicMock()
+        mock_mgr._databases = {}
+        with patch("src.controllers.scc_engine.VulnDbManager", return_value=mock_mgr), \
+             patch("src.controllers.scc_engine.init_global_databases_lock"), \
+             patch("src.controllers.scc_engine.GitDatabase"), \
+             patch("src.controllers.scc_engine.init_products_database"), \
+             patch("src.controllers.scc_engine.init_cna_database"), \
+             patch("src.controllers.scc_engine._install_cpe_parse_caches"):
+            from src.controllers.scc_engine import SccEngine
+            engine = SccEngine(tmp_path, 1, auto_update=True)
+        assert engine is not None
+
+    def test_caches_initialised(self, tmp_path):
+        engine = _make_mock_engine(tmp_path)
+        assert isinstance(engine._applicable_cache, dict)
+        assert isinstance(engine._verdict_cache, dict)
+
+    def test_sets_databases_dir(self, tmp_path):
+        engine = _make_mock_engine(tmp_path)
+        assert engine._databases_dir == tmp_path
+
+
+class TestInstallGetVulnCaches:
+
+    def test_wraps_get_vuln_with_lru_cache(self, tmp_path):
+        engine = _make_mock_engine(tmp_path)
+
+        class _FakeDb:
+            calls = 0
+
+            def get_vuln(self, cve_id):
+                self.calls += 1
+                return {"id": cve_id}
+
+        db = _FakeDb()
+        engine._manager._databases = {"nvd": [db]}
+        engine._install_get_vuln_caches()
+
+        # After wrapping, repeated calls with the same arg should hit the cache.
+        assert getattr(db.get_vuln, "__wrapped__", None) is not None
+
+    def test_skips_already_wrapped(self, tmp_path):
+        engine = _make_mock_engine(tmp_path)
+
+        db = MagicMock()
+        # Mark as already wrapped.
+        db.get_vuln.__wrapped__ = db.get_vuln
+        engine._manager._databases = {"nvd": [db]}
+        engine._install_get_vuln_caches()
+
+        # Should not wrap again.
+        assert db.get_vuln.__wrapped__ is db.get_vuln
+
+    def test_no_databases_attr_is_safe(self, tmp_path):
+        engine = _make_mock_engine(tmp_path)
+        engine._manager._databases = None
+        # Must not raise.
+        engine._install_get_vuln_caches()
+
+
+class TestVexStatusStr:
+
+    @pytest.fixture(autouse=True)
+    def _get_cls(self):
+        from src.controllers.scc_engine import SccEngine
+        self.SccEngine = SccEngine
+
+    def _computed(self, status):
+        c = MagicMock()
+        c.vex_assessment.status = status
+        return c
+
+    def test_affected(self):
+        assert self.SccEngine._vex_status_str(self._computed(VexStatus.AFFECTED)) == "affected"
+
+    def test_not_affected(self):
+        assert self.SccEngine._vex_status_str(self._computed(VexStatus.NOT_AFFECTED)) == "not_affected"
+
+    def test_fixed(self):
+        assert self.SccEngine._vex_status_str(self._computed(VexStatus.FIXED)) == "fixed"
+
+    def test_under_investigation_for_unknown(self):
+        assert self.SccEngine._vex_status_str(
+            self._computed(VexStatus.UNDER_INVESTIGATION)
+        ) == "under_investigation"
+
+    def test_unknown_falls_back_to_under_investigation(self):
+        assert self.SccEngine._vex_status_str(
+            self._computed(VexStatus.UNKNOWN)
+        ) == "under_investigation"
+
+
+class TestApplicableVulns:
+
+    def _make_bare_engine(self, tmp_path):
+        """Bypass __init__ entirely to isolate applicable_vulns logic."""
+        from src.controllers.scc_engine import SccEngine
+        engine = object.__new__(SccEngine)
+        engine._manager = MagicMock()
+        engine._applicable_cache = {}
+        engine._verdict_cache = {}
+        return engine
+
+    def test_none_comp_build_yields_nothing(self, tmp_path):
+        engine = self._make_bare_engine(tmp_path)
+        pkg = MagicMock()
+        pkg.name = ""
+        pkg.version = ""
+        pkg.cpe = []
+        pkg.purl = []
+
+        with patch("src.controllers.scc_engine.build_comp_build", return_value=None):
+            results = list(engine.applicable_vulns(pkg))
+        assert results == []
+
+    def test_cache_miss_calls_get_applicable_vulns(self, tmp_path):
+        engine = self._make_bare_engine(tmp_path)
+        engine._manager._index_comp_vuln = {"openssl": []}
+
+        mock_comp = MagicMock()
+        mock_comp._vuln_db_entries = ("entry",)
+        mock_comp.identifier = "CVE-2023-0001"
+        engine._manager.get_applicable_vulns.return_value = [mock_comp]
+
+        mock_build = MagicMock()
+        mock_build.version = "1.1.1"
+        mock_build.ids_for_matching.return_value = [CompId(name="openssl")]
+
+        with patch("src.controllers.scc_engine.build_comp_build", return_value=mock_build), \
+             patch("src.controllers.scc_engine.ComputedVulnInfo") as MockCVI:
+            fake_cvi = MagicMock()
+            fake_cvi.vex_assessment.status = VexStatus.AFFECTED
+            fake_cvi.identifier = "CVE-2023-0001"
+            MockCVI.return_value = fake_cvi
+
+            pkg = MagicMock()
+            results = list(engine.applicable_vulns(pkg))
+
+        assert len(results) == 1
+        engine._manager.get_applicable_vulns.assert_called_once()
+
+    def test_cache_hit_skips_get_applicable_vulns(self, tmp_path):
+        engine = self._make_bare_engine(tmp_path)
+        engine._manager._index_comp_vuln = {"openssl": []}
+
+        mock_build = MagicMock()
+        mock_build.version = "1.1.1"
+        mock_build.ids_for_matching.return_value = [CompId(name="openssl")]
+
+        key = (frozenset({CompId(name="openssl")}), "1.1.1")
+        engine._applicable_cache[key] = [("entry",)]
+
+        with patch("src.controllers.scc_engine.build_comp_build", return_value=mock_build), \
+             patch("src.controllers.scc_engine.ComputedVulnInfo") as MockCVI:
+            fake_cvi = MagicMock()
+            fake_cvi.vex_assessment.status = VexStatus.NOT_AFFECTED
+            fake_cvi.identifier = "CVE-2023-0001"
+            MockCVI.return_value = fake_cvi
+
+            pkg = MagicMock()
+            results = list(engine.applicable_vulns(pkg))
+
+        engine._manager.get_applicable_vulns.assert_not_called()
+        assert len(results) == 1
+
+    def test_verdict_cached_on_second_pkg(self, tmp_path):
+        engine = self._make_bare_engine(tmp_path)
+        engine._manager._index_comp_vuln = {"openssl": []}
+
+        mock_build = MagicMock()
+        mock_build.version = "1.1.1"
+        mock_build.ids_for_matching.return_value = [CompId(name="openssl")]
+
+        key = (frozenset({CompId(name="openssl")}), "1.1.1")
+        engine._applicable_cache[key] = [("entry",)]
+        engine._verdict_cache[key] = {"CVE-2023-0001": "fixed"}
+
+        with patch("src.controllers.scc_engine.build_comp_build", return_value=mock_build), \
+             patch("src.controllers.scc_engine.ComputedVulnInfo") as MockCVI:
+            fake_cvi = MagicMock()
+            fake_cvi.identifier = "CVE-2023-0001"
+            MockCVI.return_value = fake_cvi
+
+            pkg = MagicMock()
+            results = list(engine.applicable_vulns(pkg))
+
+        # Status comes from the verdict cache, not _vex_status_str.
+        assert results[0][1] == "fixed"
+
+    def test_cache_overflow_clears_both_caches(self, tmp_path):
+        engine = self._make_bare_engine(tmp_path)
+        engine._manager._index_comp_vuln = {"openssl": []}
+        # Fill caches past the 50 000-entry limit.
+        engine._applicable_cache = {i: [] for i in range(50_001)}
+        engine._verdict_cache = {i: {} for i in range(50_001)}
+
+        mock_comp = MagicMock()
+        mock_comp._vuln_db_entries = ()
+        engine._manager.get_applicable_vulns.return_value = [mock_comp]
+
+        mock_build = MagicMock()
+        mock_build.version = "2.0"
+        mock_build.ids_for_matching.return_value = [CompId(name="openssl")]
+
+        with patch("src.controllers.scc_engine.build_comp_build", return_value=mock_build), \
+             patch("src.controllers.scc_engine.ComputedVulnInfo"):
+            pkg = MagicMock()
+            list(engine.applicable_vulns(pkg))
+
+        # Both caches cleared then one new entry added.
+        assert len(engine._applicable_cache) == 1
+        assert len(engine._verdict_cache) <= 1
+
+    def test_ids_not_in_index_excluded_from_key(self, tmp_path):
+        """Identifiers whose name is absent from the index are excluded from the
+        cache key, so packages sharing the same indexed ids share the cache."""
+        engine = self._make_bare_engine(tmp_path)
+        # Only "curl" is in the index; "libcurl" is not.
+        engine._manager._index_comp_vuln = {"curl": []}
+
+        mock_build = MagicMock()
+        mock_build.version = "8.0"
+        mock_build.ids_for_matching.return_value = [
+            CompId(name="curl"),
+            CompId(name="libcurl"),  # not in index → excluded
+        ]
+        engine._manager.get_applicable_vulns.return_value = []
+
+        with patch("src.controllers.scc_engine.build_comp_build", return_value=mock_build):
+            pkg = MagicMock()
+            list(engine.applicable_vulns(pkg))
+
+        key = list(engine._applicable_cache.keys())[0]
+        key_names = {c.name for c in key[0]}
+        assert "curl" in key_names
+        assert "libcurl" not in key_names
+
+
+# ---------------------------------------------------------------------------
+# get_engine / reset_engine
+# ---------------------------------------------------------------------------
+
+class TestGetAndResetEngine:
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        """Ensure the module-level engine cache is clean before and after each test."""
+        import src.controllers.scc_engine as mod
+        mod._ENGINE = None
+        yield
+        mod._ENGINE = None
+
+    def test_get_engine_creates_once(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCC_DATABASES_DIR", str(tmp_path))
+        monkeypatch.delenv("SCC_GIT_FETCH_DEPTH", raising=False)
+        monkeypatch.delenv("SCC_AUTO_UPDATE", raising=False)
+
+        nvd = tmp_path / "nvd-fkie"
+        nvd.mkdir()
+        cvelist = tmp_path / "cvelist"
+        cvelist.mkdir()
+
+        mock_mgr = MagicMock()
+        mock_mgr._databases = {}
+
+        with patch("src.controllers.scc_engine.VulnDbManager", return_value=mock_mgr), \
+             patch("src.controllers.scc_engine.init_global_databases_lock"), \
+             patch("src.controllers.scc_engine.GitDatabase"), \
+             patch("src.controllers.scc_engine.init_products_database"), \
+             patch("src.controllers.scc_engine.init_cna_database"), \
+             patch("src.controllers.scc_engine._install_cpe_parse_caches"):
+            from src.controllers.scc_engine import get_engine
+            e1 = get_engine()
+            e2 = get_engine()
+
+        assert e1 is e2  # cached — not rebuilt on second call
+
+    def test_get_engine_respects_fetch_depth_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCC_DATABASES_DIR", str(tmp_path))
+        monkeypatch.setenv("SCC_GIT_FETCH_DEPTH", "5")
+        monkeypatch.delenv("SCC_AUTO_UPDATE", raising=False)
+
+        nvd = tmp_path / "nvd-fkie"
+        nvd.mkdir()
+        cvelist = tmp_path / "cvelist"
+        cvelist.mkdir()
+
+        captured = {}
+        mock_mgr = MagicMock()
+        mock_mgr._databases = {}
+
+        original_init = None
+
+        def fake_init(self, databases_dir, fetch_depth, auto_update):
+            captured["fetch_depth"] = fetch_depth
+            self._databases_dir = databases_dir
+            self._manager = mock_mgr
+            self._applicable_cache = {}
+            self._verdict_cache = {}
+
+        with patch("src.controllers.scc_engine.VulnDbManager", return_value=mock_mgr), \
+             patch("src.controllers.scc_engine.init_global_databases_lock"), \
+             patch("src.controllers.scc_engine.GitDatabase"), \
+             patch("src.controllers.scc_engine.init_products_database"), \
+             patch("src.controllers.scc_engine.init_cna_database"), \
+             patch("src.controllers.scc_engine._install_cpe_parse_caches"), \
+             patch("src.controllers.scc_engine.SccEngine.__init__", fake_init):
+            from src.controllers.scc_engine import get_engine
+            get_engine()
+
+        assert captured["fetch_depth"] == 5
+
+    def test_get_engine_invalid_depth_defaults_to_1(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCC_DATABASES_DIR", str(tmp_path))
+        monkeypatch.setenv("SCC_GIT_FETCH_DEPTH", "notanint")
+        monkeypatch.delenv("SCC_AUTO_UPDATE", raising=False)
+
+        nvd = tmp_path / "nvd-fkie"
+        nvd.mkdir()
+        cvelist = tmp_path / "cvelist"
+        cvelist.mkdir()
+
+        captured = {}
+        mock_mgr = MagicMock()
+        mock_mgr._databases = {}
+
+        def fake_init(self, databases_dir, fetch_depth, auto_update):
+            captured["fetch_depth"] = fetch_depth
+            self._databases_dir = databases_dir
+            self._manager = mock_mgr
+            self._applicable_cache = {}
+            self._verdict_cache = {}
+
+        with patch("src.controllers.scc_engine.VulnDbManager", return_value=mock_mgr), \
+             patch("src.controllers.scc_engine.init_global_databases_lock"), \
+             patch("src.controllers.scc_engine.GitDatabase"), \
+             patch("src.controllers.scc_engine.init_products_database"), \
+             patch("src.controllers.scc_engine.init_cna_database"), \
+             patch("src.controllers.scc_engine._install_cpe_parse_caches"), \
+             patch("src.controllers.scc_engine.SccEngine.__init__", fake_init):
+            from src.controllers.scc_engine import get_engine
+            get_engine()
+
+        assert captured["fetch_depth"] == 1
+
+    def test_reset_engine_clears_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SCC_DATABASES_DIR", str(tmp_path))
+        monkeypatch.delenv("SCC_GIT_FETCH_DEPTH", raising=False)
+        monkeypatch.delenv("SCC_AUTO_UPDATE", raising=False)
+
+        nvd = tmp_path / "nvd-fkie"
+        nvd.mkdir()
+        cvelist = tmp_path / "cvelist"
+        cvelist.mkdir()
+
+        mock_mgr = MagicMock()
+        mock_mgr._databases = {}
+
+        with patch("src.controllers.scc_engine.VulnDbManager", return_value=mock_mgr), \
+             patch("src.controllers.scc_engine.init_global_databases_lock"), \
+             patch("src.controllers.scc_engine.GitDatabase"), \
+             patch("src.controllers.scc_engine.init_products_database"), \
+             patch("src.controllers.scc_engine.init_cna_database"), \
+             patch("src.controllers.scc_engine._install_cpe_parse_caches"):
+            from src.controllers.scc_engine import get_engine, reset_engine
+            e = get_engine()
+            assert e is not None
+
+            reset_engine()
+            import src.controllers.scc_engine as mod
+            assert mod._ENGINE is None

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -405,3 +405,29 @@ def test_documents_list_categories_enrichment(monkeypatch, client):
     # "vex" should have been appended, "misc" was already present (not duplicated)
     assert "vex" in item["category"]
     assert item["category"].count("misc") == 1
+
+
+def test_packages_variant_no_active_scans(app, client):
+    """packages.py line 80: variant with no active sbom scans returns empty list."""
+    from src.models.project import Project
+    from src.models.variant import Variant
+    with app.app_context():
+        project = Project.create("PkgEmptyProj1")
+        variant = Variant.create("PkgEmptyVar1", project.id)
+        variant_id = str(variant.id)
+    response = client.get(f"/api/packages?variant_id={variant_id}&format=list")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert isinstance(data, list)
+
+
+def test_packages_project_no_active_scans(app, client):
+    """packages.py line 93: project with no active sbom scans returns empty list."""
+    from src.models.project import Project
+    with app.app_context():
+        project = Project.create("PkgEmptyProj2")
+        project_id = str(project.id)
+    response = client.get(f"/api/packages?project_id={project_id}&format=list")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert isinstance(data, list)

--- a/tests/webapp_tests/test_scan_cli.py
+++ b/tests/webapp_tests/test_scan_cli.py
@@ -648,3 +648,143 @@ class TestOsvScanCoverage:
             from src.models.vulnerability import Vulnerability
             updated = _db.session.get(Vulnerability, "CVE-BARE-001")
             assert updated.description == "enriched from osv scan"
+
+
+# ---------------------------------------------------------------------------
+# SCC scan CLI tests
+# ---------------------------------------------------------------------------
+
+class TestSccScanCLI:
+    """flask scc-scan CLI command (engine is fully mocked)."""
+
+    @patch("src.controllers.scc_engine.get_engine")
+    def test_scc_scan_creates_findings(self, mock_get_engine, app, ids):
+        """scc-scan records findings and assessments via the bulk writer."""
+        from src.bin.cmd_vuln_scan import _SccBulkWriter
+        from unittest.mock import MagicMock
+
+        class _FakeComputed:
+            _id = "CVE-2024-SCC-001"
+            description = "scc vuln"
+            date_published = None
+            date_modified = None
+            external_refs = []
+            cvss_metrics = []
+
+            class _FakeAssessment:
+                status_notes = "engine note"
+
+            vex_assessment = _FakeAssessment()
+
+            @property
+            def identifier(self):
+                return self._id
+
+        fake_engine = MagicMock()
+        fake_engine.applicable_vulns.return_value = [
+            (_FakeComputed(), "affected")
+        ]
+        mock_get_engine.return_value = fake_engine
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "scc-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "Scan complete" in result.output
+
+        with app.app_context():
+            from src.models.scan import Scan
+            scans = _db.session.execute(
+                _db.select(Scan).where(Scan.scan_source == "scc")
+            ).scalars().all()
+            assert len(scans) >= 1
+
+    @patch("src.controllers.scc_engine.get_engine")
+    def test_scc_scan_no_vulns(self, mock_get_engine, app, ids):
+        """scc-scan with an engine that returns nothing completes without error."""
+        fake_engine = MagicMock()
+        fake_engine.applicable_vulns.return_value = []
+        mock_get_engine.return_value = fake_engine
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "scc-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "0 unique vulnerabilities" in result.output
+
+    @patch("src.controllers.scc_engine.get_engine")
+    def test_scc_scan_engine_exception_per_package(self, mock_get_engine, app, ids):
+        """Exception from applicable_vulns for one package is logged and scan continues."""
+        fake_engine = MagicMock()
+        fake_engine.applicable_vulns.side_effect = RuntimeError("engine exploded")
+        mock_get_engine.return_value = fake_engine
+
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "scc-scan",
+            "--project", ids["project_name"],
+            "--variant", ids["variant_name"],
+        ])
+        assert result.exit_code == 0, result.output
+        assert "ERROR" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Export scope helper tests
+# ---------------------------------------------------------------------------
+
+class TestExportScope:
+    """Cover helpers/export_scope.py (lines 49, 58-73)."""
+
+    def test_as_uuid_with_uuid_object(self, app):
+        import uuid
+        with app.app_context():
+            from src.helpers.export_scope import _as_uuid
+            uid = uuid.uuid4()
+            assert _as_uuid(uid) is uid
+
+    def test_as_uuid_with_string(self, app):
+        import uuid
+        with app.app_context():
+            from src.helpers.export_scope import _as_uuid
+            uid = uuid.uuid4()
+            result = _as_uuid(str(uid))
+            assert result == uid
+            assert isinstance(result, uuid.UUID)
+
+    def test_compute_export_scope_neither_returns_none(self, app):
+        with app.app_context():
+            from src.helpers.export_scope import compute_export_scope
+            assert compute_export_scope() is None
+
+    def test_compute_export_scope_by_variant(self, app):
+        from src.models.project import Project
+        from src.models.variant import Variant
+        with app.app_context():
+            project = Project.create("ScopeProj")
+            variant = Variant.create("ScopeVar", project.id)
+            _db.session.commit()
+
+            from src.helpers.export_scope import compute_export_scope, ExportScope
+            scope = compute_export_scope(variant_id=variant.id)
+            assert isinstance(scope, ExportScope)
+            assert variant.id in scope.variant_ids
+
+    def test_compute_export_scope_by_project(self, app):
+        from src.models.project import Project
+        from src.models.variant import Variant
+        with app.app_context():
+            project = Project.create("ScopeProjP")
+            variant = Variant.create("ScopeVarP", project.id)
+            _db.session.commit()
+
+            from src.helpers.export_scope import compute_export_scope, ExportScope
+            scope = compute_export_scope(project_id=project.id)
+            assert isinstance(scope, ExportScope)
+            assert variant.id in scope.variant_ids

--- a/tests/webapp_tests/test_scan_cli.py
+++ b/tests/webapp_tests/test_scan_cli.py
@@ -651,15 +651,15 @@ class TestOsvScanCoverage:
 
 
 # ---------------------------------------------------------------------------
-# SCC scan CLI tests
+# sbom-cve-check scan CLI tests
 # ---------------------------------------------------------------------------
 
 class TestSccScanCLI:
-    """flask scc-scan CLI command (engine is fully mocked)."""
+    """flask sbom-cve-check-scan CLI command (engine is fully mocked)."""
 
     @patch("src.controllers.scc_engine.get_engine")
     def test_scc_scan_creates_findings(self, mock_get_engine, app, ids):
-        """scc-scan records findings and assessments via the bulk writer."""
+        """sbom-cve-check-scan records findings and assessments via the bulk writer."""
         from src.bin.cmd_vuln_scan import _SccBulkWriter
         from unittest.mock import MagicMock
 
@@ -688,7 +688,7 @@ class TestSccScanCLI:
 
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "scc-scan",
+            "sbom-cve-check-scan",
             "--project", ids["project_name"],
             "--variant", ids["variant_name"],
         ])
@@ -704,14 +704,14 @@ class TestSccScanCLI:
 
     @patch("src.controllers.scc_engine.get_engine")
     def test_scc_scan_no_vulns(self, mock_get_engine, app, ids):
-        """scc-scan with an engine that returns nothing completes without error."""
+        """sbom-cve-check-scan with an engine that returns nothing completes without error."""
         fake_engine = MagicMock()
         fake_engine.applicable_vulns.return_value = []
         mock_get_engine.return_value = fake_engine
 
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "scc-scan",
+            "sbom-cve-check-scan",
             "--project", ids["project_name"],
             "--variant", ids["variant_name"],
         ])
@@ -727,7 +727,7 @@ class TestSccScanCLI:
 
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
-            "scc-scan",
+            "sbom-cve-check-scan",
             "--project", ids["project_name"],
             "--variant", ids["variant_name"],
         ])

--- a/tests/webapp_tests/test_scc_bulk_writer.py
+++ b/tests/webapp_tests/test_scc_bulk_writer.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
-"""Integration tests for the scc-scan bulk persistence writer.
+"""Integration tests for the sbom-cve-check-scan bulk persistence writer.
 
 These run against a live in-memory SQLite database (the real models, real
 foreign-key relationships and the real priority write lock) — only the engine
@@ -101,7 +101,7 @@ def _scan_pkg(writer, pkg, computed_status_pairs):
     """Feed one package's engine output through the writer.
 
     Every verdict is forwarded — including ``not_affected`` and ``fixed`` — so
-    the full VEX picture reaches persistence, mirroring the scc-scan callers.
+    the full VEX picture reaches persistence, mirroring the sbom-cve-check-scan callers.
     """
     seen = set()
     for computed, status in computed_status_pairs:
@@ -321,7 +321,7 @@ class TestSccBulkWriter:
 
     def test_existing_finding_without_assessment_not_given_pending(self, app):
         """A pre-existing finding that has no assessment must not receive a new
-        'Pending Assessment' from the scc-scan (only brand-new findings should)."""
+        'Pending Assessment' from the sbom-cve-check-scan (only brand-new findings should)."""
         with app.app_context():
             project = Project.create("P")
             variant = Variant.create("V", project.id)
@@ -344,7 +344,7 @@ class TestSccBulkWriter:
             assert findings[0].id == existing_fid
 
             # No assessment added — the pre-existing finding had none and the
-            # scc-scan must not inject a "Pending Assessment" for it.
+            # sbom-cve-check-scan must not inject a "Pending Assessment" for it.
             assert _db.session.query(Assessment).filter_by(
                 finding_id=existing_fid, variant_id=variant.id).count() == 0
             # The scan still recorded the observation.
@@ -352,7 +352,7 @@ class TestSccBulkWriter:
                 finding_id=existing_fid, scan_id=scan.id).count() == 1
 
     def test_changed_status_writes_no_new_assessment_if_one_exists(self, app):
-        """When a finding already has an assessment the scc-scan leaves it
+        """When a finding already has an assessment the sbom-cve-check-scan leaves it
         untouched, regardless of the engine's current verdict."""
         with app.app_context():
             project = Project.create("P")

--- a/tests/webapp_tests/test_scc_bulk_writer.py
+++ b/tests/webapp_tests/test_scc_bulk_writer.py
@@ -116,7 +116,8 @@ class TestSccBulkWriter:
 
     def test_kernel_explosion_persists_once_per_package_cve(self, app):
         """Many sibling packages sharing the same CVE set each get their own
-        finding/observation/assessment, while each CVE row is inserted once."""
+        finding/observation, while pending assessments are only created once per
+        new CVE in the variant."""
         with app.app_context():
             project = Project.create("P")
             variant = Variant.create("V", project.id)
@@ -142,10 +143,11 @@ class TestSccBulkWriter:
             assert _db.session.query(Vulnerability).count() == 2
             assert _db.session.query(Metrics).count() == 2
 
-            # 5 packages x 2 CVEs = 10 findings / observations / assessments.
+            # 5 packages x 2 CVEs = 10 findings / observations.
             assert _db.session.query(Finding).count() == 10
             assert _db.session.query(Observation).count() == 10
-            assert _db.session.query(Assessment).count() == 10
+            # Only two assessments: one pending row for each new CVE.
+            assert _db.session.query(Assessment).count() == 2
 
             # Every observation belongs to this scan; every assessment to variant.
             assert all(o.scan_id == scan.id
@@ -215,8 +217,51 @@ class TestSccBulkWriter:
             assert _db.session.query(Finding).filter_by(
                 package_id=pkg.id, vulnerability_id="CVE-2023-0001").count() == 1
 
-    def test_not_affected_and_fixed_are_persisted(self, app):
-        """Every engine verdict — including not_affected and fixed — is recorded."""
+    def test_existing_variant_cve_gets_no_pending_on_new_package_finding(self, app):
+        """When a CVE already exists in the variant, new findings for that same
+        CVE on other packages must not get a fresh pending assessment."""
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+
+            old_scan = Scan.create("old", variant.id, scan_type="tool")
+            new_scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg_old, pkg_new = _make_packages([
+                ("openssl", "1.1.1"),
+                ("openssl", "3.0.0"),
+            ])
+
+            # Existing CVE already present in this variant via an older package.
+            old_finding = Finding.create(pkg_old.id, "CVE-2023-0001", commit=False)
+            Observation.create(finding_id=old_finding.id, scan_id=old_scan.id, commit=False)
+            Assessment.create(
+                status="not_affected",
+                finding_id=old_finding.id,
+                variant_id=variant.id,
+                origin="manual",
+                commit=False,
+            )
+            _db.session.commit()
+
+            writer = _SccBulkWriter(new_scan.id, variant.id, [pkg_new])
+            _scan_pkg(writer, pkg_new, [(_Computed("CVE-2023-0001"), "affected")])
+            writer.flush()
+
+            # New finding for the second package exists.
+            new_finding = _db.session.query(Finding).filter_by(
+                package_id=pkg_new.id,
+                vulnerability_id="CVE-2023-0001",
+            ).one()
+
+            # No assessment was added for the existing-variant CVE.
+            assert _db.session.query(Assessment).filter_by(
+                finding_id=new_finding.id,
+                variant_id=variant.id,
+            ).count() == 0
+
+    def test_not_affected_and_fixed_are_persisted_as_pending_for_new_cves(self, app):
+        """For new CVEs, one pending assessment is created per new vulnerability
+        regardless of the engine verdict."""
         with app.app_context():
             project = Project.create("P")
             variant = Variant.create("V", project.id)

--- a/tests/webapp_tests/test_scc_bulk_writer.py
+++ b/tests/webapp_tests/test_scc_bulk_writer.py
@@ -1,0 +1,550 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Integration tests for the scc-scan bulk persistence writer.
+
+These run against a live in-memory SQLite database (the real models, real
+foreign-key relationships and the real priority write lock) — only the engine
+*output* objects are constructed as lightweight value carriers, mirroring the
+``ComputedVulnInfo`` instances ``SccEngine.applicable_vulns`` yields.
+"""
+
+import os
+from datetime import datetime, timezone
+import pytest
+
+from src.bin.webapp import create_app
+from src.bin.cmd_vuln_scan import _SccBulkWriter
+from src.extensions import db as _db
+from src.models.project import Project
+from src.models.variant import Variant
+from src.models.scan import Scan
+from src.models.package import Package
+from src.models.finding import Finding
+from src.models.observation import Observation
+from src.models.assessment import Assessment
+from src.models.vulnerability import Vulnerability
+from src.models.metrics import Metrics
+
+
+# ---------------------------------------------------------------------------
+# Engine-output value carriers (shape of sbom_cve_check ComputedVulnInfo)
+# ---------------------------------------------------------------------------
+
+class _Ref:
+    def __init__(self, url):
+        self.url = url
+
+
+class _CvssVer:
+    def __init__(self, value):
+        self.value = value
+
+
+class _Metric:
+    def __init__(self, score, version=(3, 1), vector="AV:N/AC:L", source="nvd"):
+        self.score = score
+        self.cvss_ver = _CvssVer(version)
+        self.vector_str = vector
+        self.source = source
+
+
+class _VexAssessment:
+    def __init__(self, notes):
+        self.status_notes = notes
+
+
+class _Computed:
+    """Mirrors the attributes _SccBulkWriter reads from a ComputedVulnInfo."""
+
+    def __init__(self, cve_id, description="desc", score=7.5, notes="note"):
+        self._cve_id = cve_id
+        self.description = description
+        self.date_published = datetime(2023, 1, 2, tzinfo=timezone.utc)
+        self.date_modified = datetime(2023, 6, 1, tzinfo=timezone.utc)
+        self.external_refs = [_Ref(f"https://example/{cve_id}")]
+        self.cvss_metrics = [_Metric(score)]
+        self.vex_assessment = _VexAssessment(notes)
+
+    @property
+    def identifier(self):
+        return self._cve_id
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def app():
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True})
+        with application.app_context():
+            _db.drop_all()
+            _db.create_all()
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+def _make_packages(names):
+    pkgs = []
+    for name, version in names:
+        pkgs.append(Package.find_or_create(name, version))
+    _db.session.commit()
+    return pkgs
+
+
+def _scan_pkg(writer, pkg, computed_status_pairs):
+    """Feed one package's engine output through the writer.
+
+    Every verdict is forwarded — including ``not_affected`` and ``fixed`` — so
+    the full VEX picture reaches persistence, mirroring the scc-scan callers.
+    """
+    seen = set()
+    for computed, status in computed_status_pairs:
+        writer.add(pkg, computed, status, seen)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSccBulkWriter:
+
+    def test_kernel_explosion_persists_once_per_package_cve(self, app):
+        """Many sibling packages sharing the same CVE set each get their own
+        finding/observation/assessment, while each CVE row is inserted once."""
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+
+            # 5 kernel-module siblings, all carrying the same 2 CVEs.
+            pkgs = _make_packages([(f"kernel-module-{i}", "6.6") for i in range(5)])
+            shared = [
+                (_Computed("CVE-2023-0001", score=9.8), "affected"),
+                (_Computed("CVE-2023-0002", score=5.0), "under_investigation"),
+            ]
+
+            writer = _SccBulkWriter(scan.id, variant.id, pkgs)
+            writer.FLUSH_THRESHOLD = 3  # force several chunked flushes
+            for pkg in pkgs:
+                # Fresh _Computed per package (engine yields per-package instances).
+                pairs = [(_Computed(c.identifier, score=float(c.cvss_metrics[0].score)), s)
+                         for c, s in shared]
+                _scan_pkg(writer, pkg, pairs)
+            writer.flush()
+
+            # 2 distinct vulnerabilities, each with exactly one metric row.
+            assert _db.session.query(Vulnerability).count() == 2
+            assert _db.session.query(Metrics).count() == 2
+
+            # 5 packages x 2 CVEs = 10 findings / observations / assessments.
+            assert _db.session.query(Finding).count() == 10
+            assert _db.session.query(Observation).count() == 10
+            assert _db.session.query(Assessment).count() == 10
+
+            # Every observation belongs to this scan; every assessment to variant.
+            assert all(o.scan_id == scan.id
+                       for o in _db.session.query(Observation).all())
+            assert all(a.variant_id == variant.id and a.origin == "scc"
+                       for a in _db.session.query(Assessment).all())
+            assert writer.cves_found == {"CVE-2023-0001", "CVE-2023-0002"}
+
+    def test_existing_finding_is_reused_not_duplicated(self, app):
+        """A finding from a prior scan must be reused (no duplicate row), and its
+        already-present assessment must not be duplicated."""
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("openssl", "1.1.1")])[0]
+
+            # Pre-existing finding + assessment for (pkg, CVE) from an earlier run.
+            existing = Finding.create(pkg.id, "CVE-2023-0001", commit=False)
+            Assessment.create(
+                status="affected", finding_id=existing.id, variant_id=variant.id,
+                origin="nvd", commit=False,
+            )
+            _db.session.commit()
+            existing_fid = existing.id
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            _scan_pkg(writer, pkg, [(_Computed("CVE-2023-0001"), "affected")])
+            writer.flush()
+
+            # No duplicate finding: still exactly one for this (pkg, CVE).
+            findings = _db.session.query(Finding).filter_by(
+                package_id=pkg.id, vulnerability_id="CVE-2023-0001").all()
+            assert len(findings) == 1
+            assert findings[0].id == existing_fid
+
+            # The existing assessment is reused (not duplicated).
+            assert _db.session.query(Assessment).filter_by(
+                finding_id=existing_fid, variant_id=variant.id).count() == 1
+            # One observation recorded for this scan against the reused finding.
+            assert _db.session.query(Observation).filter_by(
+                finding_id=existing_fid, scan_id=scan.id).count() == 1
+
+    def test_existing_vulnerability_not_reinserted(self, app):
+        """A CVE already present in the vulnerabilities table is left intact and
+        not re-inserted (no primary-key collision)."""
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("curl", "8.0")])[0]
+
+            Vulnerability.create_record(
+                id="CVE-2023-0001", description="pre-existing")
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            _scan_pkg(writer, pkg, [(_Computed("CVE-2023-0001", description="new"),
+                                     "affected")])
+            writer.flush()
+
+            vulns = _db.session.query(Vulnerability).filter_by(
+                id="CVE-2023-0001").all()
+            assert len(vulns) == 1
+            # Original description preserved (writer does not overwrite existing).
+            assert vulns[0].description == "pre-existing"
+            # Finding for the existing vuln was still created.
+            assert _db.session.query(Finding).filter_by(
+                package_id=pkg.id, vulnerability_id="CVE-2023-0001").count() == 1
+
+    def test_not_affected_and_fixed_are_persisted(self, app):
+        """Every engine verdict — including not_affected and fixed — is recorded."""
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("zlib", "1.3")])[0]
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            _scan_pkg(writer, pkg, [
+                (_Computed("CVE-2023-0001"), "affected"),
+                (_Computed("CVE-2023-0002"), "not_affected"),
+                (_Computed("CVE-2023-0003"), "fixed"),
+            ])
+            writer.flush()
+
+            ids = {f.vulnerability_id for f in _db.session.query(Finding).all()}
+            assert ids == {"CVE-2023-0001", "CVE-2023-0002", "CVE-2023-0003"}
+
+            statuses = {
+                a.finding.vulnerability_id: a.status
+                for a in _db.session.query(Assessment).all()
+            }
+            # All new findings start as under_investigation regardless of the
+            # engine verdict; a human must triage before a verdict is recorded.
+            assert statuses == {
+                "CVE-2023-0001": "under_investigation",
+                "CVE-2023-0002": "under_investigation",
+                "CVE-2023-0003": "under_investigation",
+            }
+
+    def test_matching_last_assessment_writes_no_new_one(self, app):
+        """When the engine confirms a finding's current state (even via an
+        equivalent CDX-VEX synonym) no new assessment is recorded."""
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("openssl", "1.1.1")])[0]
+
+            existing = Finding.create(pkg.id, "CVE-2023-0001", commit=False)
+            # CDX-VEX "exploitable" is the synonym of OpenVEX "affected".
+            Assessment.create(
+                status="exploitable", finding_id=existing.id,
+                variant_id=variant.id, origin="manual", commit=False,
+            )
+            _db.session.commit()
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            _scan_pkg(writer, pkg, [(_Computed("CVE-2023-0001"), "affected")])
+            writer.flush()
+
+            # No new assessment: the engine verdict matches the recorded state.
+            assert _db.session.query(Assessment).filter_by(
+                finding_id=existing.id, variant_id=variant.id).count() == 1
+            # The scan still observed the finding.
+            assert _db.session.query(Observation).filter_by(
+                finding_id=existing.id, scan_id=scan.id).count() == 1
+
+    def test_existing_finding_without_assessment_not_given_pending(self, app):
+        """A pre-existing finding that has no assessment must not receive a new
+        'Pending Assessment' from the scc-scan (only brand-new findings should)."""
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("curl", "8.0")])[0]
+
+            # Pre-existing finding with NO assessment.
+            existing = Finding.create(pkg.id, "CVE-2023-0001", commit=False)
+            _db.session.commit()
+            existing_fid = existing.id
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            _scan_pkg(writer, pkg, [(_Computed("CVE-2023-0001"), "affected")])
+            writer.flush()
+
+            # The finding is reused, no new one created.
+            findings = _db.session.query(Finding).filter_by(
+                package_id=pkg.id, vulnerability_id="CVE-2023-0001").all()
+            assert len(findings) == 1
+            assert findings[0].id == existing_fid
+
+            # No assessment added — the pre-existing finding had none and the
+            # scc-scan must not inject a "Pending Assessment" for it.
+            assert _db.session.query(Assessment).filter_by(
+                finding_id=existing_fid, variant_id=variant.id).count() == 0
+            # The scan still recorded the observation.
+            assert _db.session.query(Observation).filter_by(
+                finding_id=existing_fid, scan_id=scan.id).count() == 1
+
+    def test_changed_status_writes_no_new_assessment_if_one_exists(self, app):
+        """When a finding already has an assessment the scc-scan leaves it
+        untouched, regardless of the engine's current verdict."""
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("curl", "8.0")])[0]
+
+            existing = Finding.create(pkg.id, "CVE-2023-0001", commit=False)
+            Assessment.create(
+                status="not_affected", finding_id=existing.id,
+                variant_id=variant.id, origin="manual", commit=False,
+            )
+            _db.session.commit()
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            _scan_pkg(writer, pkg, [(_Computed("CVE-2023-0001"), "affected")])
+            writer.flush()
+
+            # Assessment count must remain 1 — the existing one is preserved.
+            assessments = _db.session.query(Assessment).filter_by(
+                finding_id=existing.id, variant_id=variant.id).all()
+            assert len(assessments) == 1
+            assert assessments[0].status == "not_affected"
+            # The scan still observed the finding.
+            assert _db.session.query(Observation).filter_by(
+                finding_id=existing.id, scan_id=scan.id).count() == 1
+
+    def test_duplicate_cve_within_package_deduped(self, app):
+        """If the same CVE is offered twice for one package it yields one finding."""
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("bash", "5.2")])[0]
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            _scan_pkg(writer, pkg, [
+                (_Computed("CVE-2023-0001"), "affected"),
+                (_Computed("CVE-2023-0001"), "affected"),
+            ])
+            writer.flush()
+
+            assert _db.session.query(Finding).filter_by(
+                package_id=pkg.id, vulnerability_id="CVE-2023-0001").count() == 1
+            assert _db.session.query(Observation).count() == 1
+            assert _db.session.query(Assessment).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Pure-function helper coverage (no DB needed)
+# ---------------------------------------------------------------------------
+
+class TestTsKey:
+    """Cover all branches of _ts_key (line 370 area)."""
+
+    def test_none_returns_empty_string(self):
+        from src.bin.cmd_vuln_scan import _ts_key
+        assert _ts_key(None) == ""
+
+    def test_string_returned_unchanged(self):
+        from src.bin.cmd_vuln_scan import _ts_key
+        assert _ts_key("2023-01-01T00:00:00") == "2023-01-01T00:00:00"
+
+    def test_datetime_uses_isoformat(self):
+        from src.bin.cmd_vuln_scan import _ts_key
+        dt = datetime(2023, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        assert _ts_key(dt) == dt.isoformat()
+
+    def test_object_without_isoformat_uses_str(self):
+        from src.bin.cmd_vuln_scan import _ts_key
+
+        class _Bad:
+            def isoformat(self):
+                raise RuntimeError("no isoformat")
+
+            def __str__(self):
+                return "fallback"
+
+        assert _ts_key(_Bad()) == "fallback"
+
+
+class TestSccCvssVersion:
+    """Cover error and edge branches of _scc_cvss_version (line 382 area)."""
+
+    def _metric(self, ver_value):
+        class _CV:
+            value = ver_value
+
+        class _M:
+            cvss_ver = _CV()
+
+        return _M()
+
+    def test_valid_version_returns_string(self):
+        from src.bin.cmd_vuln_scan import _scc_cvss_version
+        assert _scc_cvss_version(self._metric((3, 1))) == "3.1"
+
+    def test_zero_major_returns_empty(self):
+        from src.bin.cmd_vuln_scan import _scc_cvss_version
+        assert _scc_cvss_version(self._metric((0, 1))) == ""
+
+    def test_non_iterable_value_returns_empty(self):
+        from src.bin.cmd_vuln_scan import _scc_cvss_version
+        # None cannot be unpacked → TypeError → ""
+        assert _scc_cvss_version(self._metric(None)) == ""
+
+    def test_wrong_length_tuple_returns_empty(self):
+        from src.bin.cmd_vuln_scan import _scc_cvss_version
+        # ValueError: not enough values to unpack
+        assert _scc_cvss_version(self._metric((3,))) == ""
+
+
+class TestBuildVulnEdgeCases:
+    """Cover skipped-metric branches inside _SccBulkWriter._build_vuln."""
+
+    def test_metric_with_none_score_skipped(self):
+        from src.bin.cmd_vuln_scan import _SccBulkWriter
+
+        class _CV:
+            value = (3, 1)
+
+        class _M:
+            score = None
+            cvss_ver = _CV()
+            vector_str = ""
+            source = "nvd"
+
+        class _Computed:
+            description = "d"
+            date_published = None
+            date_modified = None
+            external_refs = []
+            cvss_metrics = [_M()]
+
+        vuln_row, metric_rows = _SccBulkWriter._build_vuln("CVE-2099-0001", _Computed())
+        assert metric_rows == []
+
+    def test_duplicate_version_score_deduped(self):
+        from src.bin.cmd_vuln_scan import _SccBulkWriter
+
+        class _CV:
+            value = (3, 1)
+
+        class _M:
+            score = 7.5
+            cvss_ver = _CV()
+            vector_str = "AV:N"
+            source = "nvd"
+
+        class _Computed:
+            description = "d"
+            date_published = None
+            date_modified = None
+            external_refs = []
+            # Two metrics with the same (version, score) → only one inserted.
+            cvss_metrics = [_M(), _M()]
+
+        vuln_row, metric_rows = _SccBulkWriter._build_vuln("CVE-2099-0002", _Computed())
+        assert len(metric_rows) == 1
+
+
+class TestMaybeFlushAndEarlyReturn:
+    """Cover maybe_flush() and the early-return path of flush()."""
+
+    def test_maybe_flush_does_not_flush_below_threshold(self, app):
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("curl", "8.0")])[0]
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            # Below threshold — maybe_flush must be a no-op (nothing committed).
+            writer.maybe_flush()
+            assert _db.session.query(Finding).count() == 0
+
+    def test_maybe_flush_triggers_flush_at_threshold(self, app):
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("curl", "8.0")])[0]
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            writer.FLUSH_THRESHOLD = 0  # force flush on any count
+            writer._buffered_findings = 1
+            writer.maybe_flush()
+            # flush() ran — row buffers are cleared.
+            assert writer._vuln_rows == []
+
+    def test_flush_with_empty_rows_returns_early(self, app):
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("curl", "8.0")])[0]
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            # All row lists are empty → flush() must return without DB writes.
+            writer.flush()
+            assert _db.session.query(Finding).count() == 0
+
+
+class TestAddExceptionInStatusNotes:
+    """Cover the except branch when vex_assessment.status_notes raises."""
+
+    def test_status_notes_exception_records_none(self, app):
+        with app.app_context():
+            project = Project.create("P")
+            variant = Variant.create("V", project.id)
+            scan = Scan.create("scc", variant.id, scan_type="tool")
+            pkg = _make_packages([("bash", "5.2")])[0]
+
+            class _BadAssessment:
+                @property
+                def status_notes(self):
+                    raise RuntimeError("status_notes unavailable")
+
+            class _ComputedNoNotes:
+                _cve_id = "CVE-2099-NOTES"
+                description = "test"
+                date_published = None
+                date_modified = None
+                external_refs = []
+                cvss_metrics = []
+                vex_assessment = _BadAssessment()
+
+                @property
+                def identifier(self):
+                    return self._cve_id
+
+            writer = _SccBulkWriter(scan.id, variant.id, [pkg])
+            seen: set = set()
+            writer.add(pkg, _ComputedNoNotes(), "affected", seen)
+            writer.flush()
+
+            # Assessment row should exist with status_notes=None (no crash).
+            assessments = _db.session.query(Assessment).all()
+            assert len(assessments) == 1
+            assert assessments[0].status_notes is None

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,9 @@ ignore_missing_imports = true
 [mypy-uuid_extensions]
 ignore_missing_imports = true
 
+[mypy-sbom_cve_check.*]
+ignore_missing_imports = true
+
 # ── Per-module ratchet (added phase by phase) ──────────────────────────────
 # Phase 1a: helpers
 

--- a/vulnscout
+++ b/vulnscout
@@ -66,7 +66,7 @@ Input commands (can be chained, triggers scan automatically):
   --perform-grype-scan            Run Grype on the current DB content (after merging any added inputs)
   --perform-nvd-scan              Run an NVD CPE-based vulnerability scan
   --perform-osv-scan              Run an OSV PURL-based vulnerability scan
-  --perform-scc-scan              Run a local sbom-cve-check vulnerability scan
+  --perform-sbom-cve-check-scan          Run a sbom-cve-check vulnerability scan
 
 Scan & output commands:
   --match-condition <expr>        Run vulnerability scan
@@ -209,9 +209,9 @@ REFRESH_REMOTE_DELAY=2w
 EOF
         echo "Created default config at $VULNSCOUT_CONFIG_FILE"
     fi
-    # Resolve SCC databases host path before config.env is sourced into env_args
-    # so that the host path is not overridden by SCC_DATABASES_DIR from config.env.
-    local _scc_host_db="${VULNSCOUT_SCC_DB_DIR:-${HOME}/.cache/sbom_cve_check/databases}"
+    # Resolve sbom-cve-check databases host path before config.env is sourced into env_args
+    # so that the host path is not overridden by SBOM_CVE_CHECK_DATABASES_DIR from config.env.
+    local _sbom_cve_check_host_db="${VULNSCOUT_SBOM_CVE_CHECK_DB_DIR:-${HOME}/.cache/sbom_cve_check/databases}"
 
     local -a env_args=()
     _detect_legacy
@@ -221,15 +221,15 @@ EOF
         env_args+=(-e "${key}=${value}")
     done < "$VULNSCOUT_CONFIG_FILE"
     [[ "$LEGACY_SETUP_DETECTED" == true ]] && env_args+=(-e LEGACY_SETUP_DETECTED=true)
-    # Pass SCC_AUTO_UPDATE from the host environment if the operator exported it,
+    # Pass SBOM_CVE_CHECK_AUTO_UPDATE from the host environment if the operator exported it,
     # since it is not a launcher-level variable (unlike VULNSCOUT_IMAGE) and
     # therefore does not appear in config.env.
-    [[ -n "${SCC_AUTO_UPDATE:-}" ]] && env_args+=(-e "SCC_AUTO_UPDATE=$SCC_AUTO_UPDATE")
+    [[ -n "${SBOM_CVE_CHECK_AUTO_UPDATE:-}" ]] && env_args+=(-e "SBOM_CVE_CHECK_AUTO_UPDATE=$SBOM_CVE_CHECK_AUTO_UPDATE")
     local -a vol_args=(
         -v "$VULNSCOUT_CACHE_DIR:/cache/vulnscout:Z"
         -v "$VULNSCOUT_OUTPUTS_DIR:/scan/outputs:Z"
         -v "$VULNSCOUT_CONFIG_FILE:/etc/vulnscout/config.env:Z"
-        -v "$_scc_host_db:/scc_databases:Z"
+        -v "$_sbom_cve_check_host_db:/sbom_cve_check_databases:Z"
     )
     if [ "$DEV_MODE" = true ] && [ -d "$SCRIPT_DIR/src" ]; then
         vol_args+=(-v "$SCRIPT_DIR/src":/scan/src:Z)
@@ -324,8 +324,8 @@ parse_and_run() {
                 ensure_running; PENDING_ARGS+=(--perform-nvd-scan); shift ;;
             perform-osv-scan|--perform-osv-scan)
                 ensure_running; PENDING_ARGS+=(--perform-osv-scan); shift ;;
-            perform-scc-scan|--perform-scc-scan|scc-scan|--scc-scan)
-                ensure_running; PENDING_ARGS+=(--perform-scc-scan); shift ;;
+            perform-sbom-cve-check-scan|--perform-sbom-cve-check-scan|sbom-cve-check-scan|--sbom-cve-check-scan)
+                ensure_running; PENDING_ARGS+=(--perform-sbom-cve-check-scan); shift ;;
             export-spdx|--export-spdx)
                 ensure_running; EXPORT_ARGS+=(--export-spdx); shift ;;
             export-cdx|--export-cdx)

--- a/vulnscout
+++ b/vulnscout
@@ -66,6 +66,7 @@ Input commands (can be chained, triggers scan automatically):
   --perform-grype-scan            Run Grype on the current DB content (after merging any added inputs)
   --perform-nvd-scan              Run an NVD CPE-based vulnerability scan
   --perform-osv-scan              Run an OSV PURL-based vulnerability scan
+  --perform-scc-scan              Run a local sbom-cve-check vulnerability scan
 
 Scan & output commands:
   --match-condition <expr>        Run vulnerability scan
@@ -208,6 +209,10 @@ REFRESH_REMOTE_DELAY=2w
 EOF
         echo "Created default config at $VULNSCOUT_CONFIG_FILE"
     fi
+    # Resolve SCC databases host path before config.env is sourced into env_args
+    # so that the host path is not overridden by SCC_DATABASES_DIR from config.env.
+    local _scc_host_db="${VULNSCOUT_SCC_DB_DIR:-${HOME}/.cache/sbom_cve_check/databases}"
+
     local -a env_args=()
     _detect_legacy
     while IFS='=' read -r key value; do
@@ -216,10 +221,15 @@ EOF
         env_args+=(-e "${key}=${value}")
     done < "$VULNSCOUT_CONFIG_FILE"
     [[ "$LEGACY_SETUP_DETECTED" == true ]] && env_args+=(-e LEGACY_SETUP_DETECTED=true)
+    # Pass SCC_AUTO_UPDATE from the host environment if the operator exported it,
+    # since it is not a launcher-level variable (unlike VULNSCOUT_IMAGE) and
+    # therefore does not appear in config.env.
+    [[ -n "${SCC_AUTO_UPDATE:-}" ]] && env_args+=(-e "SCC_AUTO_UPDATE=$SCC_AUTO_UPDATE")
     local -a vol_args=(
         -v "$VULNSCOUT_CACHE_DIR:/cache/vulnscout:Z"
         -v "$VULNSCOUT_OUTPUTS_DIR:/scan/outputs:Z"
         -v "$VULNSCOUT_CONFIG_FILE:/etc/vulnscout/config.env:Z"
+        -v "$_scc_host_db:/scc_databases:Z"
     )
     if [ "$DEV_MODE" = true ] && [ -d "$SCRIPT_DIR/src" ]; then
         vol_args+=(-v "$SCRIPT_DIR/src":/scan/src:Z)
@@ -314,6 +324,8 @@ parse_and_run() {
                 ensure_running; PENDING_ARGS+=(--perform-nvd-scan); shift ;;
             perform-osv-scan|--perform-osv-scan)
                 ensure_running; PENDING_ARGS+=(--perform-osv-scan); shift ;;
+            perform-scc-scan|--perform-scc-scan|scc-scan|--scc-scan)
+                ensure_running; PENDING_ARGS+=(--perform-scc-scan); shift ;;
             export-spdx|--export-spdx)
                 ensure_running; EXPORT_ARGS+=(--export-spdx); shift ;;
             export-cdx|--export-cdx)

--- a/vulnscout
+++ b/vulnscout
@@ -209,9 +209,12 @@ REFRESH_REMOTE_DELAY=2w
 EOF
         echo "Created default config at $VULNSCOUT_CONFIG_FILE"
     fi
-    # Resolve sbom-cve-check databases host path before config.env is sourced into env_args
-    # so that the host path is not overridden by SBOM_CVE_CHECK_DATABASES_DIR from config.env.
-    local _sbom_cve_check_host_db="${VULNSCOUT_SBOM_CVE_CHECK_DB_DIR:-${HOME}/.cache/sbom_cve_check/databases}"
+    # The sbom-cve-check advisory databases (NVD-FKIE + CVEList) live inside the
+    # VulnScout cache directory by default (sub-folder next to vulnscout.db), so the
+    # existing cache mount already covers them and no extra mount is needed.  An
+    # explicit VULNSCOUT_SBOM_CVE_CHECK_DB_DIR override (e.g. a shared host clone) is
+    # mounted separately and pointed at by SBOM_CVE_CHECK_DATABASES_DIR.
+    local _sbom_cve_check_host_db="${VULNSCOUT_SBOM_CVE_CHECK_DB_DIR:-}"
 
     local -a env_args=()
     _detect_legacy
@@ -221,16 +224,19 @@ EOF
         env_args+=(-e "${key}=${value}")
     done < "$VULNSCOUT_CONFIG_FILE"
     [[ "$LEGACY_SETUP_DETECTED" == true ]] && env_args+=(-e LEGACY_SETUP_DETECTED=true)
-    # Pass SBOM_CVE_CHECK_AUTO_UPDATE from the host environment if the operator exported it,
-    # since it is not a launcher-level variable (unlike VULNSCOUT_IMAGE) and
-    # therefore does not appear in config.env.
+    # Pass SBOM_CVE_CHECK_AUTO_UPDATE from the host environment so the operator can
+    # override the container default (1 = on) e.g. to run offline (SBOM_CVE_CHECK_AUTO_UPDATE=0).
     [[ -n "${SBOM_CVE_CHECK_AUTO_UPDATE:-}" ]] && env_args+=(-e "SBOM_CVE_CHECK_AUTO_UPDATE=$SBOM_CVE_CHECK_AUTO_UPDATE")
     local -a vol_args=(
         -v "$VULNSCOUT_CACHE_DIR:/cache/vulnscout:Z"
         -v "$VULNSCOUT_OUTPUTS_DIR:/scan/outputs:Z"
         -v "$VULNSCOUT_CONFIG_FILE:/etc/vulnscout/config.env:Z"
-        -v "$_sbom_cve_check_host_db:/sbom_cve_check_databases:Z"
     )
+    if [[ -n "$_sbom_cve_check_host_db" ]]; then
+        mkdir -p "$_sbom_cve_check_host_db"
+        vol_args+=(-v "$_sbom_cve_check_host_db:/sbom_cve_check_databases:Z")
+        env_args+=(-e "SBOM_CVE_CHECK_DATABASES_DIR=/sbom_cve_check_databases")
+    fi
     if [ "$DEV_MODE" = true ] && [ -d "$SCRIPT_DIR/src" ]; then
         vol_args+=(-v "$SCRIPT_DIR/src":/scan/src:Z)
         env_args+=(-e DEV_MODE=true)


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

Integrates [sbom-cve-check](https://github.com/savoirfairelinux/sbom-cve-check) as a scan source alongside Grype, NVD, and OSV. The engine matches packages against locally-cloned NVD-FKIE and CVEList V5 advisory databases using CPE/PURL identifiers and semantic version-range evaluation

This PR does not include:
- Scoping to Yocto source files (ProgramFiles)
- Full scan delta counts like in Gtype scans 

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Configure environment:
```sh
docker build -t sfl:custom .
export VULNSCOUT_IMAGE="sfl:custom"
```

Test the CLI:
```sh
./vulnscout  --project scarthgap --variant default --scc-scan
```

Test the web dashboard:
1. Open the Scan tab for any variant with packages loaded.  
2. Ensure SCC is checked in the scanner selector.  
3. Click Run scan. A progress panel should appear showing log window.  
4. On completion the scan list refreshes and new `scc`-sourced findings appear in the vulnerability table.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


