### PR TITLE
fix: Restyle action buttons and reposition edit panels

### DIFF
--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -465,12 +465,13 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                 {/* Change status */}
                 <button
                     className={[
-                        "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed",
+                        "inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-semibold transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed",
                         panelOpened === 1
-                            ? "bg-cyan-400 text-cyan-950 hover:bg-cyan-300"
-                            : "text-white bg-white/10 hover:bg-white/20 disabled:hover:bg-white/10"
+                            ? "border-cyan-300/80 bg-cyan-300 text-cyan-950 shadow-sm shadow-cyan-950/20 hover:bg-cyan-200"
+                            : "border-white/20 text-cyan-50 bg-white/10 hover:bg-white/20 hover:border-white/35 disabled:hover:bg-white/10"
                     ].join(' ')}
                     disabled={!hasSelection}
+                    aria-pressed={panelOpened === 1}
                     onClick={() => { hideBanner(); setPanelOpened(panelOpened == 1 ? 0 : 1); }}
                 >
                     <FontAwesomeIcon icon={faPenToSquare} />
@@ -480,16 +481,17 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                 {/* Change estimated time */}
                 <button
                     className={[
-                        "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed",
+                        "inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-semibold transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed",
                         panelOpened === 2
-                            ? "bg-cyan-400 text-cyan-950 hover:bg-cyan-300"
-                            : "text-white bg-white/10 hover:bg-white/20 disabled:hover:bg-white/10"
+                            ? "border-cyan-300/80 bg-cyan-300 text-cyan-950 shadow-sm shadow-cyan-950/20 hover:bg-cyan-200"
+                            : "border-white/20 text-cyan-50 bg-white/10 hover:bg-white/20 hover:border-white/35 disabled:hover:bg-white/10"
                     ].join(' ')}
                     disabled={!hasSelection}
+                    aria-pressed={panelOpened === 2}
                     onClick={() => { hideBanner(); setPanelOpened(panelOpened == 2 ? 0 : 2); }}
                 >
                     <FontAwesomeIcon icon={faClock} />
-                    Change estimated time
+                    Change time estimate
                 </button>
 
                 <div className="w-px h-6 bg-white/15 mx-1"></div>
@@ -639,48 +641,50 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                     </div>
                 </div>
 
