### PR TITLE
fix(import): use .first() instead of scalar_one_or_none()

### DIFF
--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -748,7 +748,7 @@ def import_custom_data(
                             DBAssessment.variant_id == target_variant_id,
                             DBAssessment.status == status,
                         )
-                    ).scalar_one_or_none()
+                    ).scalars().first()
                     if existing is not None:
                         result["assessments_skipped"] += 1
                         continue

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -1119,6 +1119,51 @@ def test_import_custom_data_duplicate_skipped(client):
     assert r2["assessments_imported"] == 0
 
 
+def test_import_custom_data_duplicate_multiple_existing_rows(app, client):
+    """Dedup must not crash when several matching assessments already exist.
+
+    ``--export-custom-assessments`` can yield an item whose finding/variant/
+    status matches more than one existing assessment row. The dedup query
+    previously used ``scalar_one_or_none()`` which raised
+    "Multiple rows were found when one or none was required" and dropped the
+    item. The import should skip it cleanly instead.
+    """
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.assessment import Assessment
+
+    with app.app_context():
+        pkg = Package.find_or_create("generic/glibc", "2.39", supplier="")
+        Vulnerability.get_or_create("CVE-2026-5450")
+        finding = Finding.get_or_create(pkg.id, "CVE-2026-5450")
+        # Two assessments sharing finding + variant + status.
+        for _ in range(2):
+            Assessment.create(
+                status="affected",
+                finding_id=finding.id,
+                variant_id=VARIANT_UUID,
+                origin="custom",
+            )
+
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2026-5450",
+        "status": "affected",
+        "packages": ["generic/glibc@2.39"],
+        "variant_id": VARIANT_UUID,
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload, content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["status"] == "success"
+    assert result["assessments_skipped"] >= 1
+    # No error entry for the CVE that previously triggered the crash.
+    assert all(e.get("vuln_id") != "CVE-2026-5450" for e in result["errors"])
+
+
 def test_import_custom_data_cvss(client):
     """Import CVSS via the custom-data endpoint."""
     payload = _custom_data_payload(cvss=[{


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

Based on the issue: https://github.com/savoirfairelinux/vulnscout/issues/408

### Changes proposed in this pull request:

* scalar_one_or_none() raised "Multiple rows were found" when several
assessments shared the same finding/variant/status, dropping the item
with a warning. The dedup only needs existence, so .scalars().first() is
correct.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1) Perform two assessments on the same vulnerability/package/version with the same status
2) Export with the command `docker exec vulnscout /scan/src/entrypoint.sh --project wrynose --export-custom-assessments`

Without this fix

```
(.venv) vboudevin@vboudevin-pc:~/Documents/vs/vulnscout$ docker exec vulnscout /scan/src/entrypoint.sh --project wrynose --variant core-image-minimal-stm32mp25-eval --import-custom-assessments /scan/outputs/core-image-minimal-stm32mp25-eval.json
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
  Warning: {'vuln_id': 'CVE-1999-0061', 'package': 'linux-stm32mp@6.6.116-stm32mp-r3', 'error': 'Multiple rows were found when one or none was required'}
  Warning: {'vuln_id': 'CVE-1999-0061', 'package': 'linux-stm32mp@6.6.116-stm32mp-r3', 'error': 'Multiple rows were found when one or none was required'}
Imported 0 assessments (0 skipped as duplicates)
```

With this fix: 

```
(.venv) vboudevin@vboudevin-pc:~/Documents/vs/vulnscout$ docker exec vulnscout /scan/src/entrypoint.sh --project wrynose --variant core-image-minimal-stm32mp25-eval --import-custom-assessments /scan/outputs/core-image-minimal-stm32mp25-eval.json
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Imported 0 assessments (3 skipped as duplicates)
```