### PR TITLE
fix: Attribute source from exact per-document provenance

### DIFF
--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -23,6 +23,7 @@ from ..models import (
     Metrics,
     SBOMDocument,
     SBOMPackage,
+    SBOMObservation,
     Iso8601Duration
 )
 from ..helpers.datetime_utils import ensure_utc_iso
@@ -65,11 +66,10 @@ def _sbom_pkg_filter(pkg_ids):
 
 
 # Formats that are exclusively vulnerability scanners (never pure package BOMs)
-_DEDICATED_SCANNER_FORMATS = frozenset({"grype", "yocto_cve_check"})
-
 # Mapping from SBOMDocument.format to the found_by string exposed by the API
 _FORMAT_TO_FOUND_BY: dict[str, str] = {
     "grype": "grype",
+    "yocto_cve_check": "yocto_cve_check",
     "spdx": "spdx3",
     "cdx": "cyclonedx",
     "openvex": "openvex",
@@ -200,86 +200,70 @@ def _populate_found_by(
     project_uuid=None,
     active_scan_ids: list | None = None,
 ) -> None:
-    """Populate the transient found_by list on each record.
+    """Populate transient found_by with factual provenance.
 
-    For each vulnerability, find the **earliest** scan that first observed
-    it and attribute it to that scan's source (SBOMDocument format or
-    tool scan_source).  The first scan that introduced a CVE gets credit.
+    Attribution strategy:
+      1) Exact per-file provenance from SBOMObservation -> SBOMDocument.format
+      2) Fallback for vulns without an observation-backed format: derive from
+         observing scans/documents in scope, without preference heuristics.
     """
     if not records:
         return
 
     vuln_ids = [r.id for r in records]
 
-    # For every vuln, get the scan that first observed it (min timestamp).
-    first_scan_subq = (
-        db.select(
-            Finding.vulnerability_id,
-            func.min(Scan.timestamp).label("min_ts"),
-        )
-        .join(Observation, Observation.finding_id == Finding.id)
-        .join(Scan, Scan.id == Observation.scan_id)
-        .where(Finding.vulnerability_id.in_(vuln_ids))
-        .group_by(Finding.vulnerability_id)
-    ).subquery()
-
-    # Now join back to get the scan details for that earliest observation.
-    rows = db.session.execute(
-        db.select(
-            Finding.vulnerability_id,
-            Scan.scan_type,
-            Scan.scan_source,
-            SBOMDocument.format.label("doc_format"),
-        )
-        .select_from(Finding)
-        .join(Observation, Observation.finding_id == Finding.id)
-        .join(Scan, Scan.id == Observation.scan_id)
-        .join(
-            first_scan_subq,
-            db.and_(
-                first_scan_subq.c.vulnerability_id == Finding.vulnerability_id,
-                first_scan_subq.c.min_ts == Scan.timestamp,
-            ),
-        )
-        .outerjoin(
-            SBOMDocument,
-            db.and_(
-                SBOMDocument.scan_id == Scan.id,
-                SBOMDocument.format.isnot(None),
-            ),
-        )
-        .distinct()
-    ).all()
-
-    # When a scan has multiple SBOMDocuments (e.g. spdx + grype in same
-    # merge), collect all formats and prefer non-dedicated scanner formats
-    # (spdx, cdx) over dedicated ones (grype) for attribution.
-    vuln_formats: dict[str, dict] = {}
-    for vuln_id, scan_type, scan_source, doc_format in rows:
-        entry = vuln_formats.setdefault(vuln_id, {
-            "doc_formats": set(),
-            "scan_type": scan_type,
-            "scan_source": scan_source,
-        })
-        if doc_format is not None:
-            entry["doc_formats"].add(doc_format)
-
     found_by_map: dict[str, set[str]] = {}
-    for vuln_id, entry in vuln_formats.items():
-        doc_formats = entry["doc_formats"]
-        scan_source = entry["scan_source"]
-        if doc_formats:
-            # Prefer non-dedicated (spdx, cdx, openvex) over dedicated (grype, yocto)
-            non_dedicated = doc_formats - _DEDICATED_SCANNER_FORMATS
-            chosen = non_dedicated if non_dedicated else doc_formats
-            for fmt in chosen:
-                if not isinstance(fmt, str):
-                    continue
-                mapped = _FORMAT_TO_FOUND_BY.get(fmt, fmt)
+
+    # 1) Exact provenance from existing SBOMObservations.
+    provenance_q = (
+        db.select(SBOMObservation.vulnerability_id, SBOMDocument.format)
+        .join(SBOMDocument, SBOMObservation.sbom_document_id == SBOMDocument.id)
+        .where(SBOMObservation.vulnerability_id.in_(vuln_ids))
+        .where(SBOMDocument.format.isnot(None))
+    )
+    if active_scan_ids:
+        provenance_q = provenance_q.where(SBOMDocument.scan_id.in_(active_scan_ids))
+    provenance_rows = db.session.execute(provenance_q.distinct()).all()
+
+    for vuln_id, doc_format in provenance_rows:
+        if not isinstance(doc_format, str):
+            continue
+        mapped = _FORMAT_TO_FOUND_BY.get(doc_format, doc_format)
+        found_by_map.setdefault(vuln_id, set()).add(mapped)
+
+    unresolved_vuln_ids = [vid for vid in vuln_ids if vid not in found_by_map]
+
+    # 2) Fallback: derive from observing scans/documents in scope.
+    if unresolved_vuln_ids:
+        fallback_q = (
+            db.select(
+                Finding.vulnerability_id,
+                Scan.scan_source,
+                SBOMDocument.format.label("doc_format"),
+            )
+            .select_from(Finding)
+            .join(Observation, Observation.finding_id == Finding.id)
+            .join(Scan, Scan.id == Observation.scan_id)
+            .outerjoin(
+                SBOMDocument,
+                db.and_(
+                    SBOMDocument.scan_id == Scan.id,
+                    SBOMDocument.format.isnot(None),
+                ),
+            )
+            .where(Finding.vulnerability_id.in_(unresolved_vuln_ids))
+        )
+        if active_scan_ids:
+            fallback_q = fallback_q.where(Observation.scan_id.in_(active_scan_ids))
+        fallback_rows = db.session.execute(fallback_q.distinct()).all()
+
+        for vuln_id, scan_source, doc_format in fallback_rows:
+            if isinstance(doc_format, str):
+                mapped = _FORMAT_TO_FOUND_BY.get(doc_format, doc_format)
                 found_by_map.setdefault(vuln_id, set()).add(mapped)
-        elif isinstance(scan_source, str):
-            mapped = _TOOL_SOURCE_TO_FOUND_BY.get(scan_source, scan_source)
-            found_by_map.setdefault(vuln_id, set()).add(mapped)
+            elif isinstance(scan_source, str):
+                mapped = _TOOL_SOURCE_TO_FOUND_BY.get(scan_source, scan_source)
+                found_by_map.setdefault(vuln_id, set()).add(mapped)
 
     for record in records:
         for scanner in found_by_map.get(record.id, set()):

--- a/tests/end_to_end_tests/test_merger_ci.py
+++ b/tests/end_to_end_tests/test_merger_ci.py
@@ -261,9 +261,9 @@ def test_yocto_description(app, init_files):
     _run_main()
 
     observations = SBOMObservation.get_by_vuln("CVE-2007-3152")
-    assert len(observations) == 1
-    assert observations[0].key == "Yocto Description"
-    assert observations[0].description == "Yocto-specfic description"
+    yocto_observations = [obs for obs in observations if obs.key == "Yocto Description"]
+    assert len(yocto_observations) == 1
+    assert yocto_observations[0].description == "Yocto-specfic description"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webapp_tests/test_vulnerabilities_coverage.py
+++ b/tests/webapp_tests/test_vulnerabilities_coverage.py
@@ -863,7 +863,8 @@ def test_apply_variant_scoped_overrides_skips_missing_vuln():
 
 
 def test_populate_found_by_handles_non_string_doc_formats(monkeypatch):
-    """Non-string doc formats are skipped and tool scan sources are mapped."""
+    """In the legacy fallback, non-string doc formats are skipped and tool
+    scan sources are mapped."""
     from src.routes.vulnerabilities import _populate_found_by
 
     class _Record:
@@ -881,20 +882,31 @@ def test_populate_found_by_handles_non_string_doc_formats(monkeypatch):
         def all(self):
             return self._rows
 
-    rows = [
-        ("v1", "tool", "nvd", 123),
-        ("v2", "tool", "nvd", None),
+    # The function runs two queries: (1) provenance markers, (2) legacy
+    # fallback. Return no provenance markers so both vulns fall through to the
+    # fallback, then return fallback rows shaped (vuln_id, scan_source,
+    # doc_format).
+    fallback_rows = [
+        ("v1", "nvd", None),      # non-string doc format -> use scan_source
+        ("v2", None, 12345),      # both non-string -> nothing added
     ]
+    calls = {"n": 0}
+
+    def _fake_execute(*args, **kwargs):
+        calls["n"] += 1
+        # 1st call: provenance query (empty), 2nd call: fallback query
+        return _Result([] if calls["n"] == 1 else fallback_rows)
+
     monkeypatch.setattr(
         "src.routes.vulnerabilities.db.session.execute",
-        lambda *args, **kwargs: _Result(rows),
+        _fake_execute,
     )
 
     records = [_Record("v1"), _Record("v2")]
     _populate_found_by(records)
 
-    assert records[0].found_by == []
-    assert records[1].found_by == ["nvd_cpe"]
+    assert records[0].found_by == ["nvd_cpe"]
+    assert records[1].found_by == []
 
 
 # ---------------------------------------------------------------------------
@@ -993,8 +1005,10 @@ def test_found_by_tool_scan_nvd(app, client):
     assert "nvd_cpe" in nvd_vuln["found_by"]
 
 
-def test_found_by_mixed_formats_prefers_non_dedicated(app, client):
-    """When a scan has both spdx + grype docs, found_by should prefer the non-dedicated (spdx) format."""
+def test_found_by_mixed_formats_reports_all(app, client):
+    """When a scan has both spdx + grype docs (legacy rows without provenance
+    markers), found_by reports all observed formats — the old preference
+    heuristic was dropped."""
     from src.extensions import db
     from src.models.scan import Scan
     from src.models.sbom_document import SBOMDocument
@@ -1010,7 +1024,7 @@ def test_found_by_mixed_formats_prefers_non_dedicated(app, client):
         db.session.commit()
         vuln = Vulnerability.create_record(
             id="CVE-MIXED-0001",
-            description="Test vuln for mixed format preference",
+            description="Test vuln for mixed format reporting",
             status="high",
         )
         db.session.commit()
@@ -1043,9 +1057,56 @@ def test_found_by_mixed_formats_prefers_non_dedicated(app, client):
     data = json.loads(response.data)
     mixed_vuln = next((v for v in data if v["id"] == "CVE-MIXED-0001"), None)
     assert mixed_vuln is not None
-    # Should prefer spdx (non-dedicated) over grype (dedicated)
+    # No preference heuristic: both formats are reported.
     assert "spdx3" in mixed_vuln["found_by"]
-    assert "grype" not in mixed_vuln["found_by"]
+    assert "grype" in mixed_vuln["found_by"]
+
+
+def test_found_by_yocto_cve_check_mapping(app, client):
+    """A vuln observed in a yocto_cve_check document maps found_by to
+    'yocto_cve_check' via the observing-scan derivation."""
+    from src.extensions import db
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.observation import Observation
+    from src.models.finding import Finding
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.sbom_package import SBOMPackage
+    from datetime import datetime, timezone
+
+    with app.app_context():
+        pkg = Package.find_or_create("yocto-test-pkg", "6.0.0", [], [], "")
+        db.session.commit()
+        Vulnerability.create_record(
+            id="CVE-YOCTO-0001",
+            description="Test vuln for yocto_cve_check mapping",
+            status="medium",
+        )
+        db.session.commit()
+        finding = Finding.get_or_create(pkg.id, "CVE-YOCTO-0001")
+
+        import uuid as _uuid
+        scan = Scan(
+            id=_uuid.uuid4(),
+            variant_id=_uuid.UUID("22222222-2222-2222-2222-222222222222"),
+            timestamp=datetime(2016, 1, 1, tzinfo=timezone.utc),
+        )
+        db.session.add(scan)
+        yocto_doc = SBOMDocument(
+            id=_uuid.uuid4(), path="/demo/yocto.json", source_name="yocto.json",
+            format="yocto_cve_check", scan_id=scan.id,
+        )
+        db.session.add(yocto_doc)
+        db.session.add(SBOMPackage(sbom_document_id=yocto_doc.id, package_id=pkg.id))
+        db.session.add(Observation(finding_id=finding.id, scan_id=scan.id))
+        db.session.commit()
+
+    response = client.get("/api/vulnerabilities")
+    data = json.loads(response.data)
+    yocto_vuln = next((v for v in data if v["id"] == "CVE-YOCTO-0001"), None)
+    assert yocto_vuln is not None
+    assert "yocto_cve_check" in yocto_vuln["found_by"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The found_by source was inferred heuristically from the earliest scan that observed a vulnerability, preferring SBOM formats over dedicated scanners. This wrongly attributed origins when several documents/scanners contributed in the same merge.

- Record a provenance marker (SBOMObservation) per (vulnerability, current SBOM document) at ingestion, deduped within a run.
- Populate found_by from these markers via SBOMDocument.format, falling back to in-scope observing documents for legacy rows without markers.
- Drop the scanner-vs-BOM preference heuristic; map yocto_cve_check explicitly in _FORMAT_TO_FOUND_BY.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Without this PR: 

<img width="354" height="537" alt="image" src="https://github.com/user-attachments/assets/ddda76a6-62e2-4082-ae00-23febd0058be" />

With this PR:

<img width="354" height="537" alt="image" src="https://github.com/user-attachments/assets/b6bb22f2-b2a8-4fd0-ad6b-d4f020b2aec7" />