-            <div className={[
-                'absolute z-40 p-4 bg-slate-700 shadow-md shadow-slate-400/40 top-48 left-32 w-1/2',
-                panelOpened == 1 ? 'block' : 'hidden'
-            ].join(' ')} data-testid="multi-edit-status-panel">
-                <StatusEditor
-                    onAddAssessment={(data) => addAssessment(data)}
-                    progressBar={undefined}
-                    defaultStatus={uniformStatus}
-                />
-                {(isAllVariantsMode || affectedVariantNames.length > 0) && (
-                    <div className="mt-3 pt-3 border-t border-slate-500">
-                        {isAllVariantsMode ? (
-                            <p className="text-sm font-medium text-gray-300">
-                                Will be applied to all possible variants on each CVE
-                            </p>
-                        ) : (
-                            <>
-                                <p className="text-sm font-medium text-gray-300 mb-1">
-                                    Will be applied to variant{affectedVariantNames.length > 1 ? 's' : ''}:
+            <div className="relative z-50 w-full">
+                <div className={[
+                    'absolute left-0 top-0 mt-1 z-50 w-full max-w-4xl rounded-lg border border-sky-700/60 bg-neutral-900 shadow-xl p-3',
+                    panelOpened == 1 ? 'block' : 'hidden'
+                ].join(' ')} data-testid="multi-edit-status-panel">
+                    <StatusEditor
+                        onAddAssessment={(data) => addAssessment(data)}
+                        progressBar={undefined}
+                        defaultStatus={uniformStatus}
+                    />
+                    {(isAllVariantsMode || affectedVariantNames.length > 0) && (
+                        <div className="mt-3 pt-3 border-t border-slate-500">
+                            {isAllVariantsMode ? (
+                                <p className="text-sm font-medium text-gray-300">
+                                    Will be applied to all possible variants on each CVE
                                 </p>
-                                <div className="flex flex-wrap gap-1">
-                                    {affectedVariantNames.map(name => (
-                                        <span key={name} className="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
-                                            {name}
-                                        </span>
-                                    ))}
-                                </div>
-                            </>
-                        )}
-                    </div>
-                )}
-            </div>
+                            ) : (
+                                <>
+                                    <p className="text-sm font-medium text-gray-300 mb-1">
+                                        Will be applied to variant{affectedVariantNames.length > 1 ? 's' : ''}:
+                                    </p>
+                                    <div className="flex flex-wrap gap-1">
+                                        {affectedVariantNames.map(name => (
+                                            <span key={name} className="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                                                {name}
+                                            </span>
+                                        ))}
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    )}
+                </div>
 
-            <div className={[
-                'absolute z-40 p-4 bg-slate-700 shadow-md shadow-slate-400/40 top-48 left-32 w-1/2',
-                panelOpened == 2 ? 'block' : 'hidden'
-            ].join(' ')} data-testid="multi-edit-time-panel">
-                <TimeEstimateEditor
-                    onSaveTimeEstimation={(data) => saveTimeEstimation(data)}
-                    progressBar={undefined}
-                    actualEstimate={{optimistic: '', likely: '', pessimistic: ''}}
-                />
+                <div className={[
+                    'absolute left-0 top-0 mt-1 z-50 w-full max-w-4xl rounded-lg border border-sky-700/60 bg-neutral-900 shadow-xl p-3',
+                    panelOpened == 2 ? 'block' : 'hidden'
+                ].join(' ')} data-testid="multi-edit-time-panel">
+                    <TimeEstimateEditor
+                        onSaveTimeEstimation={(data) => saveTimeEstimation(data)}
+                        progressBar={undefined}
+                        actualEstimate={{optimistic: '', likely: '', pessimistic: ''}}
+                    />
+                </div>
             </div>
     </>);
 }

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -121,7 +121,41 @@ describe('MultiEditBar', () => {
         expect(getByText('Selected vulnerabilities')).toBeInTheDocument();
         expect(getByText('Reset selection').closest('button')).toBeDisabled();
         expect(getByText('Change status').closest('button')).toBeDisabled();
-        expect(getByText('Change estimated time').closest('button')).toBeDisabled();
+        expect(getByText('Change time estimate').closest('button')).toBeDisabled();
+    });
+
+    test('renders the renamed "Change time estimate" button label', () => {
+        const props = { ...mockProps, selectedVulns: ['vuln-1'] };
+        const { getByText, queryByText } = render(<MultiEditBar {...props} />);
+        expect(getByText('Change time estimate')).toBeInTheDocument();
+        expect(queryByText('Change estimated time')).toBeNull();
+    });
+
+    test('toggle buttons expose aria-pressed reflecting the open panel', async () => {
+        const props = { ...mockProps, selectedVulns: ['vuln-1'] };
+        const { getByText } = render(<MultiEditBar {...props} />);
+
+        const statusButton = getByText('Change status').closest('button') as HTMLButtonElement;
+        const timeButton = getByText('Change time estimate').closest('button') as HTMLButtonElement;
+
+        // No panel open initially
+        expect(statusButton).toHaveAttribute('aria-pressed', 'false');
+        expect(timeButton).toHaveAttribute('aria-pressed', 'false');
+
+        // Opening the status panel sets aria-pressed only on the status button
+        await act(async () => { statusButton.click(); });
+        expect(statusButton).toHaveAttribute('aria-pressed', 'true');
+        expect(timeButton).toHaveAttribute('aria-pressed', 'false');
+
+        // Opening the time panel moves aria-pressed to the time button
+        await act(async () => { timeButton.click(); });
+        expect(statusButton).toHaveAttribute('aria-pressed', 'false');
+        expect(timeButton).toHaveAttribute('aria-pressed', 'true');
+
+        // Clicking the open button again closes the panel and clears aria-pressed
+        await act(async () => { timeButton.click(); });
+        expect(statusButton).toHaveAttribute('aria-pressed', 'false');
+        expect(timeButton).toHaveAttribute('aria-pressed', 'false');
     });
 
     test('renders with selection', () => {
@@ -236,7 +270,7 @@ describe('MultiEditBar', () => {
         };
 
         const { getByText, getByPlaceholderText } = render(<MultiEditBar {...props} />);
-        const changeTimeButton = getByText('Change estimated time');
+        const changeTimeButton = getByText('Change time estimate');
         act(() => { changeTimeButton.click(); });
 
         // TimeEstimateEditor should be visible (check by finding an input with its placeholder)
@@ -251,7 +285,7 @@ describe('MultiEditBar', () => {
         };
 
         const { getByText, getByPlaceholderText, getByTestId } = render(<MultiEditBar {...props} />);
-        await act(async () => { getByText('Change estimated time').click(); });
+        await act(async () => { getByText('Change time estimate').click(); });
 
         expect(getByPlaceholderText('shortest estimate [eg: 5h]')).toBeInTheDocument();
         expect(getByTestId('multi-edit-time-panel')).toHaveClass('block');
@@ -472,7 +506,7 @@ describe('MultiEditBar', () => {
 
         const { getByText, getByPlaceholderText } = render(<MultiEditBar {...props} />);
 
-        await act(async () => { getByText('Change estimated time').click(); });
+        await act(async () => { getByText('Change time estimate').click(); });
 
         fireEvent.input(getByPlaceholderText('shortest estimate [eg: 5h]'), { target: { value: '1h' } });
         fireEvent.input(getByPlaceholderText('balanced estimate [eg: 2d 4h, or 2.5d]'), { target: { value: '2h' } });
@@ -599,7 +633,7 @@ describe('MultiEditBar', () => {
 
         const { getByText, getByPlaceholderText } = render(<MultiEditBar {...props} />);
 
-        await act(async () => { getByText('Change estimated time').click(); });
+        await act(async () => { getByText('Change time estimate').click(); });
 
         fireEvent.input(getByPlaceholderText('shortest estimate [eg: 5h]'), { target: { value: '1h' } });
         fireEvent.input(getByPlaceholderText('balanced estimate [eg: 2d 4h, or 2.5d]'), { target: { value: '2h' } });
@@ -636,7 +670,7 @@ describe('MultiEditBar', () => {
 
         const { getByText, getByPlaceholderText } = render(<MultiEditBar {...props} />);
 
-        await act(async () => { getByText('Change estimated time').click(); });
+        await act(async () => { getByText('Change time estimate').click(); });
 
         fireEvent.input(getByPlaceholderText('shortest estimate [eg: 5h]'), { target: { value: '1h' } });
         fireEvent.input(getByPlaceholderText('balanced estimate [eg: 2d 4h, or 2.5d]'), { target: { value: '2h' } });
@@ -671,7 +705,7 @@ describe('MultiEditBar', () => {
 
         const { getByText, getByPlaceholderText } = render(<MultiEditBar {...props} />);
 
-        await act(async () => { getByText('Change estimated time').click(); });
+        await act(async () => { getByText('Change time estimate').click(); });
 
         fireEvent.input(getByPlaceholderText('shortest estimate [eg: 5h]'), { target: { value: '1h' } });
         fireEvent.input(getByPlaceholderText('balanced estimate [eg: 2d 4h, or 2.5d]'), { target: { value: '2h' } });

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -777,7 +777,7 @@ describe('Vulnerability Table', () => {
 
         await user.click(select_all)
 
-        const edit_time_btn = await screen.getByRole('button', {name: /Change estimated time/i});
+        const edit_time_btn = await screen.getByRole('button', {name: /Change time estimate/i});
         expect(edit_time_btn).toBeInTheDocument();
         await user.click(edit_time_btn);
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The multi-edit bar's status/time panels were absolutely positioned with fixed offsets (top-48 left-32, w-1/2), causing misalignment and overlap, and the toggle buttons lacked pressed-state semantics.

- Wrap both panels in a relative container and anchor them under the bar (full-width, max-w-4xl) so they align consistently.
- Restyle the "Change status" and "Change time estimate" buttons with borders, semibold text and active styling; add aria-pressed for the open panel.
- Rename the button label "Change estimated time" to "Change time estimate".

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Before this change:

<img width="1825" height="354" alt="image" src="https://github.com/user-attachments/assets/b1e31fd9-d916-45d0-be42-e8d14cbc9956" />

After this change:

<img width="1843" height="405" alt="image" src="https://github.com/user-attachments/assets/0361eb0e-b542-4b23-8f5d-e340b8816609" />

