### PR TITLE
fix: drop OpenEmbedded supplier from packages

### DIFF
--- a/src/migrations/versions/q3f4a5b6c7d8_clean_openembedded_suppliers.py
+++ b/src/migrations/versions/q3f4a5b6c7d8_clean_openembedded_suppliers.py
@@ -1,0 +1,154 @@
+"""clean OpenEmbedded/OpenEmnedded supplier values in packages
+
+Revision ID: q3f4a5b6c7d8
+Revises: p2e3f4a5b6c7
+Create Date: 2026-06-18 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'q3f4a5b6c7d8'
+down_revision = 'p2e3f4a5b6c7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    candidate_rows = list(conn.execute(sa.text("""
+        SELECT id, name, version, supplier, cpe, purl, licences
+        FROM packages
+        WHERE lower(coalesce(supplier, '')) LIKE '%openembedded%'
+           OR lower(coalesce(supplier, '')) LIKE '%openemnedded%'
+    """)).mappings())
+
+    for src in candidate_rows:
+        target = conn.execute(sa.text("""
+            SELECT id, cpe, purl, licences
+            FROM packages
+            WHERE name = :name
+              AND version = :version
+              AND coalesce(supplier, '') = ''
+              AND id != :src_id
+            LIMIT 1
+        """), {
+            "name": src["name"],
+            "version": src["version"],
+            "src_id": src["id"],
+        }).mappings().first()
+
+        if target is None:
+            conn.execute(sa.text("""
+                UPDATE packages
+                SET supplier = ''
+                WHERE id = :src_id
+            """), {"src_id": src["id"]})
+            continue
+
+        # Preserve source data when the canonical target row is still empty.
+        conn.execute(sa.text("""
+            UPDATE packages
+            SET cpe = CASE
+                    WHEN (cpe IS NULL OR cpe = '[]') AND :src_cpe IS NOT NULL AND :src_cpe != '[]'
+                    THEN :src_cpe
+                    ELSE cpe
+                END,
+                purl = CASE
+                    WHEN (purl IS NULL OR purl = '[]') AND :src_purl IS NOT NULL AND :src_purl != '[]'
+                    THEN :src_purl
+                    ELSE purl
+                END,
+                licences = CASE
+                    WHEN (licences IS NULL OR licences = '') AND :src_licences IS NOT NULL AND :src_licences != ''
+                    THEN :src_licences
+                    ELSE licences
+                END
+            WHERE id = :target_id
+        """), {
+            "target_id": target["id"],
+            "src_cpe": src["cpe"],
+            "src_purl": src["purl"],
+            "src_licences": src["licences"],
+        })
+
+        # Move SBOM/package links to the canonical row and drop duplicates.
+        conn.execute(sa.text("""
+            INSERT OR IGNORE INTO sbom_packages (sbom_document_id, package_id)
+            SELECT sbom_document_id, :target_id
+            FROM sbom_packages
+            WHERE package_id = :src_id
+        """), {"target_id": target["id"], "src_id": src["id"]})
+        conn.execute(sa.text("DELETE FROM sbom_packages WHERE package_id = :src_id"), {"src_id": src["id"]})
+
+        # Observations tied directly to a package can point to the canonical row.
+        conn.execute(sa.text("""
+            UPDATE sbom_observation
+            SET package_id = :target_id
+            WHERE package_id = :src_id
+        """), {"target_id": target["id"], "src_id": src["id"]})
+
+        source_findings = list(conn.execute(sa.text("""
+            SELECT id, vulnerability_id
+            FROM findings
+            WHERE package_id = :src_id
+        """), {"src_id": src["id"]}).mappings())
+
+        for finding in source_findings:
+            target_finding = conn.execute(sa.text("""
+                SELECT id
+                FROM findings
+                WHERE package_id = :target_id
+                  AND vulnerability_id = :vulnerability_id
+                LIMIT 1
+            """), {
+                "target_id": target["id"],
+                "vulnerability_id": finding["vulnerability_id"],
+            }).scalar()
+
+            if target_finding is None:
+                conn.execute(sa.text("""
+                    UPDATE findings
+                    SET package_id = :target_id
+                    WHERE id = :finding_id
+                """), {
+                    "target_id": target["id"],
+                    "finding_id": finding["id"],
+                })
+                continue
+
+            conn.execute(sa.text("""
+                UPDATE observations
+                SET finding_id = :target_finding_id
+                WHERE finding_id = :source_finding_id
+            """), {
+                "target_finding_id": target_finding,
+                "source_finding_id": finding["id"],
+            })
+            conn.execute(sa.text("""
+                UPDATE assessments
+                SET finding_id = :target_finding_id
+                WHERE finding_id = :source_finding_id
+            """), {
+                "target_finding_id": target_finding,
+                "source_finding_id": finding["id"],
+            })
+            conn.execute(sa.text("""
+                UPDATE time_estimates
+                SET finding_id = :target_finding_id
+                WHERE finding_id = :source_finding_id
+            """), {
+                "target_finding_id": target_finding,
+                "source_finding_id": finding["id"],
+            })
+            conn.execute(sa.text("DELETE FROM findings WHERE id = :finding_id"), {"finding_id": finding["id"]})
+
+        conn.execute(sa.text("DELETE FROM packages WHERE id = :src_id"), {"src_id": src["id"]})
+
+
+def downgrade():
+    # Data cleanup migration is not reversible.
+    pass

--- a/src/models/package.py
+++ b/src/models/package.py
@@ -19,6 +19,14 @@ if typing.TYPE_CHECKING:
     from ..models import SBOMObservation, SBOMPackage, Finding
 
 
+def _normalize_supplier(value: str | None) -> str:
+    """Normalize supplier values and drop OpenEmbedded/OpenEmnedded."""
+    supplier = (value or "").strip()
+    if re.search(r"openem[bn]edded", supplier, flags=re.IGNORECASE):
+        return ""
+    return supplier
+
+
 def _normalize_purl(purl: str) -> str:
     """Normalize PURL to a canonical form.
 
