### PR TITLE
fix: pass ControllersCache to post_treatment

### DIFF
--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -36,11 +36,9 @@ def _launch_enrichment(app):
             # the lock is only held during commit() itself (milliseconds).
             db.session.autoflush = False
             try:
-                from ..controllers.packages import PackagesController
-                from ..controllers.vulnerabilities import VulnerabilitiesController
-                pkgCtrl = PackagesController()
-                vulnCtrl = VulnerabilitiesController(pkgCtrl)
-                post_treatment({"vulnerabilities": vulnCtrl, "packages": pkgCtrl})
+                from ..controllers import ControllersCache
+                controllers = ControllersCache()
+                post_treatment(controllers)
             except Exception as e:
                 print(f"[enrichment/epss] {e}", flush=True)
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The background EPSS enrichment thread passed a plain dict ({"vulnerabilities": ..., "packages": ...}) to post_treatment(), but that function expects a ControllersCache and accesses controllers.vulnerabilities as an attribute. The dict therefore raised "'dict' object has no attribute 'vulnerabilities'", aborting enrichment immediately.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

VulnScout won´t produce any error at loading.

Removed error:

```
[enrichment/epss] 'dict' object has no attribute 'vulnerabilities' 
```
