### PR TITLE
Refactoring:  Settings tab UI modification and add variants copy

### DIFF
--- a/frontend/src/handlers/variant.ts
+++ b/frontend/src/handlers/variant.ts
@@ -133,6 +133,29 @@ class Variants {
         }
         return response.json();
     }
+
+    static async copyAssessments(
+        sourceVariantId: string,
+        targetVariantId: string,
+    ): Promise<{ copied: number; skipped: number; message: string }> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + "/api/variants/copy-assessments",
+            {
+                mode: "cors",
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    source_variant_id: sourceVariantId,
+                    target_variant_id: targetVariantId,
+                }),
+            }
+        );
+        if (!response.ok) {
+            const err = await response.json().catch(() => ({}));
+            throw new Error(err.error || `Copy failed (${response.status})`);
+        }
+        return response.json();
+    }
 }
 
 export default Variants;

--- a/frontend/src/handlers/variant.ts
+++ b/frontend/src/handlers/variant.ts
@@ -4,7 +4,34 @@ type Variant = {
     project_id: string;
 };
 
-export type { Variant };
+type CopyAssessmentsPreviewEntry = {
+    source_assessment_id: string;
+    source_finding_id: string;
+    target_finding_id: string;
+    vulnerability_id: string;
+    source_package: string;
+    target_package: string;
+};
+
+type CopyAssessmentsPreview = {
+    count: number;
+    skipped: number;
+    message: string;
+    entries: CopyAssessmentsPreviewEntry[];
+};
+
+type CopyAssessmentsPreviewUnsupported = {
+    unsupported: true;
+    status: number;
+    message: string;
+};
+
+export type {
+    Variant,
+    CopyAssessmentsPreview,
+    CopyAssessmentsPreviewEntry,
+    CopyAssessmentsPreviewUnsupported,
+};
 
 class Variants {
     static async list(projectId: string): Promise<Variant[]> {
@@ -137,6 +164,7 @@ class Variants {
     static async copyAssessments(
         sourceVariantId: string,
         targetVariantId: string,
+        ignorePackageVersion = false,
     ): Promise<{ copied: number; skipped: number; message: string }> {
         const response = await fetch(
             import.meta.env.VITE_API_URL + "/api/variants/copy-assessments",
@@ -147,12 +175,45 @@ class Variants {
                 body: JSON.stringify({
                     source_variant_id: sourceVariantId,
                     target_variant_id: targetVariantId,
+                    ignore_package_version: ignorePackageVersion,
                 }),
             }
         );
         if (!response.ok) {
             const err = await response.json().catch(() => ({}));
             throw new Error(err.error || `Copy failed (${response.status})`);
+        }
+        return response.json();
+    }
+
+    static async previewCopyAssessments(
+        sourceVariantId: string,
+        targetVariantId: string,
+        ignorePackageVersion = false,
+    ): Promise<CopyAssessmentsPreview | CopyAssessmentsPreviewUnsupported> {
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + "/api/variants/copy-assessments/preview",
+            {
+                mode: "cors",
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    source_variant_id: sourceVariantId,
+                    target_variant_id: targetVariantId,
+                    ignore_package_version: ignorePackageVersion,
+                }),
+            }
+        );
+        if (!response.ok) {
+            if (response.status === 404 || response.status === 405) {
+                return {
+                    unsupported: true,
+                    status: response.status,
+                    message: "Preview is unavailable on the current backend. Restart or redeploy the server to load the new preview endpoint.",
+                };
+            }
+            const err = await response.json().catch(() => ({}));
+            throw new Error(err.error || `Preview failed (${response.status})`);
         }
         return response.json();
     }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -12,6 +12,7 @@ import {
   faXmark,
   faKey,
   faPenToSquare,
+  faCopy,
 } from "@fortawesome/free-solid-svg-icons";
 import Projects from "../handlers/project";
 import type { Project } from "../handlers/project";
@@ -197,6 +198,12 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
   const [confirmDeleteVariant, setConfirmDeleteVariant] = useState(false);
   const [deleteVariantBusy, setDeleteVariantBusy] = useState(false);
 
+  // ---- Copy Custom Assessments ----
+  const [copySourceId, setCopySourceId] = useState<string>("");
+  const [copyTargetId, setCopyTargetId] = useState<string>("");
+  const [copyBusy, setCopyBusy] = useState(false);
+  const [copyMsg, setCopyMsg] = useState<string | null>(null);
+
   const reloadVariants = useCallback((projectId: string) => {
     if (!projectId) { setVariantProjectVariants([]); return; }
     Variants.list(projectId)
@@ -258,6 +265,25 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
       setConfirmDeleteVariant(false);
     } finally {
       setDeleteVariantBusy(false);
+    }
+  };
+
+  const handleCopyAssessments = async () => {
+    if (!copySourceId || !copyTargetId || copyBusy) return;
+    if (copySourceId === copyTargetId) {
+      setCopyMsg("Source and target variants must be different.");
+      return;
+    }
+    setCopyBusy(true);
+    setCopyMsg(null);
+    try {
+      const result = await Variants.copyAssessments(copySourceId, copyTargetId);
+      setCopyMsg(result.message);
+      onDataChanged?.("Copying assessments...");
+    } catch (e: any) {
+      setCopyMsg(e.message);
+    } finally {
+      setCopyBusy(false);
     }
   };
 
@@ -1029,6 +1055,76 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
               <span role="alert" className="text-red-400 text-sm">
                 <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
                 {variantMsg}
