### PR TITLE
Fix the import-custom-assessments feature

### DIFF
--- a/src/bin/cmd_assessments.py
+++ b/src/bin/cmd_assessments.py
@@ -18,6 +18,7 @@ from ..helpers.assessment_io import (
     import_statements,
     import_archive_bytes,
     import_directory,
+    import_custom_data,
 )
 from ..models.assessment import Assessment as DBAssessment
 from ..models.variant import Variant as DBVariant
@@ -181,6 +182,39 @@ def import_custom_assessments_command(file_path: str, project: str, variant: str
             raise SystemExit(1)
 
     elif file_path.endswith(".json"):
+        try:
+            with open(file_path) as fh:
+                data = _json.load(fh)
+        except Exception:
+            click.echo("Error: invalid JSON file.", err=True)
+            raise SystemExit(1)
+
+        # Custom-data export format (web "export custom data" button):
+        # {version, assessments, cvss, time_estimates}. Routed to the
+        # dedicated importer; the embedded per-item variant is used unless
+        # --variant forces a target.
+        if isinstance(data, dict) and "version" in data and not is_openvex_doc(data):
+            result = import_custom_data(
+                data, variant_by_name,
+                variant_obj.id if variant_obj is not None else None,
+            )
+            if result.get("status") != "success":
+                click.echo("Error: failed to import custom-data file.", err=True)
+                for err in result.get("errors", []):
+                    click.echo(f"  {err}", err=True)
+                raise SystemExit(1)
+            for err in result.get("errors", []):
+                click.echo(f"  Warning: {err}", err=True)
+            click.echo(
+                f"Imported {result['assessments_imported']} assessments"
+                f" ({result['assessments_skipped']} skipped as duplicates),"
+                f" {result['cvss_imported']} CVSS,"
+                f" {result['time_estimates_imported']} time estimates"
+            )
+            return
+
+        # OpenVEX single-document format: requires a variant (from --variant
+        # or the filename matching an existing variant name).
         if variant:
             assert variant_obj
         else:
@@ -195,13 +229,6 @@ def import_custom_assessments_command(file_path: str, project: str, variant: str
                     err=True,
                 )
                 raise SystemExit(1)
-
-        try:
-            with open(file_path) as fh:
-                data = _json.load(fh)
-        except Exception:
-            click.echo("Error: invalid JSON file.", err=True)
-            raise SystemExit(1)
 
         if not is_openvex_doc(data):
             click.echo("Error: not a valid OpenVEX document.", err=True)

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -468,10 +468,12 @@ cmd_import_custom_assessments() {
     raw_basename="$(basename "$file")"
     dest_name="${raw_basename#vulnscout_stage_}"
     if [[ "$dest_name" != "$raw_basename" ]]; then
+        # Strip the staging prefix added by the wrapper before importing.
         dest_file="$(dirname "$file")/$dest_name"
         mv "$file" "$dest_file"
-        import_args+=("$dest_file")
+        file="$dest_file"
     fi
+    import_args+=("$file")
 
     flask --app src.bin.webapp db upgrade
     flask --app src.bin.webapp import-custom-assessments "${import_args[@]}"

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -296,6 +296,7 @@ def import_statements(
                         DBAssessment.finding_id == finding.id,
                         DBAssessment.variant_id == variant_id,
                         DBAssessment.status == status,
+                        DBAssessment.origin == "custom",
                     )
                 ).scalars().first()
                 if existing is not None:

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -747,6 +747,7 @@ def import_custom_data(
                             DBAssessment.finding_id == finding.id,
                             DBAssessment.variant_id == target_variant_id,
                             DBAssessment.status == status,
+                            DBAssessment.origin == "custom",
                         )
                     ).scalar_one_or_none()
                     if existing is not None:

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -297,7 +297,7 @@ def import_statements(
                         DBAssessment.variant_id == variant_id,
                         DBAssessment.status == status,
                     )
-                ).scalar_one_or_none()
+                ).scalars().first()
                 if existing is not None:
                     skipped += 1
                     continue
