### PR TITLE
fix: key package enrichment by UUID and scope variants

### DIFF
--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -125,7 +125,10 @@ class Packages {
                 vulnerabilities: counts,
                 maxSeverity: severities,
                 source: [...new Set([...pkg.source, ...vulnerabilities.map((vuln) => vuln.found_by).flat()])],
-                variants: [...new Set([...pkg.variants, ...vulnerabilities.flatMap((vuln) => vuln.variants || [])])],
+                // Keep variants package-scoped (from /api/packages enrichment).
+                // vuln.variants is vulnerability-scoped and can include
+                // variants unrelated to this exact package record.
+                variants: pkg.variants,
                 sbom_documents: pkg.sbom_documents,
             };
         });

--- a/frontend/tests/unit_tests/test_handlers.ts
+++ b/frontend/tests/unit_tests/test_handlers.ts
@@ -164,6 +164,38 @@ describe('Packages', () => {
         expect(enrichedPackages[1].source).toEqual(['cve-finder']);
     });
 
+    test('enrich_with_vulns keeps variants strictly package-scoped', async () => {
+        // The package carries its own (package-scoped) variants from the
+        // /api/packages enrichment.
+        fetchMock.resetMocks();
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                json: () => Promise.resolve([
+                    { name: 'aaabbbccc', version: '1.0.0', variants: ['VariantA'] }
+                ])
+            } as Response)
+        );
+        const packages = await Packages.list();
+        expect(packages[0].variants).toEqual(['VariantA']);
+
+        // The matching vulnerability is vulnerability-scoped and references
+        // extra variants that must NOT leak into the package.
+        fetchMock.resetMocks();
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({
+                json: () => Promise.resolve([
+                    { ...VULNERABILITIES[0], variants: ['VariantA', 'VariantB', 'OtherVariant'] }
+                ])
+            } as Response)
+        );
+        const vulnerabilities = await Vulnerabilities.list();
+
+        const enriched = Packages.enrich_with_vulns(packages, vulnerabilities);
+        expect(enriched.length).toEqual(1);
+        // variants stay package-scoped — vuln.variants are ignored
+        expect(enriched[0].variants).toEqual(['VariantA']);
+    });
+
     test('asPackage parses supplier field', async () => {
         fetchMock.mockImplementationOnce(() =>
             Promise.resolve({

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -259,6 +259,8 @@ class Package(Base):
 
     def to_dict(self) -> dict:
         return {
+            "id": self.string_id,
+            "package_id": str(self.id) if self.id is not None else None,
             "name": self.name,
             "version": self.version,
             "cpe": list(self.cpe or []),

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -116,6 +116,7 @@ def init_app(app):
         if pkg_ids:
             enrich_query = (
                 db.select(
+                    Package.id.label("package_id"),
                     Package.name,
                     Package.version,
                     Variant.name.label("variant_name"),
@@ -145,10 +146,11 @@ def init_app(app):
                 enrich_query = enrich_query.where(Variant.project_id == uuid.UUID(project_id))
             rows = db.session.execute(enrich_query).all()
 
-            # Build lookup: "name@version" → {variants: set, sources: set, sbom_documents: set}
+            # Build lookup by package UUID to avoid conflating similarly-named
+            # package rows (e.g. different supplier or near-identical versions).
             meta: dict = {}
             for row in rows:
-                key = f"{row.name}@{row.version}"
+                key = str(row.package_id)
                 if key not in meta:
                     meta[key] = {"variants": set(), "sources": set(), "sbom_documents": set()}
                 if row.variant_name:
@@ -159,7 +161,7 @@ def init_app(app):
                     meta[key]["sbom_documents"].add(row.doc_source_name)
 
             for p in result:
-                key = f"{p['name']}@{p['version']}"
+                key = str(p.get("package_id", ""))
                 info = meta.get(key, {})
                 p["variants"] = sorted(info.get("variants", set()))
                 p["sources"] = sorted(info.get("sources", set()))

--- a/tests/unit_tests/test_package.py
+++ b/tests/unit_tests/test_package.py
@@ -251,6 +251,52 @@ def test_supplier_in_to_dict_from_dict():
     assert restored.string_id == "foo@1.0::Organization: Acme Corp"
 
 
+def test_to_dict_exposes_id_and_package_id():
+    """
+    GIVEN a Package with an explicit database UUID
+    WHEN serialising with to_dict
+    THEN check it exposes both the human-readable id (string_id) and the
+         database UUID as package_id
+    """
+    import uuid
+    pkg_uuid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    pkg = Package("foo", "1.0", supplier="Organization: Acme Corp")
+    pkg.id = pkg_uuid
+    data = pkg.to_dict()
+    assert data["id"] == pkg.string_id
+    assert data["id"] == "foo@1.0::Organization: Acme Corp"
+    assert data["package_id"] == str(pkg_uuid)
+
+
+def test_to_dict_package_id_distinguishes_same_string_id():
+    """
+    GIVEN two packages sharing the same name@version but with different UUIDs
+    WHEN serialising with to_dict
+    THEN check package_id differs so enrichment cannot conflate them
+    """
+    import uuid
+    pkg_a = Package("foo", "1.0")
+    pkg_a.id = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    pkg_b = Package("foo", "1.0")
+    pkg_b.id = uuid.UUID("22222222-2222-2222-2222-222222222222")
+    data_a = pkg_a.to_dict()
+    data_b = pkg_b.to_dict()
+    assert data_a["id"] == data_b["id"]
+    assert data_a["package_id"] != data_b["package_id"]
+
+
+def test_to_dict_package_id_is_none_when_unpersisted():
+    """
+    GIVEN a Package that has not been persisted (no database id yet)
+    WHEN serialising with to_dict
+    THEN check package_id is None rather than the literal string "None"
+    """
+    pkg = Package("foo", "1.0")
+    assert pkg.id is None
+    data = pkg.to_dict()
+    assert data["package_id"] is None
+
+
 def test_sort_packages_mixed_suppliers():
     pkg_acme = Package("foo", "1.0", supplier="Organization: Acme Corp")
     pkg_bar  = Package("foo", "1.0", supplier="Organization: Bar Inc")

--- a/tests/webapp_tests/test_project_variant_endpoints.py
+++ b/tests/webapp_tests/test_project_variant_endpoints.py
@@ -468,6 +468,30 @@ class TestPackagesFiltering:
         assert isinstance(body, dict)
         assert "cairo@1.16.0" in body
 
+    def test_packages_response_exposes_package_id(self, client_and_data):
+        """to_dict now exposes the package UUID as package_id alongside the
+        human-readable string id."""
+        client, _ = client_and_data
+        response = client.get("/api/packages?format=list")
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        cairo = next(p for p in body if p["name"] == "cairo")
+        assert cairo["id"] == "cairo@1.16.0"
+        assert "package_id" in cairo
+        # package_id is a valid UUID string used as the enrichment lookup key
+        uuid.UUID(cairo["package_id"])
+
+    def test_packages_variants_keyed_by_package_uuid(self, client_and_data):
+        """Enrichment is keyed by package UUID, so cairo's variants are scoped
+        to VariantA (where its SBOMPackage lives) and not leaked elsewhere."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        response = client.get(f"/api/packages?variant_id={variant_a_id}&format=list")
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        cairo = next(p for p in body if p["name"] == "cairo")
+        assert cairo["variants"] == ["VariantA"]
+
     # Compare-filtering tests:
     # VariantA has cairo@1.16.0, VariantB has no packages (via observations).
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Package enrichment was keyed by "name@version", which conflated distinct package rows (e.g. different supplier or near-identical versions) and leaked unrelated variants into the SBOM tab.

- Expose id/package_id from Package.to_dict and select Package.id in the enrichment query.
- Key the variants/sources/sbom_documents lookup by package UUID instead of name@version.
- Keep package variants strictly package-scoped on the frontend instead of merging vulnerability-scoped variants.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Context: st-image-core-openstlinux-rt-stm32mp2 is linked with 6.6.116.rt66-stm32mp-rt-r3 and core-image-minimal-stm32mp25-eval, st-image-optenstlinux-stm32mp25-eval with 6.6.116-stm32mp-r3

Before this change list of packages is not link with correct variants:

<img width="1825" height="263" alt="image" src="https://github.com/user-attachments/assets/e7d1c19a-75e4-4b9b-a7f8-6e7d18f69ef3" />

After this change:

<img width="1827" height="211" alt="image" src="https://github.com/user-attachments/assets/1ef90565-3bd7-435a-9c4a-520ca0c5ec17" />


