### PR TITLE
fix: report variants and packages in assessment success message

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -761,6 +761,8 @@ type VariantScopedSnapshot = {
 
         let successCount = 0;
         let lastCasted: Assessment | null = null;
+        const touchedVariantIds = new Set<string>();
+        const touchedPackages = new Set<string>();
 
         setSubmittingMessage('Adding assessment...');
         try {
@@ -783,6 +785,8 @@ type VariantScopedSnapshot = {
                     if (!Array.isArray(casted) && typeof casted === 'object') {
                         successCount++;
                         lastCasted = casted;
+                        if (casted.variant_id) touchedVariantIds.add(casted.variant_id);
+                        for (const pkg of casted.packages ?? []) touchedPackages.add(pkg);
 
                         // Highlight the very first created assessment
                         if (successCount === 1) {
@@ -817,9 +821,26 @@ type VariantScopedSnapshot = {
                 simplified_status: statusSummary.dominant_status,
                 status_summary: statusSummary,
             });
-            const msg = successCount > 1
-                ? `Successfully added assessment to ${successCount} variants.`
-                : 'Successfully added assessment.';
+
+            const variantCount = touchedVariantIds.size;
+            const packageCount = touchedPackages.size;
+            const variantPart = variantCount > 0
+                ? `${variantCount} variant${variantCount === 1 ? '' : 's'}`
+                : '';
+            const packagePart = packageCount > 0
+                ? `${packageCount} package${packageCount === 1 ? '' : 's'}`
+                : '';
+
+            let msg = 'Successfully added assessment.';
+            if (packagePart && variantPart) {
+                msg = `Successfully added assessment to ${packagePart} across ${variantPart}.`;
+            } else if (packagePart) {
+                msg = `Successfully added assessment to ${packagePart}.`;
+            } else if (variantPart) {
+                msg = `Successfully added assessment to ${variantPart}.`;
+            } else if (successCount > 1) {
+                msg = `Successfully added ${successCount} assessments.`;
+            }
             showMessage(msg, 'success');
             setClearAssessmentFields(true);
             setTimeout(() => setClearAssessmentFields(false), 100);

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -217,7 +217,90 @@ describe('Vulnerability Modal', () => {
         alertSpy.mockRestore();
     })
 
+    /**
+     * Success-toast wording: the message must report the variants and packages
+     * actually touched by the created assessments, with correct pluralisation.
+     */
+    const submitAssessment = async (postResponse: object) => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify(postResponse)); // POST assessment
+
+        render(<VulnModal vuln={{ ...vulnerability, assessments: [] }} isEditing={true} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        const selects = await screen.getAllByRole('combobox');
+        const selectStatus = selects.find((el) => el.getAttribute('name')?.includes('new_assessment_status')) as HTMLElement;
+        await user.selectOptions(selectStatus, 'fixed');
+        const btn = await screen.getByText(/add assessment/i);
+        await user.click(btn);
+    };
+
+    test('success message reports both variants and packages', async () => {
+        const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+        await submitAssessment({
+            status: 'success',
+            assessments: [
+                { id: 'a1', vuln_id: vulnerability.id, status: 'fixed', timestamp: '2021-01-02T00:00:00Z', variant_id: 'v1', packages: ['pkgA@1.0'] },
+                { id: 'a2', vuln_id: vulnerability.id, status: 'fixed', timestamp: '2021-01-02T00:00:00Z', variant_id: 'v2', packages: ['pkgB@1.0'] },
+            ],
+        });
+        expect(await screen.findByText('Successfully added assessment to 2 packages across 2 variants.')).toBeInTheDocument();
+        alertSpy.mockRestore();
+    })
+
+    test('success message uses singular wording for one variant and one package', async () => {
+        const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+        await submitAssessment({
+            status: 'success',
+            assessments: [
+                { id: 'a1', vuln_id: vulnerability.id, status: 'fixed', timestamp: '2021-01-02T00:00:00Z', variant_id: 'v1', packages: ['pkgA@1.0'] },
+            ],
+        });
+        expect(await screen.findByText('Successfully added assessment to 1 package across 1 variant.')).toBeInTheDocument();
+        alertSpy.mockRestore();
+    })
+
+    test('success message falls back to package-only when no variant touched', async () => {
+        const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+        await submitAssessment({
+            status: 'success',
+            assessments: [
+                { id: 'a1', vuln_id: vulnerability.id, status: 'fixed', timestamp: '2021-01-02T00:00:00Z', packages: ['pkgA@1.0', 'pkgB@1.0'] },
+            ],
+        });
+        expect(await screen.findByText('Successfully added assessment to 2 packages.')).toBeInTheDocument();
+        alertSpy.mockRestore();
+    })
+
+    test('success message falls back to variant-only when no package touched', async () => {
+        const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+        await submitAssessment({
+            status: 'success',
+            assessments: [
+                { id: 'a1', vuln_id: vulnerability.id, status: 'fixed', timestamp: '2021-01-02T00:00:00Z', variant_id: 'v1', packages: [] },
+            ],
+        });
+        expect(await screen.findByText('Successfully added assessment to 1 variant.')).toBeInTheDocument();
+        alertSpy.mockRestore();
+    })
+
+    test('success message falls back to a plain count with neither variant nor package', async () => {
+        const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+        await submitAssessment({
+            status: 'success',
+            assessments: [
+                { id: 'a1', vuln_id: vulnerability.id, status: 'fixed', timestamp: '2021-01-02T00:00:00Z', packages: [] },
+                { id: 'a2', vuln_id: vulnerability.id, status: 'fixed', timestamp: '2021-01-02T00:00:00Z', packages: [] },
+            ],
+        });
+        expect(await screen.findByText('Successfully added 2 assessments.')).toBeInTheDocument();
+        alertSpy.mockRestore();
+    })
+
     test('help button for time estimates', async () => {
+
         // ARRANGE
         render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} isEditing={true} />);
 
@@ -1992,7 +2075,7 @@ describe('Vulnerability Modal', () => {
         await user.click(btn);
 
         // Should show multi-variant success message
-        const successMsg = await screen.findByText(/successfully added assessment to 2 variants/i);
+        const successMsg = await screen.findByText(/successfully added assessment to 1 package across 2 variants/i);
         expect(successMsg).toBeInTheDocument();
         expect(appendCb).toHaveBeenCalledTimes(2);
         expect(patchCb).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

When adding an assessment from VulnModal, the success toast only counted variants and showed a generic message that ignored packages. Track the variant IDs and packages actually touched by the created assessments and build the message from those counts, with correct singular/plural wording.

- "Successfully added assessment to N variants and M packages."
- Falls back to variant-only, package-only, or a plain count message when one dimension is empty.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Before this change, the message displayed is wrong:

<img width="903" height="378" alt="image" src="https://github.com/user-attachments/assets/623907ab-0ced-4a0a-82eb-b44d242d5a5f" />

<img width="373" height="47" alt="image" src="https://github.com/user-attachments/assets/1ce532b6-5082-46a3-a238-bbccf5a10ba7" />

After this change: 

<img width="418" height="74" alt="image" src="https://github.com/user-attachments/assets/5b2e6df6-18a4-489e-bde9-ca0651493539" />

