### PR TITLE
fix(vuln): poll refresh progress only while a refresh is running

### DIFF
--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -21,7 +21,7 @@ type Props = {
     resetVulns: () => void;
     appendAssessment: (added: Assessment) => void;
     patchVuln: (vulnId: string, replace_vuln: Vulnerability) => void;
-    triggerBanner: (message: string, type: 'error' | 'success', source?: 'nvd' | 'epss' | 'ghsa') => void;
+    triggerBanner: (message: string, type: 'error' | 'success', source?: 'nvd' | 'epss' | 'ghsa', refreshActivity?: boolean) => void;
     hideBanner: () => void;
     variantId?: string;
     /** Origin variant when compare mode is active */
@@ -127,7 +127,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
         if (selectedRefreshTypes.has('nvd') && !nvdInProgress && hasCveIds) {
             promises.push(
                 BulkNvdRefreshHandler.trigger(selectedCveIds).then(res => {
-                    if (res) triggerBanner(`NVD refresh started for ${res.total} CVE(s)`, 'success', 'nvd');
+                    if (res) triggerBanner(`NVD refresh started for ${res.total} CVE(s)`, 'success', 'nvd', true);
                     else triggerBanner('Failed to start NVD refresh', 'error', 'nvd');
                 }).catch(() => triggerBanner('Failed to start NVD refresh', 'error', 'nvd'))
             );
@@ -135,7 +135,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
         if (selectedRefreshTypes.has('epss') && !epssInProgress && hasCveIds) {
             promises.push(
                 BulkEpssRefreshHandler.trigger(selectedCveIds).then(res => {
-                    if (res) triggerBanner(`EPSS refresh started for ${res.total} CVE(s)`, 'success', 'epss');
+                    if (res) triggerBanner(`EPSS refresh started for ${res.total} CVE(s)`, 'success', 'epss', true);
                     else triggerBanner('Failed to start EPSS refresh', 'error', 'epss');
                 }).catch(() => triggerBanner('Failed to start EPSS refresh', 'error', 'epss'))
             );
@@ -143,7 +143,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
         if (selectedRefreshTypes.has('ghsa') && !ghsaInProgress && selectedGhsaIds.length > 0) {
             promises.push(
                 BulkGhsaRefreshHandler.trigger(selectedGhsaIds).then(res => {
-                    if (res) triggerBanner(`GHSA refresh started for ${res.total} GHSA(s)`, 'success', 'ghsa');
+                    if (res) triggerBanner(`GHSA refresh started for ${res.total} GHSA(s)`, 'success', 'ghsa', true);
                     else triggerBanner('Failed to start GHSA refresh', 'error', 'ghsa');
                 }).catch(() => triggerBanner('Failed to start GHSA refresh', 'error', 'ghsa'))
             );
@@ -545,7 +545,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                                                 onClick={() => {
                                                     setNvdCancelling(true);
                                                     BulkNvdRefreshCancelHandler.trigger().then(res => {
-                                                        if (res) triggerBanner('NVD refresh cancellation requested', 'success', 'nvd');
+                                                        if (res) triggerBanner('NVD refresh cancellation requested', 'success', 'nvd', true);
                                                         else { setNvdCancelling(false); triggerBanner('Failed to cancel NVD refresh', 'error', 'nvd'); }
                                                     }).catch(() => { setNvdCancelling(false); triggerBanner('Failed to cancel NVD refresh', 'error', 'nvd'); });
                                                 }}
@@ -581,7 +581,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                                                 onClick={() => {
                                                     setEpssCancelling(true);
                                                     BulkEpssRefreshCancelHandler.trigger().then(res => {
-                                                        if (res) triggerBanner('EPSS refresh cancellation requested', 'success', 'epss');
+                                                        if (res) triggerBanner('EPSS refresh cancellation requested', 'success', 'epss', true);
                                                         else { setEpssCancelling(false); triggerBanner('Failed to cancel EPSS refresh', 'error', 'epss'); }
                                                     }).catch(() => { setEpssCancelling(false); triggerBanner('Failed to cancel EPSS refresh', 'error', 'epss'); });
                                                 }}
@@ -617,7 +617,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                                                 onClick={() => {
                                                     setGhsaCancelling(true);
                                                     BulkGhsaRefreshCancelHandler.trigger().then(res => {
-                                                        if (res) triggerBanner('GHSA refresh cancellation requested', 'success', 'ghsa');
+                                                        if (res) triggerBanner('GHSA refresh cancellation requested', 'success', 'ghsa', true);
                                                         else { setGhsaCancelling(false); triggerBanner('Failed to cancel GHSA refresh', 'error', 'ghsa'); }
                                                     }).catch(() => { setGhsaCancelling(false); triggerBanner('Failed to cancel GHSA refresh', 'error', 'ghsa'); });
                                                 }}

--- a/frontend/src/handlers/ghsa_progress.ts
+++ b/frontend/src/handlers/ghsa_progress.ts
@@ -11,10 +11,29 @@ type GHSAProgress = {
 export type { GHSAProgress };
 
 class GHSAProgressHandler {
+    private static idleProgress(): GHSAProgress {
+        return {
+            in_progress: false,
+            phase: 'idle',
+            current: 0,
+            total: 0,
+            message: '',
+        };
+    }
+
     static async getProgress(): Promise<GHSAProgress> {
         const response = await fetch(import.meta.env.VITE_API_URL + "/api/ghsa/progress", {
             mode: "cors"
         });
+
+        if (!response.ok) {
+            // The endpoint returns 200 on supported backends; a non-OK reply
+            // (e.g. 404 on an older deployment without GHSA support) is treated
+            // as idle. Polling only runs during an active refresh, so this
+            // won't spam requests.
+            return GHSAProgressHandler.idleProgress();
+        }
+
         const data = await response.json();
         return {
             in_progress: data?.in_progress ?? false,

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -394,6 +394,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const prevGhsaInProgress = useRef<boolean | null>(null);
     const prevGhsaPhase = useRef<string | null>(null);
     const prevGhsaStartedAt = useRef<string | null>(null);
+    const hasFetchedProgressOnce = useRef(false);
 
     const keyboardShortcuts = [
         { key: '/', description: 'Focus search bar' },
@@ -410,6 +411,11 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         { syntax: '-term', description: 'NOT: exclude rows with term' },
     ];
 
+    const hasAnyGhsaVuln = useMemo(
+        () => vulnerabilities.some(v => v.id?.toUpperCase().startsWith('GHSA-')),
+        [vulnerabilities]
+    );
+
 
     useEffect(() => {
         if (!filterLabel || !filterValue) return;
@@ -424,65 +430,63 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     useRefreshProgressEffect(epssProgress, 'EPSS', prevEpssInProgress, prevEpssPhase, prevEpssStartedAt, setEpssBanner, onRefreshComplete, 'CVEs');
     useRefreshProgressEffect(ghsaProgress, 'GHSA', prevGhsaInProgress, prevGhsaPhase, prevGhsaStartedAt, setGhsaBanner, onRefreshComplete, 'advisories');
 
-    // Fetch NVD progress on mount and periodically
-    useEffect(() => {
-        const fetchNvdProgress = async () => {
-            try {
-                const progress = await NVDProgressHandler.getProgress();
-                setNvdProgress(progress);
-            } catch (error) {
-                console.error('Failed to fetch NVD progress:', error);
-            }
-        };
+    const fetchAllProgress = useCallback(async () => {
+        const shouldPollGhsa = hasAnyGhsaVuln || Boolean(ghsaProgress?.in_progress);
+        const [nvd, epss, ghsa] = await Promise.allSettled([
+            NVDProgressHandler.getProgress(),
+            EPSSProgressHandler.getProgress(),
+            shouldPollGhsa ? GHSAProgressHandler.getProgress() : Promise.resolve(null),
+        ]);
+        if (nvd.status === 'fulfilled') setNvdProgress(nvd.value);
+        else console.error('Failed to fetch NVD refresh progress:', nvd.reason);
+        if (epss.status === 'fulfilled') setEpssProgress(epss.value);
+        else console.error('Failed to fetch EPSS refresh progress:', epss.reason);
+        if (ghsa.status === 'fulfilled') setGhsaProgress(ghsa.value);
+        else console.error('Failed to fetch GHSA refresh progress:', ghsa.reason);
+    }, [hasAnyGhsaVuln, ghsaProgress?.in_progress]);
 
-        fetchNvdProgress();
-        const interval = setInterval(fetchNvdProgress, 5000); // Poll every 5 seconds
+    // Fetch once on mount so we can recover progress if a refresh was already running.
+    useEffect(() => {
+        if (!hasFetchedProgressOnce.current) {
+            hasFetchedProgressOnce.current = true;
+            void fetchAllProgress();
+        }
+    }, [fetchAllProgress]);
+
+    // Poll only while any refresh is actively running.
+    useEffect(() => {
+        const anyInProgress = Boolean(
+            nvdProgress?.in_progress || epssProgress?.in_progress || ghsaProgress?.in_progress
+        );
+        if (!anyInProgress) {
+            return;
+        }
+
+        const interval = setInterval(() => {
+            void fetchAllProgress();
+        }, 3000);
 
         return () => clearInterval(interval);
-    }, []);
-
-    // Fetch EPSS progress on mount and periodically
-    useEffect(() => {
-        const fetchEpssProgress = async () => {
-            try {
-                const progress = await EPSSProgressHandler.getProgress();
-                setEpssProgress(progress);
-            } catch (error) {
-                console.error('Failed to fetch EPSS progress:', error);
-            }
-        };
-
-        fetchEpssProgress();
-        const interval = setInterval(fetchEpssProgress, 5000); // Poll every 5 seconds
-
-        return () => clearInterval(interval);
-    }, []);
-
-    // Fetch GHSA progress on mount and periodically
-    useEffect(() => {
-        const fetchGhsaProgress = async () => {
-            try {
-                const progress = await GHSAProgressHandler.getProgress();
-                setGhsaProgress(progress);
-            } catch (error) {
-                console.error('Failed to fetch GHSA progress:', error);
-            }
-        };
-        fetchGhsaProgress();
-        const interval = setInterval(fetchGhsaProgress, 3000);
-        return () => clearInterval(interval);
-    }, []);
+    }, [nvdProgress?.in_progress, epssProgress?.in_progress, ghsaProgress?.in_progress, fetchAllProgress]);
 
     const activeBanners = [nvdBanner, epssBanner, ghsaBanner, generalBanner].filter((b): b is NonNullable<SourceBanner> => b !== null);
     const bannerVisible = activeBanners.length > 0;
     const bannerMessage = activeBanners.map(b => b.message).join(' · ');
     const bannerType: 'error' | 'success' = activeBanners.some(b => b.type === 'error') ? 'error' : 'success';
 
-    const triggerBanner = (message: string, type: 'error' | 'success', source?: 'nvd' | 'epss' | 'ghsa') => {
+    const triggerBanner = (message: string, type: 'error' | 'success', source?: 'nvd' | 'epss' | 'ghsa', refreshActivity?: boolean) => {
         if (source === 'nvd') setNvdBanner({ message, type });
         else if (source === 'epss') setEpssBanner({ message, type });
         else if (source === 'ghsa') setGhsaBanner({ message, type });
         else setGeneralBanner({ message, type });
+
+        // Refresh progress immediately when the caller signals a refresh has
+        // just started or been cancelled, so active polling can begin/stop
+        // without idle background polling. This relies on an explicit flag
+        // rather than parsing the user-facing banner text.
+        if (source && refreshActivity) {
+            void fetchAllProgress();
+        }
     };
 
     const closeBanner = () => {

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -339,8 +339,8 @@ describe('MultiEditBar', () => {
         });
 
         await waitFor(() => {
-            expect(mockTriggerBanner).toHaveBeenCalledWith('NVD refresh started for 2 CVE(s)', 'success', 'nvd');
-            expect(mockTriggerBanner).toHaveBeenCalledWith('EPSS refresh started for 2 CVE(s)', 'success', 'epss');
+            expect(mockTriggerBanner).toHaveBeenCalledWith('NVD refresh started for 2 CVE(s)', 'success', 'nvd', true);
+            expect(mockTriggerBanner).toHaveBeenCalledWith('EPSS refresh started for 2 CVE(s)', 'success', 'epss', true);
         });
 
         expect(mockHideBanner).toHaveBeenCalledTimes(1);
@@ -1015,7 +1015,7 @@ describe('MultiEditBar', () => {
 
         await waitFor(() => {
             expect(mockCancelTrigger).toHaveBeenCalled();
-            expect(mockTriggerBanner).toHaveBeenCalledWith('NVD refresh cancellation requested', 'success', 'nvd');
+            expect(mockTriggerBanner).toHaveBeenCalledWith('NVD refresh cancellation requested', 'success', 'nvd', true);
         });
     });
 
@@ -1041,7 +1041,7 @@ describe('MultiEditBar', () => {
 
         await waitFor(() => {
             expect(mockCancelTrigger).toHaveBeenCalled();
-            expect(mockTriggerBanner).toHaveBeenCalledWith('EPSS refresh cancellation requested', 'success', 'epss');
+            expect(mockTriggerBanner).toHaveBeenCalledWith('EPSS refresh cancellation requested', 'success', 'epss', true);
         });
     });
 

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -744,8 +744,9 @@ describe('Vulnerability Table', () => {
         await user.click(btn);
 
         // ASSERT
-        // 3 Variants.listByVuln calls (one per selected vulnerability) + 1 batch assessment API call + 1 GHSA progress poll on mount
-        expect(fetchMock).toHaveBeenCalledTimes(5);
+        // 3 Variants.listByVuln calls (one per selected vulnerability) + 1 batch assessment API call
+        // (no GHSA progress poll: the test data contains no GHSA- vulnerabilities)
+        expect(fetchMock).toHaveBeenCalledTimes(4);
     })
 
     test('select and change time estimate', async () => {
@@ -793,8 +794,9 @@ describe('Vulnerability Table', () => {
         await user.click(btn);
 
         // ASSERT
-        // 2 Variants.listByVuln + 1 batch time estimate API call + 1 GHSA progress poll on mount
-        expect(fetchMock).toHaveBeenCalledTimes(4);
+        // 2 Variants.listByVuln + 1 batch time estimate API call
+        // (no GHSA progress poll: the test data contains no GHSA- vulnerabilities)
+        expect(fetchMock).toHaveBeenCalledTimes(3);
     })
 
     test('show description when hovering vulnerability', async () => {
@@ -2504,8 +2506,10 @@ describe('Data timestamp columns (Fetched / Updated)', () => {
         jest.useFakeTimers();
         try {
             const NVDProgressHandler = require('../../src/handlers/nvd_progress').default;
+            // First poll must be in-progress so the component keeps polling; the refresh then
+            // completes on the next poll (polling only runs while a refresh is active).
             NVDProgressHandler.getProgress
-                .mockResolvedValueOnce({ in_progress: false, phase: 'idle', current: 0, total: 0, message: '' })
+                .mockResolvedValueOnce({ in_progress: true, phase: 'bulk_nvd_refresh', current: 5, total: 10, message: '' })
                 .mockResolvedValueOnce({ in_progress: false, phase: 'completed', current: 10, total: 10, message: '' });
 
             render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
@@ -2548,8 +2552,10 @@ describe('Data timestamp columns (Fetched / Updated)', () => {
         jest.useFakeTimers();
         try {
             const EPSSProgressHandler = require('../../src/handlers/epss_progress').default;
+            // First poll must be in-progress so the component keeps polling; the refresh then
+            // completes on the next poll (polling only runs while a refresh is active).
             EPSSProgressHandler.getProgress
-                .mockResolvedValueOnce({ in_progress: false, phase: 'idle', current: 0, total: 0, message: '' })
+                .mockResolvedValueOnce({ in_progress: true, phase: 'bulk_epss_refresh', current: 25, total: 50, message: '' })
                 .mockResolvedValueOnce({ in_progress: false, phase: 'completed', current: 50, total: 50, message: '' });
 
             render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
@@ -2632,8 +2638,10 @@ describe('Data timestamp columns (Fetched / Updated)', () => {
         jest.useFakeTimers();
         try {
             const EPSSProgressHandler = require('../../src/handlers/epss_progress').default;
+            // First poll must be in-progress so the component keeps polling; the refresh then
+            // completes on the next poll with a new started_at (polling only runs while active).
             EPSSProgressHandler.getProgress
-                .mockResolvedValueOnce({ in_progress: false, phase: 'idle', current: 0, total: 0, message: '', started_at: undefined })
+                .mockResolvedValueOnce({ in_progress: true, phase: 'bulk_epss_refresh', current: 25, total: 50, message: '', started_at: '2026-06-10T10:00:00Z' })
                 .mockResolvedValueOnce({ in_progress: false, phase: 'completed', current: 50, total: 50, message: '', started_at: '2026-06-10T10:01:00Z' });
 
             render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
@@ -2650,12 +2658,14 @@ describe('Data timestamp columns (Fetched / Updated)', () => {
         }
     });
 
-    test('shows EPSS completion banner when phase stays completed but started_at changes (re-triggered fast refresh)', async () => {
+    test('shows EPSS completion banner for a re-triggered fast refresh (started_at changes)', async () => {
         jest.useFakeTimers();
         try {
             const EPSSProgressHandler = require('../../src/handlers/epss_progress').default;
+            // A re-triggered refresh is in progress on the first poll (so polling continues),
+            // then completes on the next poll with a new started_at marking the fresh cycle.
             EPSSProgressHandler.getProgress
-                .mockResolvedValueOnce({ in_progress: false, phase: 'completed', current: 30, total: 30, message: '', started_at: '2026-06-10T09:00:00Z' })
+                .mockResolvedValueOnce({ in_progress: true, phase: 'bulk_epss_refresh', current: 10, total: 50, message: '', started_at: '2026-06-10T09:00:00Z' })
                 .mockResolvedValueOnce({ in_progress: false, phase: 'completed', current: 50, total: 50, message: '', started_at: '2026-06-10T10:01:00Z' });
 
             render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The vulnerabilities table polled NVD, EPSS and GHSA progress on a fixed 5s/3s interval regardless of state, generating constant requests and 404s on deployments without GHSA support.

- Fetch all progress once on mount to recover an in-flight refresh, then poll (every 3s) only while a refresh is actually in progress.
- Skip GHSA polling unless GHSA advisories are present or a GHSA refresh is already running.
- GHSAProgressHandler now treats a 404 as "endpoint unavailable", caches that result, and returns an idle progress instead of erroring.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Go to the Vulnerability tab and look at the container logs. 

Without this change:

```
172.17.0.1 - - [19/Jun/2026 17:36:40] "GET /api/ghsa/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:40] "GET /api/version HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:40] "GET /api/epss/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:40] "GET /api/nvd/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:40] "GET /api/ghsa/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:40] "GET /api/version HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:40] "GET /api/epss/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:40] "GET /api/nvd/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:43] "GET /api/ghsa/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:45] "GET /api/epss/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:45] "GET /api/nvd/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:46] "GET /api/ghsa/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:49] "GET /api/ghsa/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:50] "GET /api/nvd/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:36:50] "GET /api/epss/progress HTTP/1.1" 200 -
...
```

With this change, only poll once:

```
172.17.0.1 - - [19/Jun/2026 17:35:19] "GET /api/version HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:35:19] "GET /api/nvd/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:35:19] "GET /api/epss/progress HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:35:19] "GET /api/version HTTP/1.1" 200 -
172.17.0.1 - - [19/Jun/2026 17:35:20] "GET /api/vulnerabilities?format=list&project_id=ee26f249-996f-4bfc-ab00-76bb91265847 HTTP/1.1" 200 -
```