@@ -749,7 +749,7 @@ def import_custom_data(
                             DBAssessment.status == status,
                             DBAssessment.origin == "custom",
                         )
-                    ).scalar_one_or_none()
+                    ).scalars().first()
                     if existing is not None:
                         result["assessments_skipped"] += 1
                         continue

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -801,6 +801,7 @@ def init_app(app: Flask) -> None:
         if existing is None:
             return {"error": "Assessment not found"}, 404
         existing.delete()
+        _save_openvex()
         return {"status": "success", "message": "Assessment deleted successfully"}, 200
 
 

--- a/tests/end_to_end_tests/test_merger_ci.py
+++ b/tests/end_to_end_tests/test_merger_ci.py
@@ -648,6 +648,33 @@ def test_import_custom_assessments_json_success(app, tmp_path):
     assert "Imported 1 assessments" in result.output
 
 
+def test_import_custom_assessments_custom_data_format(app, tmp_path):
+    """Import the web 'export custom data' format (non-OpenVEX) via the CLI.
+
+    The filename does not match a variant; the embedded ``variant_id`` is used.
+    """
+    _create_custom_assessment(app)
+    with app.app_context():
+        from src.helpers.assessment_io import build_custom_data_export
+        from src.models.variant import Variant
+        variant_id = Variant.get_all()[0].id
+        data = build_custom_data_export([variant_id])
+    assert data["assessments"], "fixture should produce at least one assessment"
+
+    json_file = tmp_path / "custom_data_export_20260101_000000.json"
+    json_file.write_text(json.dumps(data))
+    with app.app_context():
+        runner = app.test_cli_runner()
+        result = runner.invoke(args=[
+            "import-custom-assessments",
+            "--project", _PROJECT_NAME,
+            str(json_file),
+        ])
+    assert result.exit_code == 0, result.output
+    assert "assessments" in result.output.lower()
+    assert "time estimates" in result.output.lower()
+
+
 def test_import_custom_assessments_json_success_variant_flag(app, tmp_path):
     """Import a .json with a filename that doesn't match any variant."""
     doc = {

--- a/tests/webapp_tests/test_post_endpoints.py
+++ b/tests/webapp_tests/test_post_endpoints.py
@@ -293,3 +293,27 @@ def test_delete_assessment_not_found(client):
     
     data = json.loads(response.data)
     assert data["error"] == "Assessment not found"
+
+
+def test_delete_assessment_updates_openvex_file(app, client):
+    # Create an assessment for a vulnerability not already present
+    response = client.post("/api/vulnerabilities/CVE-1999-54321/assessments", json={
+        'packages': ['abc@1.2.3'],
+        'status': 'exploitable',
+        'status_notes': 'Assessment to be deleted'
+    })
+    assert response.status_code == 200
+    assessment_id = json.loads(response.data)["assessment"]["id"]
+
+    # The OpenVEX output file should now reference this vulnerability
+    openvex_path = app.config["OPENVEX_FILE"]
+    with open(openvex_path) as f:
+        assert "CVE-1999-54321" in f.read()
+
+    # Delete the assessment
+    response = client.delete(f"/api/assessments/{assessment_id}")
+    assert response.status_code == 200
+
+    # The OpenVEX file must be regenerated without the deleted assessment
+    with open(openvex_path) as f:
+        assert "CVE-1999-54321" not in f.read()

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -1119,6 +1119,78 @@ def test_import_custom_data_duplicate_skipped(client):
     assert r2["assessments_imported"] == 0
 
 
+def _seed_assessment(app, *, vuln_id, pkg_name, pkg_version, status, origin):
+    """Create an assessment with a specific origin directly in the DB."""
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.assessment import Assessment
+    with app.app_context():
+        pkg = Package.find_or_create(pkg_name, pkg_version, supplier="")
+        Vulnerability.get_or_create(vuln_id)
+        finding = Finding.get_or_create(pkg.id, vuln_id)
+        Assessment.create(
+            status=status,
+            finding_id=finding.id,
+            variant_id=VARIANT_UUID,
+            origin=origin,
+        )
+
+
+def test_import_custom_data_not_skipped_when_only_scanner_assessment_exists(app, client):
+    """A scanner-origin assessment must not block importing a custom one.
+
+    The dedup is origin-aware: importing custom data only deduplicates
+    against existing ``origin == "custom"`` assessments, so a deleted custom
+    assessment can be restored even when a scanner assessment with the same
+    finding/variant/status is still present.
+    """
+    _seed_assessment(
+        app, vuln_id="CVE-2099-00001", pkg_name="scannerpkg",
+        pkg_version="1.0.0", status="affected", origin="Imported SBOM",
+    )
+
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2099-00001",
+        "status": "affected",
+        "packages": ["scannerpkg@1.0.0"],
+        "variant_id": VARIANT_UUID,
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["status"] == "success"
+    assert result["assessments_imported"] == 1
+    assert result["assessments_skipped"] == 0
+
+
+def test_import_custom_data_skipped_when_custom_assessment_exists(app, client):
+    """An existing custom assessment with the same key is still deduplicated."""
+    _seed_assessment(
+        app, vuln_id="CVE-2099-00002", pkg_name="custompkg",
+        pkg_version="2.0.0", status="affected", origin="custom",
+    )
+
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2099-00002",
+        "status": "affected",
+        "packages": ["custompkg@2.0.0"],
+        "variant_id": VARIANT_UUID,
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["status"] == "success"
+    assert result["assessments_imported"] == 0
+    assert result["assessments_skipped"] == 1
+
+
 def test_import_custom_data_cvss(client):
     """Import CVSS via the custom-data endpoint."""
     payload = _custom_data_payload(cvss=[{

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -1137,6 +1137,92 @@ def _seed_assessment(app, *, vuln_id, pkg_name, pkg_version, status, origin):
         )
 
 
+def test_import_custom_data_duplicate_multiple_existing_rows(app, client):
+    """Dedup must not crash when several matching assessments already exist.
+
+    ``--export-custom-assessments`` can yield an item whose finding/variant/
+    status matches more than one existing assessment row. The dedup query
+    previously used ``scalar_one_or_none()`` which raised
+    "Multiple rows were found when one or none was required" and dropped the
+    item. The import should skip it cleanly instead.
+    """
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.assessment import Assessment
+
+    with app.app_context():
+        pkg = Package.find_or_create("generic/glibc", "2.39", supplier="")
+        Vulnerability.get_or_create("CVE-2026-5450")
+        finding = Finding.get_or_create(pkg.id, "CVE-2026-5450")
+        # Two assessments sharing finding + variant + status.
+        for _ in range(2):
+            Assessment.create(
+                status="affected",
+                finding_id=finding.id,
+                variant_id=VARIANT_UUID,
+                origin="custom",
+            )
+
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2026-5450",
+        "status": "affected",
+        "packages": ["generic/glibc@2.39"],
+        "variant_id": VARIANT_UUID,
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["status"] == "success"
+    assert result["assessments_skipped"] >= 1
+    # No error entry for the CVE that previously triggered the crash.
+    assert all(e.get("vuln_id") != "CVE-2026-5450" for e in result["errors"])
+
+
+def test_import_statements_duplicate_multiple_existing_rows(app):
+    """OpenVEX import (import_statements) must not crash on multiple matches.
+
+    Files produced by ``--export-custom-assessments`` are OpenVEX documents
+    re-imported through ``import_statements``. When two existing assessments
+    share the same finding/variant/status, the dedup query previously used
+    ``scalar_one_or_none()`` which raised "Multiple rows were found when one
+    or none was required" and dropped the statement.
+    """
+    from src.helpers.assessment_io import import_statements
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.assessment import Assessment
+
+    with app.app_context():
+        pkg = Package.find_or_create("linux-stm32mp", "6.6.116-stm32mp-r3", supplier="")
+        Vulnerability.get_or_create("CVE-1999-0061")
+        finding = Finding.get_or_create(pkg.id, "CVE-1999-0061")
+        for _ in range(2):
+            Assessment.create(
+                status="fixed",
+                finding_id=finding.id,
+                variant_id=VARIANT_UUID,
+                origin="custom",
+            )
+
+        statements = [{
+            "vulnerability": {"name": "CVE-1999-0061"},
+            "status": "fixed",
+            "products": ["linux-stm32mp@6.6.116-stm32mp-r3"],
+        }]
+        created, errors, skipped = import_statements(statements, VARIANT_UUID)
+
+    assert skipped >= 1
+    # The statement must not be dropped with a "Multiple rows" error.
+    assert all(
+        "Multiple rows" not in str(e.get("error", "")) for e in errors
+    )
+
+
 def test_import_custom_data_not_skipped_when_only_scanner_assessment_exists(app, client):
     """A scanner-origin assessment must not block importing a custom one.
 

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -1223,6 +1223,43 @@ def test_import_statements_duplicate_multiple_existing_rows(app):
     )
 
 
+def test_import_statements_not_skipped_when_only_scanner_assessment_exists(app):
+    """A scanner-origin assessment must not block importing an OpenVEX one.
+
+    Like ``import_custom_data``, the OpenVEX import dedup is origin-aware: it
+    only deduplicates against existing ``origin == "custom"`` assessments, so a
+    scanner/SBOM assessment with the same finding/variant/status must not
+    prevent the custom statement from being created.
+    """
+    from src.helpers.assessment_io import import_statements
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.assessment import Assessment
+
+    with app.app_context():
+        pkg = Package.find_or_create("scannerpkg", "1.0.0", supplier="")
+        Vulnerability.get_or_create("CVE-2099-00003")
+        finding = Finding.get_or_create(pkg.id, "CVE-2099-00003")
+        Assessment.create(
+            status="fixed",
+            finding_id=finding.id,
+            variant_id=VARIANT_UUID,
+            origin="Imported SBOM",
+        )
+
+        statements = [{
+            "vulnerability": {"name": "CVE-2099-00003"},
+            "status": "fixed",
+            "products": ["scannerpkg@1.0.0"],
+        }]
+        created, errors, skipped = import_statements(statements, VARIANT_UUID)
+
+    assert errors == []
+    assert skipped == 0
+    assert len(created) == 1
+
+
 def test_import_custom_data_not_skipped_when_only_scanner_assessment_exists(app, client):
     """A scanner-origin assessment must not block importing a custom one.
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

Based on the issue: https://github.com/savoirfairelinux/vulnscout/issues/408
Based on the issue: https://github.com/savoirfairelinux/vulnscout/issues/407

### Changes proposed in this pull request:

* Fix the `import-custom-assessments` CLI only accepted OpenVEX documents for
.json input, rejecting the web "export custom data" format ({version, assessments, cvss, time_estimates}) with "not a valid OpenVEX document".

* Restrict the dedup query to origin == "custom" so imports only collapse
against existing custom assessments, allowing deleted custom
assessments to be restored.

* The DELETE /api/assessments/<id> route remove the row from the DB

* scalar_one_or_none() raised "Multiple rows were found" when several
assessments shared the same finding/variant/status, dropping the item
with a warning. The dedup only needs existence, so .scalars().first() is
correct.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1) Generate two assessments on the same vulnerability/package/version with the same status and export it in Review tab
2) Delete the custom assessments
3) In another terminal, export/import the custom assessments via `docker exec` command

```
docker exec vulnscout /scan/src/entrypoint.sh --project wrynose --export-custom-assessments
```
Output:

```
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Custom assessments exported: /scan/outputs/core-image-minimal-stm32mp25-eval.json
```

```
docker exec vulnscout /scan/src/entrypoint.sh --project wrynose --variant core-image-minimal-stm32mp25-eval --import-custom-assessments /scan/outputs/core-image-minimal-stm32mp25-eval.json
 ```

Should be successfully re-imported:

```
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Imported 0 assessments (3 skipped as duplicates)
```
