### PR TITLE
fix: prevent selecting incompatible variant/pkg pairs in assessments

### DIFF
--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -24,12 +24,18 @@ type Props = {
     variants?: Variant[];
     availablePackages?: string[];
     defaultSelectedPackages?: string[];
+    /** variant_id -> packages that exist for this CVE in that variant */
+    variantPackageMap?: Record<string, string[]>;
 }
 
-function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants, availablePackages, defaultSelectedPackages}: Readonly<Props>) {
-    const initialPackages = useMemo(() =>
-        (defaultSelectedPackages && defaultSelectedPackages.length > 0) ? defaultSelectedPackages : (availablePackages ?? [])
-    , [defaultSelectedPackages, availablePackages]);
+function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants, availablePackages, defaultSelectedPackages, variantPackageMap}: Readonly<Props>) {
+    // When multiple choices exist, start fully unchecked so the user makes an
+    // explicit selection; when exactly one exists auto-select it.
+    const initialPackages = useMemo(() => {
+        if (availablePackages && availablePackages.length === 1) return availablePackages;
+        if (defaultSelectedPackages && defaultSelectedPackages.length === 1) return defaultSelectedPackages;
+        return [];
+    }, [defaultSelectedPackages, availablePackages]);
 
     const [status, setStatus] = useState(defaultStatus);
     const [justification, setJustification] = useState("none");
@@ -40,6 +46,54 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         variants?.length === 1 ? [variants[0].id] : []
     );
     const [selectedPackages, setSelectedPackages] = useState<string[]>(initialPackages);
+
+    // Derived: which packages are reachable from the currently selected variants,
+    // and which variants are reachable from the currently selected packages.
+    const allowedPackages = useMemo<Set<string> | null>(() => {
+        if (!variantPackageMap) return null;
+
+        // Use selected variant IDs if any are checked; otherwise derive from selected packages.
+        let effectiveVariantIds: string[];
+        if (selectedVariantIds.length > 0) {
+            effectiveVariantIds = selectedVariantIds;
+        } else if (selectedPackages.length > 0) {
+            effectiveVariantIds = Object.entries(variantPackageMap)
+                .filter(([, pkgs]) => selectedPackages.some(p => pkgs.includes(p)))
+                .map(([vid]) => vid);
+        } else {
+            return null;
+        }
+
+        const union = new Set<string>();
+        for (const vid of effectiveVariantIds) {
+            for (const pkg of variantPackageMap[vid] ?? []) union.add(pkg);
+        }
+        return union.size > 0 ? union : null;
+    }, [variantPackageMap, selectedVariantIds, selectedPackages]);
+
+    const allowedVariants = useMemo<Set<string> | null>(() => {
+        if (!variantPackageMap) return null;
+
+        // Use selected packages if any are checked; otherwise derive from selected variants.
+        let effectivePackages: string[];
+        if (selectedPackages.length > 0) {
+            effectivePackages = selectedPackages;
+        } else if (selectedVariantIds.length > 0) {
+            const union = new Set<string>();
+            for (const vid of selectedVariantIds) {
+                for (const pkg of variantPackageMap[vid] ?? []) union.add(pkg);
+            }
+            effectivePackages = [...union];
+        } else {
+            return null;
+        }
+
+        const allowed = new Set<string>();
+        for (const [vid, pkgs] of Object.entries(variantPackageMap)) {
+            if (effectivePackages.some(p => pkgs.includes(p))) allowed.add(vid);
+        }
+        return allowed.size > 0 ? allowed : null;
+    }, [variantPackageMap, selectedPackages, selectedVariantIds]);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -63,6 +117,44 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
     useEffect(() => {
         setSelectedVariantIds(variants?.length === 1 ? [variants[0].id] : []);
     }, [variants]);
