### PR TITLE
Unify columns for updated_at and fetched_at

### DIFF
--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -36,9 +36,8 @@ type Vulnerability = {
     variants: string[];
     urls: string[];
     published?: string;
-    nvd_fetched_at?: string;
-    nvd_data_updated_at?: string;
-    ghsa_fetched_at?: string;
+    data_fetched_at?: string;
+    data_updated_at?: string;
     first_scan_date?: string;
     texts: {
         title: string;
@@ -256,9 +255,8 @@ const asVulnerability = (data: any): Vulnerability | [] => {
     if (typeof data?.effort?.pessimistic === "string") vuln.effort.pessimistic = new Iso8601Duration(data.effort.pessimistic)
     if (typeof data?.fix?.state === "string") vuln.fix.state = data.fix.state
     if (typeof data?.published === "string") vuln.published = data.published
-    if (typeof data?.nvd_fetched_at === "string") vuln.nvd_fetched_at = data.nvd_fetched_at
-    if (typeof data?.nvd_data_updated_at === "string") vuln.nvd_data_updated_at = data.nvd_data_updated_at
-    if (typeof data?.ghsa_fetched_at === "string") vuln.ghsa_fetched_at = data.ghsa_fetched_at
+    if (typeof data?.data_fetched_at === "string") vuln.data_fetched_at = data.data_fetched_at
+    if (typeof data?.data_updated_at === "string") vuln.data_updated_at = data.data_updated_at
     if (typeof data?.first_scan_date === "string") vuln.first_scan_date = data.first_scan_date
     return vuln
 }

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -583,9 +583,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         'assessments': 'Last Assessed',
         'published': 'Published Date',
         'first_scan_date': 'First Scan Date',
-        'nvd_fetched_at': 'NVD Fetched',
-        'nvd_data_updated_at': 'NVD Updated',
-        'ghsa_fetched_at': 'GHSA Fetched',
+        'data_fetched_at': 'Last Fetched',
+        'data_updated_at': 'Last Updated',
         'found_by': 'Sources',
         'actions': 'Actions'
     }), []);
@@ -896,9 +895,9 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             },
             size: 110
             }),
