### PR TITLE
fix: Scan Grype scope exported SBOM to variant

### DIFF
--- a/frontend/src/pages/Exports.tsx
+++ b/frontend/src/pages/Exports.tsx
@@ -108,7 +108,7 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
         <div className="text-lg font-medium">No documents found</div>
         {tab === 'custom' && (
           <div className="mt-2 text-sm">
-            You can upload your own templates in 
+            You can upload your own templates in
             <code className="p-1 mx-1 bg-white/10 rounded">.vulnscout/templates</code>
           </div>
         )}

--- a/src/bin/cmd_export.py
+++ b/src/bin/cmd_export.py
@@ -19,6 +19,7 @@ from datetime import date as _date
 import click
 import json
 import os
+import uuid
 from flask.cli import with_appcontext
 
 
@@ -32,8 +33,18 @@ from flask.cli import with_appcontext
               help="Project name. When set, the export is scoped to this project.")
 @click.option("--variant", "-v", default=None,
               help="Variant name. When omitted, all variants of the project are exported.")
+@click.option("--variant-id", "variant_id", default=None,
+              help="Variant UUID. Takes precedence over --project/--variant and "
+                   "resolves the variant unambiguously (use when variant names "
+                   "are not unique within a project).")
 @with_appcontext
-def export_command(export_format: str, output_dir: str, project: str | None, variant: str | None) -> None:
+def export_command(
+    export_format: str,
+    output_dir: str,
+    project: str | None,
+    variant: str | None,
+    variant_id: str | None,
+) -> None:
     """Export the current project data as an SBOM (SPDX, CycloneDX, or OpenVEX)."""
     # Resolve the optional project/variant scope so the export only contains
     # the packages/vulnerabilities/assessments of the selected variant (or all
@@ -41,7 +52,20 @@ def export_command(export_format: str, output_dir: str, project: str | None, var
     # project/variant is non-fatal: we warn and fall back to a global export so
     # existing pipelines keep working.
     scope = None
-    if project:
+    if variant_id:
+        # Exact-UUID scoping (used by the Grype trigger).  Avoids the ambiguity
+        # of resolving a variant by name when several variants share the same
+        # name within a project.
+        try:
+            vid = uuid.UUID(str(variant_id))
+        except (ValueError, TypeError):
+            click.echo(f"Warning: invalid variant id '{variant_id}'; exporting all data.", err=True)
+        else:
+            if DBVariant.get_by_id(vid) is None:
+                click.echo(f"Warning: variant id '{variant_id}' not found; exporting all data.", err=True)
+            else:
+                scope = compute_export_scope(variant_id=vid)
+    elif project:
         project_obj = ProjectController.get_by_name(project)
         if project_obj is None:
             click.echo(f"Warning: project '{project}' not found; exporting all data.", err=True)

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -95,14 +95,18 @@ def init_app(app):
                 )
                 grype_tmp = tempfile.mkdtemp(prefix="vulnscout_grype_")
                 try:
-                    # 1. Export current DB as CycloneDX
+                    # 1. Export this variant's DB packages as CycloneDX.
+                    #    The export is scoped to the project/variant so it only
+                    #    emits this variant's packages — Grype never sees the
+                    #    other projects'/variants' components.
                     _grype_scans_in_progress[vid_str]["progress"] = "1/4 Exporting CycloneDX"
                     _grype_scans_in_progress[vid_str]["logs"].append(
-                        "[1/4] Exporting current DB as CycloneDX…"
+                        "[1/4] Exporting variant packages as CycloneDX…"
                     )
                     subprocess.run(
                         ["flask", "--app", "src.bin.webapp", "export",
-                         "--format", "cdx16", "--output-dir", grype_tmp],
+                         "--format", "cdx16", "--output-dir", grype_tmp,
+                         "--variant-id", vid_str],
                         cwd=base_dir, check=True, capture_output=True, text=True,
                         timeout=120,
                     )
@@ -116,6 +120,53 @@ def init_app(app):
                     _grype_scans_in_progress[vid_str]["logs"].append(
                         "[1/4] CycloneDX export complete"
                     )
+
+                    # 1.5 De-duplicate components that share the same
+                    #     name@version before running Grype.  Even when scoped
+                    #     to a single variant, the export emits one row per
+                    #     package, so a package appears multiple times when it
+                    #     differs only by supplier (the supplier-less
+                    #     Grype/NOASSERTION base alongside the SBOM-declared
+                    #     supplier).  Grype only needs one, and feeding
+                    #     duplicates just multiplies its work and produces
+                    #     duplicate matches.  Key on the *raw* name@version:
+                    #     supplier duplicates carry an identical raw name,
+                    #     whereas normalising would over-collapse genuinely
+                    #     distinct packages that happen to share a normalised
+                    #     name.
+                    if sbom_pkg_set:
+                        import json as _json
+                        with open(exported_cdx, "r") as cf:
+                            cdx_data = _json.load(cf)
+                        components = cdx_data.get("components", [])
+                        orig_components = len(components)
+                        kept = []
+                        kept_refs = set()
+                        seen_nv: set = set()
+                        for comp in components:
+                            name = comp.get("name", "")
+                            version = comp.get("version", "")
+                            nv = (name, version)
+                            if nv in seen_nv:
+                                continue
+                            seen_nv.add(nv)
+                            kept.append(comp)
+                            ref = comp.get("bom-ref")
+                            if ref:
+                                kept_refs.add(ref)
+                        cdx_data["components"] = kept
+                        # Prune dependency edges that reference dropped components.
+                        if isinstance(cdx_data.get("dependencies"), list):
+                            cdx_data["dependencies"] = [
+                                dep for dep in cdx_data["dependencies"]
+                                if dep.get("ref") in kept_refs
+                            ]
+                        with open(exported_cdx, "w") as cf:
+                            _json.dump(cdx_data, cf)
+                        _grype_scans_in_progress[vid_str]["logs"].append(
+                            f"[1/4] De-duplicated components: "
+                            f"{len(kept)}/{orig_components} kept"
+                        )
 
                     # 2. Run grype on the exported SBOM
                     _grype_scans_in_progress[vid_str]["progress"] = "2/4 Running Grype"
@@ -141,11 +192,11 @@ def init_app(app):
                         "[2/4] Grype scan complete"
                     )
 
-                    # 2.5 Filter grype output to only keep matches for
+                    # 2.5 Defensive filter: keep only grype matches for
                     #     packages present in this variant's SBOM.  The
-                    #     CycloneDX export is global (all variants), so
-                    #     grype may report vulnerabilities for packages
-                    #     that do not belong to this variant.
+                    #     CycloneDX input is already scoped to the variant, so
+                    #     this is normally a no-op, but it guards against any
+                    #     stray artifact grype might synthesise.
                     if sbom_pkg_set:
                         import json as _json
                         with open(grype_out, "r") as gf:


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

`flask export` dumps every project/variant, so Grype was scanning tens of thousands of components and `--add-cpes-if-none` made that pathologically slow.

Trim the exported CycloneDX SBOM down to the current variant's packages before invoking Grype, and drop supplier duplicates (same raw name@version) so Grype's workload stays proportional to the variant and matches aren't duplicated.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Perform a Grype scan on a VulnScout instance with two projects.

The second  project packages won´t be parsed in Grype, making it way faster. 

Can be confirm with a new log which explicit how many packages are included in the scan:

<img width="1776" height="214" alt="image" src="https://github.com/user-attachments/assets/e88e79f0-d787-4887-98ab-74ae92b42add" />