+              </span>
+            )}
+          </div>
+        </section>
+
+        {/* ======== Copy Custom Assessments ======== */}
+        <section
+          aria-labelledby="settings-heading-copy-assessments"
+          aria-disabled={!variantProjectId}
+          className={!variantProjectId ? "opacity-50" : ""}
+        >
+          <div className={cardHeader}>
+            <FontAwesomeIcon icon={faCopy} className="text-cyan-400" aria-hidden="true" />
+            <h2 id="settings-heading-copy-assessments" className="text-xl font-bold text-white">Copy Custom Assessments</h2>
+          </div>
+          <div className={cardBody + " space-y-4"}>
+            <p className="text-sm text-zinc-400">
+              Copy every custom assessment from a source variant onto a target variant,
+              for all packages they have in common. Avoids re-entering assessments on a new variant.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <label htmlFor="copy-source-select" className="block text-sm text-zinc-300 font-semibold">Source</label>
+                <select
+                  id="copy-source-select"
+                  value={copySourceId}
+                  onChange={(e) => { setCopySourceId(e.target.value); setCopyMsg(null); }}
+                  className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
+                  disabled={!variantProjectId}
+                >
+                  <option value="">— select a variant —</option>
+                  {variantProjectVariants.map((v) => (
+                    <option key={v.id} value={v.id}>{v.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="copy-target-select" className="block text-sm text-zinc-300 font-semibold">Copy to</label>
+                <select
+                  id="copy-target-select"
+                  value={copyTargetId}
+                  onChange={(e) => { setCopyTargetId(e.target.value); setCopyMsg(null); }}
+                  className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
+                  disabled={!variantProjectId}
+                >
+                  <option value="">— select a variant —</option>
+                  {variantProjectVariants.map((v) => (
+                    <option key={v.id} value={v.id}>{v.name}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <button
+              onClick={handleCopyAssessments}
+              disabled={!variantProjectId || !copySourceId || !copyTargetId || copySourceId === copyTargetId || copyBusy}
+              className={btnPrimary}
+            >
+              {copyBusy ? (
+                <FontAwesomeIcon icon={faSpinner} spin className="mr-2" aria-hidden="true" />
+              ) : (
+                <FontAwesomeIcon icon={faCopy} className="mr-2" aria-hidden="true" />
+              )}
+              Copy Assessments
+            </button>
+
+            {/* -- Feedback -- */}
+            {copyMsg && (
+              <span role="alert" className="block text-sm text-cyan-300">
+                <FontAwesomeIcon icon={faCheck} className="mr-1" aria-hidden="true" />
+                {copyMsg}
               </span>
             )}
           </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -28,7 +28,7 @@ type Props = {
   onLoadingMessage?: (message: string | null) => void;
 };
 
-type SettingsTab = "general" | "projects" | "variants";
+type SettingsTab = "general" | "projects" | "variants" | "scan";
 
 function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
   // ---- Active category tab ----
@@ -482,6 +482,16 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
             onClick={() => setActiveTab("variants")}
           >
             Variants Settings
+          </button>
+          <button
+            className={`px-4 py-2 text-sm font-medium rounded-t transition-colors ${
+              activeTab === "scan"
+                ? "bg-sky-800 text-white border-b-2 border-sky-400"
+                : "text-gray-400 hover:text-gray-200 hover:bg-gray-800"
+            }`}
+            onClick={() => setActiveTab("scan")}
+          >
+            Scan Settings
           </button>
         </div>
 
@@ -1129,7 +1139,12 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
             )}
           </div>
         </section>
+        </>
+        )}
 
+        {/* ======== Scan Settings tab ======== */}
+        {activeTab === "scan" && (
+        <>
         {/* ======== Import SBOM ======== */}
         <section aria-labelledby="settings-heading-import">
           <div className={cardHeader}>
@@ -1199,7 +1214,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
               <input
                 key={importFiles.length}
                 type="file"
-                accept=".json,.spdx,.cdx,.xml"
+                accept=".json,.spdx,.cdx,.xml,.tar,.tar.gz,.tgz,.tar.zst"
                 onChange={(e) => handleFileSelected(importFiles.length, e.target.files?.[0] ?? null)}
                 disabled={importBusy}
                 aria-labelledby="sbom-files-label"
@@ -1208,6 +1223,10 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
                   " file:mr-3 file:py-1 file:px-3 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-cyan-900 file:text-cyan-300 hover:file:bg-cyan-800"
                 }
               />
+              <p className="text-xs text-zinc-400">
+                Accepts JSON SBOMs (SPDX, CycloneDX, OpenVEX, Grype, Yocto) or tar archives
+                (<code>.tar</code>, <code>.tar.gz</code>, <code>.tar.zst</code>) used for SPDX2.
+              </p>
             </div>
 
             {/* ---- Submit ---- */}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -13,11 +13,16 @@ import {
   faKey,
   faPenToSquare,
   faCopy,
+  faRightLeft,
 } from "@fortawesome/free-solid-svg-icons";
 import Projects from "../handlers/project";
 import type { Project } from "../handlers/project";
 import Variants from "../handlers/variant";
-import type { Variant } from "../handlers/variant";
+import type {
+  Variant,
+  CopyAssessmentsPreview,
+  CopyAssessmentsPreviewUnsupported,
+} from "../handlers/variant";
 import Config from "../handlers/config";
 import ConfirmationModal from "../components/ConfirmationModal";
 import MessageBanner from "../components/MessageBanner";
@@ -28,7 +33,7 @@ type Props = {
   onLoadingMessage?: (message: string | null) => void;
 };
 
-type SettingsTab = "general" | "projects" | "variants" | "scan";
+type SettingsTab = "general" | "projects" | "variants" | "customData" | "scan";
 
 function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
   // ---- Active category tab ----
@@ -173,6 +178,12 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         setRenameProjectId("");
         setRenameProjectName("");
       }
+      if (customProjectId === deleteProjectId) {
+        setCustomProjectId("");
+        setCustomProjectVariants([]);
+        setCopySourceId("");
+        setCopyTargetId("");
+      }
       setDeleteProjectId("");
       setConfirmDeleteProject(false);
       loadProjects();
@@ -199,10 +210,17 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
   const [deleteVariantBusy, setDeleteVariantBusy] = useState(false);
 
   // ---- Copy Custom Assessments ----
+  const [customProjectId, setCustomProjectId] = useState<string>("");
+  const [customProjectVariants, setCustomProjectVariants] = useState<Variant[]>([]);
   const [copySourceId, setCopySourceId] = useState<string>("");
   const [copyTargetId, setCopyTargetId] = useState<string>("");
+  const [copyIgnorePackageVersion, setCopyIgnorePackageVersion] = useState(false);
   const [copyBusy, setCopyBusy] = useState(false);
   const [copyMsg, setCopyMsg] = useState<string | null>(null);
+  const [copyPreviewBusy, setCopyPreviewBusy] = useState(false);
+  const [copyPreviewError, setCopyPreviewError] = useState<string | null>(null);
+  const [copyPreview, setCopyPreview] = useState<CopyAssessmentsPreview | null>(null);
+  const [copyPreviewUnavailableMsg, setCopyPreviewUnavailableMsg] = useState<string | null>(null);
 
   const reloadVariants = useCallback((projectId: string) => {
     if (!projectId) { setVariantProjectVariants([]); return; }
@@ -222,6 +240,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
     try {
       await Variants.rename(renameVariantId, renameVariantName.trim());
       reloadVariants(variantProjectId);
+      if (customProjectId === variantProjectId) {
+        Variants.list(customProjectId)
+          .then(setCustomProjectVariants)
+          .catch(() => setCustomProjectVariants([]));
+      }
       onDataChanged?.("Renaming variant...");
     } catch (e: any) {
       setVariantMsg(e.message);
@@ -238,6 +261,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
       await Variants.create(variantProjectId, newVariantName.trim());
       setNewVariantName("");
       reloadVariants(variantProjectId);
+      if (customProjectId === variantProjectId) {
+        Variants.list(customProjectId)
+          .then(setCustomProjectVariants)
+          .catch(() => setCustomProjectVariants([]));
+      }
       onDataChanged?.("Creating variant...");
     } catch (e: any) {
       setVariantMsg(e.message);
@@ -255,10 +283,18 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
       if (renameVariantId === deleteVariantId) {
         setRenameVariantId("");
         setRenameVariantName("");
+        setCopyPreview(null);
+        setCopyPreviewError(null);
+        setCopyPreviewBusy(false);
       }
       setDeleteVariantId("");
       setConfirmDeleteVariant(false);
       reloadVariants(variantProjectId);
+      if (customProjectId === variantProjectId) {
+        Variants.list(customProjectId)
+          .then(setCustomProjectVariants)
+          .catch(() => setCustomProjectVariants([]));
+      }
       onDataChanged?.("Deleting variant...");
     } catch (e: any) {
       setVariantMsg(e.message);
@@ -277,7 +313,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
     setCopyBusy(true);
     setCopyMsg(null);
     try {
-      const result = await Variants.copyAssessments(copySourceId, copyTargetId);
+      const result = await Variants.copyAssessments(
+        copySourceId,
+        copyTargetId,
+        copyIgnorePackageVersion,
+      );
       setCopyMsg(result.message);
       onDataChanged?.("Copying assessments...");
     } catch (e: any) {
@@ -286,6 +326,62 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
       setCopyBusy(false);
     }
   };
+
+  useEffect(() => {
+    if (!customProjectId) {
+      setCustomProjectVariants([]);
+      setCopySourceId("");
+      setCopyTargetId("");
+      setCopyPreview(null);
+      setCopyPreviewError(null);
+      setCopyPreviewUnavailableMsg(null);
+      setCopyPreviewBusy(false);
+      return;
+    }
+    Variants.list(customProjectId)
+      .then(setCustomProjectVariants)
+      .catch(() => setCustomProjectVariants([]));
+  }, [customProjectId]);
+
+  useEffect(() => {
+    if (!customProjectId || !copySourceId || !copyTargetId || copySourceId === copyTargetId) {
+      setCopyPreview(null);
+      setCopyPreviewError(null);
+      setCopyPreviewUnavailableMsg(null);
+      setCopyPreviewBusy(false);
+      return;
+    }
+
+    let cancelled = false;
+    setCopyPreviewBusy(true);
+    setCopyPreviewError(null);
+    setCopyPreviewUnavailableMsg(null);
+
+    Variants.previewCopyAssessments(copySourceId, copyTargetId, copyIgnorePackageVersion)
+      .then((data) => {
+        if (cancelled || unmountedRef.current) return;
+        if ((data as CopyAssessmentsPreviewUnsupported).unsupported) {
+          setCopyPreview(null);
+          setCopyPreviewUnavailableMsg(data.message);
+          return;
+        }
+        setCopyPreview(data as CopyAssessmentsPreview);
+      })
+      .catch((e: any) => {
+        if (cancelled || unmountedRef.current) return;
+        setCopyPreview(null);
+        setCopyPreviewUnavailableMsg(null);
+        setCopyPreviewError(e?.message || "Failed to generate preview.");
+      })
+      .finally(() => {
+        if (cancelled || unmountedRef.current) return;
+        setCopyPreviewBusy(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [customProjectId, copySourceId, copyTargetId, copyIgnorePackageVersion]);
 
   // ---- Import SBOM ----
   const [importProjectId, setImportProjectId] = useState<string>("");
@@ -492,6 +588,16 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
             onClick={() => setActiveTab("scan")}
           >
             Scan Settings
+          </button>
+          <button
+            className={`px-4 py-2 text-sm font-medium rounded-t transition-colors ${
+              activeTab === "customData"
+                ? "bg-sky-800 text-white border-b-2 border-sky-400"
+                : "text-gray-400 hover:text-gray-200 hover:bg-gray-800"
+            }`}
+            onClick={() => setActiveTab("customData")}
+          >
+            Custom Data Settings
           </button>
         </div>
 
@@ -1070,11 +1176,52 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
           </div>
         </section>
 
+        </>
+        )}
+
+        {/* ======== Custom Data Settings tab ======== */}
+        {activeTab === "customData" && (
+        <>
+        {/* ======== Select Project ======== */}
+        <section aria-labelledby="settings-heading-custom-project">
+          <div className={cardHeader}>
+            <FontAwesomeIcon icon={faFolderOpen} className="text-cyan-400" aria-hidden="true" />
+            <h2 id="settings-heading-custom-project" className="text-xl font-bold text-white">Select Project</h2>
+          </div>
+          <div className={cardBody + " space-y-4"}>
+            <div>
+              <label htmlFor="custom-project-select" className="block text-sm text-zinc-300 mb-1">Project</label>
+              <select
+                id="custom-project-select"
+                value={customProjectId}
+                onChange={(e) => {
+                  setCustomProjectId(e.target.value);
+                  setCopyMsg(null);
+                  setCopyPreview(null);
+                  setCopyPreviewError(null);
+                  setCopyPreviewUnavailableMsg(null);
+                }}
+                className={selectClass}
+              >
+                <option value="">— select a project —</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </select>
+              {!customProjectId && (
+                <p className="text-zinc-400 text-sm mt-2">
+                  Select a project to manage custom data operations.
+                </p>
+              )}
+            </div>
+          </div>
+        </section>
+
         {/* ======== Copy Custom Assessments ======== */}
         <section
           aria-labelledby="settings-heading-copy-assessments"
-          aria-disabled={!variantProjectId}
-          className={!variantProjectId ? "opacity-50" : ""}
+          aria-disabled={!customProjectId}
+          className={!customProjectId ? "opacity-50" : ""}
         >
           <div className={cardHeader}>
             <FontAwesomeIcon icon={faCopy} className="text-cyan-400" aria-hidden="true" />
@@ -1082,8 +1229,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
           </div>
           <div className={cardBody + " space-y-4"}>
             <p className="text-sm text-zinc-400">
-              Copy every custom assessment from a source variant onto a target variant,
-              for all packages they have in common. Avoids re-entering assessments on a new variant.
+              Copy custom assessments from a source variant to a target variant in the selected project.
             </p>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-2">
@@ -1091,35 +1237,141 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
                 <select
                   id="copy-source-select"
                   value={copySourceId}
-                  onChange={(e) => { setCopySourceId(e.target.value); setCopyMsg(null); }}
+                  onChange={(e) => {
+                    setCopySourceId(e.target.value);
+                    setCopyMsg(null);
+                    setCopyPreviewError(null);
+                    setCopyPreviewUnavailableMsg(null);
+                  }}
                   className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
-                  disabled={!variantProjectId}
+                  disabled={!customProjectId}
                 >
                   <option value="">— select a variant —</option>
-                  {variantProjectVariants.map((v) => (
+                  {customProjectVariants.map((v) => (
                     <option key={v.id} value={v.id}>{v.name}</option>
                   ))}
                 </select>
+              </div>
+              <div className="flex items-end justify-center sm:justify-start">
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!customProjectId || copyBusy) return;
+                    setCopySourceId(copyTargetId);
+                    setCopyTargetId(copySourceId);
+                    setCopyMsg(null);
+                    setCopyPreviewError(null);
+                    setCopyPreviewUnavailableMsg(null);
+                  }}
+                  disabled={!customProjectId || copyBusy || !copySourceId || !copyTargetId}
+                  className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+                  title="Swap source and target variants"
+                  aria-label="Swap source and target variants"
+                >
+                  <FontAwesomeIcon icon={faRightLeft} className="mr-2" aria-hidden="true" />
+                  Swap
+                </button>
               </div>
               <div className="space-y-2">
                 <label htmlFor="copy-target-select" className="block text-sm text-zinc-300 font-semibold">Copy to</label>
                 <select
                   id="copy-target-select"
                   value={copyTargetId}
-                  onChange={(e) => { setCopyTargetId(e.target.value); setCopyMsg(null); }}
+                  onChange={(e) => {
+                    setCopyTargetId(e.target.value);
+                    setCopyMsg(null);
+                    setCopyPreviewError(null);
+                    setCopyPreviewUnavailableMsg(null);
+                  }}
                   className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
-                  disabled={!variantProjectId}
+                  disabled={!customProjectId}
                 >
                   <option value="">— select a variant —</option>
-                  {variantProjectVariants.map((v) => (
+                  {customProjectVariants.map((v) => (
                     <option key={v.id} value={v.id}>{v.name}</option>
                   ))}
                 </select>
               </div>
             </div>
+
+            <label className="inline-flex items-center gap-2 text-sm text-zinc-300">
+              <input
+                type="checkbox"
+                checked={copyIgnorePackageVersion}
+                onChange={(e) => {
+                  setCopyIgnorePackageVersion(e.target.checked);
+                  setCopyMsg(null);
+                  setCopyPreviewError(null);
+                  setCopyPreviewUnavailableMsg(null);
+                }}
+                disabled={!customProjectId || copyBusy}
+                className="rounded border-slate-500 bg-slate-900"
+              />
+              Ignore packages version
+            </label>
+
+            <p className="text-xs text-zinc-400">
+              When enabled, copy by vulnerabilities in common, regardless of package name/version differences.
+            </p>
+
+            <div className="rounded-md border border-slate-600/70 bg-slate-900/40 p-3 space-y-2">
+              <h3 className="text-sm font-semibold text-zinc-200">Preview</h3>
+              {(!customProjectId || !copySourceId || !copyTargetId) && (
+                <p className="text-xs text-zinc-400">Select a source and a target variant to generate a preview.</p>
+              )}
+              {copySourceId && copyTargetId && copySourceId === copyTargetId && (
+                <p className="text-xs text-amber-300">Source and target variants must be different.</p>
+              )}
+              {copyPreviewBusy && (
+                <p className="text-xs text-zinc-300">
+                  <FontAwesomeIcon icon={faSpinner} spin className="mr-1" aria-hidden="true" />
+                  Computing preview...
+                </p>
+              )}
+              {copyPreviewError && (
+                <p className="text-xs text-red-300">
+                  <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
+                  {copyPreviewError}
+                </p>
+              )}
+              {copyPreviewUnavailableMsg && (
+                <p className="text-xs text-amber-300">
+                  <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
+                  {copyPreviewUnavailableMsg}
+                </p>
+              )}
+              {!copyPreviewBusy && !copyPreviewError && copyPreview && (
+                <>
+                  <p className="text-xs text-cyan-300">{copyPreview.message}</p>
+                  {copyPreview.entries.length > 0 && (
+                    <div className="max-h-56 overflow-auto rounded border border-slate-700/80">
+                      <table className="min-w-full text-xs text-zinc-200">
+                        <thead className="bg-slate-800/80 text-zinc-300">
+                          <tr>
+                            <th className="px-2 py-1 text-left">Vulnerability</th>
+                            <th className="px-2 py-1 text-left">Source package</th>
+                            <th className="px-2 py-1 text-left">Target package</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {copyPreview.entries.map((entry) => (
+                            <tr key={`${entry.source_assessment_id}-${entry.target_finding_id}`} className="border-t border-slate-700/70">
+                              <td className="px-2 py-1 font-mono">{entry.vulnerability_id}</td>
+                              <td className="px-2 py-1">{entry.source_package || "-"}</td>
+                              <td className="px-2 py-1">{entry.target_package || "-"}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+
             <button
               onClick={handleCopyAssessments}
-              disabled={!variantProjectId || !copySourceId || !copyTargetId || copySourceId === copyTargetId || copyBusy}
+              disabled={!customProjectId || !copySourceId || !copyTargetId || copySourceId === copyTargetId || copyBusy}
               className={btnPrimary}
             >
               {copyBusy ? (
@@ -1130,7 +1382,6 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
               Copy Assessments
             </button>
 
-            {/* -- Feedback -- */}
             {copyMsg && (
               <span role="alert" className="block text-sm text-cyan-300">
                 <FontAwesomeIcon icon={faCheck} className="mr-1" aria-hidden="true" />

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -828,11 +828,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         {/* ======== Variants Settings tab ======== */}
         {activeTab === "variants" && (
         <>
-        {/* ======== Manage Variants ======== */}
-        <section aria-labelledby="settings-heading-variants">
+        {/* ======== Select Project ======== */}
+        <section aria-labelledby="settings-heading-variant-project">
           <div className={cardHeader}>
             <FontAwesomeIcon icon={faFolderOpen} className="text-cyan-400" aria-hidden="true" />
-            <h2 id="settings-heading-variants" className="text-xl font-bold text-white">Manage Variants</h2>
+            <h2 id="settings-heading-variant-project" className="text-xl font-bold text-white">Select Project</h2>
           </div>
           <div className={cardBody + " space-y-4"}>
 
@@ -857,118 +857,172 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
                   <option key={p.id} value={p.id}>{p.name}</option>
                 ))}
               </select>
+              {!variantProjectId && (
+                <p className="text-zinc-400 text-sm mt-2">
+                  Select a project to manage its variants.
+                </p>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* ======== Add Variant ======== */}
+        <section
+          aria-labelledby="settings-heading-variant-add"
+          aria-disabled={!variantProjectId}
+          className={!variantProjectId ? "opacity-50" : ""}
+        >
+          <div className={cardHeader}>
+            <FontAwesomeIcon icon={faPlus} className="text-cyan-400" aria-hidden="true" />
+            <h2 id="settings-heading-variant-add" className="text-xl font-bold text-white">Add Variant</h2>
+          </div>
+          <div className={cardBody + " space-y-4"}>
+            <div className="space-y-2">
+              <label htmlFor="new-variant-name" className="block text-sm text-zinc-300 font-semibold">Add Variant</label>
+              <div className="flex gap-2">
+                <input
+                  id="new-variant-name"
+                  type="text"
+                  value={newVariantName}
+                  onChange={(e) => { setNewVariantName(e.target.value); setVariantMsg(null); }}
+                  placeholder="New variant name"
+                  className={inputClass + " flex-1 disabled:opacity-50 disabled:cursor-not-allowed"}
+                  disabled={!variantProjectId}
+                  aria-required="true"
+                  onKeyDown={(e) => e.key === "Enter" && handleCreateVariant()}
+                />
+                <button
+                  onClick={handleCreateVariant}
+                  disabled={!variantProjectId || createVariantBusy || !newVariantName.trim()}
+                  className={btnPrimary}
+                  aria-busy={createVariantBusy}
+                >
+                  {createVariantBusy ? (
+                    <FontAwesomeIcon icon={faSpinner} spin className="mr-1" aria-hidden="true" />
+                  ) : (
+                    <FontAwesomeIcon icon={faPlus} className="mr-1" aria-hidden="true" />
+                  )}
+                  Add
+                </button>
+              </div>
             </div>
 
-            {/* -- Create variant -- */}
-            {variantProjectId && (
-              <div className="space-y-2">
-                <label htmlFor="new-variant-name" className="block text-sm text-zinc-300 font-semibold">Add Variant</label>
-                <div className="flex gap-2">
-                  <input
-                    id="new-variant-name"
-                    type="text"
-                    value={newVariantName}
-                    onChange={(e) => { setNewVariantName(e.target.value); setVariantMsg(null); }}
-                    placeholder="New variant name"
-                    className={inputClass + " flex-1"}
-                    aria-required="true"
-                    onKeyDown={(e) => e.key === "Enter" && handleCreateVariant()}
-                  />
-                  <button
-                    onClick={handleCreateVariant}
-                    disabled={createVariantBusy || !newVariantName.trim()}
-                    className={btnPrimary}
-                    aria-busy={createVariantBusy}
-                  >
-                    {createVariantBusy ? (
-                      <FontAwesomeIcon icon={faSpinner} spin className="mr-1" aria-hidden="true" />
-                    ) : (
-                      <FontAwesomeIcon icon={faPlus} className="mr-1" aria-hidden="true" />
-                    )}
-                    Add
-                  </button>
-                </div>
-              </div>
+            {/* -- Feedback -- */}
+            {variantMsg && (
+              <span role="alert" className="text-red-400 text-sm">
+                <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
+                {variantMsg}
+              </span>
             )}
+          </div>
+        </section>
 
-            {/* -- Rename variant -- */}
-            {variantProjectId && (
-              <div className="border-t border-slate-600/60 pt-4 space-y-2">
-                <label htmlFor="rename-variant-select" className="block text-sm text-zinc-300 font-semibold">Rename Variant</label>
+        {/* ======== Rename Variant ======== */}
+        <section
+          aria-labelledby="settings-heading-variant-rename"
+          aria-disabled={!variantProjectId}
+          className={!variantProjectId ? "opacity-50" : ""}
+        >
+          <div className={cardHeader}>
+            <FontAwesomeIcon icon={faPenToSquare} className="text-cyan-400" aria-hidden="true" />
+            <h2 id="settings-heading-variant-rename" className="text-xl font-bold text-white">Rename Variant</h2>
+          </div>
+          <div className={cardBody + " space-y-4"}>
+            <div className="space-y-2">
+              <label htmlFor="rename-variant-select" className="block text-sm text-zinc-300 font-semibold">Rename Variant</label>
+              <select
+                id="rename-variant-select"
+                value={renameVariantId}
+                onChange={(e) => {
+                  setRenameVariantId(e.target.value);
+                  setVariantMsg(null);
+                  const v = variantProjectVariants.find((x) => x.id === e.target.value);
+                  setRenameVariantName(v?.name ?? "");
+                }}
+                className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
+                disabled={!variantProjectId}
+              >
+                <option value="">— select a variant —</option>
+                {variantProjectVariants.map((v) => (
+                  <option key={v.id} value={v.id}>{v.name}</option>
+                ))}
+              </select>
+
+              <div className="flex gap-2">
+                <label htmlFor="rename-variant-name" className="sr-only">New variant name</label>
+                <input
+                  id="rename-variant-name"
+                  type="text"
+                  value={renameVariantName}
+                  onChange={(e) => setRenameVariantName(e.target.value)}
+                  placeholder="Enter new name"
+                  className={inputClass + " flex-1 disabled:opacity-50 disabled:cursor-not-allowed"}
+                  disabled={!variantProjectId || !renameVariantId}
+                  aria-required="true"
+                  onKeyDown={(e) => e.key === "Enter" && handleRenameVariant()}
+                />
+                <button
+                  onClick={handleRenameVariant}
+                  disabled={!variantProjectId || renameVariantBusy || !renameVariantId || !renameVariantName.trim()}
+                  className={btnPrimary}
+                  aria-busy={renameVariantBusy}
+                >
+                  {renameVariantBusy ? (
+                    <FontAwesomeIcon icon={faSpinner} spin className="mr-1" aria-hidden="true" />
+                  ) : (
+                    <FontAwesomeIcon icon={faCheck} className="mr-1" aria-hidden="true" />
+                  )}
+                  Rename
+                </button>
+              </div>
+            </div>
+
+            {/* -- Feedback -- */}
+            {variantMsg && (
+              <span role="alert" className="text-red-400 text-sm">
+                <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
+                {variantMsg}
+              </span>
+            )}
+          </div>
+        </section>
+
+        {/* ======== Delete Variant ======== */}
+        <section
+          aria-labelledby="settings-heading-variant-delete"
+          aria-disabled={!variantProjectId}
+          className={!variantProjectId ? "opacity-50" : ""}
+        >
+          <div className={cardHeader}>
+            <FontAwesomeIcon icon={faTrash} className="text-cyan-400" aria-hidden="true" />
+            <h2 id="settings-heading-variant-delete" className="text-xl font-bold text-white">Delete Variant</h2>
+          </div>
+          <div className={cardBody + " space-y-4"}>
+            <div className="space-y-2">
+              <label htmlFor="delete-variant-select" className="block text-sm text-zinc-300 font-semibold">Delete Variant</label>
+              <div className="flex gap-2">
                 <select
-                  id="rename-variant-select"
-                  value={renameVariantId}
-                  onChange={(e) => {
-                    setRenameVariantId(e.target.value);
-                    setVariantMsg(null);
-                    const v = variantProjectVariants.find((x) => x.id === e.target.value);
-                    setRenameVariantName(v?.name ?? "");
-                  }}
-                  className={selectClass}
+                  id="delete-variant-select"
+                  value={deleteVariantId}
+                  onChange={(e) => { setDeleteVariantId(e.target.value); setVariantMsg(null); }}
+                  className={selectClass + " flex-1 disabled:opacity-50 disabled:cursor-not-allowed"}
+                  disabled={!variantProjectId}
                 >
                   <option value="">— select a variant —</option>
                   {variantProjectVariants.map((v) => (
                     <option key={v.id} value={v.id}>{v.name}</option>
                   ))}
                 </select>
-
-                <div className="flex gap-2">
-                  <label htmlFor="rename-variant-name" className="sr-only">New variant name</label>
-                  <input
-                    id="rename-variant-name"
-                    type="text"
-                    value={renameVariantName}
-                    onChange={(e) => setRenameVariantName(e.target.value)}
-                    placeholder="Enter new name"
-                    className={inputClass + " flex-1"}
-                    disabled={!renameVariantId}
-                    aria-required="true"
-                    onKeyDown={(e) => e.key === "Enter" && handleRenameVariant()}
-                  />
-                  <button
-                    onClick={handleRenameVariant}
-                    disabled={renameVariantBusy || !renameVariantId || !renameVariantName.trim()}
-                    className={btnPrimary}
-                    aria-busy={renameVariantBusy}
-                  >
-                    {renameVariantBusy ? (
-                      <FontAwesomeIcon icon={faSpinner} spin className="mr-1" aria-hidden="true" />
-                    ) : (
-                      <FontAwesomeIcon icon={faCheck} className="mr-1" aria-hidden="true" />
-                    )}
-                    Rename
-                  </button>
-                </div>
+                <button
+                  onClick={() => setConfirmDeleteVariant(true)}
+                  disabled={!variantProjectId || !deleteVariantId}
+                  className="px-4 py-2 rounded-lg bg-red-900 hover:bg-red-800 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+                >
+                  <FontAwesomeIcon icon={faTrash} className="mr-1" aria-hidden="true" />
+                  Delete
+                </button>
               </div>
-            )}
-
-            {/* -- Delete variant -- */}
-            {variantProjectId && (
-              <div className="border-t border-slate-600/60 pt-4 space-y-2">
-                <label htmlFor="delete-variant-select" className="block text-sm text-zinc-300 font-semibold">Delete Variant</label>
-                <div className="flex gap-2">
-                  <select
-                    id="delete-variant-select"
-                    value={deleteVariantId}
-                    onChange={(e) => { setDeleteVariantId(e.target.value); setVariantMsg(null); }}
-                    className={selectClass + " flex-1"}
-                  >
-                    <option value="">— select a variant —</option>
-                    {variantProjectVariants.map((v) => (
-                      <option key={v.id} value={v.id}>{v.name}</option>
-                    ))}
-                  </select>
-                  <button
-                    onClick={() => setConfirmDeleteVariant(true)}
-                    disabled={!deleteVariantId}
-                    className="px-4 py-2 rounded-lg bg-red-900 hover:bg-red-800 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
-                  >
-                    <FontAwesomeIcon icon={faTrash} className="mr-1" aria-hidden="true" />
-                    Delete
-                  </button>
-                </div>
-              </div>
-            )}
+            </div>
 
             {/* -- Feedback -- */}
             {variantMsg && (

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -9,7 +9,6 @@ import {
   faSpinner,
   faTriangleExclamation,
   faTrash,
-  faLayerGroup,
   faXmark,
   faKey,
   faPenToSquare,
@@ -665,11 +664,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         {/* ======== Projects Settings tab ======== */}
         {activeTab === "projects" && (
         <>
-        {/* ======== Manage Projects ======== */}
-        <section aria-labelledby="settings-heading-projects">
+        {/* ======== Add Project ======== */}
+        <section aria-labelledby="settings-heading-project-add">
           <div className={cardHeader}>
-            <FontAwesomeIcon icon={faLayerGroup} className="text-cyan-400" aria-hidden="true" />
-            <h2 id="settings-heading-projects" className="text-xl font-bold text-white">Manage Projects</h2>
+            <FontAwesomeIcon icon={faPlus} className="text-cyan-400" aria-hidden="true" />
+            <h2 id="settings-heading-project-add" className="text-xl font-bold text-white">Add Project</h2>
           </div>
           <div className={cardBody + " space-y-4"}>
 
@@ -703,8 +702,26 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
               </div>
             </div>
 
+            {/* -- Feedback -- */}
+            {projectMsg && (
+              <span role="alert" className="text-red-400 text-sm">
+                <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
+                {projectMsg}
+              </span>
+            )}
+          </div>
+        </section>
+
+        {/* ======== Rename Project ======== */}
+        <section aria-labelledby="settings-heading-project-rename">
+          <div className={cardHeader}>
+            <FontAwesomeIcon icon={faPenToSquare} className="text-cyan-400" aria-hidden="true" />
+            <h2 id="settings-heading-project-rename" className="text-xl font-bold text-white">Rename Project</h2>
+          </div>
+          <div className={cardBody + " space-y-4"}>
+
             {/* -- Rename project -- */}
-            <div className="border-t border-slate-600/60 pt-4 space-y-2">
+            <div className="space-y-2">
               <label htmlFor="rename-project-select" className="block text-sm text-zinc-300 font-semibold">Rename Project</label>
               <select
                 id="rename-project-select"
@@ -752,8 +769,26 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
               </div>
             </div>
 
+            {/* -- Feedback -- */}
+            {projectMsg && (
+              <span role="alert" className="text-red-400 text-sm">
+                <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
+                {projectMsg}
+              </span>
+            )}
+          </div>
+        </section>
+
+        {/* ======== Delete Project ======== */}
+        <section aria-labelledby="settings-heading-project-delete">
+          <div className={cardHeader}>
+            <FontAwesomeIcon icon={faTrash} className="text-cyan-400" aria-hidden="true" />
+            <h2 id="settings-heading-project-delete" className="text-xl font-bold text-white">Delete Project</h2>
+          </div>
+          <div className={cardBody + " space-y-4"}>
+
             {/* -- Delete project -- */}
-            <div className="border-t border-slate-600/60 pt-4 space-y-2">
+            <div className="space-y-2">
               <label htmlFor="delete-project-select" className="block text-sm text-zinc-300 font-semibold">Delete Project</label>
               <div className="flex gap-2">
                 <select

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -28,7 +28,12 @@ type Props = {
   onLoadingMessage?: (message: string | null) => void;
 };
 
+type SettingsTab = "general" | "projects" | "variants";
+
 function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
+  // ---- Active category tab ----
+  const [activeTab, setActiveTab] = useState<SettingsTab>("general");
+
   // ---- Unmount guard for async operations ----
   const unmountedRef = useRef(false);
   useEffect(() => {
@@ -419,6 +424,43 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
           Manage projects, variants, and import SBOM files.
         </p>
 
+        {/* ======== Category tabs ======== */}
+        <div className="mb-3 flex items-center gap-1 border-b border-gray-700">
+          <button
+            className={`px-4 py-2 text-sm font-medium rounded-t transition-colors ${
+              activeTab === "general"
+                ? "bg-sky-800 text-white border-b-2 border-sky-400"
+                : "text-gray-400 hover:text-gray-200 hover:bg-gray-800"
+            }`}
+            onClick={() => setActiveTab("general")}
+          >
+            General Settings
+          </button>
+          <button
+            className={`px-4 py-2 text-sm font-medium rounded-t transition-colors ${
+              activeTab === "projects"
+                ? "bg-sky-800 text-white border-b-2 border-sky-400"
+                : "text-gray-400 hover:text-gray-200 hover:bg-gray-800"
+            }`}
+            onClick={() => setActiveTab("projects")}
+          >
+            Projects Settings
+          </button>
+          <button
+            className={`px-4 py-2 text-sm font-medium rounded-t transition-colors ${
+              activeTab === "variants"
+                ? "bg-sky-800 text-white border-b-2 border-sky-400"
+                : "text-gray-400 hover:text-gray-200 hover:bg-gray-800"
+            }`}
+            onClick={() => setActiveTab("variants")}
+          >
+            Variants Settings
+          </button>
+        </div>
+
+        {/* ======== General Settings tab ======== */}
+        {activeTab === "general" && (
+        <>
         {/* ======== Report Metadata ======== */}
         <div>
           <div className="bg-zinc-700 px-4 py-2 flex items-center gap-2 rounded-t-md">
@@ -510,6 +552,117 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
           </div>
         </div>
 
+        {/* ======== NVD API Key ======== */}
+        <section aria-labelledby="settings-heading-nvd">
+          <div className="bg-zinc-700 px-4 py-2 flex items-center gap-2 rounded-t-md">
+            <FontAwesomeIcon icon={faKey} className="text-cyan-400" aria-hidden="true" />
+            <h2 id="settings-heading-nvd" className="text-xl font-bold text-white">NVD API Key</h2>
+          </div>
+          <div className="bg-zinc-700 p-4 rounded-b-md space-y-4">
+            <p id="nvd-key-description" className="text-zinc-400 text-sm">
+              An NVD API key increases the rate limit for vulnerability enrichment from 5 to 50 requests per 30 seconds.
+              Get a free key at{" "}
+              <a
+                href="https://nvd.nist.gov/developers/request-an-api-key"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-cyan-400 hover:text-cyan-300 underline"
+              >
+                nvd.nist.gov
+              </a>.
+            </p>
+
+            {/* -- Feedback -- */}
+            {nvdMsg && (
+              <MessageBanner
+                type={nvdMsg.type}
+                message={nvdMsg.text}
+                isVisible={true}
+                onClose={() => setNvdMsg(null)}
+              />
+            )}
+
+            {nvdHasKey && !nvdEditing ? (
+              <>
+                {/* -- Key is set: show masked key + modify / remove buttons -- */}
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-zinc-300">NVD API key:</span>
+                  <code className="text-sm text-zinc-300 bg-zinc-900 px-2 py-0.5 rounded font-mono">{nvdMaskedKey}</code>
+                </div>
+
+                <div className="flex items-center gap-3 pt-1">
+                  <button
+                    onClick={() => { setNvdEditing(true); setNvdKeyInput(""); setNvdMsg(null); }}
+                    className={btnPrimary}
+                  >
+                    <FontAwesomeIcon icon={faPenToSquare} className="mr-1" aria-hidden="true" />
+                    Modify
+                  </button>
+                  <button
+                    onClick={() => setConfirmDeleteNvdKey(true)}
+                    disabled={nvdBusy}
+                    className="px-4 py-2 rounded-lg bg-red-900 hover:bg-red-800 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+                  >
+                    <FontAwesomeIcon icon={faTrash} className="mr-1" aria-hidden="true" />
+                    Remove
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                {/* -- No key or editing: show input field -- */}
+                <div className="space-y-2">
+                  <label htmlFor="nvd-api-key-input" className="block text-sm text-zinc-300 font-semibold">
+                    {nvdEditing ? "New API Key" : "API Key"}
+                  </label>
+                  <input
+                    id="nvd-api-key-input"
+                    type="password"
+                    value={nvdKeyInput}
+                    onChange={e => setNvdKeyInput(e.target.value)}
+                    placeholder="Paste your NVD API key..."
+                    className={inputClass}
+                    disabled={nvdBusy}
+                    autoComplete="off"
+                    aria-required="true"
+                    aria-describedby="nvd-key-description"
+                  />
+                </div>
+
+                <div className="flex items-center gap-3 pt-1">
+                  <button
+                    onClick={handleSaveNvdKey}
+                    disabled={nvdBusy || !nvdKeyInput.trim()}
+                    className={btnPrimary}
+                    aria-busy={nvdBusy}
+                  >
+                    {nvdBusy ? (
+                      <FontAwesomeIcon icon={faSpinner} spin className="mr-1" aria-hidden="true" />
+                    ) : (
+                      <FontAwesomeIcon icon={faCheck} className="mr-1" aria-hidden="true" />
+                    )}
+                    Save
+                  </button>
+                  {nvdEditing && (
+                    <button
+                      onClick={() => { setNvdEditing(false); setNvdKeyInput(""); setNvdMsg(null); }}
+                      className="px-4 py-2 rounded-lg bg-zinc-600 hover:bg-zinc-500 text-white text-sm font-medium transition-colors duration-150"
+                    >
+                      <FontAwesomeIcon icon={faXmark} className="mr-1" aria-hidden="true" />
+                      Cancel
+                    </button>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        </section>
+        </>
+        )}
+
+        {/* ======== Projects Settings tab ======== */}
+        {activeTab === "projects" && (
+        <>
         {/* ======== Manage Projects ======== */}
         <section aria-labelledby="settings-heading-projects">
           <div className="bg-zinc-700 px-4 py-2 flex items-center gap-2 rounded-t-md">
@@ -632,7 +785,12 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
             )}
           </div>
         </section>
+        </>
+        )}
 
+        {/* ======== Variants Settings tab ======== */}
+        {activeTab === "variants" && (
+        <>
         {/* ======== Manage Variants ======== */}
         <section aria-labelledby="settings-heading-variants">
           <div className="bg-zinc-700 px-4 py-2 flex items-center gap-2 rounded-t-md">
@@ -889,112 +1047,8 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
             </div>
           </div>
         </section>
-
-        {/* ======== NVD API Key ======== */}
-        <section aria-labelledby="settings-heading-nvd">
-          <div className="bg-zinc-700 px-4 py-2 flex items-center gap-2 rounded-t-md">
-            <FontAwesomeIcon icon={faKey} className="text-cyan-400" aria-hidden="true" />
-            <h2 id="settings-heading-nvd" className="text-xl font-bold text-white">NVD API Key</h2>
-          </div>
-          <div className="bg-zinc-700 p-4 rounded-b-md space-y-4">
-            <p id="nvd-key-description" className="text-zinc-400 text-sm">
-              An NVD API key increases the rate limit for vulnerability enrichment from 5 to 50 requests per 30 seconds.
-              Get a free key at{" "}
-              <a
-                href="https://nvd.nist.gov/developers/request-an-api-key"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-cyan-400 hover:text-cyan-300 underline"
-              >
-                nvd.nist.gov
-              </a>.
-            </p>
-
-            {/* -- Feedback -- */}
-            {nvdMsg && (
-              <MessageBanner
-                type={nvdMsg.type}
-                message={nvdMsg.text}
-                isVisible={true}
-                onClose={() => setNvdMsg(null)}
-              />
-            )}
-
-            {nvdHasKey && !nvdEditing ? (
-              <>
-                {/* -- Key is set: show masked key + modify / remove buttons -- */}
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-zinc-300">NVD API key:</span>
-                  <code className="text-sm text-zinc-300 bg-zinc-900 px-2 py-0.5 rounded font-mono">{nvdMaskedKey}</code>
-                </div>
-
-                <div className="flex items-center gap-3 pt-1">
-                  <button
-                    onClick={() => { setNvdEditing(true); setNvdKeyInput(""); setNvdMsg(null); }}
-                    className={btnPrimary}
-                  >
-                    <FontAwesomeIcon icon={faPenToSquare} className="mr-1" aria-hidden="true" />
-                    Modify
-                  </button>
-                  <button
-                    onClick={() => setConfirmDeleteNvdKey(true)}
-                    disabled={nvdBusy}
-                    className="px-4 py-2 rounded-lg bg-red-900 hover:bg-red-800 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
-                  >
-                    <FontAwesomeIcon icon={faTrash} className="mr-1" aria-hidden="true" />
-                    Remove
-                  </button>
-                </div>
-              </>
-            ) : (
-              <>
-                {/* -- No key or editing: show input field -- */}
-                <div className="space-y-2">
-                  <label htmlFor="nvd-api-key-input" className="block text-sm text-zinc-300 font-semibold">
-                    {nvdEditing ? "New API Key" : "API Key"}
-                  </label>
-                  <input
-                    id="nvd-api-key-input"
-                    type="password"
-                    value={nvdKeyInput}
-                    onChange={e => setNvdKeyInput(e.target.value)}
-                    placeholder="Paste your NVD API key..."
-                    className={inputClass}
-                    disabled={nvdBusy}
-                    autoComplete="off"
-                    aria-required="true"
-                    aria-describedby="nvd-key-description"
-                  />
-                </div>
-
-                <div className="flex items-center gap-3 pt-1">
-                  <button
-                    onClick={handleSaveNvdKey}
-                    disabled={nvdBusy || !nvdKeyInput.trim()}
-                    className={btnPrimary}
-                    aria-busy={nvdBusy}
-                  >
-                    {nvdBusy ? (
-                      <FontAwesomeIcon icon={faSpinner} spin className="mr-1" aria-hidden="true" />
-                    ) : (
-                      <FontAwesomeIcon icon={faCheck} className="mr-1" aria-hidden="true" />
-                    )}
-                    Save
-                  </button>
-                  {nvdEditing && (
-                    <button
-                      onClick={() => { setNvdEditing(false); setNvdKeyInput(""); setNvdMsg(null); }}
-                      className="px-4 py-2 rounded-lg bg-zinc-600 hover:bg-zinc-500 text-white text-sm font-medium transition-colors duration-150"
-                    >
-                      <FontAwesomeIcon icon={faXmark} className="mr-1" aria-hidden="true" />
-                      Cancel
-                    </button>
-                  )}
-                </div>
-              </>
-            )}
-          </div>
-        </section>
+        </>
+        )}
       </div>
 
       {/* ======== Confirmation Modals ======== */}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -409,20 +409,22 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
     }
   };
 
-  // ---- Styles matching Metrics.tsx (zinc-700 dark cards) ----
+  // ---- Styles ----
   const inputClass =
-    "w-full rounded px-2 py-1.5 text-sm bg-zinc-800 border border-zinc-600 text-white focus:outline-none focus:border-cyan-400";
+    "w-full rounded px-2 py-1.5 text-sm bg-slate-900/60 border border-slate-600 text-white focus:outline-none focus:border-cyan-400";
   const selectClass = inputClass;
   const btnPrimary =
     "px-4 py-2 rounded-lg bg-cyan-800 hover:bg-cyan-700 focus:ring-4 focus:outline-none focus:ring-blue-800 text-white text-sm font-semibold disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150";
+  // ---- Card styles: gradient header + slate body with ring & shadow ----
+  const cardHeader =
+    "bg-gradient-to-r from-slate-700 to-slate-800 px-4 py-2.5 flex items-center gap-2 rounded-t-lg border-b border-slate-600/60";
+  const cardBody =
+    "bg-slate-800/60 p-4 rounded-b-lg ring-1 ring-slate-700/70 shadow-lg shadow-black/20";
 
   return (
-    <div className="w-full flex justify-center pt-8">
-      <div className="w-full max-w-3xl space-y-6">
+    <div className="w-full">
+      <div className="w-full space-y-6">
         <h1 className="text-3xl font-bold text-white mb-2">Settings</h1>
-        <p className="text-zinc-400 mb-4">
-          Manage projects, variants, and import SBOM files.
-        </p>
 
         {/* ======== Category tabs ======== */}
         <div className="mb-3 flex items-center gap-1 border-b border-gray-700">
@@ -463,11 +465,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         <>
         {/* ======== Report Metadata ======== */}
         <div>
-          <div className="bg-zinc-700 px-4 py-2 flex items-center gap-2 rounded-t-md">
+          <div className={cardHeader}>
             <FontAwesomeIcon icon={faFileLines} className="text-cyan-400" />
             <h2 className="text-xl font-bold text-white">Report Metadata</h2>
           </div>
-          <div className="bg-zinc-700 p-4 rounded-b-md space-y-3">
+          <div className={cardBody + " space-y-3"}>
             <div>
               <label className="block text-sm text-zinc-300 mb-1">PRODUCT_NAME</label>
               <input
@@ -554,11 +556,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
 
         {/* ======== NVD API Key ======== */}
         <section aria-labelledby="settings-heading-nvd">
-          <div className="bg-zinc-700 px-4 py-2 flex items-center gap-2 rounded-t-md">
+          <div className={cardHeader}>
             <FontAwesomeIcon icon={faKey} className="text-cyan-400" aria-hidden="true" />
             <h2 id="settings-heading-nvd" className="text-xl font-bold text-white">NVD API Key</h2>
           </div>
-          <div className="bg-zinc-700 p-4 rounded-b-md space-y-4">
+          <div className={cardBody + " space-y-4"}>
             <p id="nvd-key-description" className="text-zinc-400 text-sm">
               An NVD API key increases the rate limit for vulnerability enrichment from 5 to 50 requests per 30 seconds.
               Get a free key at{" "}
@@ -587,7 +589,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
                 {/* -- Key is set: show masked key + modify / remove buttons -- */}
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-zinc-300">NVD API key:</span>
-                  <code className="text-sm text-zinc-300 bg-zinc-900 px-2 py-0.5 rounded font-mono">{nvdMaskedKey}</code>
+                  <code className="text-sm text-zinc-300 bg-slate-900 px-2 py-0.5 rounded font-mono">{nvdMaskedKey}</code>
                 </div>
 
                 <div className="flex items-center gap-3 pt-1">
@@ -646,7 +648,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
                   {nvdEditing && (
                     <button
                       onClick={() => { setNvdEditing(false); setNvdKeyInput(""); setNvdMsg(null); }}
-                      className="px-4 py-2 rounded-lg bg-zinc-600 hover:bg-zinc-500 text-white text-sm font-medium transition-colors duration-150"
+                      className="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-white text-sm font-medium transition-colors duration-150"
                     >
                       <FontAwesomeIcon icon={faXmark} className="mr-1" aria-hidden="true" />
                       Cancel
@@ -665,11 +667,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         <>
         {/* ======== Manage Projects ======== */}
         <section aria-labelledby="settings-heading-projects">
-          <div className="bg-zinc-700 px-4 py-2 flex items-center gap-2 rounded-t-md">
+          <div className={cardHeader}>
             <FontAwesomeIcon icon={faLayerGroup} className="text-cyan-400" aria-hidden="true" />
             <h2 id="settings-heading-projects" className="text-xl font-bold text-white">Manage Projects</h2>
           </div>
-          <div className="bg-zinc-700 p-4 rounded-b-md space-y-4">
+          <div className={cardBody + " space-y-4"}>
 
             {/* -- Create project -- */}
             <div className="space-y-2">
@@ -702,7 +704,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
             </div>
 
             {/* -- Rename project -- */}
-            <div className="border-t border-zinc-600 pt-4 space-y-2">
+            <div className="border-t border-slate-600/60 pt-4 space-y-2">
               <label htmlFor="rename-project-select" className="block text-sm text-zinc-300 font-semibold">Rename Project</label>
               <select
                 id="rename-project-select"
@@ -751,7 +753,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
             </div>
 
             {/* -- Delete project -- */}
-            <div className="border-t border-zinc-600 pt-4 space-y-2">
+            <div className="border-t border-slate-600/60 pt-4 space-y-2">
               <label htmlFor="delete-project-select" className="block text-sm text-zinc-300 font-semibold">Delete Project</label>
               <div className="flex gap-2">
                 <select
@@ -793,11 +795,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         <>
         {/* ======== Manage Variants ======== */}
         <section aria-labelledby="settings-heading-variants">
-          <div className="bg-zinc-700 px-4 py-2 flex items-center gap-2 rounded-t-md">
+          <div className={cardHeader}>
             <FontAwesomeIcon icon={faFolderOpen} className="text-cyan-400" aria-hidden="true" />
             <h2 id="settings-heading-variants" className="text-xl font-bold text-white">Manage Variants</h2>
           </div>
-          <div className="bg-zinc-700 p-4 rounded-b-md space-y-4">
+          <div className={cardBody + " space-y-4"}>
 
             {/* -- Project picker -- */}
             <div>
@@ -856,7 +858,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
 
             {/* -- Rename variant -- */}
             {variantProjectId && (
-              <div className="border-t border-zinc-600 pt-4 space-y-2">
+              <div className="border-t border-slate-600/60 pt-4 space-y-2">
                 <label htmlFor="rename-variant-select" className="block text-sm text-zinc-300 font-semibold">Rename Variant</label>
                 <select
                   id="rename-variant-select"
@@ -907,7 +909,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
 
             {/* -- Delete variant -- */}
             {variantProjectId && (
-              <div className="border-t border-zinc-600 pt-4 space-y-2">
+              <div className="border-t border-slate-600/60 pt-4 space-y-2">
                 <label htmlFor="delete-variant-select" className="block text-sm text-zinc-300 font-semibold">Delete Variant</label>
                 <div className="flex gap-2">
                   <select
@@ -945,11 +947,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
 
         {/* ======== Import SBOM ======== */}
         <section aria-labelledby="settings-heading-import">
-          <div className="bg-zinc-700 px-4 py-2 flex items-center gap-2 rounded-t-md">
+          <div className={cardHeader}>
             <FontAwesomeIcon icon={faFileImport} className="text-cyan-400" aria-hidden="true" />
             <h2 id="settings-heading-import" className="text-xl font-bold text-white">Import SBOM</h2>
           </div>
-          <div className="bg-zinc-700 p-4 rounded-b-md space-y-3">
+          <div className={cardBody + " space-y-3"}>
 
             {/* ---- Project selector ---- */}
             <div>
@@ -994,14 +996,14 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
               {/* Existing files */}
               {importFiles.map((file, idx) => (
                 <div key={idx} className="flex items-center gap-2">
-                  <span className="flex-1 truncate text-sm text-zinc-200 bg-zinc-800 border border-zinc-600 rounded px-2 py-1.5">
+                  <span className="flex-1 truncate text-sm text-zinc-200 bg-slate-900/60 border border-slate-600 rounded px-2 py-1.5">
                     {file.name}
                   </span>
                   <button
                     type="button"
                     onClick={() => handleRemoveFile(idx)}
                     disabled={importBusy}
-                    className="p-1.5 rounded text-zinc-400 hover:text-red-400 hover:bg-zinc-600 disabled:opacity-40 transition-colors"
+                    className="p-1.5 rounded text-zinc-400 hover:text-red-400 hover:bg-slate-600 disabled:opacity-40 transition-colors"
                     aria-label={`Remove file ${file.name}`}
                   >
                     <FontAwesomeIcon icon={faXmark} aria-hidden="true" />

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -23,7 +23,6 @@ from ..models.scan import Scan as ScanModel
 from ..helpers.verbose import verbose
 from ._scan_helpers import parse_uuid_or_400
 
-
 # Tracks in-progress SBOM uploads: upload_id → {status, message, ts}
 _upload_status: dict[str, dict] = {}
 _UPLOAD_STATUS_TTL = 3600  # seconds – entries older than this are pruned
@@ -39,6 +38,22 @@ def _prune_upload_status():
     ]
     for uid in stale:
         _upload_status.pop(uid, None)
+
+
+def _regenerate_openvex(app):
+    """Re-generate and save the OpenVEX file from current DB state."""
+    try:
+        from ..views.openvex import OpenVex
+        from ..controllers import ControllersCache
+
+        openvex_file = app.config.get("OPENVEX_FILE", "/scan/outputs/openvex.json")
+        ctrls = ControllersCache()
+        ctrls.packages._preload_cache()
+        vex = OpenVex(ctrls)
+        with open(openvex_file, "w") as f:
+            f.write(json.dumps(vex.to_dict(), indent=2))
+    except Exception as e:
+        verbose(f"[_regenerate_openvex] {e}")
 
 
 def _retry_on_lock(fn, max_retries=5, delay=0.5):
@@ -278,6 +293,97 @@ def init_app(app):
 
         variant = _retry_on_lock(lambda: VariantController.create(new_name, project_id))
         return jsonify(VariantController.serialize(variant)), 201
+
+    # ------------------------------------------------------------------
+    # Copy custom assessments between two variants
+    # ------------------------------------------------------------------
+    @app.route('/api/variants/copy-assessments', methods=['POST'])
+    def copy_variant_assessments():
+        from ..models.assessment import Assessment as DBAssessment
+        from ..helpers.active_scans import (
+            active_sbom_scan_ids_for_variant,
+            active_package_ids_for_scans,
+        )
+
+        payload = request.get_json(silent=True) or {}
+        source_id = payload.get("source_variant_id")
+        target_id = payload.get("target_variant_id")
+
+        source_uuid, err = parse_uuid_or_400(source_id, "source_variant_id")
+        if err:
+            return err
+        target_uuid, err = parse_uuid_or_400(target_id, "target_variant_id")
+        if err:
+            return err
+
+        if source_uuid == target_uuid:
+            return jsonify({"error": "Source and target variants must be different."}), 400
+
+        source = VariantController.get(source_id)
+        target = VariantController.get(target_id)
+        if source is None or target is None:
+            return jsonify({"error": "Variant not found."}), 404
+        if source.project_id != target.project_id:
+            return jsonify({"error": "Both variants must belong to the same project."}), 400
+
+        # Resolve the package set of each variant (SBOM elements).
+        source_pkg_ids = active_package_ids_for_scans(
+            active_sbom_scan_ids_for_variant(source_uuid))
+        target_pkg_ids = active_package_ids_for_scans(
+            active_sbom_scan_ids_for_variant(target_uuid))
+        common_pkg_ids = source_pkg_ids & target_pkg_ids
+
+        if not common_pkg_ids:
+            return jsonify({
+                "copied": 0,
+                "skipped": 0,
+                "message": "No packages in common between the two variants.",
+            }), 200
+
+        # Custom (handmade) assessments belonging to the source variant.
+        source_assessments = DBAssessment.get_handmade([source_uuid])
+
+        copied = 0
+        skipped = 0
+        with batch_session():
+            for a in source_assessments:
+                finding_id = a.finding_id
+                finding = a.finding
+                if finding is None or finding.package_id not in common_pkg_ids:
+                    continue
+                # Skip if the target already has a custom assessment for this finding.
+                existing = DBAssessment.get_by_finding_and_variant(finding_id, target_uuid)
+                if any(e.origin == "custom" for e in existing):
+                    skipped += 1
+                    continue
+                DBAssessment.create(
+                    status=a.status or "under_investigation",
+                    finding_id=finding_id,
+                    variant_id=target_uuid,
+                    source=a.source,
+                    origin="custom",
+                    simplified_status=a.simplified_status,
+                    status_notes=a.status_notes,
+                    justification=a.justification,
+                    impact_statement=a.impact_statement,
+                    workaround=a.workaround,
+                    responses=list(a.responses) if a.responses else [],
+                    commit=False,
+                )
+                copied += 1
+
+        if copied:
+            _regenerate_openvex(app)
+
+        return jsonify({
+            "copied": copied,
+            "skipped": skipped,
+            "message": (
+                f"Copied {copied} assessment{'s' if copied != 1 else ''} to "
+                f"'{target.name}'."
+                + (f" Skipped {skipped} already present." if skipped else "")
+            ),
+        }), 200
 
     # ------------------------------------------------------------------
     # Delete project

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -7,6 +7,9 @@ import uuid
 import time
 import tempfile
 import threading
+import tarfile
+import subprocess
+import shutil
 
 from flask import jsonify, request
 from sqlalchemy.exc import OperationalError
@@ -95,6 +98,60 @@ def _detect_format(filename: str, data: dict) -> str:
     if "@context" in data or "spdxDocument" in str(data.get("type", "")):
         return "spdx"
     return "unknown"
+
+
+def _is_archive(filename: str) -> bool:
+    """True when *filename* looks like a tar archive (optionally compressed)."""
+    lower = filename.lower()
+    return lower.endswith((".tar", ".tar.gz", ".tgz", ".tar.zst"))
+
+
+def _extract_spdx_archive(archive_path: str, filename: str) -> list[tuple[str, str]]:
+    """Extract an SPDX archive (.tar / .tar.gz / .tar.zst) and return the
+    contained ``*.spdx.json`` files as a list of ``(tmp_path, member_name)``.
+
+    Used for SPDX2 inputs which are commonly shipped as tar archives.
+    """
+    lower = filename.lower()
+    extract_dir = tempfile.mkdtemp(prefix="vulnscout_archive_")
+    tar_path = archive_path
+    decompressed: str | None = None
+    try:
+        if lower.endswith(".tar.zst"):
+            # No zstandard python module bundled — use the unzstd CLI.
+            decompressed = os.path.join(extract_dir, "archive.tar")
+            subprocess.run(
+                ["unzstd", "-q", "-f", "-o", decompressed, archive_path],
+                check=True,
+            )
+            tar_path = decompressed
+
+        with tarfile.open(tar_path, "r:*") as tar:
+            results: list[tuple[str, str]] = []
+            for member in tar.getmembers():
+                if not member.isfile():
+                    continue
+                if not member.name.lower().endswith(".spdx.json"):
+                    continue
+                src = tar.extractfile(member)
+                if src is None:
+                    continue
+                base = os.path.basename(member.name)
+                fd, out_path = tempfile.mkstemp(suffix=".spdx.json", prefix="vulnscout_upload_")
+                with os.fdopen(fd, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                results.append((out_path, base))
+            return results
+    finally:
+        if decompressed and os.path.exists(decompressed):
+            try:
+                os.unlink(decompressed)
+            except OSError:
+                pass
+        try:
+            shutil.rmtree(extract_dir, ignore_errors=True)
+        except OSError:
+            pass
 
 
 def _process_sbom_background(app, upload_id: str, file_paths: list[str], scan_id, variant_id):
@@ -442,6 +499,13 @@ def init_app(app):
         # Validate all files and detect formats before creating the scan
         validated_files: list[tuple[str, str, str]] = []  # (tmp_path, filename, fmt)
 
+        def _cleanup_validated():
+            for p, _, _ in validated_files:
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
+
         for uploaded in uploaded_files:
             if not uploaded.filename:
                 continue
@@ -459,6 +523,27 @@ def init_app(app):
                 os.unlink(tmp_path)
                 raise
 
+            # Tar archives (commonly used for SPDX2) — extract the contained
+            # .spdx.json documents and register each one individually.
+            if _is_archive(filename):
+                try:
+                    members = _extract_spdx_archive(tmp_path, filename)
+                except (subprocess.CalledProcessError, tarfile.TarError, OSError) as e:
+                    os.unlink(tmp_path)
+                    _cleanup_validated()
+                    return jsonify({
+                        "error": f"Could not extract archive '{filename}': {e}",
+                    }), 400
+                os.unlink(tmp_path)
+                if not members:
+                    _cleanup_validated()
+                    return jsonify({
+                        "error": f"No .spdx.json files found inside archive '{filename}'.",
+                    }), 400
+                for member_path, member_name in members:
+                    validated_files.append((member_path, member_name, "spdx"))
+                continue
+
             # Auto-detect format if not provided
             if not fmt:
                 try:
@@ -466,22 +551,14 @@ def init_app(app):
                         data = json.load(f)
                     fmt = _detect_format(filename, data)
                     if fmt == "unknown":
-                        for p, _, _ in validated_files:
-                            try:
-                                os.unlink(p)
-                            except OSError:
-                                pass
+                        _cleanup_validated()
                         os.unlink(tmp_path)
                         return jsonify({
                             "error": f"Unrecognized SBOM format for '{filename}'.",
                         }), 400
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     # Clean up all temp files saved so far
-                    for p, _, _ in validated_files:
-                        try:
-                            os.unlink(p)
-                        except OSError:
-                            pass
+                    _cleanup_validated()
                     os.unlink(tmp_path)
                     return jsonify({"error": f"Could not parse '{filename}' as JSON."}), 400
 

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -354,69 +354,194 @@ def init_app(app):
     # ------------------------------------------------------------------
     # Copy custom assessments between two variants
     # ------------------------------------------------------------------
-    @app.route('/api/variants/copy-assessments', methods=['POST'])
-    def copy_variant_assessments():
+    def _compute_copy_assessment_operations(source_id, target_id, ignore_package_version):
         from ..models.assessment import Assessment as DBAssessment
+        from ..models.finding import Finding
         from ..helpers.active_scans import (
             active_sbom_scan_ids_for_variant,
             active_package_ids_for_scans,
         )
 
-        payload = request.get_json(silent=True) or {}
-        source_id = payload.get("source_variant_id")
-        target_id = payload.get("target_variant_id")
-
         source_uuid, err = parse_uuid_or_400(source_id, "source_variant_id")
         if err:
-            return err
+            return None, err
         target_uuid, err = parse_uuid_or_400(target_id, "target_variant_id")
         if err:
-            return err
+            return None, err
 
         if source_uuid == target_uuid:
-            return jsonify({"error": "Source and target variants must be different."}), 400
+            return None, (jsonify({"error": "Source and target variants must be different."}), 400)
 
         source = VariantController.get(source_id)
         target = VariantController.get(target_id)
         if source is None or target is None:
-            return jsonify({"error": "Variant not found."}), 404
+            return None, (jsonify({"error": "Variant not found."}), 404)
         if source.project_id != target.project_id:
-            return jsonify({"error": "Both variants must belong to the same project."}), 400
+            return None, (jsonify({"error": "Both variants must belong to the same project."}), 400)
 
-        # Resolve the package set of each variant (SBOM elements).
         source_pkg_ids = active_package_ids_for_scans(
             active_sbom_scan_ids_for_variant(source_uuid))
         target_pkg_ids = active_package_ids_for_scans(
             active_sbom_scan_ids_for_variant(target_uuid))
         common_pkg_ids = source_pkg_ids & target_pkg_ids
 
-        if not common_pkg_ids:
-            return jsonify({
-                "copied": 0,
-                "skipped": 0,
-                "message": "No packages in common between the two variants.",
-            }), 200
-
-        # Custom (handmade) assessments belonging to the source variant.
         source_assessments = DBAssessment.get_handmade([source_uuid])
 
-        copied = 0
+        source_vuln_ids: set[str] = set()
+        target_findings_by_vuln: dict[str, list[Finding]] = {}
+
+        if ignore_package_version:
+            source_vuln_ids = {
+                a.finding.vulnerability_id
+                for a in source_assessments
+                if a.finding is not None and a.finding.package_id in source_pkg_ids
+            }
+
+            if source_vuln_ids:
+                target_findings = list(db.session.execute(
+                    db.select(Finding).where(
+                        Finding.package_id.in_(target_pkg_ids),
+                        Finding.vulnerability_id.in_(source_vuln_ids),
+                    )
+                ).scalars().all())
+            else:
+                target_findings = []
+
+            for f in target_findings:
+                target_findings_by_vuln.setdefault(f.vulnerability_id, []).append(f)
+
+            if not target_findings_by_vuln:
+                return {
+                    "source": source,
+                    "target": target,
+                    "operations": [],
+                    "skipped": 0,
+                    "empty_message": "No vulnerabilities in common between the two variants.",
+                }, None
+        else:
+            if not common_pkg_ids:
+                return {
+                    "source": source,
+                    "target": target,
+                    "operations": [],
+                    "skipped": 0,
+                    "empty_message": "No packages in common between the two variants.",
+                }, None
+
+        operations = []
         skipped = 0
-        with batch_session():
-            for a in source_assessments:
-                finding_id = a.finding_id
-                finding = a.finding
-                if finding is None or finding.package_id not in common_pkg_ids:
+        processed_target_finding_ids: set = set()
+
+        for assessment in source_assessments:
+            source_finding = assessment.finding
+            if source_finding is None:
+                continue
+
+            if ignore_package_version:
+                target_findings = target_findings_by_vuln.get(source_finding.vulnerability_id, [])
+            else:
+                if source_finding.package_id not in common_pkg_ids:
                     continue
-                # Skip if the target already has a custom assessment for this finding.
-                existing = DBAssessment.get_by_finding_and_variant(finding_id, target_uuid)
+                target_findings = [source_finding]
+
+            for target_finding in target_findings:
+                if target_finding.id in processed_target_finding_ids:
+                    continue
+                processed_target_finding_ids.add(target_finding.id)
+
+                existing = DBAssessment.get_by_finding_and_variant(target_finding.id, target_uuid)
                 if any(e.origin == "custom" for e in existing):
                     skipped += 1
                     continue
+
+                operations.append((assessment, source_finding, target_finding))
+
+        return {
+            "source": source,
+            "target": target,
+            "operations": operations,
+            "skipped": skipped,
+            "empty_message": None,
+        }, None
+
+    @app.route('/api/variants/copy-assessments/preview', methods=['POST'])
+    def preview_copy_variant_assessments():
+        payload = request.get_json(silent=True) or {}
+        source_id = payload.get("source_variant_id")
+        target_id = payload.get("target_variant_id")
+        ignore_package_version = bool(payload.get("ignore_package_version", False))
+
+        result, err = _compute_copy_assessment_operations(
+            source_id,
+            target_id,
+            ignore_package_version,
+        )
+        if err:
+            return err
+        assert result is not None
+
+        operations = result["operations"]
+        preview_rows = []
+        for assessment, source_finding, target_finding in operations:
+            preview_rows.append({
+                "source_assessment_id": str(assessment.id),
+                "source_finding_id": str(source_finding.id),
+                "target_finding_id": str(target_finding.id),
+                "vulnerability_id": source_finding.vulnerability_id,
+                "source_package": source_finding.package.string_id if source_finding.package else "",
+                "target_package": target_finding.package.string_id if target_finding.package else "",
+            })
+
+        message = result["empty_message"]
+        if message is None:
+            message = (
+                f"{len(preview_rows)} assessment{'s' if len(preview_rows) != 1 else ''} "
+                "would be copied."
+                + (f" {result['skipped']} already present would be skipped." if result["skipped"] else "")
+            )
+
+        return jsonify({
+            "count": len(preview_rows),
+            "skipped": result["skipped"],
+            "message": message,
+            "entries": preview_rows,
+        }), 200
+
+    @app.route('/api/variants/copy-assessments', methods=['POST'])
+    def copy_variant_assessments():
+        from ..models.assessment import Assessment as DBAssessment
+
+        payload = request.get_json(silent=True) or {}
+        source_id = payload.get("source_variant_id")
+        target_id = payload.get("target_variant_id")
+        ignore_package_version = bool(payload.get("ignore_package_version", False))
+
+        result, err = _compute_copy_assessment_operations(
+            source_id,
+            target_id,
+            ignore_package_version,
+        )
+        if err:
+            return err
+        assert result is not None
+
+        target = result["target"]
+        operations = result["operations"]
+        skipped = result["skipped"]
+        if not operations and result["empty_message"]:
+            return jsonify({
+                "copied": 0,
+                "skipped": skipped,
+                "message": result["empty_message"],
+            }), 200
+
+        copied = 0
+        with batch_session():
+            for a, _source_finding, target_finding in operations:
                 DBAssessment.create(
                     status=a.status or "under_investigation",
-                    finding_id=finding_id,
-                    variant_id=target_uuid,
+                    finding_id=target_finding.id,
+                    variant_id=target.id,
                     source=a.source,
                     origin="custom",
                     simplified_status=a.simplified_status,

--- a/tests/webapp_tests/test_scan_export.py
+++ b/tests/webapp_tests/test_scan_export.py
@@ -101,6 +101,71 @@ def ids(app):
 
 
 # ---------------------------------------------------------------------------
+# Export helper unit tests
+# ---------------------------------------------------------------------------
+
+class TestExportHelpers:
+
+    def test_extract_supplier_name_strips_prefix_and_suffix(self):
+        from src.routes.scans import _extract_supplier_name
+
+        assert _extract_supplier_name("SPDX: Example Corp (contact@example.com)") == "Example Corp"
+
+    def test_strip_helpers_include_supplier_when_present(self):
+        from src.routes.scans import (
+            _strip_finding,
+            _strip_package,
+            _strip_package_upgrade,
+            _strip_finding_upgrade,
+            _strip_assessment,
+        )
+
+        finding = _strip_finding({
+            "vulnerability_id": "CVE-1",
+            "package_name": "pkg",
+            "package_version": "1.0",
+            "package_supplier": "SPDX: Vendor (x)",
+        })
+        package = _strip_package({
+            "package_name": "pkg",
+            "package_version": "1.0",
+            "package_supplier": "SPDX: Vendor (x)",
+        })
+        package_upgrade = _strip_package_upgrade({
+            "package_name": "pkg",
+            "old_version": "1.0",
+            "new_version": "2.0",
+            "package_supplier": "SPDX: Vendor (x)",
+        })
+        finding_upgrade = _strip_finding_upgrade({
+            "vulnerability_id": "CVE-1",
+            "package_name": "pkg",
+            "old_version": "1.0",
+            "new_version": "2.0",
+            "package_supplier": "SPDX: Vendor (x)",
+        })
+        assessment = _strip_assessment({
+            "vulnerability_id": "CVE-1",
+            "status": "fixed",
+            "simplified_status": "Done",
+            "justification": "mitigated",
+            "impact_statement": "none",
+            "status_notes": "ok",
+        })
+
+        assert finding["supplier"] == "Vendor"
+        assert package["supplier"] == "Vendor"
+        assert package_upgrade["supplier"] == "Vendor"
+        assert finding_upgrade["supplier"] == "Vendor"
+        assert assessment["status"] == "fixed"
+
+    def test_format_timestamp_for_filename_accepts_string(self):
+        from src.routes.scans import _format_timestamp_for_filename
+
+        assert _format_timestamp_for_filename("2025-01-02T03:04:05+00:00") == "20250102_030405"
+
+
+# ---------------------------------------------------------------------------
 # GET /api/scans/<scan_id>/export-diff
 # ---------------------------------------------------------------------------
 

--- a/tests/webapp_tests/test_scan_triggers.py
+++ b/tests/webapp_tests/test_scan_triggers.py
@@ -12,6 +12,20 @@ from src.bin.webapp import create_app
 from src.extensions import db as _db
 
 
+def _sync_thread_patch():
+    """Run background scan threads synchronously in tests."""
+    return patch(
+        "threading.Thread",
+        side_effect=lambda **kwargs: type(
+            "SyncThread", (), {
+                "_target": kwargs.get("target"),
+                "start": lambda self: kwargs.get("target")(),
+                "daemon": True,
+            }
+        )(),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -139,6 +153,49 @@ class TestTriggerGrypeScan:
         assert resp2.status_code == 409
         assert b"already in progress" in resp2.data
 
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    @patch("subprocess.run")
+    def test_scan_filters_matches_to_variant_sbom(self, mock_run, mock_which, client, ids):
+        """The grype worker filters matches to packages present in the variant SBOM."""
+        import json as _json
+        from src.models.vulnerability import Vulnerability
+        from src.models.package import Package
+
+        with client.application.app_context():
+            Vulnerability.create_record(id="CVE-GRYPE-0001", description="seed")
+            Package.find_or_create("openssl", "1.1.1")
+            _db.session.commit()
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "export" in cmd:
+                out_dir = cmd[cmd.index("--output-dir") + 1]
+                with open(f"{out_dir}/sbom_cyclonedx_v1_6.cdx.json", "w") as f:
+                    f.write("{}")
+            elif isinstance(cmd, list) and "grype" in cmd:
+                stdout_file = kwargs.get("stdout")
+                if stdout_file is not None:
+                    stdout_file.write(_json.dumps({
+                        "matches": [{
+                            "artifact": {
+                                "name": "openssl",
+                                "version": "1.1.1",
+                            }
+                        }]
+                    }))
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = _fake_run
+
+        with _sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/grype-scan")
+
+        assert resp.status_code == 202
+
+        resp_s = client.get(f"/api/variants/{ids['variant_id']}/grype-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "done"
+        assert any("Filtered: 1/1 matches kept" in line for line in data["logs"])
+
 
 # ---------------------------------------------------------------------------
 # Grype scan — status
@@ -209,6 +266,65 @@ class TestTriggerNvdScan:
         resp2 = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
         assert resp2.status_code == 409
         assert b"already in progress" in resp2.data
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_scan_updates_existing_vuln_and_handles_missing_cve_id(self, mock_nvd, client, ids):
+        """The worker skips empty CVE ids and updates an existing vulnerability in place."""
+        mock_db = mock_nvd.return_value
+        mock_db.api_get_cves_by_cpe.return_value = [
+            {"cve": {}},
+            {"cve": {"id": "CVE-TRIGGER-0001"}},
+        ]
+        mock_nvd.extract_cve_details.return_value = {
+            "description": "updated desc",
+            "status": "high",
+            "publish_date": "2025-01-01",
+            "attack_vector": "NETWORK",
+            "links": ["https://example.org"],
+            "weaknesses": ["CWE-79"],
+            "nvd_last_modified": "2025-01-02",
+            "base_score": 7.5,
+            "cvss_version": "3.1",
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "cvss_exploitability": 3.2,
+            "cvss_impact": 4.3,
+        }
+
+        class _ExistingVuln:
+            def __init__(self):
+                self.id = "CVE-TRIGGER-0001"
+                self.description = None
+                self.status = None
+                self.publish_date = None
+                self.attack_vector = None
+                self.links = None
+                self.weaknesses = None
+                self.update_record = MagicMock()
+                self.add_found_by = MagicMock()
+
+        fake_vuln = _ExistingVuln()
+        original_get = _db.session.get
+
+        def _fake_get(model, identity):
+            if getattr(model, "__name__", "") == "Vulnerability" and str(identity) == "CVE-TRIGGER-0001":
+                return fake_vuln
+            return original_get(model, identity)
+
+        with patch.object(_db.session, "get", side_effect=_fake_get):
+            with patch("src.models.metrics.Metrics.from_cvss", side_effect=Exception("boom")):
+                with _sync_thread_patch():
+                    resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+
+        assert resp.status_code == 202
+
+        fake_vuln.update_record.assert_called_once()
+        kwargs = fake_vuln.update_record.call_args.kwargs
+        assert kwargs["description"] == "updated desc"
+        assert kwargs["status"] == "high"
+
+        resp_s = client.get(f"/api/variants/{ids['variant_id']}/nvd-scan/status")
+        data = json.loads(resp_s.data)
+        assert data["status"] == "done"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webapp_tests/test_settings_endpoints.py
+++ b/tests/webapp_tests/test_settings_endpoints.py
@@ -249,6 +249,133 @@ class TestDeleteVariant:
         assert resp.status_code == 404
 
 
+class TestCopyCustomAssessments:
+
+    def _seed_copy_data(self, app):
+        from src.extensions import db
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.package import Package
+        from src.models.vulnerability import Vulnerability
+        from src.models.finding import Finding
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.assessment import Assessment
+
+        with app.app_context():
+            project = Project.create("CopyDataProject")
+            source = Variant.create("SourceVariant", project.id)
+            target = Variant.create("TargetVariant", project.id)
+
+            source_scan = Scan.create("source sbom", source.id, scan_type="sbom")
+            target_scan = Scan.create("target sbom", target.id, scan_type="sbom")
+
+            source_pkg = Package.find_or_create("openssl", "1.1.1")
+            target_pkg = Package.find_or_create("openssl", "3.0.0")
+            vuln = Vulnerability.create_record(id="CVE-COPY-0001", description="Copy me")
+            db.session.commit()
+
+            source_finding = Finding.get_or_create(source_pkg.id, vuln.id)
+            target_finding = Finding.get_or_create(target_pkg.id, vuln.id)
+
+            source_doc = SBOMDocument.create("/tmp/source.spdx.json", "spdx", source_scan.id)
+            target_doc = SBOMDocument.create("/tmp/target.spdx.json", "spdx", target_scan.id)
+            SBOMPackage.create(source_doc.id, source_pkg.id)
+            SBOMPackage.create(target_doc.id, target_pkg.id)
+
+            Assessment.create(
+                status="affected",
+                origin="custom",
+                finding_id=source_finding.id,
+                variant_id=source.id,
+                source="manual",
+            )
+            db.session.commit()
+
+            return {
+                "source_variant_id": str(source.id),
+                "target_variant_id": str(target.id),
+                "target_finding_id": str(target_finding.id),
+            }
+
+    def test_copy_assessments_default_requires_common_packages(self, app, client):
+        ids = self._seed_copy_data(app)
+
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["copied"] == 0
+        assert "No packages in common" in data["message"]
+
+    def test_copy_assessments_ignore_package_version_copies_by_vuln(self, app, client):
+        from src.models.assessment import Assessment
+
+        ids = self._seed_copy_data(app)
+
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "ignore_package_version": True,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["copied"] == 1
+
+        with app.app_context():
+            target_assessments = Assessment.get_by_finding_and_variant(
+                ids["target_finding_id"],
+                ids["target_variant_id"],
+            )
+            assert any(a.origin == "custom" for a in target_assessments)
+
+    def test_copy_assessments_preview_default_no_common_packages(self, app, client):
+        ids = self._seed_copy_data(app)
+
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["count"] == 0
+        assert data["skipped"] == 0
+        assert data["entries"] == []
+        assert "No packages in common" in data["message"]
+
+    def test_copy_assessments_preview_ignore_package_version_lists_candidates(self, app, client):
+        ids = self._seed_copy_data(app)
+
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "ignore_package_version": True,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["count"] == 1
+        assert data["skipped"] == 0
+        assert len(data["entries"]) == 1
+        assert data["entries"][0]["vulnerability_id"] == "CVE-COPY-0001"
+        assert data["entries"][0]["source_package"] == "openssl@1.1.1"
+        assert data["entries"][0]["target_package"] == "openssl@3.0.0"
+
+
 # ---------------------------------------------------------------------------
 # SBOM Upload (multi-file)
 # ---------------------------------------------------------------------------

--- a/tests/webapp_tests/test_settings_endpoints.py
+++ b/tests/webapp_tests/test_settings_endpoints.py
@@ -9,6 +9,7 @@ import io
 import json
 import os
 import uuid
+import tarfile
 import pytest
 from unittest.mock import patch, MagicMock
 from werkzeug.datastructures import MultiDict
@@ -272,6 +273,18 @@ def _make_spdx_json(name="test-pkg", version="1.0.0"):
     return json.dumps(doc).encode("utf-8")
 
 
+def _make_spdx_tar_archive(member_name="archive.spdx.json", package_name="archive-pkg"):
+    """Return bytes for a tar archive containing one SPDX JSON document."""
+    archive = io.BytesIO()
+    payload = _make_spdx_json(package_name, "1.0.0")
+    with tarfile.open(fileobj=archive, mode="w") as tar:
+        info = tarfile.TarInfo(name=member_name)
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    archive.seek(0)
+    return archive.getvalue()
+
+
 class TestSBOMUpload:
     """Tests for POST /api/sbom/upload (multi-file support)."""
 
@@ -430,6 +443,78 @@ class TestSBOMUpload:
         assert resp.status_code == 400
         assert "Could not parse" in resp.get_json()["error"]
 
+    @patch("src.routes.settings.threading.Thread")
+    def test_upload_tar_archive_is_extracted(self, mock_thread, client):
+        """A tar archive containing SPDX JSON files is accepted and extracted."""
+        mock_thread.return_value = MagicMock()
+        pid = _get_project_id(client)
+        vid = _get_variant_id(client, pid)
+
+        data = {
+            "project_id": pid,
+            "variant_id": vid,
+            "files": (io.BytesIO(_make_spdx_tar_archive()), "sbom.tar"),
+        }
+        resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 202
+        assert "upload_id" in resp.get_json()
+        mock_thread.return_value.start.assert_called_once()
+
+    @patch("src.routes.settings.threading.Thread")
+    def test_upload_empty_tar_archive_rejected(self, mock_thread, client):
+        """A tar archive without SPDX JSON files is rejected."""
+        mock_thread.return_value = MagicMock()
+        pid = _get_project_id(client)
+        vid = _get_variant_id(client, pid)
+
+        empty_archive = io.BytesIO()
+        with tarfile.open(fileobj=empty_archive, mode="w"):
+            pass
+        empty_archive.seek(0)
+
+        data = {
+            "project_id": pid,
+            "variant_id": vid,
+            "files": (empty_archive, "empty.tar"),
+        }
+        resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 400
+        assert "No .spdx.json files" in resp.get_json()["error"]
+
+    @patch("src.routes.settings.threading.Thread")
+    @patch("src.routes.settings.subprocess.run")
+    def test_upload_tar_zst_archive_is_extracted(self, mock_run, mock_thread, client):
+        """A .tar.zst archive is decompressed and extracted like a normal tar."""
+        mock_thread.return_value = MagicMock()
+        pid = _get_project_id(client)
+        vid = _get_variant_id(client, pid)
+
+        payload = _make_spdx_json("zst-pkg", "1.2.3")
+        archive = io.BytesIO()
+        with tarfile.open(fileobj=archive, mode="w") as tar:
+            info = tarfile.TarInfo(name="inner.spdx.json")
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+        archive.seek(0)
+
+        def _fake_run(cmd, check=True, **kwargs):
+            if cmd and cmd[0] == "unzstd":
+                out_path = cmd[cmd.index("-o") + 1]
+                with open(cmd[-1], "rb") as src, open(out_path, "wb") as dst:
+                    dst.write(src.read())
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = _fake_run
+
+        data = {
+            "project_id": pid,
+            "variant_id": vid,
+            "files": (io.BytesIO(archive.getvalue()), "sbom.tar.zst"),
+        }
+        resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 202
+        mock_thread.return_value.start.assert_called_once()
+
 
 class TestUploadStatus:
 
@@ -455,6 +540,34 @@ class TestUploadStatus:
         status_resp = client.get(f"/api/sbom/upload/{upload_id}/status")
         assert status_resp.status_code == 200
         assert status_resp.get_json()["status"] == "processing"
+
+
+class TestUploadHelpers:
+
+    def test_prune_upload_status_removes_stale_entries(self):
+        from src.routes.settings import _prune_upload_status, _upload_status, _UPLOAD_STATUS_TTL
+
+        original = dict(_upload_status)
+        try:
+            now = 10_000.0
+            _upload_status.clear()
+            _upload_status.update({
+                "keep": {"status": "processing", "ts": now},
+                "done-old": {"status": "done", "ts": now - _UPLOAD_STATUS_TTL - 1},
+                "error-old": {"status": "error", "ts": now - _UPLOAD_STATUS_TTL - 1},
+                "done-fresh": {"status": "done", "ts": now},
+            })
+
+            with patch("src.routes.settings.time.time", return_value=now):
+                _prune_upload_status()
+
+            assert "keep" in _upload_status
+            assert "done-fresh" in _upload_status
+            assert "done-old" not in _upload_status
+            assert "error-old" not in _upload_status
+        finally:
+            _upload_status.clear()
+            _upload_status.update(original)
 
 
 # ---------------------------------------------------------------------------
@@ -676,6 +789,44 @@ class TestProcessSBOMBackground:
             status = _upload_status[upload_id]
             # Should either succeed (no docs to parse) or fail gracefully
             assert status["status"] in ("done", "error")
+
+    def test_process_read_inputs_failure_sets_error_status(self, app, monkeypatch, tmp_path):
+        """A processing failure inside read_inputs is converted to an error status."""
+        from src.routes.settings import _process_sbom_background, _upload_status
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+
+        with app.app_context():
+            project = Project.create("BgReadErrProject")
+            variant = Variant.create("BgReadErrVariant", project.id)
+            scan = Scan.create("", variant.id)
+
+            sbom_path = tmp_path / "input.spdx.json"
+            sbom_path.write_text("{}")
+
+            monkeypatch.setattr(
+                "src.bin.cmd_process.read_inputs",
+                lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+            )
+
+            upload_id = "bg-test-read-inputs-fail"
+            _process_sbom_background(app, upload_id, [str(sbom_path)], scan.id, variant.id)
+
+            assert _upload_status[upload_id]["status"] == "error"
+
+    def test_regenerate_openvex_handles_exception(self, app, tmp_path):
+        """_regenerate_openvex() must swallow OpenVEX generation failures."""
+        from src.routes.settings import _regenerate_openvex
+
+        out_file = tmp_path / "openvex.json"
+        app.config["OPENVEX_FILE"] = str(out_file)
+
+        with patch("src.views.openvex.OpenVex.to_dict", side_effect=RuntimeError("boom")):
+            _regenerate_openvex(app)
+
+        assert out_file.exists()
+        assert out_file.stat().st_size == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webapp_tests/test_vulnerabilities_coverage.py
+++ b/tests/webapp_tests/test_vulnerabilities_coverage.py
@@ -612,6 +612,82 @@ def test_get_vulnerabilities_compare_difference_no_scan(client):
     assert data == []
 
 
+def test_get_vulnerabilities_compare_with_data(app, client):
+    """GET with real compare data exercises the populated compare branch."""
+    from src.extensions import db
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.observation import Observation
+    from src.models.finding import Finding
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from datetime import datetime, timezone
+    import uuid as _uuid
+
+    with app.app_context():
+        project = Project.create("CompareProject")
+        base_variant = Variant.create("BaseVariant", project.id)
+        compare_variant = Variant.create("CompareVariant", project.id)
+        pkg = Package.find_or_create("compare-pkg", "1.0.0", [], [], "")
+        db.session.commit()
+        vuln = Vulnerability.create_record(
+            id="CVE-COMPARE-0001",
+            description="Compare branch vuln",
+            status="medium",
+        )
+        db.session.commit()
+        base_finding = Finding.get_or_create(pkg.id, vuln.id)
+        compare_finding = Finding.get_or_create(pkg.id, vuln.id)
+
+        base_scan = Scan(
+            id=_uuid.uuid4(),
+            variant_id=base_variant.id,
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        compare_scan = Scan(
+            id=_uuid.uuid4(),
+            variant_id=compare_variant.id,
+            timestamp=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        )
+        db.session.add(base_scan)
+        db.session.add(compare_scan)
+
+        base_doc = SBOMDocument(
+            id=_uuid.uuid4(),
+            path="/demo/base.spdx.json",
+            source_name="base.spdx.json",
+            format="spdx",
+            scan_id=base_scan.id,
+        )
+        compare_doc = SBOMDocument(
+            id=_uuid.uuid4(),
+            path="/demo/compare.spdx.json",
+            source_name="compare.spdx.json",
+            format="spdx",
+            scan_id=compare_scan.id,
+        )
+        db.session.add(base_doc)
+        db.session.add(compare_doc)
+        db.session.add(SBOMPackage(sbom_document_id=base_doc.id, package_id=pkg.id))
+        db.session.add(SBOMPackage(sbom_document_id=compare_doc.id, package_id=pkg.id))
+        db.session.add(Observation(finding_id=base_finding.id, scan_id=base_scan.id))
+        db.session.add(Observation(finding_id=compare_finding.id, scan_id=compare_scan.id))
+        db.session.commit()
+
+        base_id = str(base_variant.id)
+        compare_id = str(compare_variant.id)
+
+    response = client.get(
+        f"/api/vulnerabilities?variant_id={base_id}&compare_variant_id={compare_id}&operation=intersection"
+    )
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert any(v["id"] == "CVE-COMPARE-0001" for v in data)
+
+
 # ---------------------------------------------------------------------------
 # GET /api/vulnerabilities — invalid variant_id/project_id (lines 140, 162)
 # ---------------------------------------------------------------------------
@@ -630,6 +706,97 @@ def test_get_vulnerabilities_invalid_project_id(client):
     assert response.status_code == 400
     data = json.loads(response.data)
     assert "invalid" in data["error"].lower() or "project" in data["error"].lower()
+
+
+def test_get_vulnerability_by_id_with_variant_scope(app, client):
+    """GET /api/vulnerabilities/<id>?variant_id=... applies scoped effort/CVSS."""
+    from src.extensions import db
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.observation import Observation
+    from src.models.finding import Finding
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.metrics import Metrics
+    from src.models.time_estimate import TimeEstimate
+    from datetime import datetime, timezone
+    import uuid as _uuid
+
+    with app.app_context():
+        project = Project.create("DetailScopeProject")
+        variant = Variant.create("DetailScopeVariant", project.id)
+        pkg = Package.find_or_create("detail-scope-pkg", "1.0.0", [], [], "")
+        db.session.commit()
+        vuln = Vulnerability.create_record(
+            id="CVE-DETAIL-0001",
+            description="Detail branch vuln",
+            status="high",
+        )
+        db.session.commit()
+        finding = Finding.get_or_create(pkg.id, vuln.id)
+
+        scan = Scan(
+            id=_uuid.uuid4(),
+            variant_id=variant.id,
+            timestamp=datetime(2024, 1, 3, tzinfo=timezone.utc),
+        )
+        db.session.add(scan)
+        doc = SBOMDocument(
+            id=_uuid.uuid4(),
+            path="/demo/detail.spdx.json",
+            source_name="detail.spdx.json",
+            format="spdx",
+            scan_id=scan.id,
+        )
+        db.session.add(doc)
+        db.session.add(SBOMPackage(sbom_document_id=doc.id, package_id=pkg.id))
+        db.session.add(Observation(finding_id=finding.id, scan_id=scan.id))
+
+        Metrics.create(
+            vulnerability_id=vuln.id,
+            variant_id=None,
+            version="3.1",
+            score=5.0,
+            vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            author="scanner",
+            origin="scanner",
+        )
+        Metrics.create(
+            vulnerability_id=vuln.id,
+            variant_id=variant.id,
+            version="3.1",
+            score=8.5,
+            vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            author="tester",
+            origin="custom",
+        )
+        TimeEstimate.create(
+            finding_id=finding.id,
+            variant_id=None,
+            optimistic=1,
+            likely=2,
+            pessimistic=3,
+        )
+        TimeEstimate.create(
+            finding_id=finding.id,
+            variant_id=variant.id,
+            optimistic=4,
+            likely=5,
+            pessimistic=6,
+        )
+        db.session.commit()
+
+        variant_id = str(variant.id)
+
+    response = client.get(f"/api/vulnerabilities/CVE-DETAIL-0001?variant_id={variant_id}")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data["id"] == "CVE-DETAIL-0001"
+    assert data["effort"]["likely"] == "PT5H"
+    assert any(cvss["origin"] == "custom" for cvss in data["severity"]["cvss"])
 
 
 # ---------------------------------------------------------------------------
@@ -672,6 +839,62 @@ def test_patch_batch_vulnerability_effort_invalid_variant_id(client):
     assert data["error_count"] >= 1
     assert any("variant_id" in str(e).lower() or "invalid" in str(e).lower()
                for e in data["errors"])
+
+
+def test_apply_variant_scoped_overrides_skips_missing_vuln():
+    """Missing vuln keys in the overrides map are ignored."""
+    from src.routes.vulnerabilities import _apply_variant_scoped_overrides_to_vuln_dicts, _ScopedOverrides
+    from src.models.metrics import Metrics
+    from src.helpers.vuln_helpers import Effort
+
+    vulns = {
+        "keep": {"id": "keep", "severity": {"cvss": []}, "effort": None},
+        "skip": {"id": "skip", "severity": {"cvss": []}, "effort": None},
+    }
+    override = _ScopedOverrides(
+        cvss=[Metrics(vulnerability_id="keep", variant_id=None, version="3.1", score=7.0, vector="x", author="a")],
+        effort=Effort(1, 2, 3),
+    )
+
+    _apply_variant_scoped_overrides_to_vuln_dicts(vulns, {"keep": override})
+
+    assert vulns["keep"]["effort"]["likely"] == "PT2H"
+    assert vulns["skip"]["effort"] is None
+
+
+def test_populate_found_by_handles_non_string_doc_formats(monkeypatch):
+    """Non-string doc formats are skipped and tool scan sources are mapped."""
+    from src.routes.vulnerabilities import _populate_found_by
+
+    class _Record:
+        def __init__(self, vuln_id):
+            self.id = vuln_id
+            self.found_by = []
+
+        def add_found_by(self, scanner):
+            self.found_by.append(scanner)
+
+    class _Result:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    rows = [
+        ("v1", "tool", "nvd", 123),
+        ("v2", "tool", "nvd", None),
+    ]
+    monkeypatch.setattr(
+        "src.routes.vulnerabilities.db.session.execute",
+        lambda *args, **kwargs: _Result(rows),
+    )
+
+    records = [_Record("v1"), _Record("v2")]
+    _populate_found_by(records)
+
+    assert records[0].found_by == []
+    assert records[1].found_by == ["nvd_cpe"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

- Copy Custom Assessments: new UI card + POST /api/variants/copy-assessments. Copies all custom assessments from a source variant to a target variant for their shared packages, skipping duplicates> Eliminating manual re-entry on new variants.

- Tar archive SBOM import: the new Scan Settings tab accepts .tar, .tar.gz, and .tar.zst archives. They're extracted server-side and each .spdx.json inside is imported individually, enabling SPDX2 archive uploads.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

<img width="1796" height="720" alt="image" src="https://github.com/user-attachments/assets/b385980d-ca41-4bec-a544-d4d48758b804" />

<img width="1796" height="720" alt="image" src="https://github.com/user-attachments/assets/ea9b19bc-0b7c-4ec3-921f-18b509f4cb13" />


<img width="1796" height="720" alt="image" src="https://github.com/user-attachments/assets/cee2dd43-c11a-4157-9fde-1d3aa874fe74" />