-            columnHelper.accessor('nvd_fetched_at', {
-            id: 'nvd_fetched_at',
-            header: () => <div className="flex items-center justify-center">NVD Fetched</div>,
+            columnHelper.accessor('data_fetched_at', {
+            id: 'data_fetched_at',
+            header: () => <div className="flex items-center justify-center">Last Fetched</div>,
             cell: info => {
                 const val = info.getValue();
                 if (!val) return <div className="flex items-center justify-center h-full text-center text-gray-400">Never</div>;
@@ -916,15 +915,15 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             },
             enableSorting: true,
             sortingFn: (rowA, rowB) => {
-                const a = rowA.original.nvd_fetched_at ? new Date(rowA.original.nvd_fetched_at).getTime() : 0;
-                const b = rowB.original.nvd_fetched_at ? new Date(rowB.original.nvd_fetched_at).getTime() : 0;
+                const a = rowA.original.data_fetched_at ? new Date(rowA.original.data_fetched_at).getTime() : 0;
+                const b = rowB.original.data_fetched_at ? new Date(rowB.original.data_fetched_at).getTime() : 0;
                 return a - b;
             },
             size: 130
             }),
-            columnHelper.accessor('nvd_data_updated_at', {
-            id: 'nvd_data_updated_at',
-            header: () => <div className="flex items-center justify-center">NVD Updated</div>,
+            columnHelper.accessor('data_updated_at', {
+            id: 'data_updated_at',
+            header: () => <div className="flex items-center justify-center">Last Updated</div>,
             cell: info => {
                 const val = info.getValue();
                 if (!val) return <div className="flex items-center justify-center h-full text-center text-gray-400">Never</div>;
@@ -942,34 +941,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             },
             enableSorting: true,
             sortingFn: (rowA, rowB) => {
-                const a = rowA.original.nvd_data_updated_at ? new Date(rowA.original.nvd_data_updated_at).getTime() : 0;
-                const b = rowB.original.nvd_data_updated_at ? new Date(rowB.original.nvd_data_updated_at).getTime() : 0;
-                return a - b;
-            },
-            size: 130
-            }),
-            columnHelper.accessor('ghsa_fetched_at', {
-            id: 'ghsa_fetched_at',
-            header: () => <div className="flex items-center justify-center">GHSA Fetched</div>,
-            cell: info => {
-                const val = info.getValue();
-                if (!val) return <div className="flex items-center justify-center h-full text-center text-gray-400">Never</div>;
-                const date = new Date(val);
-                const formattedDate = date.toLocaleDateString(undefined, {
-                    year: 'numeric',
-                    month: 'short',
-                    day: '2-digit',
-                }) + ' ' + date.toLocaleTimeString(undefined, {
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    timeZoneName: 'short',
-                });
-                return <div className="flex items-center justify-center h-full text-center text-sm">{formattedDate}</div>;
-            },
-            enableSorting: true,
-            sortingFn: (rowA, rowB) => {
-                const a = rowA.original.ghsa_fetched_at ? new Date(rowA.original.ghsa_fetched_at).getTime() : 0;
-                const b = rowB.original.ghsa_fetched_at ? new Date(rowB.original.ghsa_fetched_at).getTime() : 0;
+                const a = rowA.original.data_updated_at ? new Date(rowA.original.data_updated_at).getTime() : 0;
+                const b = rowB.original.data_updated_at ? new Date(rowB.original.data_updated_at).getTime() : 0;
                 return a - b;
             },
             size: 130
@@ -1334,9 +1307,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     'Last Assessed',
                     'Published Date',
                     'First Scan Date',
-                    'NVD Fetched',
-                    'NVD Updated',
-                    'GHSA Fetched',
+                    'Last Fetched',
+                    'Last Updated',
                     'Sources'
                 ]}
                 selected={visibleColumns}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -362,7 +362,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const [generalBanner, setGeneralBanner] = useState<SourceBanner>(null);
     const [searchFilteredData, setSearchFilteredData] = useState<Vulnerability[]>([]);
     const [visibleColumns, setVisibleColumns] = useState<string[]>([
-        'ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Updated'
+        'ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Assessed'
     ]);
     const [focusedRowIndex, setFocusedRowIndex] = useState<number | null>(null);
 
@@ -580,7 +580,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         'severity': 'Attack Vector',
         'simplified_status': 'Status',
         'effort.likely': 'Estimated Effort',
-        'assessments': 'Last Updated',
+        'assessments': 'Last Assessed',
         'published': 'Published Date',
         'first_scan_date': 'First Scan Date',
         'nvd_fetched_at': 'NVD Fetched',
@@ -779,7 +779,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             }),
             columnHelper.accessor('assessments', {
             id: 'assessments',
-            header: () => <div className="flex items-center justify-center">Last Updated</div>,
+            header: () => <div className="flex items-center justify-center">Last Assessed</div>,
             cell: info => {
                 const assessments = info.getValue();
                 if (!assessments || assessments.length === 0) {
@@ -1172,7 +1172,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         setPublishedDateFrom('');
         setPublishedDateTo('');
         setSelectedRows({});
-        setVisibleColumns(['ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Updated']);
+        setVisibleColumns(['ID', 'Severity', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Assessed']);
         setShowCustomSeverityFilter(false);
         setSeverityRange({ min: SEVERITY_RANGE_MIN, max: SEVERITY_RANGE_MAX });
         setShowCustomEpssFilter(false);
@@ -1331,7 +1331,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     'Attack Vector',
                     'Status',
                     'Estimated Effort',
-                    'Last Updated',
+                    'Last Assessed',
                     'Published Date',
                     'First Scan Date',
                     'NVD Fetched',

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -2346,8 +2346,8 @@ describe('More Filters dropdown', () => {
     });
 });
 
-describe('NVD timestamp columns', () => {
-    const makeVuln = (id: string, nvd_fetched_at?: string, nvd_data_updated_at?: string): Vulnerability => ({
+describe('Data timestamp columns (Fetched / Updated)', () => {
+    const makeVuln = (id: string, data_fetched_at?: string, data_updated_at?: string): Vulnerability => ({
         id,
         aliases: [],
         related_vulnerabilities: [],
@@ -2369,8 +2369,8 @@ describe('NVD timestamp columns', () => {
         simplified_status: 'Pending Assessment',
         assessments: [],
         variants: [],
-        nvd_fetched_at,
-        nvd_data_updated_at,
+        data_fetched_at,
+        data_updated_at,
     });
 
     const enableColumn = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
@@ -2380,43 +2380,43 @@ describe('NVD timestamp columns', () => {
         await user.click(checkbox);
     };
 
-    test('NVD Fetched column is hidden by default and can be enabled', async () => {
+    test('Fetched column is hidden by default and can be enabled', async () => {
         render(<TableVulnerabilities vulnerabilities={[makeVuln('CVE-2024-0001', '2024-01-15T10:00:00Z')]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
 
-        expect(screen.queryByRole('columnheader', { name: /nvd fetched/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('columnheader', { name: /^last fetched$/i })).not.toBeInTheDocument();
 
-        await enableColumn(user, 'NVD Fetched');
+        await enableColumn(user, 'Last Fetched');
 
         await waitFor(() => {
-            expect(screen.getByRole('columnheader', { name: /nvd fetched/i })).toBeInTheDocument();
+            expect(screen.getByRole('columnheader', { name: /^last fetched$/i })).toBeInTheDocument();
         });
     });
 
-    test('NVD Fetched shows formatted date when value is present', async () => {
+    test('Fetched shows formatted date when value is present', async () => {
         render(<TableVulnerabilities vulnerabilities={[makeVuln('CVE-2024-0001', '2024-01-15T10:00:00Z')]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
 
-        await enableColumn(user, 'NVD Fetched');
+        await enableColumn(user, 'Last Fetched');
 
         await waitFor(() => {
             expect(screen.queryByText('Never')).not.toBeInTheDocument();
-            expect(screen.getByRole('columnheader', { name: /nvd fetched/i })).toBeInTheDocument();
+            expect(screen.getByRole('columnheader', { name: /^last fetched$/i })).toBeInTheDocument();
         });
     });
 
-    test('NVD Fetched shows "Never" when value is absent', async () => {
+    test('Fetched shows "Never" when value is absent', async () => {
         render(<TableVulnerabilities vulnerabilities={[makeVuln('CVE-2024-0001', undefined)]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
 
-        await enableColumn(user, 'NVD Fetched');
+        await enableColumn(user, 'Last Fetched');
 
         await waitFor(() => {
             expect(screen.getByText('Never')).toBeInTheDocument();
         });
     });
 
-    test('NVD Fetched column sorts by fetch time', async () => {
+    test('Fetched column sorts by fetch time', async () => {
         const vulns = [
             makeVuln('CVE-EARLIER', '2023-03-01T00:00:00Z'),
             makeVuln('CVE-LATER', '2024-09-01T00:00:00Z'),
@@ -2424,9 +2424,9 @@ describe('NVD timestamp columns', () => {
         render(<TableVulnerabilities vulnerabilities={vulns} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
 
-        await enableColumn(user, 'NVD Fetched');
+        await enableColumn(user, 'Last Fetched');
 
-        const header = screen.getByRole('columnheader', { name: /nvd fetched/i });
+        const header = screen.getByRole('columnheader', { name: /^last fetched$/i });
         await user.click(header);
         await waitFor(() => {
             const html = document.body.innerHTML;
@@ -2440,43 +2440,43 @@ describe('NVD timestamp columns', () => {
         });
     });
 
-    test('NVD Updated column is hidden by default and can be enabled', async () => {
+    test('Updated column is hidden by default and can be enabled', async () => {
         render(<TableVulnerabilities vulnerabilities={[makeVuln('CVE-2024-0001', undefined, '2024-03-10T12:00:00Z')]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
 
-        expect(screen.queryByRole('columnheader', { name: /nvd updated/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('columnheader', { name: /^last updated$/i })).not.toBeInTheDocument();
 
-        await enableColumn(user, 'NVD Updated');
+        await enableColumn(user, 'Last Updated');
 
         await waitFor(() => {
-            expect(screen.getByRole('columnheader', { name: /nvd updated/i })).toBeInTheDocument();
+            expect(screen.getByRole('columnheader', { name: /^last updated$/i })).toBeInTheDocument();
         });
     });
 
-    test('NVD Updated shows formatted date when value is present', async () => {
+    test('Updated shows formatted date when value is present', async () => {
         render(<TableVulnerabilities vulnerabilities={[makeVuln('CVE-2024-0001', undefined, '2024-03-10T12:00:00Z')]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
 
-        await enableColumn(user, 'NVD Updated');
+        await enableColumn(user, 'Last Updated');
 
         await waitFor(() => {
             expect(screen.queryByText('Never')).not.toBeInTheDocument();
-            expect(screen.getByRole('columnheader', { name: /nvd updated/i })).toBeInTheDocument();
+            expect(screen.getByRole('columnheader', { name: /^last updated$/i })).toBeInTheDocument();
         });
     });
 
-    test('NVD Updated shows "Never" when value is absent', async () => {
+    test('Updated shows "Never" when value is absent', async () => {
         render(<TableVulnerabilities vulnerabilities={[makeVuln('CVE-2024-0001', undefined, undefined)]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
 
-        await enableColumn(user, 'NVD Updated');
+        await enableColumn(user, 'Last Updated');
 
         await waitFor(() => {
             expect(screen.getByText('Never')).toBeInTheDocument();
         });
     });
 
-    test('NVD Updated column sorts by update time', async () => {
+    test('Updated column sorts by update time', async () => {
         const vulns = [
             makeVuln('CVE-EARLIER', undefined, '2023-03-01T00:00:00Z'),
             makeVuln('CVE-LATER', undefined, '2024-09-01T00:00:00Z'),
@@ -2484,9 +2484,9 @@ describe('NVD timestamp columns', () => {
         render(<TableVulnerabilities vulnerabilities={vulns} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
 
-        await enableColumn(user, 'NVD Updated');
+        await enableColumn(user, 'Last Updated');
 
-        const header = screen.getByRole('columnheader', { name: /nvd updated/i });
+        const header = screen.getByRole('columnheader', { name: /^last updated$/i });
         await user.click(header);
         await waitFor(() => {
             const html = document.body.innerHTML;

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -273,7 +273,7 @@ describe('Vulnerability Table', () => {
         const exploit_header = await screen.getByRole('columnheader', {name: /EPSS score/i});
         const packages_header = await screen.getByRole('columnheader', {name: /SBOM Affected/i});
         const status_header = await screen.getByRole('columnheader', {name: /status/i});
-        const last_updated_header = await screen.getByRole('columnheader', {name: /last updated/i});
+        const last_updated_header = await screen.getByRole('columnheader', {name: /last assessed/i});
 
         // ASSERT - Default visible columns
         expect(id_header).toBeInTheDocument();
@@ -1193,7 +1193,7 @@ describe('Vulnerability Table', () => {
         render(<TableVulnerabilities vulnerabilities={vulnWithDifferentDates} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         const user = userEvent.setup();
-        const lastUpdatedHeader = await screen.getByRole('columnheader', {name: /last updated/i});
+        const lastUpdatedHeader = await screen.getByRole('columnheader', {name: /last assessed/i});
 
         // ACT - Sort by last updated (first click: descending - newest first, then older, then no assessments)
         await user.click(lastUpdatedHeader);
@@ -1255,7 +1255,7 @@ describe('Vulnerability Table', () => {
         render(<TableVulnerabilities vulnerabilities={vulnWithMixedDates} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         const user = userEvent.setup();
-        const lastUpdatedHeader = await screen.getByRole('columnheader', {name: /last updated/i});
+        const lastUpdatedHeader = await screen.getByRole('columnheader', {name: /last assessed/i});
 
         // ACT - Sort descending (newest first) - should only need one click
         await user.click(lastUpdatedHeader);

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -538,6 +538,7 @@ class VulnerabilitiesController:
                                 patch_url=vuln.patch_url,
                                 nvd_last_modified=vuln.nvd_last_modified,
                                 nvd_fetched_at=datetime.datetime.utcnow(),
+                                nvd_data_updated_at=datetime.datetime.utcnow(),
                                 commit=False,
                             )
                     except Exception as e:
@@ -571,6 +572,7 @@ class VulnerabilitiesController:
                                     rec.update_record(
                                         publish_date=publish_date,
                                         ghsa_fetched_at=datetime.datetime.utcnow(),
+                                        ghsa_data_updated_at=datetime.datetime.utcnow(),
                                         commit=False,
                                     )
                             except Exception as e:

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import datetime
+import decimal
 import time
 import os
 import json
@@ -373,9 +374,12 @@ class VulnerabilitiesController:
                     vuln.set_epss(result['score'], result['percentile'])
                     rec = self._db_record_cache.get(cve_id) or Vulnerability.get_by_id(cve_id)
                     if rec is not None:
+                        now = datetime.datetime.utcnow()
+                        new_score = decimal.Decimal(str(result['score']))
                         rec.update_record(
-                            epss_score=result['score'],
-                            epss_fetched_at=datetime.datetime.utcnow(),
+                            epss_score=new_score,
+                            epss_fetched_at=now,
+                            epss_data_updated_at=now,
                             commit=False,
                         )
                     nb_vuln += 1

--- a/src/migrations/versions/p2e3f4a5b6c7_add_data_updated_at_columns.py
+++ b/src/migrations/versions/p2e3f4a5b6c7_add_data_updated_at_columns.py
@@ -1,0 +1,35 @@
+"""add epss_data_updated_at and ghsa_data_updated_at to vulnerabilities
+
+Revision ID: p2e3f4a5b6c7
+Revises: o1d2e3f4a5b6
+Create Date: 2026-06-15 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'p2e3f4a5b6c7'
+down_revision = 'o1d2e3f4a5b6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('vulnerabilities', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('epss_data_updated_at', sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column('ghsa_data_updated_at', sa.DateTime(), nullable=True))
+
+    # Backfill so existing rows don't show "Never" for Updated when data is present.
+    op.execute(
+        "UPDATE vulnerabilities SET epss_data_updated_at = epss_fetched_at "
+        "WHERE epss_score IS NOT NULL AND epss_fetched_at IS NOT NULL"
+    )
+    op.execute(
+        "UPDATE vulnerabilities SET ghsa_data_updated_at = ghsa_fetched_at "
+        "WHERE publish_date IS NOT NULL AND ghsa_fetched_at IS NOT NULL"
+    )
+
+
+def downgrade():
+    with op.batch_alter_table('vulnerabilities', schema=None) as batch_op:
+        batch_op.drop_column('ghsa_data_updated_at')
+        batch_op.drop_column('epss_data_updated_at')

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -17,6 +17,16 @@ from .metrics import Metrics
 from .package import Package
 from ..extensions import db, Base
 from ..helpers.verbose import verbose
+from ..helpers.datetime_utils import ensure_utc_iso, normalize_timestamp_for_sort
+
+
+def _latest_iso(*dts: Optional[datetime]) -> Optional[str]:
+    """Return ensure_utc_iso of the most recent non-null datetime, or None."""
+    present = [d for d in dts if d is not None]
+    if not present:
+        return None
+    latest = max(present, key=normalize_timestamp_for_sort)
+    return ensure_utc_iso(latest)
 
 
 if typing.TYPE_CHECKING:
@@ -46,6 +56,7 @@ class Vulnerability(Base):
     attack_vector: Mapped[str | None] = mapped_column(Text)
     epss_score: Mapped[Decimal | None]
     epss_fetched_at: Mapped[datetime | None]
+    epss_data_updated_at: Mapped[datetime | None]
     links: Mapped[list | None] = mapped_column(JSON)
     weaknesses: Mapped[list | None] = mapped_column(JSON)
     versions_data: Mapped[dict | None] = mapped_column(JSON)
@@ -54,6 +65,7 @@ class Vulnerability(Base):
     nvd_fetched_at: Mapped[datetime | None]
     nvd_data_updated_at: Mapped[datetime | None]
     ghsa_fetched_at: Mapped[datetime | None]
+    ghsa_data_updated_at: Mapped[datetime | None]
 
     # ------------------------------------------------------------------
     # Relationships
@@ -329,14 +341,13 @@ class Vulnerability(Base):
             "advisories": list(self.advisories or []),
             "packages": packages,
             "published": self.published,
-            "nvd_fetched_at": (
-                self.nvd_fetched_at.isoformat() if self.nvd_fetched_at else None
+            "data_fetched_at": _latest_iso(
+                self.nvd_fetched_at, self.epss_fetched_at, self.ghsa_fetched_at
             ),
-            "nvd_data_updated_at": (
-                self.nvd_data_updated_at.isoformat() if self.nvd_data_updated_at else None
-            ),
-            "ghsa_fetched_at": (
-                self.ghsa_fetched_at.isoformat() if self.ghsa_fetched_at else None
+            "data_updated_at": _latest_iso(
+                self.nvd_data_updated_at,
+                self.epss_data_updated_at,
+                self.ghsa_data_updated_at,
             ),
         }
 
@@ -562,6 +573,7 @@ class Vulnerability(Base):
         attack_vector: Optional[str] = None,
         epss_score: Optional[float | Decimal] = None,
         epss_fetched_at: Optional[datetime] = None,
+        epss_data_updated_at: Optional[datetime] = None,
         links: Optional[list] = None,
         weaknesses: Optional[list] = None,
         versions_data: Optional[dict] = None,
@@ -570,6 +582,7 @@ class Vulnerability(Base):
         nvd_fetched_at: Optional[datetime] = None,
         nvd_data_updated_at: Optional[datetime] = None,
         ghsa_fetched_at: Optional[datetime] = None,
+        ghsa_data_updated_at: Optional[datetime] = None,
         commit: bool = True,
     ) -> "Vulnerability":
         """Update DB column fields in place, persist the change and return ``self``.
@@ -591,6 +604,8 @@ class Vulnerability(Base):
             self.epss_score = Decimal(epss_score)
         if epss_fetched_at is not None:
             self.epss_fetched_at = epss_fetched_at
+        if epss_data_updated_at is not None:
+            self.epss_data_updated_at = epss_data_updated_at
         if links is not None:
             self.links = links
         if weaknesses is not None:
@@ -607,6 +622,8 @@ class Vulnerability(Base):
             self.nvd_data_updated_at = nvd_data_updated_at
         if ghsa_fetched_at is not None:
             self.ghsa_fetched_at = ghsa_fetched_at
+        if ghsa_data_updated_at is not None:
+            self.ghsa_data_updated_at = ghsa_data_updated_at
         if commit:
             db.session.commit()
         return self

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -311,11 +311,15 @@ def init_app(app):
                                         )
                                     except ValueError:
                                         publish_date = None
-                                    rec.update_record(
-                                        publish_date=publish_date,
-                                        ghsa_fetched_at=now,
-                                        commit=False,
-                                    )
+                                    gk: dict = {
+                                        "ghsa_fetched_at": now,
+                                        "commit": False,
+                                    }
+                                    if publish_date is not None:
+                                        gk["publish_date"] = publish_date
+                                        if rec.publish_date != publish_date:
+                                            gk["ghsa_data_updated_at"] = now
+                                    rec.update_record(**gk)
                         except urllib.error.HTTPError as exc:
                             if exc.code in (403, 429):
                                 _safe_commit("bulk GHSA refresh rate-limited")

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -10,6 +10,7 @@ singletons, which are already polled by /api/nvd/progress and /api/epss/progress
 """
 
 import datetime
+import decimal
 import os
 import re
 import threading
@@ -218,11 +219,15 @@ def init_app(app):
                                 try:
                                     rec = db.session.get(Vulnerability, cve_id)
                                     if rec is not None:
-                                        rec.update_record(
-                                            epss_score=result["score"],
-                                            epss_fetched_at=now,
-                                            commit=False,
-                                        )
+                                        new_score = decimal.Decimal(str(result["score"]))
+                                        ek: dict = {
+                                            "epss_score": new_score,
+                                            "epss_fetched_at": now,
+                                            "commit": False,
+                                        }
+                                        if rec.epss_score is None or rec.epss_score != new_score:
+                                            ek["epss_data_updated_at"] = now
+                                        rec.update_record(**ek)
                                 except Exception as exc:
                                     print(
                                         f"[bulk EPSS refresh] error updating {cve_id}: {exc}",

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -1106,11 +1106,14 @@ def init_app(app):
             publish_date = datetime.date.fromisoformat(published_at[:10])
         except (ValueError, AttributeError):
             return jsonify({"error": "GitHub Advisory Database returned an unparseable date"}), 503
-        rec.update_record(
-            publish_date=publish_date,
-            ghsa_fetched_at=now,
-            commit=False,
-        )
+        update_kwargs: dict = {
+            "publish_date": publish_date,
+            "ghsa_fetched_at": now,
+            "commit": False,
+        }
+        if rec.publish_date != publish_date:
+            update_kwargs["ghsa_data_updated_at"] = now
+        rec.update_record(**update_kwargs)
         db.session.commit()
 
         db.session.refresh(rec)

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import datetime
+import decimal
 import os
 import dataclasses
 import typing
@@ -1057,11 +1058,11 @@ def init_app(app):
             return jsonify({"error": "EPSS API returned no data for this CVE"}), 503
 
         now = datetime.datetime.now(datetime.timezone.utc)
-        rec.update_record(
-            epss_score=epss_data["score"],
-            epss_fetched_at=now,
-            commit=False,
-        )
+        new_score = decimal.Decimal(str(epss_data["score"]))
+        update_kwargs: dict = {"epss_score": new_score, "epss_fetched_at": now, "commit": False}
+        if rec.epss_score is None or rec.epss_score != new_score:
+            update_kwargs["epss_data_updated_at"] = now
+        rec.update_record(**update_kwargs)
         db.session.commit()
 
         db.session.refresh(rec)

--- a/tests/unit_tests/test_epss_refresh.py
+++ b/tests/unit_tests/test_epss_refresh.py
@@ -91,3 +91,38 @@ def test_epss_refresh_does_not_overwrite_score_on_api_failure(app_with_scan):
         rec = db.session.get(Vulnerability, cve_id)
         assert rec is not None
         assert rec.epss_score == original_score
+
+
+def test_initial_epss_enrichment_sets_data_updated_at(app_with_scan):
+    """fetch_epss_scores() stamps epss_data_updated_at on first-time population."""
+    from decimal import Decimal
+    from unittest.mock import MagicMock
+    from src.controllers.vulnerabilities import VulnerabilitiesController
+
+    cve_id = "CVE-2020-35492"
+
+    # Reset so the controller considers it un-enriched
+    with app_with_scan.app_context():
+        rec = db.session.get(Vulnerability, cve_id)
+        rec.epss_fetched_at = None
+        rec.epss_data_updated_at = None
+        db.session.commit()
+
+    # Build a minimal controller with just the one CVE
+    with app_with_scan.app_context():
+        rec = db.session.get(Vulnerability, cve_id)
+        ctrl = VulnerabilitiesController.__new__(VulnerabilitiesController)
+        ctrl.vulnerabilities = {cve_id: rec}
+        ctrl._db_record_cache = {}
+        mock_epss = MagicMock()
+        mock_epss.api_get_epss_batch.return_value = {cve_id: {"score": 0.42, "percentile": 0.7}}
+        ctrl.epss_api = mock_epss
+
+        ctrl.fetch_epss_scores()
+        db.session.commit()
+
+    with app_with_scan.app_context():
+        rec = db.session.get(Vulnerability, cve_id)
+        assert rec.epss_data_updated_at is not None
+        assert abs(float(rec.epss_score) - 0.42) < 1e-4
+

--- a/tests/unit_tests/test_initial_enrichment_data_updated_at.py
+++ b/tests/unit_tests/test_initial_enrichment_data_updated_at.py
@@ -1,0 +1,146 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for data_updated_at stamping during initial NVD and GHSA enrichment."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from src.bin.webapp import create_app
+from src.extensions import db
+from src.models.vulnerability import Vulnerability
+from tests.webapp_tests import write_demo_files, setup_demo_db
+
+
+@pytest.fixture()
+def app(tmp_path):
+    import os
+    files = {
+        "status": tmp_path / "status.txt",
+        "packages": tmp_path / "packages-merged.json",
+        "vulnerabilities": tmp_path / "vulnerabilities-merged.json",
+        "assessments": tmp_path / "assessments-merged.json",
+        "openvex": tmp_path / "openvex.json",
+        "time_estimates": tmp_path / "time_estimates.json",
+    }
+    write_demo_files(files)
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": files["status"],
+            "OPENVEX_FILE": files["openvex"],
+        })
+        setup_demo_db(application)
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+def _make_controller(app, cve_id):
+    """Build a minimal VulnerabilitiesController around one CVE record."""
+    from src.controllers.vulnerabilities import VulnerabilitiesController
+    with app.app_context():
+        rec = db.session.get(Vulnerability, cve_id)
+        ctrl = VulnerabilitiesController.__new__(VulnerabilitiesController)
+        ctrl.vulnerabilities = {cve_id: rec}
+        ctrl._db_record_cache = {}
+        return ctrl
+
+
+# ---------------------------------------------------------------------------
+# NVD initial enrichment
+# ---------------------------------------------------------------------------
+
+def test_nvd_initial_populate_sets_nvd_data_updated_at(app):
+    """fetch_nvd_data() stamps nvd_data_updated_at when NVD returns real data."""
+    cve_id = "CVE-2020-35492"
+
+    with app.app_context():
+        rec = db.session.get(Vulnerability, cve_id)
+        rec.nvd_fetched_at = None
+        rec.nvd_data_updated_at = None
+        db.session.commit()
+
+    ctrl = _make_controller(app, cve_id)
+
+    fake_result = {
+        "published": "2020-05-01",
+        "weaknesses": ["CWE-787"],
+        "versions_data": {},
+        "patch_url": [],
+        "lastModified": "2020-06-01",
+    }
+
+    with app.app_context():
+        with patch("src.controllers.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.fetch_cve_data.return_value = fake_result
+            ctrl.fetch_nvd_data()
+            db.session.commit()
+
+    with app.app_context():
+        rec = db.session.get(Vulnerability, cve_id)
+        assert rec.nvd_data_updated_at is not None
+
+
+def test_nvd_not_found_does_not_set_nvd_data_updated_at(app):
+    """fetch_nvd_data() does NOT stamp nvd_data_updated_at for a not_found sentinel."""
+    cve_id = "CVE-2020-35492"
+
+    with app.app_context():
+        rec = db.session.get(Vulnerability, cve_id)
+        rec.nvd_fetched_at = None
+        rec.nvd_data_updated_at = None
+        db.session.commit()
+
+    ctrl = _make_controller(app, cve_id)
+
+    with app.app_context():
+        with patch("src.controllers.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.fetch_cve_data.return_value = {"not_found": True}
+            ctrl.fetch_nvd_data()
+            db.session.commit()
+
+    with app.app_context():
+        rec = db.session.get(Vulnerability, cve_id)
+        assert rec.nvd_data_updated_at is None
+        assert rec.nvd_fetched_at is not None  # fetched_at IS set for not_found
+
+
+# ---------------------------------------------------------------------------
+# GHSA initial enrichment
+# ---------------------------------------------------------------------------
+
+def test_ghsa_initial_populate_sets_ghsa_data_updated_at(app):
+    """fetch_nvd_data() (which also handles GHSA) stamps ghsa_data_updated_at on first publish_date."""
+    import datetime as dt
+    ghsa_id = "GHSA-R7JW-VC2X-4GBH"
+
+    with app.app_context():
+        # Seed a GHSA vulnerability with no publish_date
+        Vulnerability.create_record(id=ghsa_id, description="test GHSA")
+        rec = db.session.get(Vulnerability, ghsa_id)
+        rec.publish_date = None
+        rec.ghsa_fetched_at = None
+        rec.ghsa_data_updated_at = None
+        db.session.commit()
+
+    from src.controllers.vulnerabilities import VulnerabilitiesController
+    with app.app_context():
+        rec = db.session.get(Vulnerability, ghsa_id)
+        ctrl = VulnerabilitiesController.__new__(VulnerabilitiesController)
+        ctrl.vulnerabilities = {ghsa_id: rec}
+        ctrl._db_record_cache = {}
+
+        with patch.object(VulnerabilitiesController, "_fetch_ghsa_published",
+                          return_value="2023-06-15T00:00:00Z"), \
+             patch("src.controllers.vulnerabilities.NVD_DB") as MockNVD:
+            # No CVE-prefixed IDs → NVD fetch skipped
+            MockNVD.return_value.fetch_cve_data.return_value = None
+            ctrl.fetch_nvd_data()
+            db.session.commit()
+
+    with app.app_context():
+        rec = db.session.get(Vulnerability, ghsa_id)
+        assert rec.ghsa_data_updated_at is not None
+        assert rec.publish_date == dt.date(2023, 6, 15)

--- a/tests/unit_tests/test_vulnerability_to_dict_timestamps.py
+++ b/tests/unit_tests/test_vulnerability_to_dict_timestamps.py
@@ -1,0 +1,46 @@
+"""Tests for unified data_fetched_at / data_updated_at derivation in to_dict."""
+import datetime
+import pytest
+from src.models.vulnerability import Vulnerability
+
+
+def _vuln(**kw):
+    v = Vulnerability(id="CVE-2024-0001")
+    for k, val in kw.items():
+        setattr(v, k, val)
+    return v
+
+
+def test_data_fetched_at_is_max_of_non_null_handles_mixed_tzinfo():
+    """Naive and aware datetimes are compared safely; result is ISO with +00:00."""
+    naive = datetime.datetime(2024, 1, 1, 12, 0, 0)
+    aware = datetime.datetime(2024, 1, 2, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    v = _vuln(nvd_fetched_at=naive, epss_fetched_at=aware, ghsa_fetched_at=None)
+    d = v.to_dict()
+    assert d["data_fetched_at"] == "2024-01-02T12:00:00+00:00"
+    assert "nvd_fetched_at" not in d
+    assert "nvd_data_updated_at" not in d
+    assert "ghsa_fetched_at" not in d
+
+
+def test_data_updated_at_is_max_of_non_null():
+    a = datetime.datetime(2024, 3, 1, 0, 0, 0)
+    b = datetime.datetime(2024, 3, 5, 0, 0, 0)
+    v = _vuln(nvd_data_updated_at=a, epss_data_updated_at=b, ghsa_data_updated_at=None)
+    d = v.to_dict()
+    assert d["data_updated_at"] == "2024-03-05T00:00:00+00:00"
+
+
+def test_all_null_timestamps_yield_none():
+    v = _vuln()
+    d = v.to_dict()
+    assert d["data_fetched_at"] is None
+    assert d["data_updated_at"] is None
+
+
+def test_single_fetched_value_returned():
+    t = datetime.datetime(2025, 6, 1, 8, 0, 0, tzinfo=datetime.timezone.utc)
+    v = _vuln(ghsa_fetched_at=t)
+    d = v.to_dict()
+    assert d["data_fetched_at"] == "2025-06-01T08:00:00+00:00"
+    assert d["data_updated_at"] is None

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -613,6 +613,60 @@ class TestBulkEpssRefreshBackground:
 
         MockTracker.error.assert_called_once()
 
+    def test_bulk_epss_run_sets_data_updated_at_when_score_changes(self, app, client, existing_cve_id):
+        """_run() stamps epss_data_updated_at only when the score changes."""
+        from decimal import Decimal
+        from src.models.vulnerability import Vulnerability
+        from src.extensions import db
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, existing_cve_id)
+            rec.epss_score = Decimal("0.1")
+            rec.epss_data_updated_at = None
+            db.session.commit()
+
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
+            MockEPSS.return_value.api_get_epss_batch.return_value = {
+                existing_cve_id: {"score": 0.9}
+            }
+            with app.app_context():
+                target()
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, existing_cve_id)
+            assert rec.epss_data_updated_at is not None
+
+    def test_bulk_epss_run_no_data_updated_at_when_score_unchanged(self, app, client, existing_cve_id):
+        """_run() does NOT stamp epss_data_updated_at when the score is the same."""
+        from decimal import Decimal
+        from src.models.vulnerability import Vulnerability
+        from src.extensions import db
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, existing_cve_id)
+            rec.epss_score = Decimal("0.5")
+            rec.epss_data_updated_at = None
+            db.session.commit()
+
+        target = self._capture_target(client, [existing_cve_id])
+
+        with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
+             patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
+            MockEPSS.return_value.api_get_epss_batch.return_value = {
+                existing_cve_id: {"score": 0.5}
+            }
+            with app.app_context():
+                target()
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, existing_cve_id)
+            assert rec.epss_data_updated_at is None
+
 
 # ---------------------------------------------------------------------------
 # Cancel NVD refresh — /api/vulnerabilities/cancel-nvd-refresh

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -1120,6 +1120,58 @@ class TestBulkGhsaRefreshBackground:
 
         MockTracker.error.assert_called_once()
 
+    def test_bulk_ghsa_run_sets_data_updated_at_when_date_changes(self, app, client, ghsa_vuln):
+        """_run() stamps ghsa_data_updated_at when publish_date actually changes."""
+        import datetime as dt
+        from src.models.vulnerability import Vulnerability
+        from src.extensions import db
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, ghsa_vuln)
+            rec.publish_date = dt.date(2020, 1, 1)
+            rec.ghsa_data_updated_at = None
+            db.session.commit()
+
+        target = self._capture_target(client, [ghsa_vuln])
+
+        with patch("src.routes.bulk_refresh.VulnerabilitiesController._fetch_ghsa_published",
+                   return_value="2023-06-15T00:00:00Z"), \
+             patch("src.routes.bulk_refresh.GHSAProgressTracker") as MockTracker, \
+             patch("src.routes.bulk_refresh.time.sleep"):
+            MockTracker.is_cancelled.return_value = False
+            with app.app_context():
+                target()
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, ghsa_vuln)
+            assert rec.ghsa_data_updated_at is not None
+
+    def test_bulk_ghsa_run_no_data_updated_at_when_date_unchanged(self, app, client, ghsa_vuln):
+        """_run() does NOT stamp ghsa_data_updated_at when publish_date is same."""
+        import datetime as dt
+        from src.models.vulnerability import Vulnerability
+        from src.extensions import db
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, ghsa_vuln)
+            rec.publish_date = dt.date(2023, 5, 1)
+            rec.ghsa_data_updated_at = None
+            db.session.commit()
+
+        target = self._capture_target(client, [ghsa_vuln])
+
+        with patch("src.routes.bulk_refresh.VulnerabilitiesController._fetch_ghsa_published",
+                   return_value="2023-05-01T00:00:00Z"), \
+             patch("src.routes.bulk_refresh.GHSAProgressTracker") as MockTracker, \
+             patch("src.routes.bulk_refresh.time.sleep"):
+            MockTracker.is_cancelled.return_value = False
+            with app.app_context():
+                target()
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, ghsa_vuln)
+            assert rec.ghsa_data_updated_at is None
+
 
 class TestCancelGhsaRefreshEndpoint:
 
@@ -1237,7 +1289,7 @@ class TestSingleGhsaRefreshEndpoint:
         assert resp.status_code == 200
         vuln = resp.get_json()["vulnerabilities"][0]
         assert vuln["id"] == ghsa_vuln
-        assert vuln["ghsa_fetched_at"] is not None
+        assert vuln["data_fetched_at"] is not None
 
     def test_publish_date_stored_as_date_not_datetime(self, client, ghsa_vuln, app):
         """publish_date must be a date (not datetime) — guards the type-mismatch fix."""
@@ -1312,6 +1364,46 @@ class TestSingleGhsaRefreshEndpoint:
         vuln = resp.get_json()["vulnerabilities"][0]
         assert "texts" in vuln
         assert isinstance(vuln["texts"], list)
+
+    def test_ghsa_refresh_sets_data_updated_at_when_date_changes(self, app, client, ghsa_vuln):
+        """ghsa_data_updated_at is stamped when the publish_date changes."""
+        import datetime as dt
+        from src.models.vulnerability import Vulnerability
+        from src.extensions import db
+        with app.app_context():
+            rec = db.session.get(Vulnerability, ghsa_vuln)
+            rec.publish_date = dt.date(2020, 1, 1)
+            rec.ghsa_data_updated_at = None
+            db.session.commit()
+
+        with patch("src.routes.vulnerabilities.VulnerabilitiesController._fetch_ghsa_published",
+                   return_value="2023-06-15T00:00:00Z"):
+            resp = client.post(f"/api/vulnerabilities/{ghsa_vuln}/ghsa-refresh")
+        assert resp.status_code == 200
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, ghsa_vuln)
+            assert rec.ghsa_data_updated_at is not None
+
+    def test_ghsa_refresh_no_data_updated_at_when_date_unchanged(self, app, client, ghsa_vuln):
+        """ghsa_data_updated_at is NOT stamped when the publish_date stays the same."""
+        import datetime as dt
+        from src.models.vulnerability import Vulnerability
+        from src.extensions import db
+        with app.app_context():
+            rec = db.session.get(Vulnerability, ghsa_vuln)
+            rec.publish_date = dt.date(2023, 5, 1)
+            rec.ghsa_data_updated_at = None
+            db.session.commit()
+
+        with patch("src.routes.vulnerabilities.VulnerabilitiesController._fetch_ghsa_published",
+                   return_value="2023-05-01T00:00:00Z"):
+            resp = client.post(f"/api/vulnerabilities/{ghsa_vuln}/ghsa-refresh")
+        assert resp.status_code == 200
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, ghsa_vuln)
+            assert rec.ghsa_data_updated_at is None
 
 
 class TestBulkGhsaRefreshFailedCounter:

--- a/tests/webapp_tests/test_epss_refresh_routes.py
+++ b/tests/webapp_tests/test_epss_refresh_routes.py
@@ -89,3 +89,44 @@ class TestEpssRefreshEndpoint:
                 f"/api/vulnerabilities/{existing_cve_id.lower()}/epss-refresh"
             )
         assert resp.status_code == 200
+
+    def test_epss_refresh_sets_data_updated_at_when_score_changes(self, app, client, existing_cve_id):
+        """epss_data_updated_at is stamped when the EPSS score changes."""
+        from src.models.vulnerability import Vulnerability
+        from src.extensions import db
+        # Seed a different starting score so the refresh triggers a change
+        with app.app_context():
+            rec = db.session.get(Vulnerability, existing_cve_id)
+            rec.epss_score = None
+            rec.epss_data_updated_at = None
+            db.session.commit()
+
+        with patch("src.routes.vulnerabilities.EPSS_DB") as MockEPSS:
+            MockEPSS.return_value.api_get_epss.return_value = {"score": 0.99, "percentile": 0.99}
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/epss-refresh")
+        assert resp.status_code == 200
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, existing_cve_id)
+            assert rec.epss_data_updated_at is not None
+
+    def test_epss_refresh_no_data_updated_at_when_score_unchanged(self, app, client, existing_cve_id):
+        """epss_data_updated_at is NOT stamped when the score is the same."""
+        from decimal import Decimal
+        from src.models.vulnerability import Vulnerability
+        from src.extensions import db
+        with app.app_context():
+            rec = db.session.get(Vulnerability, existing_cve_id)
+            rec.epss_score = Decimal("0.5")
+            rec.epss_data_updated_at = None
+            db.session.commit()
+
+        with patch("src.routes.vulnerabilities.EPSS_DB") as MockEPSS:
+            MockEPSS.return_value.api_get_epss.return_value = {"score": 0.5, "percentile": 0.8}
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/epss-refresh")
+        assert resp.status_code == 200
+
+        with app.app_context():
+            rec = db.session.get(Vulnerability, existing_cve_id)
+            assert rec.epss_data_updated_at is None
+

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -80,7 +80,7 @@ class TestSingleCveRefreshEndpoint:
         assert "vulnerabilities" in data
         vuln = data["vulnerabilities"][0]
         assert vuln["id"] == existing_cve_id
-        assert "nvd_fetched_at" in vuln  # timestamp always stamped
+        assert "data_fetched_at" in vuln  # timestamp always stamped
         # CVSS score should be reflected in the response
         cvss_scores = vuln["severity"]["cvss"]
         assert any(abs(c["base_score"] - 8.1) < 0.01 for c in cvss_scores)


### PR DESCRIPTION
### Changes proposed in this pull request:

- Add DB table columns for EPSS updated time and GHSA updated time
- Unify columns in the vulnerability table. No more columns for individual refresh.
- Rename previous `Last Updated` to `Last Assessed` to reflect the actual usage of the column.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Start vulnscout normally and go to the vulnerability page to see the new columns. The new columns are hidden by default; toggle them on via the column dropdown. Trigger the refresh as usual and observe how the timestamps in these columns are updated.

<img width="1776" height="742" alt="image" src="https://github.com/user-attachments/assets/64b93b8a-c688-41a0-a4e0-ed417b20ba79" />

### Additional notes

For CVE rows, the fetched_at and the updated_at timestamps use whichever is the latest of the NVD and EPSS refresh.

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [x] Added necessary reviewers


