### PR TITLE
feat: export scope SBOM/VEX to a project or variant

### DIFF
--- a/frontend/src/components/FileTag.tsx
+++ b/frontend/src/components/FileTag.tsx
@@ -10,12 +10,19 @@ const documentTypes: { [key: string]: string | undefined } = {
 type Props = {
   name: string;
   extension: string;
+  variantId?: string;
+  projectId?: string;
   opened?: boolean;
   onOpen?: () => void;
 };
 
-function FileTag({ name, extension, opened, onOpen }: Readonly<Props>) {
+function FileTag({ name, extension, variantId, projectId, opened, onOpen }: Readonly<Props>) {
   const formats = extension.split(' | ');
+
+  // SBOM/VEX exports are scoped to the current variant (preferred) or project.
+  const scopeQuery = variantId
+    ? `&variant_id=${encodeURIComponent(variantId)}`
+    : (projectId ? `&project_id=${encodeURIComponent(projectId)}` : '');
 
   return (
     <div className="relative inline-block">
@@ -39,7 +46,7 @@ function FileTag({ name, extension, opened, onOpen }: Readonly<Props>) {
             <a
               href={`${import.meta.env.VITE_API_URL}/api/documents/${encodeURIComponent(
                 name
-              )}?ext=${encodeURIComponent(value)}`}
+              )}?ext=${encodeURIComponent(value)}${scopeQuery}`}
               target="_blank"
               className="flex items-left justify-left gap-2 rounded-xl bg-sfl-dark text-white py-2 px-4"
             >

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -292,7 +292,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                 />}
                 {tab === 'scans' && <ScanHistory variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onScanComplete={handleScanComplete} />}
                 {tab === 'review' && <Review variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onAssessmentChanged={handleAssessmentChanged} />}
-                {tab === 'exports' && <Exports />}
+                {tab === 'exports' && <Exports variantId={currentVariantId} projectId={currentProjectId} />}
                 {tab === 'settings' && <Settings onDataChanged={(message) => {
                     if (message) setLoadingMessage(message);
                     Config.get().then(config => setDefaultConfig(config)).catch(() => {});

--- a/frontend/src/pages/Exports.tsx
+++ b/frontend/src/pages/Exports.tsx
@@ -30,7 +30,7 @@ const asExportDoc = (data: any): ExportDoc | [] => {
 }
 
 
-function Exports () {
+function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; projectId?: string }>) {
     const [tab, setTab] = useState<string>("all");
     const [docs, setDocs] = useState<ExportDoc[]>([]);
     const [openDl, setOpenDl] = useState<string | null>(null);
@@ -96,6 +96,8 @@ function Exports () {
         name={doc.id}
         key={encodeURIComponent(doc.id)}
         extension={doc.extension}
+        variantId={variantId}
+        projectId={projectId}
         opened={openDl === doc.id}
         onOpen={() => openDl === doc.id ? setOpenDl(null) : setOpenDl(doc.id)}
       />

--- a/src/bin/cmd_export.py
+++ b/src/bin/cmd_export.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 from ..controllers import ControllersCache, VulnerabilitiesController
+from ..controllers.projects import ProjectController
+from ..models.variant import Variant as DBVariant
 from ..views.spdx import SPDX
 from ..views.spdx3 import SPDX3
 from ..views.cyclonedx import CycloneDx
@@ -12,6 +14,7 @@ from ..views.openvex import OpenVex
 from ..views.templates import Templates
 from .cmd_process import evaluate_condition
 from ._common import get_default_author
+from ..helpers.export_scope import compute_export_scope
 from datetime import date as _date
 import click
 import json
@@ -25,10 +28,36 @@ from flask.cli import with_appcontext
               show_default=True, help="Output format.")
 @click.option("--output-dir", default="/scan/outputs", show_default=True,
               help="Directory where the exported file is written.")
+@click.option("--project", "-p", default=None,
+              help="Project name. When set, the export is scoped to this project.")
+@click.option("--variant", "-v", default=None,
+              help="Variant name. When omitted, all variants of the project are exported.")
 @with_appcontext
-def export_command(export_format: str, output_dir: str) -> None:
+def export_command(export_format: str, output_dir: str, project: str | None, variant: str | None) -> None:
     """Export the current project data as an SBOM (SPDX, CycloneDX, or OpenVEX)."""
-    ctrls = ControllersCache()
+    # Resolve the optional project/variant scope so the export only contains
+    # the packages/vulnerabilities/assessments of the selected variant (or all
+    # variants of the project when only --project is given).  A missing
+    # project/variant is non-fatal: we warn and fall back to a global export so
+    # existing pipelines keep working.
+    scope = None
+    if project:
+        project_obj = ProjectController.get_by_name(project)
+        if project_obj is None:
+            click.echo(f"Warning: project '{project}' not found; exporting all data.", err=True)
+        elif variant:
+            variant_obj = DBVariant.get_by_name_and_project(variant, project_obj.id)
+            if variant_obj is None:
+                click.echo(
+                    f"Warning: variant '{variant}' not found in project '{project}'; "
+                    f"exporting the whole project.", err=True)
+                scope = compute_export_scope(project_id=project_obj.id)
+            else:
+                scope = compute_export_scope(variant_id=variant_obj.id)
+        else:
+            scope = compute_export_scope(project_id=project_obj.id)
+
+    ctrls = ControllersCache(scope=scope)
     ctrls.packages._preload_cache()
     author = get_default_author()
 

--- a/src/controllers/assessments.py
+++ b/src/controllers/assessments.py
@@ -67,12 +67,13 @@ class AssessmentsController:
     Assessments can be added, removed, retrieved and exported or imported as dictionaries.
     """
 
-    def __init__(self, pkgCtrl: "PackagesController"):
+    def __init__(self, pkgCtrl: "PackagesController", scope=None):
         """
         Take an instance of PackagesController and VulnerabilitiesController.
         They are used to resolve package and vulnerabilities by their id.
         """
         self.packagesCtrl: "PackagesController" = pkgCtrl
+        self._scope = scope
         self.assessments: dict[str, Assessment] = {}
         self.current_variant_id: uuid.UUID | None = None
         """A dictionary of assessments, indexed by their id."""
@@ -113,7 +114,27 @@ class AssessmentsController:
                     results[str(a.id)] = a
         except Exception as e:
             verbose(f"[AssessmentsController.gets_by_vuln {vuln_str!r}] {e}")
-        return list(results.values())
+        return self._apply_scope(list(results.values()))
+
+    def _apply_scope(self, assessments: list) -> list:
+        """Restrict *assessments* to the in-scope variants for a scoped export."""
+        if self._scope is None:
+            return assessments
+        allowed = self._scope.variant_ids
+        return [a for a in assessments if getattr(a, "variant_id", None) in allowed]
+
+    def get_all(self) -> list:
+        """Return all assessments (in-memory + DB), de-duped, honouring export scope."""
+        seen: dict = {}
+        for key, a in self.assessments.items():
+            seen[str(key)] = a
+        try:
+            for a in Assessment.get_all():
+                if str(a.id) not in seen:
+                    seen[str(a.id)] = a
+        except Exception as e:
+            verbose(f"[AssessmentsController.get_all] {e}")
+        return self._apply_scope(list(seen.values()))
 
     def gets_by_pkg(self, pkg_id) -> list:
         """Return assessments for a package, querying DB then supplementing with in-memory."""

--- a/src/controllers/cache.py
+++ b/src/controllers/cache.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import typing
 from functools import cached_property
 
 from . import (
@@ -14,19 +17,31 @@ from . import (
     VariantController,
 )
 
+if typing.TYPE_CHECKING:
+    from ..helpers.export_scope import ExportScope
+
 
 class ControllersCache:
+    def __init__(self, scope: "ExportScope | None" = None):
+        """Create a cache of controllers.
+
+        When *scope* is provided the package/vulnerability/assessment
+        controllers only expose the in-scope data, so every view built from
+        this cache produces an export restricted to that project/variant.
+        """
+        self._scope = scope
+
     @cached_property
     def packages(self) -> PackagesController:
-        return PackagesController()
+        return PackagesController(scope=self._scope)
 
     @cached_property
     def assessments(self) -> AssessmentsController:
-        return AssessmentsController(self.packages)
+        return AssessmentsController(self.packages, scope=self._scope)
 
     @cached_property
     def vulnerabilities(self) -> VulnerabilitiesController:
-        return VulnerabilitiesController(self.packages)
+        return VulnerabilitiesController(self.packages, scope=self._scope)
 
     @cached_property
     def conditions_parser(self) -> ConditionParser:

--- a/src/controllers/packages.py
+++ b/src/controllers/packages.py
@@ -17,7 +17,8 @@ class PackagesController:
     directly; the session cache may be empty.
     """
 
-    def __init__(self):
+    def __init__(self, scope=None):
+        self._scope = scope
         self._cache: dict[str, Package] = {}
         self._current_sbom_document: SBOMDocument | None = None
         # Fast PK lookup: string_id → DB UUID.  Avoids SELECT in
@@ -39,9 +40,16 @@ class PackagesController:
         Also pre-populates ``_finding_cache`` so that
         :func:`Finding.get_or_create` avoids a SELECT on the first lookup
         for every known (package, vulnerability) pair.
+
+        When an export *scope* is set only the in-scope packages (and their
+        findings) are loaded, so every view built from this controller is
+        restricted to the scoped project/variant.
         """
+        allowed = self._scope.package_ids if self._scope is not None else None
         try:
             for pkg in Package.get_all():
+                if allowed is not None and pkg.id not in allowed:
+                    continue
                 sid = pkg.string_id
                 self._cache[sid] = pkg
                 self._db_id_cache[sid] = pkg.id
@@ -49,6 +57,8 @@ class PackagesController:
             verbose(f"[PackagesController._preload_cache packages] {e}")
         try:
             for f in Finding.get_all():
+                if allowed is not None and f.package_id not in allowed:
+                    continue
                 self._finding_cache[(f.package_id, f.vulnerability_id)] = f
         except Exception as e:
             verbose(f"[PackagesController._preload_cache findings] {e}")
@@ -156,6 +166,8 @@ class PackagesController:
             return self._cache[package_id]
         try:
             pkg = Package.get_by_string_id(package_id)
+            if pkg is not None and self._scope is not None and pkg.id not in self._scope.package_ids:
+                return None  # out of the export scope
             if pkg:
                 self._cache[package_id] = pkg
             return pkg
@@ -199,7 +211,12 @@ class PackagesController:
             if item in self._cache:
                 return True
             try:
-                return Package.get_by_string_id(item) is not None
+                pkg = Package.get_by_string_id(item)
+                if pkg is None:
+                    return False
+                if self._scope is not None and pkg.id not in self._scope.package_ids:
+                    return False
+                return True
             except Exception as e:
                 verbose(f"[PackagesController.__contains__ {item!r}] {e}")
                 return False
@@ -224,6 +241,9 @@ class PackagesController:
         """
         if self._cache:
             yield from self._cache.values()
+            return
+        if self._scope is not None:
+            # Scoped export: never fall back to the global package set.
             return
         try:
             yield from Package.get_all()

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -103,9 +103,10 @@ class VulnerabilitiesController:
     safe_url_regex = r"[^a-zA-Z0-9_\-\.]"
     """Regex to remove unsafe characters from URLs."""
 
-    def __init__(self, pkgCtrl: PackagesController):
+    def __init__(self, pkgCtrl: PackagesController, scope=None):
         """Take an instance of PackagesController to resolve package dependencies as parameter."""
         self.packagesCtrl: PackagesController = pkgCtrl
+        self._scope = scope
         self.vulnerabilities: dict[str, Vulnerability] = {}
         """A dictionary of vulnerabilities, indexed by their id."""
         self.alias_registered: dict[str, str] = {}
@@ -139,11 +140,27 @@ class VulnerabilitiesController:
         expensive ``to_dict()`` → ``from_dict()`` serialisation round-trip.
         """
         try:
+            # Loop-invariant: the in-scope package set depends only on the
+            # export scope, not on the vulnerability being processed.
+            allowed = self._scope.package_ids if self._scope is not None else None
             for rec in Vulnerability.get_all():
-                # Populate transient package list from eager-loaded findings
-                for f in (rec.findings or []):
-                    if f.package:
+                # Populate transient package list from eager-loaded findings.
+                # When an export scope is active, only consider findings whose
+                # package is in scope — and skip the vulnerability entirely if
+                # none of its findings touch an in-scope package.
+                if allowed is not None:
+                    in_scope_findings = [
+                        f for f in (rec.findings or [])
+                        if f.package and f.package_id in allowed
+                    ]
+                    if not in_scope_findings:
+                        continue
+                    for f in in_scope_findings:
                         rec.add_package(f.package.string_id)
+                else:
+                    for f in (rec.findings or []):
+                        if f.package:
+                            rec.add_package(f.package.string_id)
                 # Populate transient CVSS list from eager-loaded metrics
                 for m in (rec.metrics or []):
                     try:
@@ -190,6 +207,9 @@ class VulnerabilitiesController:
             return self.vulnerabilities[vuln_id]
         if vuln_id in self.alias_registered:
             return self.vulnerabilities[self.alias_registered[vuln_id]]
+        if self._scope is not None:
+            # Scoped export: only resolve vulns already loaded in scope.
+            return None
         # Fall back to DB
         try:
             rec = Vulnerability.get_by_id(vuln_id)
@@ -670,6 +690,9 @@ class VulnerabilitiesController:
         """
         if self.vulnerabilities:
             yield from self.vulnerabilities.values()
+            return
+        if self._scope is not None:
+            # Scoped export: never fall back to the global vulnerability set.
             return
         try:
             for record in Vulnerability.get_all():

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -408,8 +408,12 @@ cmd_export() {
     local fmt="$1"
     cd "$BASE_DIR"
     local output_dir="${OUTPUTS_DIR:-/scan/outputs}"
+    local -a scope_args=(--project "$PROJECT_NAME")
+    if [[ -n "$VARIANT_NAME" ]]; then
+        scope_args+=(--variant "$VARIANT_NAME")
+    fi
     flask --app src.bin.webapp db upgrade
-    flask --app src.bin.webapp export --format "$fmt" --output-dir "$output_dir"
+    flask --app src.bin.webapp export --format "$fmt" --output-dir "$output_dir" "${scope_args[@]}"
     setup_user
 }
 

--- a/src/helpers/export_scope.py
+++ b/src/helpers/export_scope.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Compute the package/variant scope used to restrict an SBOM/VEX export.
+
+An export can be scoped to:
+
+* a single **variant** — only the packages of that variant's latest (active)
+  SBOM scan, the vulnerabilities affecting those packages, and the
+  assessments belonging to that variant; or
+* a whole **project** — the union of the above across every variant in the
+  project.
+
+The resulting :class:`ExportScope` is handed to the controllers (see
+:class:`~src.controllers.cache.ControllersCache`) so that every view
+(SPDX, CycloneDX, OpenVEX) only ever sees the in-scope data.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+from .active_scans import (
+    active_sbom_scan_ids_for_variant,
+    active_sbom_scan_ids_for_project,
+    active_package_ids_for_scans,
+)
+from ..models.variant import Variant
+
+
+@dataclass
+class ExportScope:
+    """Restrict an export to a set of packages and variants.
+
+    Attributes
+    ----------
+    package_ids:
+        DB UUIDs of the packages present in the active SBOM(s) of the scope.
+    variant_ids:
+        DB UUIDs of the variants in scope (used to filter assessments).
+    """
+
+    package_ids: set[uuid.UUID] = field(default_factory=set)
+    variant_ids: set[uuid.UUID] = field(default_factory=set)
+
+
+def _as_uuid(value) -> uuid.UUID:
+    return value if isinstance(value, uuid.UUID) else uuid.UUID(str(value))
+
+
+def compute_export_scope(*, project_id=None, variant_id=None) -> ExportScope | None:
+    """Build an :class:`ExportScope` for *variant_id* or *project_id*.
+
+    ``variant_id`` takes precedence over ``project_id``. Returns ``None`` when
+    neither is provided (i.e. a global, unscoped export).
+    """
+    if variant_id is not None:
+        vid = _as_uuid(variant_id)
+        scan_ids = active_sbom_scan_ids_for_variant(vid)
+        return ExportScope(
+            package_ids=active_package_ids_for_scans(scan_ids),
+            variant_ids={vid},
+        )
+    if project_id is not None:
+        pid = _as_uuid(project_id)
+        scan_ids = active_sbom_scan_ids_for_project(pid)
+        variants = Variant.get_by_project(pid)
+        return ExportScope(
+            package_ids=active_package_ids_for_scans(scan_ids),
+            variant_ids={v.id for v in variants},
+        )
+    return None

--- a/src/routes/documents.py
+++ b/src/routes/documents.py
@@ -13,6 +13,8 @@ from ..views.cyclonedx import CycloneDx
 from ..views.spdx import SPDX
 from ..views.spdx3 import SPDX3
 from ..views.openvex import OpenVex
+from ..helpers.export_scope import compute_export_scope
+from ._scan_helpers import parse_uuid_or_400
 from typing import Dict, List
 
 
@@ -97,7 +99,29 @@ def init_app(app):
                 or doc_name == "OpenVex"
                 or doc_name.startswith("SPDX")
             ):
-                return handle_sbom_exports(doc_name, ctrls, expected_mime, metadata)
+                # SBOM/VEX exports are scoped to the current project/variant
+                # when the frontend passes variant_id / project_id.  Reports
+                # (templates) keep their global, unscoped data.
+                variant_id = request.args.get("variant_id")
+                project_id = request.args.get("project_id")
+                scope = None
+                if variant_id:
+                    variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
+                    if err is not None:
+                        return err
+                    scope = compute_export_scope(variant_id=variant_uuid)
+                elif project_id:
+                    project_uuid, err = parse_uuid_or_400(project_id, "project_id")
+                    if err is not None:
+                        return err
+                    scope = compute_export_scope(project_id=project_uuid)
+
+                if scope is not None:
+                    scoped_ctrls = ControllersCache(scope=scope)
+                    scoped_ctrls.packages._preload_cache()
+                else:
+                    scoped_ctrls = ctrls
+                return handle_sbom_exports(doc_name, scoped_ctrls, expected_mime, metadata)
 
             content = templ.render(doc_name, **metadata)
 

--- a/src/views/openvex.py
+++ b/src/views/openvex.py
@@ -5,7 +5,6 @@ from ..models.package import Package
 from ..models.vulnerability import Vulnerability
 from ..models.assessment import Assessment
 from ..controllers import ControllersCache, PackagesController, VulnerabilitiesController, AssessmentsController
-from ..helpers.verbose import verbose
 from uuid_extensions import uuid7
 from datetime import datetime, timezone
 import re
@@ -95,17 +94,8 @@ class OpenVex:
                 self.assessmentsCtrl.add(assess)
 
     def _all_assessments(self) -> list:
-        """Return all assessments from in-memory dict and DB, de-duped by id."""
-        seen: dict = {}
-        for assess_id, assess in self.assessmentsCtrl.assessments.items():
-            seen[assess_id] = assess
-        try:
-            for assess in Assessment.get_all():
-                if str(assess.id) not in seen:
-                    seen[str(assess.id)] = assess
-        except Exception as e:
-            verbose(f"[OpenVex._get_all_assessments] {e}")
-        return list(seen.values())
+        """Return all assessments, de-duped by id and restricted to the export scope."""
+        return self.assessmentsCtrl.get_all()
 
     def to_dict(self, strict_export=False, author=None) -> dict:
         output = {

--- a/tests/unit_tests/test_openvex_output.py
+++ b/tests/unit_tests/test_openvex_output.py
@@ -5,7 +5,7 @@
 
 """Tests for supplier-qualified OpenVEX product @id generation."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from src.views.openvex import OpenVex
 from src.models.package import Package
 from src.models.assessment import Assessment
@@ -34,10 +34,9 @@ def _run_to_dict(pkgs, assessments):
     ctrl.vulnerabilities = MagicMock()
     ctrl.vulnerabilities.get = MagicMock(return_value=None)
     ctrl.assessments = MagicMock()
-    ctrl.assessments.assessments = {a.vuln_id: a for a in assessments}
-    with patch('src.views.openvex.Assessment.get_all', return_value=[]):
-        view = OpenVex(ctrl)
-        return view.to_dict()
+    ctrl.assessments.get_all = MagicMock(return_value=list(assessments))
+    view = OpenVex(ctrl)
+    return view.to_dict()
 
 
 def test_openvex_no_supplier_uses_generic_purl():


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Exports previously loaded all packages, vulnerabilities and assessments
from every project/variant, so `flask export` and the Review tab download
emitted data unrelated to the current selection. Scope the export pipeline
end-to-end instead.

- Add ExportScope (package-id + variant-id sets) and compute_export_scope()
  in src/helpers/export_scope.py
- Thread an optional scope through ControllersCache into the packages,
  vulnerabilities and assessments controllers, guarding every DB-fallback
  path so a scoped controller never leaks global data. All four views
  (SPDX, SPDX3, CycloneDX, OpenVex) inherit the scope automatically;
  OpenVex now reads assessments via assessmentsCtrl.get_all().
- flask export gains --project/--variant options (missing project/variant
  warns and falls back to a wider scope); entrypoint.sh passes the
  container's PROJECT_NAME/VARIANT_NAME.
- /api/documents/<name> reads variant_id/project_id query params and builds
  a scoped controller for SBOM/VEX exports; reports stay global.
- Frontend: Explorer passes the current variant/project to Exports, which
  forwards them to FileTag so download URLs carry variant_id/project_id.
- Update the OpenVex unit test for the get_all() delegation.

Change-Id: I4f7762296cad601d8d26e62c179a712b7f5f03d4

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Make some assessments in differents projects. Exporting the data in Review tab, won't include all the projects anymore.

The command `./vulnscout --project scarthgap  --export-spdx` export a project correctly