### PR TITLE
refactor: Scan history redesign scan

### DIFF
--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback, useSyncExternalStore } from "react";
+import type { ReactNode } from "react";
 import ScansHandler from "../handlers/scans";
 import type { Scan, ScanDiff, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry, AssessmentDiffEntry, GlobalResult } from "../handlers/scans";
 import { subscribe, getSnapshot, setOnDone, triggerScan, dismiss as grypeDismiss } from "../handlers/grypeScanState";
@@ -23,7 +24,8 @@ import { extractSupplierName } from "../helpers/pkgId";
 import { formatSourceName } from "../helpers/sourceNames";
 import { downloadJson } from "../helpers/exportJson";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook, faDownload } from "@fortawesome/free-solid-svg-icons";
+import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook, faDownload, faMagnifyingGlass, faBox, faClipboardCheck } from "@fortawesome/free-solid-svg-icons";
+import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "../components/ConfirmationModal";
 import Variants from "../handlers/variant";
 import type { Variant } from "../handlers/variant";
@@ -59,6 +61,55 @@ function formatDate(iso: string): string {
         minute: '2-digit',
         timeZoneName: 'short',
     });
+}
+
+// ---------------------------------------------------------------------------
+// Scan-card presentation helpers
+// ---------------------------------------------------------------------------
+
+type ChangeTone = 'total' | 'added' | 'removed' | 'upgraded' | 'neutral';
+
+const CHANGE_TEXT_CLASSES: Record<ChangeTone, string> = {
+    total: 'text-cyan-600 dark:text-cyan-400',
+    added: 'text-green-600 dark:text-green-400',
+    removed: 'text-red-600 dark:text-red-400',
+    upgraded: 'text-yellow-600 dark:text-yellow-400',
+    neutral: 'text-neutral-500 dark:text-neutral-400',
+};
+
+// Big highlighted number + muted label, used in the "Current result" summary.
+function BigStat({ count, label }: { count: number; label: string }) {
+    return (
+        <div className="flex items-baseline gap-2">
+            <span className="text-2xl font-bold text-cyan-600 dark:text-cyan-400 tabular-nums">{count.toLocaleString()}</span>
+            <span className="text-sm font-medium text-neutral-500 dark:text-neutral-300">{label}</span>
+        </div>
+    );
+}
+
+// A single coloured "<n> <label>" segment within a change row.
+function ChangeStat({ count, label, tone }: { count: number; label: string; tone: ChangeTone }) {
+    return (
+        <span className={CHANGE_TEXT_CLASSES[tone]}>
+            <span className="font-bold tabular-nums">{count.toLocaleString()}</span> {label}
+        </span>
+    );
+}
+
+// Dot separator between change segments.
+function Dot() {
+    return <span className="text-neutral-300 dark:text-neutral-600 select-none">·</span>;
+}
+
+// Icon + label + inline change segments.
+function ChangeLine({ icon, label, children }: { icon: IconDefinition; label: string; children: ReactNode }) {
+    return (
+        <div className="flex items-center gap-2.5 text-sm">
+            <FontAwesomeIcon icon={icon} className="w-4 text-center text-neutral-400 dark:text-neutral-500 shrink-0" />
+            <span className="font-semibold text-neutral-600 dark:text-neutral-200 shrink-0">{label}:</span>
+            <div className="flex items-center gap-2 flex-wrap">{children}</div>
+        </div>
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1759,245 +1810,112 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                     }
                                 </p>
 
-                                {/* Row 2: badges + details button */}
-                                {(scan.scan_type || 'sbom') === 'tool' && (
-                                <>
-                                {/* Update Vulnerabilities row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Update Vulnerabilities:</span>
-                                    {scan.is_first ? (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
-                                            </span>
-                                            {scan.newly_detected_vulns != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_vulns > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {scan.newly_detected_vulns.toLocaleString()} new vulnerabilities discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    ) : (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
-                                            </span>
-                                            {scan.newly_detected_vulns != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_vulns > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {scan.newly_detected_vulns.toLocaleString()} new vulnerabilities discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    )}
-                                </div>
-                                {/* Update Findings row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Update Findings:</span>
-                                    {scan.is_first ? (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.finding_count ?? 0).toLocaleString()} findings detected
-                                            </span>
-                                            {scan.newly_detected_findings != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_findings > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {scan.newly_detected_findings.toLocaleString()} new findings discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    ) : (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.finding_count ?? 0).toLocaleString()} findings detected
-                                            </span>
-                                            {scan.newly_detected_findings != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${scan.newly_detected_findings > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {scan.newly_detected_findings.toLocaleString()} new findings discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    )}
-
-                                </div>
-                                {/* Update Assessments row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Update Assessments:</span>
-                                    {scan.is_first ? (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.assessment_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.assessment_count ?? 0).toLocaleString()} assessments detected
-                                            </span>
-                                            {scan.newly_detected_assessments != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.newly_detected_assessments ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.newly_detected_assessments ?? 0).toLocaleString()} new assessments discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    ) : (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.assessment_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.assessment_count ?? 0).toLocaleString()} assessments detected
-                                            </span>
-                                            {scan.newly_detected_assessments != null && (
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.newly_detected_assessments ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.newly_detected_assessments ?? 0).toLocaleString()} new assessments discovered
-                                            </span>
-                                            )}
-                                        </>
-                                    )}
-                                    {/* Details button */}
-                                    <button
-                                        onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
-                                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
-                                    >
-                                        Details
-                                    </button>
-                                </div>
-                                </>
-                                )}
-                                {(scan.scan_type || 'sbom') !== 'tool' && (
-                                <>
-                                {/* Vulnerabilities row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Vulnerabilities:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.vuln_count ?? 0).toLocaleString()} vulnerabilities detected
-                                    </span>
-                                    {!scan.is_first && (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.vulns_added ?? 0).toLocaleString()} new vulnerabilities
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.vulns_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.vulns_removed ?? 0).toLocaleString()} vulnerabilities removed
-                                            </span>
-                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
-                                                {(scan.vulns_unchanged ?? 0).toLocaleString()} vulnerabilities unchanged
-                                            </span>
-                                        </>
-                                    )}
-                                </div>
-                                {/* Findings row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Findings:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.finding_count ?? 0).toLocaleString()} findings detected
-                                    </span>
-                                    {!scan.is_first && (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.findings_added ?? 0).toLocaleString()} new findings
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.findings_removed ?? 0).toLocaleString()} findings removed
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.findings_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.findings_upgraded ?? 0).toLocaleString()} findings upgraded
-                                            </span>
-                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
-                                                {(scan.findings_unchanged ?? 0).toLocaleString()} findings unchanged
-                                            </span>
-                                        </>
-                                    )}
-                                </div>
-                                {/* Packages row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Packages:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.package_count ?? 0).toLocaleString()} packages detected
-                                    </span>
-                                    {!scan.is_first && (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.packages_added ?? 0).toLocaleString()} new packages
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.packages_removed ?? 0).toLocaleString()} packages removed
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.packages_upgraded ?? 0) > 0 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.packages_upgraded ?? 0).toLocaleString()} packages upgraded
-                                            </span>
-                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
-                                                {(scan.packages_unchanged ?? 0).toLocaleString()} packages unchanged
-                                            </span>
-                                        </>
-                                    )}
-                                </div>
-                                {/* Assessments row */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Assessments:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.assessment_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.assessment_count ?? 0).toLocaleString()} assessments detected
-                                    </span>
-                                    {!scan.is_first && (scan.assessment_count ?? 0) > 0 && (
-                                        <>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.assessments_added ?? 0) > 0 ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.assessments_added ?? 0).toLocaleString()} new assessments
-                                            </span>
-                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.assessments_removed ?? 0) > 0 ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                                {(scan.assessments_removed ?? 0).toLocaleString()} assessments removed
-                                            </span>
-                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400">
-                                                {(scan.assessments_unchanged ?? 0).toLocaleString()} assessments unchanged
-                                            </span>
-                                        </>
-                                    )}
-                                    {/* Details button */}
-                                    <button
-                                        onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
-                                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
-                                    >
-                                        Details
-                                    </button>
-                                </div>
-
-                                {/* Scan Result row — uses global counts when tool scans exist, else SBOM-only */}
-                                <div className="flex items-center gap-2 flex-wrap mb-1 mt-2 pt-2 border-t border-neutral-300 dark:border-neutral-600">
-                                    <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Scan Result:</span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${((scan.global_package_count ?? scan.package_count ?? 0)) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.global_package_count ?? scan.package_count ?? 0).toLocaleString()} packages
-                                    </span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${((scan.global_finding_count ?? scan.finding_count ?? 0)) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.global_finding_count ?? scan.finding_count ?? 0).toLocaleString()} findings
-                                    </span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${((scan.global_vuln_count ?? scan.vuln_count ?? 0)) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.global_vuln_count ?? scan.vuln_count ?? 0).toLocaleString()} vulnerabilities
-                                    </span>
-                                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_assessment_count ?? scan.assessment_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                        {(scan.global_assessment_count ?? scan.assessment_count ?? 0).toLocaleString()} assessments
-                                    </span>
+                                {/* ===== Current result (top) ===== */}
+                                <div className="mt-3 flex items-start justify-between gap-3">
+                                    <div className="min-w-0">
+                                        <h4 className="text-sm font-bold text-neutral-700 dark:text-neutral-100 mb-1.5">Current result</h4>
+                                        <div className="flex items-baseline gap-x-10 gap-y-1.5 flex-wrap">
+                                            <BigStat count={scan.global_package_count ?? scan.package_count ?? 0} label="packages" />
+                                            <BigStat count={scan.global_vuln_count ?? scan.vuln_count ?? 0} label="unique vulnerabilities" />
+                                            <BigStat count={scan.global_finding_count ?? scan.finding_count ?? 0} label="vulnerability matches" />
+                                            <BigStat count={scan.global_assessment_count ?? scan.assessment_count ?? 0} label="assessments" />
+                                        </div>
+                                    </div>
                                     <button
                                         onClick={() => setOpenGlobalId(scan.id)}
