### PR TITLE
Scan progress lost on webpage refresh

### DIFF
--- a/frontend/src/handlers/grypeScanState.ts
+++ b/frontend/src/handlers/grypeScanState.ts
@@ -22,3 +22,4 @@ export const setOnDone = manager.setOnDone;
 export const triggerScan = manager.triggerScan;
 export const dismiss = manager.dismiss;
 export const dismissAll = manager.dismissAll;
+export const restoreFromStatus = manager.restoreFromStatus;

--- a/frontend/src/handlers/nvdScanState.ts
+++ b/frontend/src/handlers/nvdScanState.ts
@@ -21,3 +21,4 @@ export const setOnDone = manager.setOnDone;
 export const triggerScan = manager.triggerScan;
 export const dismiss = manager.dismiss;
 export const dismissAll = manager.dismissAll;
+export const restoreFromStatus = manager.restoreFromStatus;

--- a/frontend/src/handlers/osvScanState.ts
+++ b/frontend/src/handlers/osvScanState.ts
@@ -21,3 +21,4 @@ export const setOnDone = manager.setOnDone;
 export const triggerScan = manager.triggerScan;
 export const dismiss = manager.dismiss;
 export const dismissAll = manager.dismissAll;
+export const restoreFromStatus = manager.restoreFromStatus;

