### PR TITLE
fix: Exclude kernel modules from scanner inputs

### DIFF
--- a/frontend/src/handlers/grypeScanState.ts
+++ b/frontend/src/handlers/grypeScanState.ts
@@ -10,7 +10,7 @@ import { ScanStateManager } from "./scanStateManager";
 export type { ScanEntryState as GrypeState, ScanManagerSnapshot } from "./scanStateManager";
 
 const manager = new ScanStateManager(
-    (vid) => ScansHandler.triggerGrypeScan(vid),
+    (vid, opts) => ScansHandler.triggerGrypeScan(vid, opts.excludeKernel ?? true),
     (vid) => ScansHandler.getGrypeScanStatus(vid),
     "Grype",
     true, // serial: run one variant at a time (flask process is global)

--- a/frontend/src/handlers/nvdScanState.ts
+++ b/frontend/src/handlers/nvdScanState.ts
@@ -10,7 +10,7 @@ import { ScanStateManager } from "./scanStateManager";
 export type { ScanEntryState as NvdState, ScanManagerSnapshot } from "./scanStateManager";
 
 const manager = new ScanStateManager(
-    (vid) => ScansHandler.triggerNvdScan(vid),
+    (vid, opts) => ScansHandler.triggerNvdScan(vid, opts.excludeKernel ?? true),
     (vid) => ScansHandler.getNvdScanStatus(vid),
     "NVD",
 );

--- a/frontend/src/handlers/osvScanState.ts
+++ b/frontend/src/handlers/osvScanState.ts
@@ -10,7 +10,7 @@ import { ScanStateManager } from "./scanStateManager";
 export type { ScanEntryState as OsvState, ScanManagerSnapshot } from "./scanStateManager";
 
 const manager = new ScanStateManager(
-    (vid) => ScansHandler.triggerOsvScan(vid),
+    (vid, opts) => ScansHandler.triggerOsvScan(vid, opts.excludeKernel ?? true),
     (vid) => ScansHandler.getOsvScanStatus(vid),
     "OSV",
 );

--- a/frontend/src/handlers/scanStateManager.ts
+++ b/frontend/src/handlers/scanStateManager.ts
@@ -25,6 +25,12 @@ export type ScanEntryState = {
 
 export type ScanManagerSnapshot = readonly ScanEntryState[];
 
+/** Options forwarded to the per-variant trigger call. */
+export type ScanTriggerOptions = {
+    /** Exclude kernel companion packages from scanner inputs (default true). */
+    excludeKernel?: boolean;
+};
+
 // Status response shape returned by the backend polling endpoints
 type StatusResponse = {
     status: string;
@@ -59,9 +65,12 @@ export class ScanStateManager {
     /** Queue of variants waiting to be triggered (serial mode only) */
     private pendingQueue: Array<{ id: string; name: string }> = [];
 
+    /** Options forwarded to every triggerFn call of the current run */
+    private currentOptions: ScanTriggerOptions = {};
+
     constructor(
         /** Function to trigger a scan for one variant */
-        private triggerFn: (vid: string) => Promise<{ ok: boolean; error?: string }>,
+        private triggerFn: (vid: string, opts: ScanTriggerOptions) => Promise<{ ok: boolean; error?: string }>,
         /** Function to poll status for one variant */
         private statusFn: (vid: string) => Promise<StatusResponse>,
         /** Human label for error messages (e.g. "Grype") */
@@ -118,8 +127,10 @@ export class ScanStateManager {
      * In **serial** mode only the first variant is triggered immediately;
      * the rest are queued and started one-by-one as each finishes.
      */
-    triggerScan = async (variants: Array<{ id: string; name: string }>) => {
+    triggerScan = async (variants: Array<{ id: string; name: string }>, opts: ScanTriggerOptions = {}) => {
         if (variants.length === 0) return;
+
+        this.currentOptions = opts;
 
         if (this.serial) {
             // Show all entries immediately; first is "running", rest are "queued"
@@ -141,7 +152,7 @@ export class ScanStateManager {
 
             // Trigger only the first variant
             const first = variants[0];
-            const result = await this.triggerFn(first.id);
+            const result = await this.triggerFn(first.id, this.currentOptions);
             if (!result.ok) {
                 this.setVariantState(first.id, {
                     status: "error",
@@ -176,7 +187,7 @@ export class ScanStateManager {
 
         // Trigger each scan sequentially (avoids overwhelming the backend)
         for (const v of variants) {
-            const result = await this.triggerFn(v.id);
+            const result = await this.triggerFn(v.id, this.currentOptions);
             if (!result.ok) {
                 this.setVariantState(v.id, {
                     status: "error",
@@ -229,7 +240,7 @@ export class ScanStateManager {
             progress: "starting",
             logs: [],
         });
-        this.triggerFn(next.id).then((result) => {
+        this.triggerFn(next.id, this.currentOptions).then((result) => {
             if (!result.ok) {
                 this.setVariantState(next.id, {
                     status: "error",

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -202,9 +202,9 @@ class ScansHandler {
         return response.ok;
     }
 
-    static async triggerGrypeScan(variantId: string): Promise<{ ok: boolean; error?: string }> {
+    static async triggerGrypeScan(variantId: string, excludeKernel: boolean = true): Promise<{ ok: boolean; error?: string }> {
         const response = await fetch(
-            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/grype-scan`,
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/grype-scan?exclude_kernel=${excludeKernel}`,
             { method: 'POST', mode: 'cors' }
         );
         if (response.ok || response.status === 202) return { ok: true };
@@ -232,9 +232,9 @@ class ScansHandler {
         return await response.json();
     }
 
-    static async triggerNvdScan(variantId: string): Promise<{ ok: boolean; error?: string }> {
+    static async triggerNvdScan(variantId: string, excludeKernel: boolean = true): Promise<{ ok: boolean; error?: string }> {
         const response = await fetch(
-            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/nvd-scan`,
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/nvd-scan?exclude_kernel=${excludeKernel}`,
             { method: 'POST', mode: 'cors' }
         );
         if (response.ok || response.status === 202) return { ok: true };
@@ -251,9 +251,9 @@ class ScansHandler {
         return await response.json();
     }
 
-    static async triggerOsvScan(variantId: string): Promise<{ ok: boolean; error?: string }> {
+    static async triggerOsvScan(variantId: string, excludeKernel: boolean = true): Promise<{ ok: boolean; error?: string }> {
         const response = await fetch(
-            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/osv-scan`,
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/osv-scan?exclude_kernel=${excludeKernel}`,
             { method: 'POST', mode: 'cors' }
         );
         if (response.ok || response.status === 202) return { ok: true };
@@ -270,9 +270,9 @@ class ScansHandler {
         return await response.json();
     }
 
-    static async triggerSbomCveCheckScan(variantId: string): Promise<{ ok: boolean; error?: string }> {
+    static async triggerSbomCveCheckScan(variantId: string, excludeKernel: boolean = true): Promise<{ ok: boolean; error?: string }> {
         const response = await fetch(
-            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/sbom-cve-check-scan`,
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/sbom-cve-check-scan?exclude_kernel=${excludeKernel}`,
             { method: 'POST', mode: 'cors' }
         );
         if (response.ok || response.status === 202) return { ok: true };

--- a/frontend/src/handlers/sccScanState.ts
+++ b/frontend/src/handlers/sccScanState.ts
@@ -10,7 +10,7 @@ import { ScanStateManager } from "./scanStateManager";
 export type { ScanEntryState as SccState, ScanManagerSnapshot } from "./scanStateManager";
 
 const manager = new ScanStateManager(
-    (vid) => ScansHandler.triggerSbomCveCheckScan(vid),
+    (vid, opts) => ScansHandler.triggerSbomCveCheckScan(vid, opts.excludeKernel ?? true),
     (vid) => ScansHandler.getSbomCveCheckScanStatus(vid),
     "sbom-cve-check",
 );

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -31,7 +31,7 @@ import { extractSupplierName } from "../helpers/pkgId";
 import { formatSourceName } from "../helpers/sourceNames";
 import { downloadJson } from "../helpers/exportJson";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook, faDownload, faMagnifyingGlass, faBox, faClipboardCheck } from "@fortawesome/free-solid-svg-icons";
+import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook, faDownload, faMagnifyingGlass, faBox, faClipboardCheck, faCircleQuestion } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "../components/ConfirmationModal";
 import Variants from "../handlers/variant";
@@ -1118,6 +1118,9 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     const [allVariants, setAllVariants] = useState<Variant[]>([]);
     const [selectedVariantIds, setSelectedVariantIds] = useState<Set<string>>(new Set());
     const [selectedScanTypes, setSelectedScanTypes] = useState<Set<string>>(new Set(['grype', 'nvd', 'osv', 'scc']));
+    // Scan options
+    const [excludeKernel, setExcludeKernel] = useState(true);
+    const [showKernelHelp, setShowKernelHelp] = useState(false);
     const scanMenuRef = useRef<HTMLDivElement>(null);
 
     // Global Grype scan state — survives tab switches (per-variant)
@@ -1298,11 +1301,12 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
             .map(v => ({ id: v.id, name: v.name }));
         if (variants.length === 0 || selectedScanTypes.size === 0) return;
         setScanMenuOpen(false);
+        const opts = { excludeKernel };
         const promises: Promise<void>[] = [];
-        if (selectedScanTypes.has('grype')) promises.push(triggerScan(variants));
-        if (selectedScanTypes.has('nvd')) promises.push(nvdTriggerScan(variants));
-        if (selectedScanTypes.has('osv')) promises.push(osvTriggerScan(variants));
-        if (selectedScanTypes.has('scc')) promises.push(sccTriggerScan(variants));
+        if (selectedScanTypes.has('grype')) promises.push(triggerScan(variants, opts));
+        if (selectedScanTypes.has('nvd')) promises.push(nvdTriggerScan(variants, opts));
+        if (selectedScanTypes.has('osv')) promises.push(osvTriggerScan(variants, opts));
+        if (selectedScanTypes.has('scc')) promises.push(sccTriggerScan(variants, opts));
         await Promise.all(promises);
     }
 
@@ -1578,6 +1582,45 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                                 onClick={() => setSelectedVariantIds(new Set())}
                                                 className="text-xs text-sky-400 hover:text-sky-300"
                                             >Select none</button>
+                                        </div>
+                                    )}
+                                </div>
+
+                                {/* Options */}
+                                <div className="mb-3">
+                                    <div className="text-xs font-semibold text-sky-300 mb-1.5">Options</div>
+                                    <div className="flex items-center gap-2 py-1 px-1 rounded hover:bg-sky-900/40 text-sm">
+                                        <label className="flex items-center gap-2 cursor-pointer flex-1 min-w-0">
+                                            <input
+                                                type="checkbox"
+                                                checked={excludeKernel}
+                                                onChange={() => setExcludeKernel(v => !v)}
+                                                className="rounded accent-cyan-500"
+                                            />
+                                            <span className="text-neutral-200 truncate">Deactivate kernel scan</span>
+                                        </label>
+                                        <button
+                                            type="button"
+                                            onClick={() => setShowKernelHelp(v => !v)}
+                                            className="text-sky-400 hover:text-sky-300 transition-colors shrink-0"
+                                            title="Why deactivate kernel scan?"
+                                            aria-label="Why deactivate kernel scan?"
+                                        >
+                                            <FontAwesomeIcon icon={faCircleQuestion} className="w-3.5" />
+                                        </button>
+                                    </div>
+                                    {showKernelHelp && (
+                                        <div className="mt-1 p-2 rounded bg-sky-900/30 border border-sky-700/40 text-xs text-sky-200 leading-relaxed">
+                                            A Yocto kernel recipe expands into the real kernel package
+                                            (e.g. <span className="font-mono text-sky-100">linux-*</span>) plus many
+                                            companion packages (<span className="font-mono text-sky-100">kernel-6.6.x</span>,
+                                            {' '}<span className="font-mono text-sky-100">kernel-modules</span>,
+                                            {' '}<span className="font-mono text-sky-100">kernel-devicetree</span>,
+                                            {' '}<span className="font-mono text-sky-100">kernel-module-*</span> …) that all
+                                            inherit the same kernel CPE. Scanning them attributes the entire kernel CVE set
+                                            to every companion, producing thousands of duplicate findings and slow scans.
+                                            The real kernel package is still scanned, so kernel CVEs remain covered.
+                                            Leave this on unless you specifically need to scan each kernel sub-package.
                                         </div>
                                     )}
                                 </div>

--- a/src/bin/cmd_vuln_scan.py
+++ b/src/bin/cmd_vuln_scan.py
@@ -15,6 +15,7 @@ from ..models.package import Package
 from ..extensions import db as _db
 from ..extensions import write_lock as _write_lock
 from ..helpers.active_scans import active_sbom_scan_ids_for_variant, active_package_ids_for_scans
+from ..helpers.scan_filters import filter_scannable_packages
 from ._common import DEFAULT_VARIANT_NAME, resolve_project_variant
 import click
 import os
@@ -37,9 +38,10 @@ def _resolve_active_packages(variant_uuid):
     all_pkg_ids = active_package_ids_for_scans(latest_ids)
     if not all_pkg_ids:
         raise click.ClickException("No packages found for variant")
-    return _db.session.execute(
+    packages = _db.session.execute(
         _db.select(Package).where(Package.id.in_(all_pkg_ids))
     ).scalars().all()
+    return filter_scannable_packages(packages)
 
 
 def _create_tool_scan(variant_uuid, scan_source: str):

--- a/src/helpers/scan_filters.py
+++ b/src/helpers/scan_filters.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Filters applied to SBOM components before handing them to scanners.
+
+Kernel companion packages (``kernel-*``: ``kernel-module-*``, ``kernel-modules``,
+``kernel-image-*``, ``kernel-devicetree``, ``kernel-6.6.116`` …) are expanded
+one-per-output in SPDX 3 SBOMs, inflating a typical 50-100 package set to 1000+
+entries.  They all inherit the base kernel's ``linux`` / ``linux_kernel`` CPE, so
+feeding them to the vulnerability scanners (Grype, NVD CPE, OSV) attributes the
+entire kernel CVE set to every one of them — slow and useless.  They are kept
+as-is in the SBOM views, but excluded from scanner inputs; the real kernel recipe
+(named ``linux-*``, e.g. ``linux-stm32mp``) is unaffected and still scanned.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, TypeVar
+
+# Component names starting with this prefix are kernel recipe companion packages
+# and are excluded from scanner inputs.  Matches ``kernel-module-foo``,
+# ``kernel-modules``, ``kernel-image-*``, ``kernel-devicetree``,
+# ``kernel-6.6.116`` … without catching the real kernel recipe (``linux-*``) or
+# unrelated names such as ``kernelshark``.
+KERNEL_PACKAGE_PREFIX = "kernel-"
+
+T = TypeVar("T")
+
+
+def is_kernel_package_name(name: str | None) -> bool:
+    """Return ``True`` when *name* denotes a kernel recipe companion package."""
+    if not name:
+        return False
+    return name.strip().lower().startswith(KERNEL_PACKAGE_PREFIX)
+
+
+def filter_scannable_packages(packages: Iterable[T]) -> List[T]:
+    """Drop kernel companion packages from *packages* before scanning.
+
+    Each item must expose a ``name`` attribute (e.g. a ``Package``).
+    """
+    return [pkg for pkg in packages if not is_kernel_package_name(getattr(pkg, "name", None))]

--- a/src/routes/_scan_helpers.py
+++ b/src/routes/_scan_helpers.py
@@ -128,6 +128,7 @@ def resolve_active_packages(
     variant_uuid: uuid_module.UUID,
     progress_dict: Optional[ProgressDict] = None,
     vid_str: Optional[str] = None,
+    exclude_kernel: bool = True,
 ) -> Tuple[Sequence[Package], Optional[str]]:
     """Return the active ``Package`` list for *variant_uuid*.
 
@@ -139,9 +140,11 @@ def resolve_active_packages(
     Returns ``(packages, error_string_or_None)``.  When *progress_dict*
     and *vid_str* are provided the function sets an error state on failure.
 
-    Kernel module packages (``kernel-module-*``) are excluded: they bloat
-    SPDX 3 SBOMs to thousands of entries and make the scanners crawl with
-    no useful results.
+    When *exclude_kernel* is ``True`` (the default), kernel companion
+    packages (``kernel-*``) are dropped: they bloat SPDX 3 SBOMs to
+    thousands of entries and all inherit the base kernel CPE, so feeding
+    them to the scanners attributes the entire kernel CVE set to each with
+    no useful results.  Pass ``exclude_kernel=False`` to scan them anyway.
     """
     latest_ids = active_sbom_scan_ids_for_variant(variant_uuid)
 
@@ -163,7 +166,9 @@ def resolve_active_packages(
         db.select(Package).where(Package.id.in_(all_pkg_ids))
     ).scalars().all()
 
-    return filter_scannable_packages(packages), None
+    if exclude_kernel:
+        return filter_scannable_packages(packages), None
+    return packages, None
 
 
 # ---------------------------------------------------------------------------

--- a/src/routes/_scan_helpers.py
+++ b/src/routes/_scan_helpers.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional, Sequence, Set, Tuple, Union, cast
 
 from ..controllers.variants import VariantController
 from ..helpers.active_scans import active_sbom_scan_ids_for_variant, active_package_ids_for_scans
+from ..helpers.scan_filters import filter_scannable_packages
 from ..models.observation import Observation
 from ..models.package import Package
 from ..models.variant import Variant
@@ -137,6 +138,10 @@ def resolve_active_packages(
 
     Returns ``(packages, error_string_or_None)``.  When *progress_dict*
     and *vid_str* are provided the function sets an error state on failure.
+
+    Kernel module packages (``kernel-module-*``) are excluded: they bloat
+    SPDX 3 SBOMs to thousands of entries and make the scanners crawl with
+    no useful results.
     """
     latest_ids = active_sbom_scan_ids_for_variant(variant_uuid)
 
@@ -158,7 +163,7 @@ def resolve_active_packages(
         db.select(Package).where(Package.id.in_(all_pkg_ids))
     ).scalars().all()
 
-    return packages, None
+    return filter_scannable_packages(packages), None
 
 
 # ---------------------------------------------------------------------------

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -22,6 +22,7 @@ from ..models.sbom_package import SBOMPackage
 from ..models.sbom_document import SBOMDocument
 from ..extensions import db
 from ..views.grype_vulns import GrypeVulns
+from ..helpers.scan_filters import is_kernel_package_name
 
 from ._scan_helpers import (
     validate_trigger,
@@ -147,9 +148,17 @@ def init_app(app: Flask) -> None:
                         kept = []
                         kept_refs = set()
                         seen_nv: set = set()
+                        kernel_modules_dropped = 0
                         for comp in components:
                             name = comp.get("name", "")
                             version = comp.get("version", "")
+                            # Skip kernel companion packages: they expand to
+                            # thousands of entries in SPDX 3 SBOMs and all inherit
+                            # the base kernel CPE, so they make Grype crawl with
+                            # no useful results.
+                            if is_kernel_package_name(name):
+                                kernel_modules_dropped += 1
+                                continue
                             nv = (name, version)
                             if nv in seen_nv:
                                 continue
@@ -170,6 +179,8 @@ def init_app(app: Flask) -> None:
                         _grype_scans_in_progress[vid_str]["logs"].append(
                             f"[1/4] De-duplicated components: "
                             f"{len(kept)}/{orig_components} kept"
+                            + (f" ({kernel_modules_dropped} kernel modules excluded)"
+                               if kernel_modules_dropped else "")
                         )
 
                     # 2. Run grype on the exported SBOM

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -11,7 +11,7 @@ import os
 import threading
 import uuid
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask.typing import ResponseReturnValue
 
 from ..models.scan import Scan
@@ -32,6 +32,15 @@ from ._scan_helpers import (
     resolve_active_packages,
     create_observation_and_assessment,
 )
+
+
+def _read_exclude_kernel() -> bool:
+    """Read the ``exclude_kernel`` request option (defaults to ``True``).
+
+    Kernel companion packages are excluded from scanner inputs by default;
+    the UI can opt back in by sending ``?exclude_kernel=false``.
+    """
+    return request.args.get("exclude_kernel", "true").strip().lower() != "false"
 
 
 def init_app(app: Flask) -> None:
@@ -90,6 +99,7 @@ def init_app(app: Flask) -> None:
             ).all()
             sbom_pkg_set = {(r[0], r[1]) for r in pkg_rows}
 
+        exclude_kernel = _read_exclude_kernel()
         init_progress(_grype_scans_in_progress, vid_str, total=4)
 
         def _run_grype_scan() -> None:
@@ -155,8 +165,9 @@ def init_app(app: Flask) -> None:
                             # Skip kernel companion packages: they expand to
                             # thousands of entries in SPDX 3 SBOMs and all inherit
                             # the base kernel CPE, so they make Grype crawl with
-                            # no useful results.
-                            if is_kernel_package_name(name):
+                            # no useful results.  Skipped only when the kernel
+                            # exclusion option is enabled (the default).
+                            if exclude_kernel and is_kernel_package_name(name):
                                 kernel_modules_dropped += 1
                                 continue
                             nv = (name, version)
@@ -317,6 +328,7 @@ def init_app(app: Flask) -> None:
             return jsonify({"error": "Internal error"}), 500
 
         vid_str = str(variant_uuid)
+        exclude_kernel = _read_exclude_kernel()
         init_progress(_nvd_scans_in_progress, vid_str)
 
         def _run_nvd_scan() -> None:
@@ -338,7 +350,8 @@ def init_app(app: Flask) -> None:
                     "Resolving active packages…"
                 )
                 packages, pkg_err = resolve_active_packages(
-                    variant_uuid, _nvd_scans_in_progress, vid_str)
+                    variant_uuid, _nvd_scans_in_progress, vid_str,
+                    exclude_kernel=exclude_kernel)
                 if pkg_err:
                     return
 
@@ -560,6 +573,7 @@ def init_app(app: Flask) -> None:
             return jsonify({"error": "Internal error"}), 500
 
         vid_str = str(variant_uuid)
+        exclude_kernel = _read_exclude_kernel()
         init_progress(_osv_scans_in_progress, vid_str)
 
         def _run_osv_scan() -> None:
@@ -578,7 +592,8 @@ def init_app(app: Flask) -> None:
                     "Resolving active packages…"
                 )
                 packages, pkg_err = resolve_active_packages(
-                    variant_uuid, _osv_scans_in_progress, vid_str)
+                    variant_uuid, _osv_scans_in_progress, vid_str,
+                    exclude_kernel=exclude_kernel)
                 if pkg_err:
                     return
 
@@ -760,6 +775,7 @@ def init_app(app: Flask) -> None:
             return jsonify({"error": "Internal error"}), 500
 
         vid_str = str(variant_uuid)
+        exclude_kernel = _read_exclude_kernel()
         init_progress(_sbom_cve_check_scans_in_progress, vid_str)
 
         def _run_sbom_cve_check_scan() -> None:
@@ -778,7 +794,8 @@ def init_app(app: Flask) -> None:
                     "Resolving active packages…"
                 )
                 packages, pkg_err = resolve_active_packages(
-                    variant_uuid, _sbom_cve_check_scans_in_progress, vid_str)
+                    variant_uuid, _sbom_cve_check_scans_in_progress, vid_str,
+                    exclude_kernel=exclude_kernel)
                 if pkg_err:
                     return
 

--- a/tests/unit_tests/test_scan_filters.py
+++ b/tests/unit_tests/test_scan_filters.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the scanner input filters (kernel companion package exclusion)."""
+
+from dataclasses import dataclass
+
+from src.helpers.scan_filters import (
+    is_kernel_package_name,
+    filter_scannable_packages,
+)
+
+
+@dataclass
+class _FakePkg:
+    name: str
+
+
+class TestIsKernelPackageName:
+    def test_kernel_module_prefix(self):
+        assert is_kernel_package_name("kernel-module-foo") is True
+
+    def test_kernel_modules_meta(self):
+        assert is_kernel_package_name("kernel-modules") is True
+
+    def test_kernel_versioned_meta(self):
+        assert is_kernel_package_name("kernel-6.6.116") is True
+
+    def test_kernel_devicetree(self):
+        assert is_kernel_package_name("kernel-devicetree") is True
+
+    def test_kernel_image(self):
+        assert is_kernel_package_name("kernel-image-6.6.116") is True
+
+    def test_case_insensitive(self):
+        assert is_kernel_package_name("Kernel-Module-Bar") is True
+
+    def test_leading_whitespace(self):
+        assert is_kernel_package_name("  kernel-module-baz") is True
+
+    def test_regular_package(self):
+        assert is_kernel_package_name("openssl") is False
+
+    def test_real_kernel_recipe_kept(self):
+        # The actual kernel recipe (``linux-*``) carries the real kernel CVEs
+        # and must remain scannable.
+        assert is_kernel_package_name("linux-stm32mp") is False
+
+    def test_unrelated_kernel_prefix_kept(self):
+        # No hyphen after "kernel" -> not a kernel companion package.
+        assert is_kernel_package_name("kernelshark") is False
+
+    def test_bare_kernel_kept(self):
+        assert is_kernel_package_name("kernel") is False
+
+    def test_none(self):
+        assert is_kernel_package_name(None) is False
+
+    def test_empty(self):
+        assert is_kernel_package_name("") is False
+
+
+class TestFilterScannablePackages:
+    def test_drops_kernel_packages(self):
+        pkgs = [
+            _FakePkg("openssl"),
+            _FakePkg("kernel-module-usbcore"),
+            _FakePkg("kernel-6.6.116"),
+            _FakePkg("kernel-devicetree"),
+            _FakePkg("requests"),
+        ]
+        result = filter_scannable_packages(pkgs)
+        assert [p.name for p in result] == ["openssl", "requests"]
+
+    def test_keeps_all_when_no_kernel_packages(self):
+        pkgs = [_FakePkg("openssl"), _FakePkg("requests")]
+        assert filter_scannable_packages(pkgs) == pkgs
+
+    def test_empty_list(self):
+        assert filter_scannable_packages([]) == []

--- a/tests/webapp_tests/test_scan_triggers.py
+++ b/tests/webapp_tests/test_scan_triggers.py
@@ -198,6 +198,61 @@ class TestTriggerGrypeScan:
 
 
 # ---------------------------------------------------------------------------
+# Grype scan — kernel module exclusion
+# ---------------------------------------------------------------------------
+
+class TestGrypeKernelModuleExclusion:
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    @patch("subprocess.run")
+    def test_kernel_modules_pruned_from_cdx_before_grype(self, mock_run, mock_which, client, ids):
+        """Kernel-module components are removed from the CDX handed to Grype."""
+        import json as _json
+
+        captured = {}
+
+        def _fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "export" in cmd:
+                out_dir = cmd[cmd.index("--output-dir") + 1]
+                with open(f"{out_dir}/sbom_cyclonedx_v1_6.cdx.json", "w") as f:
+                    _json.dump({
+                        "components": [
+                            {"name": "openssl", "version": "1.1.1", "bom-ref": "ref-openssl"},
+                            {"name": "kernel-module-ext4", "version": "6.1", "bom-ref": "ref-km1"},
+                            {"name": "kernel-module-usbcore", "version": "6.1", "bom-ref": "ref-km2"},
+                        ],
+                        "dependencies": [
+                            {"ref": "ref-openssl"},
+                            {"ref": "ref-km1"},
+                        ],
+                    }, f)
+            elif isinstance(cmd, list) and "grype" in cmd:
+                # cmd[2] == "sbom:<path>"
+                sbom_path = cmd[2].split("sbom:", 1)[1]
+                with open(sbom_path) as f:
+                    captured["cdx"] = _json.load(f)
+                stdout_file = kwargs.get("stdout")
+                if stdout_file is not None:
+                    stdout_file.write(_json.dumps({"matches": []}))
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = _fake_run
+
+        with _sync_thread_patch():
+            resp = client.post(f"/api/variants/{ids['variant_id']}/grype-scan")
+        assert resp.status_code == 202
+
+        names = {c["name"] for c in captured["cdx"]["components"]}
+        assert names == {"openssl"}
+        # Dependency edges referencing dropped kernel modules are pruned too.
+        dep_refs = {d["ref"] for d in captured["cdx"]["dependencies"]}
+        assert dep_refs == {"ref-openssl"}
+
+        resp_s = client.get(f"/api/variants/{ids['variant_id']}/grype-scan/status")
+        data = json.loads(resp_s.data)
+        assert any("2 kernel modules excluded" in line for line in data["logs"])
+
+
+# ---------------------------------------------------------------------------
 # Grype scan — status
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

SPDX 3 SBOMs expand kernel modules to one component per module (kernel-module-*), inflating a typical 50-100 package set to 1000+ entries. While harmless in the SBOM tab, feeding these to the vulnerability scanners makes Grype/NVD/OSV crawl — scanning every module is prohibitively slow and yields no useful results.

- Add scan_filters helper: is_kernel_module_name() and filter_scannable_packages() to drop kernel-module-* packages.
- NVD/OSV (webapp + CLI): filter them out of resolve_active_packages and _resolve_active_packages before querying.
- Grype: prune kernel-module components (and dangling dependency edges) from the exported CycloneDX before Grype parses it.
- Tests for the helper and the Grype CDX pruning path.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

New option to desactivate the parse of linux kernel elements:

<img width="318" height="355" alt="image" src="https://github.com/user-attachments/assets/15d6e01b-375d-451e-bb78-93da991234ca" />


With this change, on a project running SPDX3 SBOM:

<img width="1336" height="295" alt="image" src="https://github.com/user-attachments/assets/e4ee4f23-964c-4af8-8ae9-1a403f365ca0" />

Wuthout this change it will endless loop and load