@@ -115,7 +123,7 @@ class Package(Base):
         self.cpe = []
         self.purl = []
         self.licences = licences or ""
-        self.supplier = supplier
+        self.supplier = _normalize_supplier(supplier)
         for c in cpes:
             self.add_cpe(c)
         for p in purls:
@@ -308,6 +316,7 @@ class Package(Base):
         supplier: str = "",
     ) -> "Package":
         """Return an existing Package for (name, version, supplier) or create a new one."""
+        supplier = _normalize_supplier(supplier)
         existing = db.session.execute(
             db.select(Package).where(
                 Package.name == name,
@@ -355,7 +364,7 @@ class Package(Base):
         if not items:
             return {}
 
-        triples = [(d["name"], d["version"], d.get("supplier", "")) for d in items]
+        triples = [(d["name"], d["version"], _normalize_supplier(d.get("supplier", ""))) for d in items]
 
         existing_rows = list(
             db.session.execute(
@@ -370,7 +379,7 @@ class Package(Base):
 
         result: dict[str, Package] = {}
         for d in items:
-            key = (d["name"], d["version"], d.get("supplier", ""))
+            key = (d["name"], d["version"], _normalize_supplier(d.get("supplier", "")))
             pkg = by_key.get(key)
             if pkg is None:
                 pkg = Package(
@@ -379,7 +388,7 @@ class Package(Base):
                     cpe=d.get("cpe", []),
                     purl=d.get("purl", []),
                     licences=d.get("licences", ""),
-                    supplier=d.get("supplier", ""),
+                    supplier=_normalize_supplier(d.get("supplier", "")),
                 )
                 db.session.add(pkg)
                 by_key[key] = pkg
@@ -398,6 +407,7 @@ class Package(Base):
     @staticmethod
     def exists(name: str, version: str, supplier: str = "") -> bool:
         """Check whether a package with (name, version, supplier) exists."""
+        supplier = _normalize_supplier(supplier)
         return db.session.query(
             db.session.query(Package).filter(
                 Package.name == name,
@@ -414,6 +424,7 @@ class Package(Base):
         supplier = ""
         if "::" in string_id:
             string_id, supplier = string_id.split("::", 1)
+        supplier = _normalize_supplier(supplier)
         name, version = string_id.split("@", 1)
         return db.session.execute(
             db.select(Package).where(

--- a/tests/unit_tests/test_package.py
+++ b/tests/unit_tests/test_package.py
@@ -361,3 +361,39 @@ def test_purl_epoch_qualifier_without_version_not_corrupted():
     no_version_purl = "pkg:deb/ubuntu/procps?epoch=2"
     pkg.add_purl(no_version_purl)
     assert "None" not in pkg.purl[0]
+
+
+@pytest.mark.parametrize("supplier", [
+    "OpenEmbedded ()",
+    "openembedded",
+    "OPENEMBEDDED",
+    "Organization: OpenEmbedded (info@openembedded.org)",
+    "OpenEmnedded ()",
+    "openemnedded",
+])
+def test_constructor_strips_openembedded_supplier(supplier):
+    """The OpenEmbedded supplier (and its OpenEmnedded typo) is dropped."""
+    pkg = Package("busybox", "1.36.1", supplier=supplier)
+    assert pkg.supplier == ""
+    assert pkg.string_id == "busybox@1.36.1"
+
+
+@pytest.mark.parametrize("supplier,expected", [
+    ("Organization: Acme Corp", "Organization: Acme Corp"),
+    ("  Acme Corp  ", "Acme Corp"),
+    ("", ""),
+    (None, ""),
+])
+def test_constructor_preserves_and_trims_other_suppliers(supplier, expected):
+    """Non-OpenEmbedded suppliers are kept (trimmed of surrounding whitespace)."""
+    pkg = Package("busybox", "1.36.1", supplier=supplier)
+    assert pkg.supplier == expected
+
+
+def test_normalize_supplier_helper_directly():
+    from src.models.package import _normalize_supplier
+    assert _normalize_supplier("OpenEmbedded ()") == ""
+    assert _normalize_supplier("prefix OpenEmbedded suffix") == ""
+    assert _normalize_supplier("OpenEmnedded ()") == ""
+    assert _normalize_supplier(None) == ""
+    assert _normalize_supplier("  Acme  ") == "Acme"

--- a/tests/unit_tests/test_package_db.py
+++ b/tests/unit_tests/test_package_db.py
@@ -118,3 +118,41 @@ def test_active_package_ids_for_scans_returns_empty_for_non_sbom_scan(app):
 def test_active_package_ids_for_scans_returns_empty_for_empty_input(app):
     from src.helpers.active_scans import active_package_ids_for_scans
     assert active_package_ids_for_scans([]) == set()
+
+
+def test_find_or_create_openembedded_collapses_into_blank_supplier(app):
+    """An OpenEmbedded supplier resolves to the same row as the blank one."""
+    pkg_oe = Package.find_or_create("busybox", "1.36.1", supplier="OpenEmbedded ()")
+    _db.session.flush()
+    pkg_blank = Package.find_or_create("busybox", "1.36.1")
+    assert pkg_oe.supplier == ""
+    assert pkg_oe.id == pkg_blank.id
+
+
+def test_exists_normalizes_openembedded_supplier(app):
+    """exists() must match the cleaned (blank) row for an OpenEmbedded query."""
+    Package.find_or_create("busybox", "1.36.1")
+    _db.session.flush()
+    assert Package.exists("busybox", "1.36.1", supplier="OpenEmbedded ()") is True
+
+
+def test_get_by_string_id_normalizes_openembedded_supplier(app):
+    """A string_id carrying an OpenEmbedded supplier resolves to the blank row."""
+    Package.find_or_create("busybox", "1.36.1")
+    _db.session.flush()
+    found = Package.get_by_string_id("busybox@1.36.1::OpenEmbedded ()")
+    assert found is not None
+    assert found.supplier == ""
+
+
+def test_bulk_find_or_create_collapses_openembedded_supplier(app):
+    """bulk_find_or_create() deduplicates OpenEmbedded with the blank supplier."""
+    result = Package.bulk_find_or_create([
+        {"name": "busybox", "version": "1.36.1", "supplier": "OpenEmbedded ()"},
+        {"name": "busybox", "version": "1.36.1", "supplier": ""},
+    ])
+    _db.session.flush()
+    ids = {pkg.id for pkg in result.values()}
+    assert len(ids) == 1
+    assert "busybox@1.36.1" in result
+    assert result["busybox@1.36.1"].supplier == ""


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Remove supplier OpenEmbedded for Yocto SPDX2 packages. All SBOMS, by default contains the supplier which makes the interface unreadable. 
Dropping the supplier for this specific case does involve any miss information on the user side, as it is the "default" provider

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Tested with the command:

```
./vulnscout --serve --add-spdx example/spdx2/example.rootfs.spdx.tar.zst --add-cve-check example/spdx2/example.rootfs.json
```

Without this change all packages are duplicated on yocto scarhgap:

<img width="1850" height="622" alt="image" src="https://github.com/user-attachments/assets/35bec168-32c0-4058-afa8-d54d0eb1288c" />

With this change:

<img width="1876" height="891" alt="image" src="https://github.com/user-attachments/assets/d1d9351a-6395-4520-a759-0cfcf47a1797" />