-                                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
+                                        className="shrink-0 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
                                     >
                                         Details
                                     </button>
                                 </div>
-                                </>
-                                )}
 
-                                {/* Scan Result (tool scans only) — SBOM ∪ all sources */}
-                                {(scan.scan_type || 'sbom') === 'tool' && scan.global_finding_count != null && (
-                                    <div className="flex items-center gap-2 flex-wrap mb-1 mt-2 pt-2 border-t border-neutral-300 dark:border-neutral-600">
-                                        <span className="text-xs font-bold text-neutral-400 dark:text-neutral-400 uppercase tracking-wide">Scan Result:</span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_package_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_package_count ?? 0).toLocaleString()} packages
-                                        </span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_finding_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_finding_count ?? 0).toLocaleString()} findings
-                                        </span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_vuln_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_vuln_count ?? 0).toLocaleString()} vulnerabilities
-                                        </span>
-                                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold ${(scan.global_assessment_count ?? 0) > 0 ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-700 dark:text-neutral-400'}`}>
-                                            {(scan.global_assessment_count ?? 0).toLocaleString()} assessments
-                                        </span>
+                                {/* ===== Changes since previous scan (skipped only for the very
+                                       first SBOM import, where the diff would simply mirror the
+                                       current result.  Tool scans always have meaningful changes —
+                                       their `is_first` only means "first scan of this source" — so
+                                       they keep showing the section.) ===== */}
+                                {!(scan.is_first && (scan.scan_type || 'sbom') !== 'tool') && (
+                                <div className="mt-3 pt-3 border-t border-neutral-200 dark:border-neutral-600">
+                                    <div className="flex items-center justify-between mb-2">
+                                        <h4 className="text-sm font-bold text-neutral-700 dark:text-neutral-100">
+                                            Changes since previous scan
+                                        </h4>
                                         <button
-                                            onClick={() => setOpenGlobalId(scan.id)}
+                                            onClick={() => { setOpenDiffId(scan.id); setOpenDiffType(scan.scan_type || 'sbom'); }}
                                             className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-neutral-200 dark:bg-neutral-600 hover:bg-neutral-300 dark:hover:bg-neutral-500 text-neutral-700 dark:text-neutral-200 transition-colors"
                                         >
                                             Details
                                         </button>
                                     </div>
+                                    <div className="space-y-1.5">
+                                        {(scan.scan_type || 'sbom') === 'tool' ? (
+                                            <>
+                                                <ChangeLine icon={faShieldHalved} label="Unique vulnerabilities">
+                                                    <ChangeStat count={scan.vuln_count ?? 0} label="detected" tone="total" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.newly_detected_vulns ?? 0} label="new" tone="added" />
+                                                </ChangeLine>
+                                                <ChangeLine icon={faMagnifyingGlass} label="Vulnerability matches">
+                                                    <ChangeStat count={scan.finding_count ?? 0} label="detected" tone="total" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.newly_detected_findings ?? 0} label="new" tone="added" />
+                                                </ChangeLine>
+                                                <ChangeLine icon={faClipboardCheck} label="Assessments">
+                                                    <ChangeStat count={scan.assessment_count ?? 0} label="detected" tone="total" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.newly_detected_assessments ?? 0} label="new" tone="added" />
+                                                </ChangeLine>
+                                            </>
+                                        ) : (
+                                            <>
+                                                <ChangeLine icon={faShieldHalved} label="Unique vulnerabilities">
+                                                    <ChangeStat count={scan.vuln_count ?? 0} label="detected" tone="total" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.vulns_added ?? 0} label="new" tone="added" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.vulns_removed ?? 0} label="no longer present" tone="removed" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.vulns_unchanged ?? 0} label="still present" tone="neutral" />
+                                                </ChangeLine>
+                                                <ChangeLine icon={faMagnifyingGlass} label="Vulnerability matches">
+                                                    <ChangeStat count={scan.finding_count ?? 0} label="detected" tone="total" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.findings_added ?? 0} label="new" tone="added" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.findings_removed ?? 0} label="no longer present" tone="removed" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.findings_upgraded ?? 0} label="upgraded" tone="upgraded" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.findings_unchanged ?? 0} label="still present" tone="neutral" />
+                                                </ChangeLine>
+                                                <ChangeLine icon={faBox} label="Packages">
+                                                    <ChangeStat count={scan.package_count ?? 0} label="detected" tone="total" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.packages_added ?? 0} label="new" tone="added" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.packages_removed ?? 0} label="no longer present" tone="removed" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.packages_upgraded ?? 0} label="upgraded" tone="upgraded" />
+                                                    <Dot />
+                                                    <ChangeStat count={scan.packages_unchanged ?? 0} label="still present" tone="neutral" />
+                                                </ChangeLine>
+                                                <ChangeLine icon={faClipboardCheck} label="Assessments">
+                                                    <ChangeStat count={scan.assessment_count ?? 0} label="detected" tone="total" />
+                                                    {(scan.assessment_count ?? 0) > 0 && (<>
+                                                        <Dot />
+                                                        <ChangeStat count={scan.assessments_added ?? 0} label="new" tone="added" />
+                                                        <Dot />
+                                                        <ChangeStat count={scan.assessments_removed ?? 0} label="no longer present" tone="removed" />
+                                                        <Dot />
+                                                        <ChangeStat count={scan.assessments_unchanged ?? 0} label="still present" tone="neutral" />
+                                                    </>)}
+                                                </ChangeLine>
+                                            </>
+                                        )}
+                                    </div>
+                                </div>
                                 )}
+
 
                                 {/* Description row */}
                                 {editingDescId === scan.id ? (


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Rework the scan card "Current result" and "Changes since previous scan" sections into a big-number + inline dotted-text layout. Add the absolute "detected" totals to each change line, hide the changes section for the initial SBOM import only, and simplify the presentation with shared BigStat/ChangeStat/ChangeLine helpers.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Before:

<img width="1832" height="696" alt="image" src="https://github.com/user-attachments/assets/de7286aa-1aad-4b32-872a-1c66851bf684" />

After:

<img width="1832" height="696" alt="image" src="https://github.com/user-attachments/assets/32c88bcd-5e22-483a-8f7e-07bd66fc5269" />