+
+    // When a variant is unchecked, drop packages that are no longer reachable.
+    const handleVariantToggle = (variantId: string, checked: boolean) => {
+        const nextVariants = checked
+            ? [...selectedVariantIds, variantId]
+            : selectedVariantIds.filter(id => id !== variantId);
+        setSelectedVariantIds(nextVariants);
+
+        if (!checked && variantPackageMap) {
+            const stillAllowed = new Set<string>();
+            for (const vid of nextVariants) {
+                for (const pkg of variantPackageMap[vid] ?? []) stillAllowed.add(pkg);
+            }
+            if (stillAllowed.size > 0) {
+                setSelectedPackages(prev => prev.filter(p => stillAllowed.has(p)));
+            } else {
+                setSelectedPackages([]);
+            }
+        }
+    };
+
+    // When a package is toggled, drop variants that are no longer compatible.
+    // Runs on both check and uncheck so a variant that was selected before a
+    // conflicting package is checked gets automatically deselected.
+    const handlePackageToggle = (pkg: string, checked: boolean) => {
+        const nextPackages = checked
+            ? [...selectedPackages, pkg]
+            : selectedPackages.filter(p => p !== pkg);
+        setSelectedPackages(nextPackages);
+
+        if (variantPackageMap && nextPackages.length > 0) {
+            setSelectedVariantIds(prev =>
+                prev.filter(vid =>
+                    nextPackages.some(p => (variantPackageMap[vid] ?? []).includes(p))
+                )
+            );
+        }
+    };
 
     // Update status when defaultStatus prop changes
     useEffect(() => {
@@ -134,8 +226,11 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         setWorkaround("");
         setImpact("");
         setSelectedVariantIds(variants?.length === 1 ? [variants[0].id] : []);
-        setSelectedPackages(initialPackages);
-    }, [defaultStatus, initialPackages, variants]);
+        setSelectedPackages(
+            (availablePackages?.length === 1 ? availablePackages :
+            defaultSelectedPackages?.length === 1 ? defaultSelectedPackages : [])
+        );
+    }, [defaultStatus, defaultSelectedPackages, availablePackages, variants]);
 
     useEffect(() => {
         if (shouldClearFields) {
@@ -189,23 +284,25 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             <div className="mt-2 mb-2 ml-1">
                 <p className="text-sm font-medium text-gray-300 mb-1">Apply to variants:</p>
                 <div className="flex flex-wrap gap-x-4 gap-y-1">
-                    {variants.map(v => (
-                        <label key={v.id} className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
+                    {variants.map(v => {
+                        const incompatible = allowedVariants !== null && !allowedVariants.has(v.id);
+                        return (
+                        <label
+                            key={v.id}
+                            className={['flex items-center gap-1.5 text-sm select-none', incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'].join(' ')}
+                            title={incompatible ? 'No selected package is present in this variant' : undefined}
+                        >
                             <input
                                 type="checkbox"
                                 checked={selectedVariantIds.includes(v.id)}
-                                onChange={(e) => {
-                                    if (e.target.checked) {
-                                        setSelectedVariantIds(prev => [...prev, v.id]);
-                                    } else {
-                                        setSelectedVariantIds(prev => prev.filter(id => id !== v.id));
-                                    }
-                                }}
+                                disabled={incompatible}
+                                onChange={(e) => handleVariantToggle(v.id, e.target.checked)}
                                 className="accent-blue-500"
                             />
                             <span className="text-gray-200">{v.name}</span>
                         </label>
-                    ))}
+                        );
+                    })}
                 </div>
             </div>
         )}
@@ -215,22 +312,21 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                 <div className="flex flex-wrap gap-x-4 gap-y-1">
                     {availablePackages.map(pkg => {
                         const isActive = !defaultSelectedPackages || defaultSelectedPackages.length === 0 || defaultSelectedPackages.includes(pkg);
+                        const incompatible = allowedPackages !== null && !allowedPackages.has(pkg);
                         return (
-                        <label key={pkg} className="flex items-center gap-1.5 text-sm cursor-pointer select-none">
+                        <label
+                            key={pkg}
+                            className={['flex items-center gap-1.5 text-sm select-none', incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'].join(' ')}
+                            title={incompatible ? 'Package is not present in selected variants' : (isActive ? undefined : 'Not in active SBOM')}
+                        >
                             <input
                                 type="checkbox"
                                 checked={selectedPackages.includes(pkg)}
-                                onChange={(e) => {
-                                    if (e.target.checked) {
-                                        setSelectedPackages(prev => [...prev, pkg]);
-                                    } else {
-                                        setSelectedPackages(prev => prev.filter(p => p !== pkg));
-                                    }
-                                }}
+                                disabled={incompatible}
+                                onChange={(e) => handlePackageToggle(pkg, e.target.checked)}
                                 className="accent-blue-400"
                             />
-                            <span className={`font-mono ${isActive ? 'text-gray-200' : 'text-gray-500 italic'}`}
-                                  title={isActive ? undefined : 'Not in active SBOM'}>{formatPkgId(pkg)}</span>
+                            <span className={`font-mono ${incompatible ? 'text-gray-500' : isActive ? 'text-gray-200' : 'text-gray-500 italic'}`}>{formatPkgId(pkg)}</span>
                         </label>
                         );
                     })}

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -19,6 +19,7 @@ import ConfirmationModal from "./ConfirmationModal";
 import EditAssessment from "./EditAssessment";
 import type { EditAssessmentData } from "./EditAssessment";
 import Variants from '../handlers/variant';
+import Packages from '../handlers/packages';
 import { formatSourceName } from '../helpers/sourceNames';
 import { useDocUrl } from '../helpers/useDocUrl';
 import { splitPkgId, formatPkgId, extractSupplierName } from '../helpers/pkgId';
@@ -90,6 +91,7 @@ type VariantScopedSnapshot = {
     const [allVulnAssessments, setAllVulnAssessments] = useState<Assessment[]>([]);
     const [selectedTargetVariantIds, setSelectedTargetVariantIds] = useState<string[]>([]);
     const [variantSnapshots, setVariantSnapshots] = useState<VariantScopedSnapshot[]>([]);
+    const [variantPackageMap, setVariantPackageMap] = useState<Record<string, string[]>>({});
     const [snapshotVersion, setSnapshotVersion] = useState(0);
     const [submittingMessage, setSubmittingMessage] = useState<string | null>(null);
     const [editingGroup, setEditingGroup] = useState<AssessmentGroup | null>(null);
@@ -205,6 +207,35 @@ type VariantScopedSnapshot = {
 
         return () => { cancelled = true; };
     }, [variantId, availableVariants, vuln.id, projectId, snapshotVersion]);
+
+    // Build variant -> package compatibility map using the same source as the
+    // SBOM tab: GET /api/packages?variant_id=<id> returns the active SBOM
+    // packages for that variant, whose ids match vuln.packages entries.
+    useEffect(() => {
+        let cancelled = false;
+        if (availableVariants.length === 0) {
+            setVariantPackageMap({});
+            return;
+        }
+        (async () => {
+            const entries: [string, string[]][] = await Promise.all(
+                availableVariants.map(async (variant): Promise<[string, string[]]> => {
+                    try {
+                        const pkgs = await Packages.list(variant.id);
+                        // Build the same key format as vuln.packages:
+                        // "name@version::supplier" when supplier present, else "name@version"
+                        return [variant.id, pkgs.map(p =>
+                            p.supplier ? `${p.name}@${p.version}::${p.supplier}` : `${p.name}@${p.version}`
+                        )];
+                    } catch {
+                        return [variant.id, []];
+                    }
+                })
+            );
+            if (!cancelled) setVariantPackageMap(Object.fromEntries(entries));
+        })();
+        return () => { cancelled = true; };
+    }, [availableVariants]);
 
     const [hasTimeChanges, setHasTimeChanges] = useState(false);
     const [hasAssessmentChanges, setHasAssessmentChanges] = useState(false);
@@ -1278,6 +1309,7 @@ type VariantScopedSnapshot = {
                                             variants={availableVariants}
                                             availablePackages={projectPackages}
                                             defaultSelectedPackages={vuln.packages_current}
+                                            variantPackageMap={Object.keys(variantPackageMap).length > 0 ? variantPackageMap : undefined}
                                         />
                                     </li>
                                 )}

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -425,10 +425,9 @@ describe('StatusEditor', () => {
         render(<StatusEditor {...defaultProps} availablePackages={packages} />);
 
         const checkboxes = screen.getAllByRole('checkbox');
-        // Uncheck one package
+        // With multiple packages and no incompatibility map, all start unchecked.
         await user.click(checkboxes[0]);
-        // Re-check it
-        await user.click(checkboxes[0]);
+        await user.click(checkboxes[1]);
 
         const statusSelect = screen.getByRole('combobox');
         await user.selectOptions(statusSelect, 'affected');
@@ -464,5 +463,234 @@ describe('StatusEditor', () => {
         expect(defaultProps.onAddAssessment).toHaveBeenCalledWith(
             expect.objectContaining({ variant_ids: ['v2'] })
         );
+    });
+
+    test('should leave multiple packages unchecked by default', () => {
+        const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
+        render(<StatusEditor {...defaultProps} availablePackages={packages} />);
+
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+        expect(checkboxes).toHaveLength(2);
+        expect(checkboxes[0].checked).toBe(false);
+        expect(checkboxes[1].checked).toBe(false);
+    });
+
+    test('should auto-select the package when only one is available', () => {
+        const packages = ['only-pkg@1.0.0'];
+        render(<StatusEditor {...defaultProps} availablePackages={packages} />);
+
+        const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+        expect(checkbox.checked).toBe(true);
+    });
+
+    test('should auto-select the package when a single defaultSelectedPackages is provided', () => {
+        const packages = ['pkg1@1.0.0', 'pkg2@2.0.0'];
+        render(
+            <StatusEditor
+                {...defaultProps}
+                availablePackages={packages}
+                defaultSelectedPackages={['pkg2@2.0.0']}
+            />
+        );
+
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+        // Order matches availablePackages: pkg1, pkg2
+        expect(checkboxes[0].checked).toBe(false);
+        expect(checkboxes[1].checked).toBe(true);
+    });
+
+    test('should disable variants that lack the selected package', async () => {
+        const user = userEvent.setup();
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
+        const packages = ['pkgA@1.0.0', 'pkgB@1.0.0'];
+        const variantPackageMap = {
+            v1: ['pkgA@1.0.0'],
+            v2: ['pkgB@1.0.0'],
+        };
+        render(
+            <StatusEditor
+                {...defaultProps}
+                variants={variants}
+                availablePackages={packages}
+                variantPackageMap={variantPackageMap}
+            />
+        );
+
+        // checkbox order: v1, v2, pkgA, pkgB
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+        // Select pkgA (only present in v1)
+        await user.click(checkboxes[2]);
+
+        // v2 has no selected package → disabled; v1 stays enabled
+        expect(checkboxes[1].disabled).toBe(true);
+        expect(checkboxes[0].disabled).toBe(false);
+    });
+
+    test('should disable packages absent from the selected variant', async () => {
+        const user = userEvent.setup();
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
+        const packages = ['pkgA@1.0.0', 'pkgB@1.0.0'];
+        const variantPackageMap = {
+            v1: ['pkgA@1.0.0'],
+            v2: ['pkgB@1.0.0'],
+        };
+        render(
+            <StatusEditor
+                {...defaultProps}
+                variants={variants}
+                availablePackages={packages}
+                variantPackageMap={variantPackageMap}
+            />
+        );
+
+        // checkbox order: v1, v2, pkgA, pkgB
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+        // Select v1 (only contains pkgA)
+        await user.click(checkboxes[0]);
+
+        // pkgB is not in v1 → disabled; pkgA stays enabled
+        expect(checkboxes[3].disabled).toBe(true);
+        expect(checkboxes[2].disabled).toBe(false);
+    });
+
+    test('should deselect an incompatible variant when a conflicting package is checked', async () => {
+        const user = userEvent.setup();
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
+        const packages = ['pkgA@1.0.0', 'pkgB@1.0.0'];
+        // v1 and v2 share pkgA so both variants can be selected together;
+        // pkgB exists only in v2.
+        const variantPackageMap = {
+            v1: ['pkgA@1.0.0'],
+            v2: ['pkgA@1.0.0', 'pkgB@1.0.0'],
+        };
+        render(
+            <StatusEditor
+                {...defaultProps}
+                variants={variants}
+                availablePackages={packages}
+                variantPackageMap={variantPackageMap}
+            />
+        );
+
+        // checkbox order: v1, v2, pkgA, pkgB
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+        // Select v2 first (reaches both packages), then v1 (shares pkgA so it
+        // stays enabled). Both variants end up selected.
+        await user.click(checkboxes[1]);
+        await user.click(checkboxes[0]);
+        expect(checkboxes[0].checked).toBe(true);
+        expect(checkboxes[1].checked).toBe(true);
+
+        // Check pkgB, which only exists in v2.
+        await user.click(checkboxes[3]);
+
+        // v1 is no longer compatible with the selected package → auto-deselected
+        expect(checkboxes[0].checked).toBe(false);
+        expect(checkboxes[1].checked).toBe(true);
+    });
+
+    test('should drop now-unreachable packages when a variant is unchecked', async () => {
+        const user = userEvent.setup();
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
+        const packages = ['pkgA@1.0.0', 'pkgB@1.0.0'];
+        const variantPackageMap = {
+            v1: ['pkgA@1.0.0'],
+            v2: ['pkgB@1.0.0'],
+        };
+        render(
+            <StatusEditor
+                {...defaultProps}
+                variants={variants}
+                availablePackages={packages}
+                variantPackageMap={variantPackageMap}
+            />
+        );
+
+        // checkbox order: v1, v2, pkgA, pkgB
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+        // Select v1 then its package pkgA
+        await user.click(checkboxes[0]);
+        await user.click(checkboxes[2]);
+        expect(checkboxes[2].checked).toBe(true);
+
+        // Unchecking v1 removes pkgA since no other selected variant reaches it
+        await user.click(checkboxes[0]);
+        expect(checkboxes[2].checked).toBe(false);
+    });
+
+    test('should keep packages reachable from a remaining variant when another variant is unchecked', async () => {
+        const user = userEvent.setup();
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+            { id: 'v2', name: 'release', project_id: 'p1' },
+        ];
+        const packages = ['pkgA@1.0.0', 'pkgB@1.0.0'];
+        // v1 is a subset of v2: both share pkgA, only v2 also has pkgB.
+        const variantPackageMap = {
+            v1: ['pkgA@1.0.0'],
+            v2: ['pkgA@1.0.0', 'pkgB@1.0.0'],
+        };
+        render(
+            <StatusEditor
+                {...defaultProps}
+                variants={variants}
+                availablePackages={packages}
+                variantPackageMap={variantPackageMap}
+            />
+        );
+
+        // checkbox order: v1, v2, pkgA, pkgB
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+        // Select both variants (shared pkgA keeps them compatible).
+        await user.click(checkboxes[1]);
+        await user.click(checkboxes[0]);
+        // Check the shared package, which both variants provide.
+        await user.click(checkboxes[2]);
+        expect(checkboxes[2].checked).toBe(true);
+
+        // Uncheck v2; v1 still provides pkgA, so it must remain selected.
+        await user.click(checkboxes[1]);
+        expect(checkboxes[1].checked).toBe(false);
+        expect(checkboxes[0].checked).toBe(true);
+        expect(checkboxes[2].checked).toBe(true);
+    });
+
+    test('should clear a package selection when its checkbox is unchecked', async () => {
+        const user = userEvent.setup();
+        const variants = [
+            { id: 'v1', name: 'default', project_id: 'p1' },
+        ];
+        const packages = ['pkgA@1.0.0', 'pkgB@1.0.0'];
+        const variantPackageMap = {
+            v1: ['pkgA@1.0.0', 'pkgB@1.0.0'],
+        };
+        render(
+            <StatusEditor
+                {...defaultProps}
+                variants={variants}
+                availablePackages={packages}
+                variantPackageMap={variantPackageMap}
+            />
+        );
+
+        // Single variant auto-selects; checkbox order: v1, pkgA, pkgB
+        const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+        // Check then uncheck pkgA.
+        await user.click(checkboxes[1]);
+        expect(checkboxes[1].checked).toBe(true);
+        await user.click(checkboxes[1]);
+        expect(checkboxes[1].checked).toBe(false);
     });
 });

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -1,7 +1,7 @@
 import fetchMock from 'jest-fetch-mock';
 fetchMock.enableMocks();
 
-import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import "@testing-library/jest-dom";
 // @ts-expect-error TS6133
@@ -247,6 +247,7 @@ describe('Vulnerability Modal', () => {
             }
         ])); // variants mount fetch
         fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // packages fetch (variantPackageMap effect)
         fetchMock.mockResponseOnce(JSON.stringify({
             id: vulnerability.id,
             packages: vulnerability.packages,
@@ -278,7 +279,7 @@ describe('Vulnerability Modal', () => {
         await user.click(btn);
 
         // ASSERT
-        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(fetchMock).toHaveBeenCalledTimes(4);
         expect(updateCb).toHaveBeenCalledTimes(1);
         alertSpy.mockRestore();
     })
@@ -1927,6 +1928,8 @@ describe('Vulnerability Modal', () => {
         ]));
         fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockResponseOnce(JSON.stringify([])); // batch variant snapshots (single fetch)
+        fetchMock.mockResponseOnce(JSON.stringify([])); // packages fetch for v1 (variantPackageMap effect)
+        fetchMock.mockResponseOnce(JSON.stringify([])); // packages fetch for v2 (variantPackageMap effect)
         // Two POST responses for two variants
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
@@ -2374,5 +2377,116 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
 
         expect(screen.queryByText('Updated')).not.toBeInTheDocument();
         expect(screen.queryByText(/NVD API unavailable/i)).not.toBeInTheDocument();
+    });
+
+    test('builds variantPackageMap and disables packages absent from the selected variant', async () => {
+        fetchMock.resetMocks();
+        // Route fetches by URL so the per-variant package lookups resolve
+        // regardless of effect ordering.
+        fetchMock.mockResponse((req) => {
+            const url = req.url;
+            if (url.includes('/api/packages')) {
+                if (url.includes('variant_id=v1')) {
+                    return Promise.resolve(JSON.stringify([{ name: 'pkgA', version: '1.0.0' }]));
+                }
+                if (url.includes('variant_id=v2')) {
+                    return Promise.resolve(JSON.stringify([{ name: 'pkgB', version: '1.0.0' }]));
+                }
+                return Promise.resolve(JSON.stringify([]));
+            }
+            if (url.includes('/variants') && !url.includes('/variant-snapshots')) {
+                // Variants.listByVuln
+                return Promise.resolve(JSON.stringify([
+                    { id: 'v1', name: 'Variant Alpha', project_id: 'proj1' },
+                    { id: 'v2', name: 'Variant Beta', project_id: 'proj1' },
+                ]));
+            }
+            // assessments mount fetch, variant-snapshots, ...
+            return Promise.resolve(JSON.stringify([]));
+        });
+
+        const multiPkgVuln: Vulnerability = {
+            ...vulnerability,
+            packages: ['pkgA@1.0.0', 'pkgB@1.0.0'],
+            packages_current: [],
+            assessments: [],
+        };
+
+        render(<VulnModal vuln={multiPkgVuln} isEditing={true} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} projectId="proj1" />);
+        const user = userEvent.setup();
+
+        // Wait for the variants to render inside the StatusEditor.
+        await screen.findByText('Apply to variants:');
+
+        // Scope checkbox lookups to the StatusEditor sections so we do not match
+        // the TimeEstimateEditor / CVSS target-variant selectors that reuse the
+        // same variant names.
+        const sectionCheckbox = (header: string, labelText: string): HTMLInputElement => {
+            const section = screen.getByText(header).closest('div') as HTMLElement;
+            const input = within(section).getByText(labelText).closest('label')?.querySelector('input[type="checkbox"]');
+            if (!input) throw new Error(`No checkbox found for "${labelText}" under "${header}"`);
+            return input as HTMLInputElement;
+        };
+        const variantCheckbox = (name: string) => sectionCheckbox('Apply to variants:', name);
+        const packageCheckbox = (label: string) => sectionCheckbox('Apply to packages:', label);
+
+        // Both packages are reachable before any variant is selected.
+        expect(packageCheckbox('pkgA@1.0.0').disabled).toBe(false);
+        expect(packageCheckbox('pkgB@1.0.0').disabled).toBe(false);
+
+        // Select Variant Alpha, which only contains pkgA.
+        await user.click(variantCheckbox('Variant Alpha'));
+
+        // pkgB is absent from Variant Alpha → its checkbox becomes disabled.
+        await waitFor(() => {
+            expect(packageCheckbox('pkgB@1.0.0').disabled).toBe(true);
+        });
+        expect(packageCheckbox('pkgA@1.0.0').disabled).toBe(false);
+    });
+
+    test('omits variantPackageMap so all packages stay enabled when package lookups fail', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponse((req) => {
+            const url = req.url;
+            if (url.includes('/api/packages')) {
+                // Simulate the package lookup failing for every variant.
+                return Promise.reject(new Error('packages unavailable'));
+            }
+            if (url.includes('/variants') && !url.includes('/variant-snapshots')) {
+                return Promise.resolve(JSON.stringify([
+                    { id: 'v1', name: 'Variant Alpha', project_id: 'proj1' },
+                    { id: 'v2', name: 'Variant Beta', project_id: 'proj1' },
+                ]));
+            }
+            return Promise.resolve(JSON.stringify([]));
+        });
+
+        const multiPkgVuln: Vulnerability = {
+            ...vulnerability,
+            packages: ['pkgA@1.0.0', 'pkgB@1.0.0'],
+            packages_current: [],
+            assessments: [],
+        };
+
+        render(<VulnModal vuln={multiPkgVuln} isEditing={true} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} projectId="proj1" />);
+        const user = userEvent.setup();
+
+        await screen.findByText('Apply to variants:');
+
+        const sectionCheckbox = (header: string, labelText: string): HTMLInputElement => {
+            const section = screen.getByText(header).closest('div') as HTMLElement;
+            const input = within(section).getByText(labelText).closest('label')?.querySelector('input[type="checkbox"]');
+            if (!input) throw new Error(`No checkbox found for "${labelText}" under "${header}"`);
+            return input as HTMLInputElement;
+        };
+        const variantCheckbox = (name: string) => sectionCheckbox('Apply to variants:', name);
+        const packageCheckbox = (label: string) => sectionCheckbox('Apply to packages:', label);
+
+        // With an empty map (all lookups failed), no incompatibility filtering
+        // applies: selecting a variant leaves every package enabled.
+        await user.click(variantCheckbox('Variant Alpha'));
+
+        expect(packageCheckbox('pkgA@1.0.0').disabled).toBe(false);
+        expect(packageCheckbox('pkgB@1.0.0').disabled).toBe(false);
     });
 });


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

When adding an assessment from the vulnerability modal, the variant and package checkboxes could be combined in ways that don't exist for the CVE (a package absent from the chosen variant, or vice versa), producing assessments that target nothing.

- StatusEditor: accept a `variantPackageMap` (variant_id -> packages present for the CVE in that variant) and derive the reachable sets in both directions. Incompatible variant/package checkboxes are disabled with an explanatory tooltip.
- Cross-deselect on toggle: unchecking a variant drops packages it uniquely provided, and checking a package deselects variants that don't contain it, so the selection always stays consistent.
- Start multi-choice lists fully unchecked to force an explicit choice; auto-select only when exactly one package (or one default) exists.
- VulnModal: build `variantPackageMap` from GET /api/packages?variant_id (the same source as the SBOM tab) and pass it to StatusEditor.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Before this change: 

<img width="1756" height="149" alt="image" src="https://github.com/user-attachments/assets/a0d6d758-bd43-494a-ba8c-da3e5a33da8e" />

After this change incompatible checkbox are deactivate and unchecked:

<img width="1843" height="405" alt="image" src="https://github.com/user-attachments/assets/0242f393-e88f-4987-ae37-04c7abc6b90a" />