--- a/frontend/src/handlers/scanStateManager.ts
+++ b/frontend/src/handlers/scanStateManager.ts
@@ -121,6 +121,52 @@ export class ScanStateManager {
     };
 
     /**
+     * Re-seed in-progress scans after a page refresh from status data that
+     * the caller has already fetched (typically via the bulk
+     * ``/api/scans/running`` endpoint, so no per-variant polling is needed).
+     *
+     * Each entry whose backend status is "running" is added to the local
+     * state map and polling is (re)started. Variants already tracked in
+     * memory are left untouched, so a scan triggered earlier in this session
+     * is never clobbered.
+     *
+     * Note: queued-but-not-yet-started variants (serial mode) are not
+     * restored — they were never started server-side, so there is nothing to
+     * resume.
+     *
+     * @param entries  Running-scan entries with variant id, name and status.
+     */
+    restoreFromStatus = (
+        entries: Array<{ variantId: string; name: string; status: StatusResponse }>,
+    ) => {
+        let anyRestored = false;
+
+        for (const { variantId, name, status } of entries) {
+            // Skip if already tracked (e.g. triggered in this session before restore ran)
+            if (this.states.has(variantId)) continue;
+            // Only restore actively running scans
+            if (status.status !== "running") continue;
+
+            this.states.set(variantId, {
+                variantId,
+                variantName: name,
+                status: "running",
+                error: null,
+                progress: status.progress ?? "starting",
+                logs: status.logs ?? [],
+                total: status.total ?? 0,
+                doneCount: status.done_count ?? 0,
+            });
+            anyRestored = true;
+        }
+
+        if (anyRestored) {
+            this.rebuildSnapshot();
+            this.startPolling();
+        }
+    };
+
+    /**
      * Trigger scans for one or more variants.
      * Each variant gets its own state entry and log panel.
      *

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -155,6 +155,17 @@ type GlobalResult = {
 
 export type { Scan, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry, AssessmentDiffEntry, ScanDiff, GlobalResult, GlobalResultFinding, GlobalResultPackage, GlobalResultVuln, GlobalResultAssessment };
 
+type ScanStatusResponse = { status: string; error?: string | null; progress?: string | null; logs?: string[]; total?: number; done_count?: number };
+type RunningScanEntry = ScanStatusResponse & { variant_id: string };
+type RunningScans = {
+    grype: RunningScanEntry[];
+    nvd: RunningScanEntry[];
+    osv: RunningScanEntry[];
+    "sbom-cve-check": RunningScanEntry[];
+};
+
+export type { ScanStatusResponse, RunningScanEntry, RunningScans };
+
 class ScansHandler {
     static async list(variantId?: string, projectId?: string): Promise<Scan[]> {
         let url: string;
@@ -287,6 +298,23 @@ class ScansHandler {
         );
         if (!response.ok) return { status: 'unknown' };
         return await response.json();
+    }
+
+    static async getRunningScans(): Promise<RunningScans> {
+        const empty: RunningScans = { grype: [], nvd: [], osv: [], 'sbom-cve-check': [] };
+        const response = await fetch(
+            import.meta.env.VITE_API_URL + `/api/scans/running`,
+            { mode: 'cors' }
+        );
+        if (!response.ok) return empty;
+        const data = await response.json().catch(() => null);
+        if (data === null || typeof data !== 'object') return empty;
+        return {
+            grype: Array.isArray(data.grype) ? data.grype : [],
+            nvd: Array.isArray(data.nvd) ? data.nvd : [],
+            osv: Array.isArray(data.osv) ? data.osv : [],
+            'sbom-cve-check': Array.isArray(data['sbom-cve-check']) ? data['sbom-cve-check'] : [],
+        };
     }
 
     static async deleteScan(scanId: string): Promise<{ ok: boolean; error?: string; orphaned_findings_removed?: number }> {

--- a/frontend/src/handlers/sccScanState.ts
+++ b/frontend/src/handlers/sccScanState.ts
@@ -21,3 +21,4 @@ export const setOnDone = manager.setOnDone;
 export const triggerScan = manager.triggerScan;
 export const dismiss = manager.dismiss;
 export const dismissAll = manager.dismissAll;
+export const restoreFromStatus = manager.restoreFromStatus;

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useRef, useState, useCallback, useSyncExternalStore } from "react";
 import type { ReactNode } from "react";
 import ScansHandler from "../handlers/scans";
-import type { Scan, ScanDiff, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry, AssessmentDiffEntry, GlobalResult } from "../handlers/scans";
-import { subscribe, getSnapshot, setOnDone, triggerScan, dismiss as grypeDismiss } from "../handlers/grypeScanState";
+import type { Scan, ScanDiff, FindingDiffEntry, FindingUpgradeEntry, PackageDiffEntry, PackageUpgradeEntry, AssessmentDiffEntry, GlobalResult, RunningScanEntry } from "../handlers/scans";
+import { subscribe, getSnapshot, setOnDone, triggerScan, dismiss as grypeDismiss, restoreFromStatus as grypeRestore } from "../handlers/grypeScanState";
 import {
     subscribe as nvdSubscribe,
     getSnapshot as nvdGetSnapshot,
     setOnDone as nvdSetOnDone,
     triggerScan as nvdTriggerScan,
     dismiss as nvdDismiss,
+    restoreFromStatus as nvdRestore,
 } from "../handlers/nvdScanState";
 import {
     subscribe as osvSubscribe,
@@ -16,6 +17,7 @@ import {
     setOnDone as osvSetOnDone,
     triggerScan as osvTriggerScan,
     dismiss as osvDismiss,
+    restoreFromStatus as osvRestore,
 } from "../handlers/osvScanState";
 import {
     subscribe as sccSubscribe,
@@ -23,6 +25,7 @@ import {
     setOnDone as sccSetOnDone,
     triggerScan as sccTriggerScan,
     dismiss as sccDismiss,
+    restoreFromStatus as sccRestore,
 } from "../handlers/sccScanState";
 import type { ScanManagerSnapshot } from "../handlers/scanStateManager";
 import ScanProgressPanel from "../components/ScanProgressPanel";
@@ -1223,6 +1226,29 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         if (sccEntries.some(e => e.status === 'done')) refreshScans();
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    // After variants are loaded, probe the backend once for any scan that was
+    // running before the page was refreshed and restore the progress panel.
+    useEffect(() => {
+        if (allVariants.length === 0) return;
+        const nameById = new Map(allVariants.map(v => [v.id, v.name]));
+        let cancelled = false;
+
+        ScansHandler.getRunningScans().then(running => {
+            if (cancelled) return;
+            const toEntries = (list: RunningScanEntry[]) =>
+                list
+                    .filter(s => nameById.has(s.variant_id))
+                    .map(s => ({ variantId: s.variant_id, name: nameById.get(s.variant_id)!, status: s }));
+
+            grypeRestore(toEntries(running.grype));
+            nvdRestore(toEntries(running.nvd));
+            osvRestore(toEntries(running.osv));
+            sccRestore(toEntries(running['sbom-cve-check']));
+        });
+
+        return () => { cancelled = true; };
+    }, [allVariants]);
 
     // Fetch variants scoped to the current view for the scan menu
     useEffect(() => {

--- a/frontend/tests/unit_tests/test_scan_state_manager.ts
+++ b/frontend/tests/unit_tests/test_scan_state_manager.ts
@@ -115,3 +115,360 @@ describe('ScanStateManager.restoreFromStatus', () => {
         expect(manager.getSnapshot()[0].status).toBe('done');
     });
 });
+
+describe('ScanStateManager.subscribe', () => {
+    test('notifies listeners on state change and stops after unsubscribe', () => {
+        const { manager } = makeManager({});
+        const listener = jest.fn();
+        const unsubscribe = manager.subscribe(listener);
+
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+        ]);
+        expect(listener).toHaveBeenCalled();
+
+        const callsAfterFirst = listener.mock.calls.length;
+        unsubscribe();
+
+        manager.dismissAll();
+        expect(listener).toHaveBeenCalledTimes(callsAfterFirst);
+    });
+});
+
+describe('ScanStateManager.setOnDone', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    test('fires the onDone callback when all scans finish', async () => {
+        const { manager } = makeManager({
+            v1: { status: 'done' },
+        });
+        const onDone = jest.fn();
+        manager.setOnDone(onDone);
+
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+        ]);
+
+        await jest.advanceTimersByTimeAsync(3000);
+        expect(onDone).toHaveBeenCalledTimes(1);
+    });
+
+    test('can clear the onDone callback', async () => {
+        const { manager } = makeManager({ v1: { status: 'done' } });
+        const onDone = jest.fn();
+        manager.setOnDone(onDone);
+        manager.setOnDone(null);
+
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+        ]);
+        await jest.advanceTimersByTimeAsync(3000);
+        expect(onDone).not.toHaveBeenCalled();
+    });
+});
+
+describe('ScanStateManager.dismiss / dismissAll', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    test('dismiss removes a single variant and stops polling when none remain running', () => {
+        const clearInterval = jest.spyOn(global, 'clearInterval');
+        const { manager } = makeManager({});
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+        ]);
+        expect(manager.getSnapshot()).toHaveLength(1);
+
+        manager.dismiss('v1');
+        expect(manager.getSnapshot()).toHaveLength(0);
+        expect(clearInterval).toHaveBeenCalled();
+        clearInterval.mockRestore();
+    });
+
+    test('dismiss keeps polling while another variant is still running', () => {
+        const clearInterval = jest.spyOn(global, 'clearInterval');
+        const { manager } = makeManager({});
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+            { variantId: 'v2', name: 'V2', status: { status: 'running' } },
+        ]);
+
+        manager.dismiss('v1');
+        expect(manager.getSnapshot()).toHaveLength(1);
+        expect(clearInterval).not.toHaveBeenCalled();
+        clearInterval.mockRestore();
+    });
+
+    test('dismissAll clears every variant and stops polling', () => {
+        const { manager } = makeManager({});
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+            { variantId: 'v2', name: 'V2', status: { status: 'running' } },
+        ]);
+
+        manager.dismissAll();
+        expect(manager.getSnapshot()).toHaveLength(0);
+    });
+});
+
+describe('ScanStateManager.triggerScan (parallel)', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    test('returns immediately when no variants are provided', async () => {
+        const { manager, triggerFn } = makeManager({});
+        await manager.triggerScan([]);
+        expect(triggerFn).not.toHaveBeenCalled();
+        expect(manager.getSnapshot()).toHaveLength(0);
+    });
+
+    test('triggers every variant and marks them running', async () => {
+        const { manager, triggerFn } = makeManager({});
+        await manager.triggerScan([
+            { id: 'v1', name: 'V1' },
+            { id: 'v2', name: 'V2' },
+        ]);
+
+        expect(triggerFn).toHaveBeenCalledWith('v1', {});
+        expect(triggerFn).toHaveBeenCalledWith('v2', {});
+        const snap = manager.getSnapshot();
+        expect(snap).toHaveLength(2);
+        expect(snap.every((s) => s.status === 'running')).toBe(true);
+    });
+
+    test('marks a variant as error when its trigger fails', async () => {
+        const triggerFn = jest.fn(async (vid: string) =>
+            vid === 'v2' ? { ok: false, error: 'boom' } : { ok: true },
+        );
+        const statusFn = jest.fn(async () => ({ status: 'running' }));
+        const manager = new ScanStateManager(triggerFn, statusFn, 'Test');
+
+        await manager.triggerScan([
+            { id: 'v1', name: 'V1' },
+            { id: 'v2', name: 'V2' },
+        ]);
+
+        const snap = manager.getSnapshot();
+        const v2 = snap.find((s) => s.variantId === 'v2');
+        expect(v2).toMatchObject({ status: 'error', error: 'boom', progress: null });
+    });
+
+    test('uses a default error message when trigger fails without one', async () => {
+        const triggerFn = jest.fn(async () => ({ ok: false }));
+        const statusFn = jest.fn(async () => ({ status: 'idle' }));
+        const manager = new ScanStateManager(triggerFn, statusFn, 'Grype');
+
+        await manager.triggerScan([{ id: 'v1', name: 'V1' }]);
+        expect(manager.getSnapshot()[0]).toMatchObject({
+            status: 'error',
+            error: 'Failed to start Grype scan',
+        });
+    });
+});
+
+describe('ScanStateManager.triggerScan (serial)', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    type TriggerFn = (vid: string) => Promise<{ ok: boolean; error?: string }>;
+
+    function makeSerialManager(
+        statusReplies: Record<string, Status>,
+        triggerFn: TriggerFn = jest.fn(async () => ({ ok: true })),
+    ) {
+        const statusFn = jest.fn(async (vid: string) => statusReplies[vid] ?? { status: 'idle' });
+        const manager = new ScanStateManager(triggerFn, statusFn, 'Test', true);
+        return { manager, triggerFn, statusFn };
+    }
+
+    test('runs the first variant and queues the rest', async () => {
+        const { manager, triggerFn } = makeSerialManager({});
+        await manager.triggerScan([
+            { id: 'v1', name: 'V1' },
+            { id: 'v2', name: 'V2' },
+            { id: 'v3', name: 'V3' },
+        ]);
+
+        const snap = manager.getSnapshot();
+        expect(snap.find((s) => s.variantId === 'v1')?.status).toBe('running');
+        expect(snap.find((s) => s.variantId === 'v2')?.status).toBe('queued');
+        expect(snap.find((s) => s.variantId === 'v3')?.status).toBe('queued');
+        expect(triggerFn).toHaveBeenCalledTimes(1);
+        expect(triggerFn).toHaveBeenCalledWith('v1', {});
+    });
+
+    test('advances the queue as each scan finishes', async () => {
+        const replies: Record<string, Status> = {
+            v1: { status: 'done' },
+            v2: { status: 'done' },
+        };
+        const { manager, triggerFn } = makeSerialManager(replies);
+
+        await manager.triggerScan([
+            { id: 'v1', name: 'V1' },
+            { id: 'v2', name: 'V2' },
+        ]);
+        expect(triggerFn).toHaveBeenCalledWith('v1', {});
+
+        // First poll: v1 finishes -> v2 starts
+        await jest.advanceTimersByTimeAsync(3000);
+        expect(triggerFn).toHaveBeenCalledWith('v2', {});
+        expect(manager.getSnapshot().find((s) => s.variantId === 'v2')?.status).toBe('running');
+
+        // Second poll: v2 finishes
+        await jest.advanceTimersByTimeAsync(3000);
+        expect(manager.getSnapshot().find((s) => s.variantId === 'v2')?.status).toBe('done');
+    });
+
+    test('marks the first variant as error and advances when its trigger fails', async () => {
+        const triggerFn = jest.fn(async (vid: string) =>
+            vid === 'v1' ? { ok: false, error: 'no start' } : { ok: true },
+        );
+        const { manager } = makeSerialManager({ v2: { status: 'done' } }, triggerFn);
+
+        await manager.triggerScan([
+            { id: 'v1', name: 'V1' },
+            { id: 'v2', name: 'V2' },
+        ]);
+
+        const snap = manager.getSnapshot();
+        expect(snap.find((s) => s.variantId === 'v1')).toMatchObject({
+            status: 'error',
+            error: 'no start',
+        });
+        // v2 should have been advanced to running
+        expect(snap.find((s) => s.variantId === 'v2')?.status).toBe('running');
+        expect(triggerFn).toHaveBeenCalledWith('v2', {});
+    });
+
+    test('queued variant trigger failure keeps the queue moving', async () => {
+        const triggerFn = jest.fn(async (vid: string) =>
+            vid === 'v2' ? { ok: false, error: 'queued fail' } : { ok: true },
+        );
+        const { manager } = makeSerialManager(
+            { v1: { status: 'done' } },
+            triggerFn,
+        );
+
+        await manager.triggerScan([
+            { id: 'v1', name: 'V1' },
+            { id: 'v2', name: 'V2' },
+            { id: 'v3', name: 'V3' },
+        ]);
+
+        // v1 finishes -> v2 starts but fails -> v3 starts
+        await jest.advanceTimersByTimeAsync(3000);
+
+        const snap = manager.getSnapshot();
+        expect(snap.find((s) => s.variantId === 'v2')).toMatchObject({ status: 'error' });
+        expect(triggerFn).toHaveBeenCalledWith('v3', {});
+    });
+});
+
+describe('ScanStateManager polling transitions', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    test('moves a running scan to error on error status', async () => {
+        const { manager } = makeManager({
+            v1: { status: 'error', error: 'scan crashed', logs: ['boom'] },
+        });
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+        ]);
+
+        await jest.advanceTimersByTimeAsync(3000);
+        expect(manager.getSnapshot()[0]).toMatchObject({
+            status: 'error',
+            error: 'scan crashed',
+            logs: ['boom'],
+        });
+    });
+
+    test('uses default error message when error status has none', async () => {
+        const { manager } = makeManager({ v1: { status: 'error' } });
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+        ]);
+
+        await jest.advanceTimersByTimeAsync(3000);
+        expect(manager.getSnapshot()[0].error).toBe('Test scan failed');
+    });
+
+    test('updates progress while a scan is still running', async () => {
+        const statusFn = jest
+            .fn<Promise<Status>, [string]>()
+            .mockResolvedValueOnce({ status: 'running', progress: '50%', total: 10, done_count: 5, logs: ['half'] })
+            .mockResolvedValue({ status: 'done', progress: 'Done' });
+        const triggerFn = jest.fn(async () => ({ ok: true }));
+        const manager = new ScanStateManager(triggerFn, statusFn, 'Test');
+
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+        ]);
+
+        await jest.advanceTimersByTimeAsync(3000);
+        expect(manager.getSnapshot()[0]).toMatchObject({
+            status: 'running',
+            progress: '50%',
+            total: 10,
+            doneCount: 5,
+            logs: ['half'],
+        });
+
+        await jest.advanceTimersByTimeAsync(3000);
+        expect(manager.getSnapshot()[0].status).toBe('done');
+    });
+
+    test('keeps polling when statusFn throws (network hiccup)', async () => {
+        const statusFn = jest
+            .fn<Promise<Status>, [string]>()
+            .mockRejectedValueOnce(new Error('network'))
+            .mockResolvedValue({ status: 'done' });
+        const triggerFn = jest.fn(async () => ({ ok: true }));
+        const manager = new ScanStateManager(triggerFn, statusFn, 'Test');
+
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+        ]);
+
+        // First tick throws but polling continues
+        await jest.advanceTimersByTimeAsync(3000);
+        expect(manager.getSnapshot()[0].status).toBe('running');
+
+        // Second tick succeeds
+        await jest.advanceTimersByTimeAsync(3000);
+        expect(manager.getSnapshot()[0].status).toBe('done');
+    });
+});

--- a/frontend/tests/unit_tests/test_scan_state_manager.ts
+++ b/frontend/tests/unit_tests/test_scan_state_manager.ts
@@ -1,0 +1,117 @@
+import { ScanStateManager } from '../../src/handlers/scanStateManager';
+import type { ScanManagerSnapshot } from '../../src/handlers/scanStateManager';
+
+type Status = {
+    status: string;
+    error?: string | null;
+    progress?: string | null;
+    logs?: string[];
+    total?: number;
+    done_count?: number;
+};
+
+function makeManager(statusReplies: Record<string, Status>) {
+    const triggerFn = jest.fn(async () => ({ ok: true }));
+    const statusFn = jest.fn(async (vid: string) => statusReplies[vid] ?? { status: 'idle' });
+    const manager = new ScanStateManager(triggerFn, statusFn, 'Test');
+    return { manager, triggerFn, statusFn };
+}
+
+describe('ScanStateManager.restoreFromStatus', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    test('seeds running scans into the snapshot', () => {
+        const { manager } = makeManager({});
+        manager.restoreFromStatus([
+            {
+                variantId: 'v1',
+                name: 'Variant 1',
+                status: { status: 'running', progress: 'scanning', logs: ['line'], total: 10, done_count: 3 },
+            },
+        ]);
+
+        const snap: ScanManagerSnapshot = manager.getSnapshot();
+        expect(snap).toHaveLength(1);
+        expect(snap[0]).toMatchObject({
+            variantId: 'v1',
+            variantName: 'Variant 1',
+            status: 'running',
+            progress: 'scanning',
+            logs: ['line'],
+            total: 10,
+            doneCount: 3,
+        });
+    });
+
+    test('defaults progress to "starting" and fills missing fields', () => {
+        const { manager } = makeManager({});
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running' } },
+        ]);
+
+        expect(manager.getSnapshot()[0]).toMatchObject({
+            progress: 'starting',
+            logs: [],
+            total: 0,
+            doneCount: 0,
+        });
+    });
+
+    test('ignores entries that are not running', () => {
+        const { manager } = makeManager({});
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'done' } },
+            { variantId: 'v2', name: 'V2', status: { status: 'idle' } },
+            { variantId: 'v3', name: 'V3', status: { status: 'error' } },
+        ]);
+        expect(manager.getSnapshot()).toHaveLength(0);
+    });
+
+    test('does not clobber a variant already tracked in this session', () => {
+        const { manager } = makeManager({});
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'Original', status: { status: 'running', progress: 'first' } },
+        ]);
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'Replacement', status: { status: 'running', progress: 'second' } },
+        ]);
+
+        const snap = manager.getSnapshot();
+        expect(snap).toHaveLength(1);
+        expect(snap[0]).toMatchObject({ variantName: 'Original', progress: 'first' });
+    });
+
+    test('does nothing and starts no timer when nothing is running', () => {
+        const setInterval = jest.spyOn(global, 'setInterval');
+        const { manager } = makeManager({});
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'done' } },
+        ]);
+        expect(setInterval).not.toHaveBeenCalled();
+        expect(manager.getSnapshot()).toHaveLength(0);
+        setInterval.mockRestore();
+    });
+
+    test('starts polling and reflects completion of a restored scan', async () => {
+        const { manager, statusFn } = makeManager({
+            v1: { status: 'done', progress: 'Done', total: 5, done_count: 5 },
+        });
+        manager.restoreFromStatus([
+            { variantId: 'v1', name: 'V1', status: { status: 'running', progress: 'scanning' } },
+        ]);
+        expect(manager.getSnapshot()[0].status).toBe('running');
+
+        // Advance to the next poll tick (3s interval) and flush the async poll.
+        await jest.advanceTimersByTimeAsync(3000);
+
+        expect(statusFn).toHaveBeenCalledWith('v1');
+        expect(manager.getSnapshot()[0].status).toBe('done');
+    });
+});

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -931,3 +931,31 @@ def init_app(app: Flask) -> None:
     def sbom_cve_check_scan_status(variant_id: str) -> ResponseReturnValue:
         """Check the status of a running sbom-cve-check scan for the given variant."""
         return scan_status_response(variant_id, _sbom_cve_check_scans_in_progress)
+
+    # ------------------------------------------------------------------
+    # Bulk running-scan discovery
+    # ------------------------------------------------------------------
+
+    @app.route('/api/scans/running')
+    def running_scans() -> ResponseReturnValue:
+        """Return every scan currently running, grouped by scan type.
+
+        Lets the frontend restore in-progress scan panels after a page
+        refresh with a single request instead of polling each variant's
+        per-type ``/status`` endpoint individually.
+        """
+        groups = {
+            "grype": _grype_scans_in_progress,
+            "nvd": _nvd_scans_in_progress,
+            "osv": _osv_scans_in_progress,
+            "sbom-cve-check": _sbom_cve_check_scans_in_progress,
+        }
+        result = {
+            label: [
+                {"variant_id": vid_str, **info}
+                for vid_str, info in progress_dict.items()
+                if info.get("status") == "running"
+            ]
+            for label, progress_dict in groups.items()
+        }
+        return jsonify(result)

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -10,7 +10,8 @@ import threading
 import tarfile
 import subprocess
 import shutil
-from typing import Callable, TypeVar
+from typing import Callable, TypeVar, cast
+import io as _io
 
 from flask import jsonify, request
 from sqlalchemy.exc import OperationalError
@@ -139,9 +140,7 @@ def _extract_spdx_archive(archive_path: str, filename: str) -> list[tuple[str, s
                     continue
                 if not member.name.lower().endswith(".spdx.json"):
                     continue
-                src = tar.extractfile(member)
-                if src is None:
-                    continue
+                src = cast(_io.BufferedReader, tar.extractfile(member))
                 base = os.path.basename(member.name)
                 fd, out_path = tempfile.mkstemp(suffix=".spdx.json", prefix="vulnscout_upload_")
                 with os.fdopen(fd, "wb") as dst:
@@ -154,10 +153,7 @@ def _extract_spdx_archive(archive_path: str, filename: str) -> list[tuple[str, s
                 os.unlink(decompressed)
             except OSError:
                 pass
-        try:
-            shutil.rmtree(extract_dir, ignore_errors=True)
-        except OSError:
-            pass
+        shutil.rmtree(extract_dir, ignore_errors=True)
 
 
 def _process_sbom_background(app, upload_id: str, file_paths: list[str], scan_id, variant_id):
@@ -275,9 +271,7 @@ def init_app(app):
                 return jsonify({"error": f"A project named '{new_name}' already exists."}), 409
 
         def _do_rename() -> Project:
-            p = ProjectController.get(project_id)
-            if p is None:
-                raise ValueError("Project not found.")
+            p = cast(Project, ProjectController.get(project_id))
             p.update(new_name)
             return p
 
@@ -308,9 +302,7 @@ def init_app(app):
                 return jsonify({"error": f"A variant named '{new_name}' already exists in this project."}), 409
 
         def _do_rename() -> Variant:
-            v = VariantController.get(variant_id)
-            if v is None:
-                raise ValueError("Variant not found.")
+            v = cast(Variant, VariantController.get(variant_id))
             VariantController.update(v, new_name)
             return v
 
@@ -375,13 +367,11 @@ def init_app(app):
         source_uuid, err = parse_uuid_or_400(source_id, "source_variant_id")
         if err:
             return None, err
-        if source_uuid is None:
-            return None, (jsonify({"error": "Invalid source variant ID."}), 400)
+        source_uuid = cast(uuid.UUID, source_uuid)
         target_uuid, err = parse_uuid_or_400(target_id, "target_variant_id")
         if err:
             return None, err
-        if target_uuid is None:
-            return None, (jsonify({"error": "Invalid target variant ID."}), 400)
+        target_uuid = cast(uuid.UUID, target_uuid)
 
         if source_uuid == target_uuid:
             return None, (jsonify({"error": "Source and target variants must be different."}), 400)

--- a/tests/webapp_tests/test_scan_triggers.py
+++ b/tests/webapp_tests/test_scan_triggers.py
@@ -474,3 +474,51 @@ class TestOsvScanStatus:
         assert resp.status_code == 200
         data = json.loads(resp.data)
         assert data["status"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# Bulk running-scan discovery
+# ---------------------------------------------------------------------------
+
+class TestRunningScans:
+    def test_empty_when_nothing_running(self, client):
+        resp = client.get("/api/scans/running")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data == {"grype": [], "nvd": [], "osv": [], "sbom-cve-check": []}
+
+    @patch("threading.Thread")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_lists_running_scans_grouped_by_type(self, mock_which, mock_thread, client, ids):
+        # Leave the spawned threads unstarted so the scans stay "running".
+        mock_thread.return_value = MagicMock()
+        vid = ids["variant_id"]
+        client.post(f"/api/variants/{vid}/grype-scan")
+        client.post(f"/api/variants/{vid}/nvd-scan")
+
+        resp = client.get("/api/scans/running")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+
+        assert len(data["grype"]) == 1
+        assert data["grype"][0]["variant_id"] == vid
+        assert data["grype"][0]["status"] == "running"
+        assert len(data["nvd"]) == 1
+        assert data["nvd"][0]["variant_id"] == vid
+        assert data["osv"] == []
+        assert data["sbom-cve-check"] == []
+
+    @patch("threading.Thread")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_excludes_finished_scans(self, mock_which, mock_thread, client, ids):
+        vid = ids["variant_id"]
+        # Run the grype scan synchronously so it completes (status -> done).
+        with _sync_thread_patch():
+            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout='{"matches": []}')):
+                client.post(f"/api/variants/{vid}/grype-scan")
+
+        resp = client.get("/api/scans/running")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["grype"] == []
+

--- a/tests/webapp_tests/test_settings_endpoints.py
+++ b/tests/webapp_tests/test_settings_endpoints.py
@@ -1215,3 +1215,461 @@ class TestNvdApiKey:
         finally:
             os.environ.pop("NVD_API_KEY", None)
             os.environ.pop("VULNSCOUT_CONFIG", None)
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: _retry_on_lock exhaustion
+# ---------------------------------------------------------------------------
+
+class TestRetryOnLockExhaustion:
+
+    def test_raises_runtime_error_when_max_retries_is_zero(self, app):
+        """_retry_on_lock with max_retries=0 never enters the loop and raises RuntimeError."""
+        from src.routes.settings import _retry_on_lock
+        with app.app_context():
+            with pytest.raises(RuntimeError, match="retry loop exhausted"):
+                _retry_on_lock(lambda: 42, max_retries=0)
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: _extract_spdx_archive member filtering
+# ---------------------------------------------------------------------------
+
+class TestExtractSpdxArchive:
+
+    def test_skips_non_file_and_non_spdx_json_members(self, tmp_path):
+        """Directory entries and non-.spdx.json files are ignored; only .spdx.json extracted."""
+        from src.routes.settings import _extract_spdx_archive
+
+        spdx_content = b'{"spdxVersion": "SPDX-2.3"}'
+        archive_path = str(tmp_path / "mixed.tar")
+
+        with tarfile.open(archive_path, "w") as tar:
+            # Directory entry — triggers the isfile() continue branch
+            dir_info = tarfile.TarInfo(name="subdir")
+            dir_info.type = tarfile.DIRTYPE
+            tar.addfile(dir_info)
+            # Non-.spdx.json regular file — triggers the name-suffix continue branch
+            txt_info = tarfile.TarInfo(name="readme.txt")
+            txt_info.size = len(b"readme")
+            tar.addfile(txt_info, io.BytesIO(b"readme"))
+            # The one valid .spdx.json member
+            spdx_info = tarfile.TarInfo(name="result.spdx.json")
+            spdx_info.size = len(spdx_content)
+            tar.addfile(spdx_info, io.BytesIO(spdx_content))
+
+        results = _extract_spdx_archive(archive_path, "mixed.tar")
+
+        assert len(results) == 1
+        extracted_path, member_name = results[0]
+        assert member_name == "result.spdx.json"
+        os.unlink(extracted_path)
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: invalid-UUID paths on CRUD routes
+# ---------------------------------------------------------------------------
+
+class TestRouteUUIDValidation:
+
+    def test_rename_project_invalid_uuid_in_path(self, client):
+        resp = client.patch("/api/projects/not-a-uuid/rename", json={"name": "X"})
+        assert resp.status_code == 400
+
+    def test_rename_variant_invalid_uuid_in_path(self, client):
+        resp = client.patch("/api/variants/not-a-uuid/rename", json={"name": "X"})
+        assert resp.status_code == 400
+
+    def test_delete_project_invalid_uuid_in_path(self, client):
+        resp = client.delete("/api/projects/not-a-uuid")
+        assert resp.status_code == 400
+
+    def test_delete_variant_invalid_uuid_in_path(self, client):
+        resp = client.delete("/api/variants/not-a-uuid")
+        assert resp.status_code == 400
+
+    def test_create_variant_invalid_project_uuid_in_path(self, client):
+        resp = client.post("/api/projects/not-a-uuid/variants", json={"name": "X"})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: copy-assessments validation edge cases
+# ---------------------------------------------------------------------------
+
+class TestCopyAssessmentsValidation:
+
+    def test_invalid_source_variant_uuid(self, client):
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={"source_variant_id": "not-a-uuid", "target_variant_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_target_variant_uuid(self, client):
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={"source_variant_id": str(uuid.uuid4()), "target_variant_id": "not-a-uuid"},
+        )
+        assert resp.status_code == 400
+
+    def test_same_source_and_target_variant(self, client):
+        vid = str(uuid.uuid4())
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={"source_variant_id": vid, "target_variant_id": vid},
+        )
+        assert resp.status_code == 400
+        assert "different" in resp.get_json()["error"].lower()
+
+    def test_variant_not_found(self, client):
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": str(uuid.uuid4()),
+                "target_variant_id": str(uuid.uuid4()),
+            },
+        )
+        assert resp.status_code == 404
+
+    def test_cross_project_variants_rejected(self, app, client):
+        from src.extensions import db
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        with app.app_context():
+            p1 = Project.create("CrossProjAlpha")
+            p2 = Project.create("CrossProjBeta")
+            v1 = Variant.create("VarAlpha", p1.id)
+            v2 = Variant.create("VarBeta", p2.id)
+            db.session.commit()
+            source_id = str(v1.id)
+            target_id = str(v2.id)
+
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={"source_variant_id": source_id, "target_variant_id": target_id},
+        )
+        assert resp.status_code == 400
+        assert "same project" in resp.get_json()["error"].lower()
+
+    def test_preview_invalid_source_variant_uuid(self, client):
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={"source_variant_id": "not-a-uuid", "target_variant_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: copy-assessments logic edge cases
+# ---------------------------------------------------------------------------
+
+class TestCopyAssessmentsEdgeCases:
+
+    def _seed_no_source_active_packages(self, app):
+        """Source variant has a custom assessment but no active SBOM scan packages."""
+        from src.extensions import db
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.package import Package
+        from src.models.vulnerability import Vulnerability
+        from src.models.finding import Finding
+        from src.models.assessment import Assessment
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+
+        with app.app_context():
+            project = Project.create("NoSrcScanProject")
+            source = Variant.create("NoSrcScan", project.id)
+            target = Variant.create("HasScan", project.id)
+
+            pkg = Package.find_or_create("unscanned-lib", "1.0")
+            vuln = Vulnerability.create_record(id="CVE-NOSCAN-010", description="x")
+            db.session.commit()
+            finding = Finding.get_or_create(pkg.id, vuln.id)
+            Assessment.create(
+                status="affected", origin="custom", finding_id=finding.id,
+                variant_id=source.id, source="manual",
+            )
+
+            # Give target an active scan so we pass the early variants-exist check
+            tgt_pkg = Package.find_or_create("tgt-lib-nosrc", "9.9")
+            tgt_scan = Scan.create("", target.id, scan_type="sbom")
+            tgt_doc = SBOMDocument.create("/tmp/tgt_nosrc.spdx.json", "spdx", tgt_scan.id)
+            SBOMPackage.create(tgt_doc.id, tgt_pkg.id)
+            db.session.commit()
+
+            return {"source_id": str(source.id), "target_id": str(target.id)}
+
+    def _seed_no_matching_target_findings(self, app):
+        """Source has active packages + assessments; target packages share no vulnerabilities."""
+        from src.extensions import db
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.package import Package
+        from src.models.vulnerability import Vulnerability
+        from src.models.finding import Finding
+        from src.models.assessment import Assessment
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+
+        with app.app_context():
+            project = Project.create("NoMatchFindingsProject")
+            source = Variant.create("NoMatchSrc", project.id)
+            target = Variant.create("NoMatchTgt", project.id)
+
+            pkg_a = Package.find_or_create("pkg-alpha-nm", "1.0")
+            cve_a = Vulnerability.create_record(id="CVE-NOMATCH-001", description="a")
+            db.session.commit()
+            finding_a = Finding.get_or_create(pkg_a.id, cve_a.id)
+            Assessment.create(
+                status="affected", origin="custom", finding_id=finding_a.id,
+                variant_id=source.id, source="manual",
+            )
+            src_scan = Scan.create("", source.id, scan_type="sbom")
+            src_doc = SBOMDocument.create("/tmp/src_nm.spdx.json", "spdx", src_scan.id)
+            SBOMPackage.create(src_doc.id, pkg_a.id)
+
+            # Target has a different package with a different vulnerability
+            pkg_b = Package.find_or_create("pkg-beta-nm", "1.0")
+            cve_b = Vulnerability.create_record(id="CVE-NOMATCH-002", description="b")
+            db.session.commit()
+            Finding.get_or_create(pkg_b.id, cve_b.id)
+            tgt_scan = Scan.create("", target.id, scan_type="sbom")
+            tgt_doc = SBOMDocument.create("/tmp/tgt_nm.spdx.json", "spdx", tgt_scan.id)
+            SBOMPackage.create(tgt_doc.id, pkg_b.id)
+            db.session.commit()
+
+            return {"source_id": str(source.id), "target_id": str(target.id)}
+
+    def _seed_non_common_packages(self, app):
+        """Source has two packages (one shared with target, one not); assessments on both."""
+        from src.extensions import db
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.package import Package
+        from src.models.vulnerability import Vulnerability
+        from src.models.finding import Finding
+        from src.models.assessment import Assessment
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+
+        with app.app_context():
+            project = Project.create("NonCommonProject")
+            source = Variant.create("NonCommonSrc", project.id)
+            target = Variant.create("NonCommonTgt", project.id)
+
+            pkg_shared = Package.find_or_create("shared-lib-nc", "1.0")
+            pkg_only = Package.find_or_create("source-only-lib-nc", "1.0")
+            vuln_x = Vulnerability.create_record(id="CVE-NCSHARED-001", description="x")
+            vuln_y = Vulnerability.create_record(id="CVE-NCONLY-001", description="y")
+            db.session.commit()
+
+            finding_sx = Finding.get_or_create(pkg_shared.id, vuln_x.id)
+            finding_oy = Finding.get_or_create(pkg_only.id, vuln_y.id)
+
+            src_scan = Scan.create("", source.id, scan_type="sbom")
+            src_doc = SBOMDocument.create("/tmp/src_nc.spdx.json", "spdx", src_scan.id)
+            SBOMPackage.create(src_doc.id, pkg_shared.id)
+            SBOMPackage.create(src_doc.id, pkg_only.id)
+
+            tgt_scan = Scan.create("", target.id, scan_type="sbom")
+            tgt_doc = SBOMDocument.create("/tmp/tgt_nc.spdx.json", "spdx", tgt_scan.id)
+            SBOMPackage.create(tgt_doc.id, pkg_shared.id)
+
+            Assessment.create(
+                status="affected", origin="custom", finding_id=finding_sx.id,
+                variant_id=source.id, source="manual",
+            )
+            Assessment.create(
+                status="affected", origin="custom", finding_id=finding_oy.id,
+                variant_id=source.id, source="manual",
+            )
+            db.session.commit()
+
+            return {"source_id": str(source.id), "target_id": str(target.id)}
+
+    def test_ignore_version_empty_source_active_packages_returns_no_vulns(self, app, client):
+        """ignore_package_version=True with no active source packages → no vulns in common."""
+        ids = self._seed_no_source_active_packages(app)
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_id"],
+                "target_variant_id": ids["target_id"],
+                "ignore_package_version": True,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["copied"] == 0
+        assert "No vulnerabilities in common" in data["message"]
+
+    def test_ignore_version_no_matching_target_findings_returns_no_vulns(self, app, client):
+        """ignore_package_version=True with non-empty source_vuln_ids but no target findings."""
+        ids = self._seed_no_matching_target_findings(app)
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_id"],
+                "target_variant_id": ids["target_id"],
+                "ignore_package_version": True,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["copied"] == 0
+        assert "No vulnerabilities in common" in data["message"]
+
+    def test_non_common_package_assessment_not_copied(self, app, client):
+        """Assessment on a source-only package is skipped; only the shared-package assessment copies."""
+        ids = self._seed_non_common_packages(app)
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_id"],
+                "target_variant_id": ids["target_id"],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # Only the shared-package assessment can be copied (source-only is skipped)
+        assert data["copied"] == 1
+
+    def test_copy_skips_already_assessed_target_and_reports_skipped(self, app, client):
+        """Re-running copy after an initial copy skips already-present custom assessments."""
+        from tests.webapp_tests.test_settings_endpoints import TestCopyCustomAssessments
+        helper = TestCopyCustomAssessments()
+        ids = helper._seed_copy_data(app)
+
+        # First copy
+        r1 = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "ignore_package_version": True,
+            },
+        )
+        assert r1.get_json()["copied"] == 1
+
+        # Second copy — all already assessed → skipped
+        r2 = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "ignore_package_version": True,
+            },
+        )
+        assert r2.status_code == 200
+        data = r2.get_json()
+        assert data["copied"] == 0
+        assert data["skipped"] == 1
+        assert "already present" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: SBOM upload edge cases
+# ---------------------------------------------------------------------------
+
+class TestSBOMUploadEdgeCases:
+
+    def test_upload_corrupt_archive_returns_400(self, client):
+        """A file with a .tar extension that is not a valid tar archive triggers a 400."""
+        pid = _get_project_id(client)
+        vid = _get_variant_id(client, pid)
+        corrupt = b"this is definitely not a tar archive"
+        data = {
+            "project_id": pid,
+            "variant_id": vid,
+            "files": (io.BytesIO(corrupt), "sbom.tar"),
+        }
+        resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 400
+        assert "Could not extract archive" in resp.get_json()["error"]
+
+    @patch("src.routes.settings.threading.Thread")
+    def test_upload_unknown_format_json_returns_400(self, mock_thread, client):
+        """Valid JSON that does not match any known SBOM format is rejected."""
+        mock_thread.return_value = MagicMock()
+        pid = _get_project_id(client)
+        vid = _get_variant_id(client, pid)
+        unknown = json.dumps({"totally": "unrecognized", "structure": True}).encode()
+        data = {
+            "project_id": pid,
+            "variant_id": vid,
+            "files": (io.BytesIO(unknown), "mystery.json"),
+        }
+        resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 400
+        assert "Unrecognized SBOM format" in resp.get_json()["error"]
+
+    @patch("src.routes.settings.threading.Thread")
+    def test_upload_second_file_error_cleans_up_first_file(self, mock_thread, client):
+        """When the second uploaded file is invalid, temp files from the first are cleaned up."""
+        mock_thread.return_value = MagicMock()
+        pid = _get_project_id(client)
+        vid = _get_variant_id(client, pid)
+        data = MultiDict([
+            ("project_id", pid),
+            ("variant_id", vid),
+            ("files", (io.BytesIO(_make_spdx_json()), "first.spdx.json")),
+            ("files", (io.BytesIO(b"not json <<<"), "second.json")),
+        ])
+        resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 400
+        assert "Could not parse" in resp.get_json()["error"]
+
+    @patch("src.routes.settings.threading.Thread")
+    def test_upload_file_with_empty_filename_skipped(self, mock_thread, client):
+        """A file entry with an empty filename is skipped; the valid file still processes."""
+        mock_thread.return_value = MagicMock()
+        pid = _get_project_id(client)
+        vid = _get_variant_id(client, pid)
+        data = MultiDict([
+            ("project_id", pid),
+            ("variant_id", vid),
+            ("files", (io.BytesIO(b"ignored"), "")),
+            ("files", (io.BytesIO(_make_spdx_json()), "real.spdx.json")),
+        ])
+        resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
+        assert resp.status_code == 202
+        mock_thread.return_value.start.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: background SBOM processing EPSS failure path
+# ---------------------------------------------------------------------------
+
+class TestProcessSBOMBackgroundEpss:
+
+    def test_epss_failure_is_swallowed_and_processing_completes(self, app, monkeypatch):
+        """A post_treatment (EPSS) exception is caught; final status is still 'done'."""
+        import tempfile as _tempfile
+        from src.routes.settings import _process_sbom_background, _upload_status
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+
+        monkeypatch.setenv("IGNORE_PARSING_ERRORS", "true")
+        monkeypatch.setattr("src.bin.cmd_process.read_inputs", lambda *a, **k: None)
+        monkeypatch.setattr("src.bin.cmd_process.populate_observations", lambda *a, **k: None)
+        monkeypatch.setattr(
+            "src.bin.cmd_process.post_treatment",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("epss unavailable")),
+        )
+
+        with app.app_context():
+            project = Project.create("EpssFailProject")
+            variant = Variant.create("EpssFailVariant", project.id)
+            scan = Scan.create("", variant.id)
+
+            upload_id = "epss-coverage-test"
+            _process_sbom_background(app, upload_id, [], scan.id, variant.id)
+
+            assert _upload_status[upload_id]["status"] == "done"


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Scan progress lost on webpage refresh

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open the web dashboard, launch a Grype scan (works with all scans, but this one is faster to test).
Refresh the page, then go back to Scan page, it should still show the scan progress.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


