### PR TITLE
Fix: Export feature is slow, doesn't respect project barrier, and were polluted based on vuln description

### DIFF
--- a/src/bin/cmd_export.py
+++ b/src/bin/cmd_export.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from ..controllers import ControllersCache, VulnerabilitiesController
+from ..controllers import ControllersCache
 from ..controllers.projects import ProjectController
 from ..models.variant import Variant as DBVariant
 from ..views.spdx import SPDX
@@ -135,9 +135,6 @@ def report_command(template_name: str, output_dir: str, output_format: str | Non
     invoked; TEMPLATE_NAME is always generated regardless.
     """
     controllers = ControllersCache()
-    controllers.vulnerabilities = VulnerabilitiesController.from_dict(
-        controllers.packages, controllers.vulnerabilities.to_dict()
-    )
     templ = Templates(controllers)
 
     # Reuse failed_vulns from flask process if available, otherwise evaluate now

--- a/src/controllers/assessments.py
+++ b/src/controllers/assessments.py
@@ -294,6 +294,11 @@ class AssessmentsController:
 
     def to_dict(self) -> dict:
         """Return all assessments preferring in-memory data when available."""
+        if self._scope is not None:
+            # Scoped export/report: restrict to the in-scope variants. get_all()
+            # merges in-memory + DB and applies the scope filter, so a fallback
+            # to the DB never leaks another project's/variant's assessments.
+            return {str(a.id): a.to_dict() for a in self.get_all()}
         return to_dict_with_fallback(
             self.assessments, Assessment.get_all,
             lambda a: str(a.id), "AssessmentsController",

--- a/src/controllers/packages.py
+++ b/src/controllers/packages.py
@@ -181,6 +181,11 @@ class PackagesController:
 
     def to_dict(self) -> dict:
         """Return all packages as a ``{id: dict}`` mapping, preferring in-memory when available."""
+        if self._scope is not None:
+            # Scoped export/report: only the in-scope packages are pre-loaded
+            # into the in-memory cache. Never fall back to the global DB set
+            # (which would leak other projects/variants when the scope is empty).
+            return {sid: pkg.to_dict() for sid, pkg in self._cache.items()}
         return to_dict_with_fallback(
             self._cache, Package.get_all,
             lambda pkg: pkg.string_id, "PackagesController",

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -633,6 +633,11 @@ class VulnerabilitiesController:
 
     def to_dict(self) -> dict:
         """Export the list of vulnerabilities preferring in-memory data when available."""
+        if self._scope is not None:
+            # Scoped export/report: only the in-scope vulns are pre-loaded into
+            # the in-memory cache. Never fall back to the global DB set (which
+            # would leak other projects/variants when the scope is empty).
+            return {k: v.to_dict() for k, v in self.vulnerabilities.items()}
         return to_dict_with_fallback(
             self.vulnerabilities, Vulnerability.get_all,
             lambda r: r.id, "VulnerabilitiesController",

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -542,9 +542,10 @@ class Vulnerability(Base):
     def get_all() -> list["Vulnerability"]:
         """Return all vulnerability records ordered by id.
 
-        Uses eager loading for ``findings`` (and their packages) and
-        ``metrics`` to avoid N+1 lazy-load queries when callers iterate
-        and call :meth:`to_dict`.
+        Uses eager loading for ``findings`` (and their packages and
+        time-estimates) and ``metrics`` to avoid N+1 lazy-load queries when
+        callers iterate and call :meth:`to_dict` (whose effort fallback reads
+        ``finding.time_estimates``).
         """
 
         return list(db.session.execute(
@@ -552,6 +553,8 @@ class Vulnerability(Base):
             .options(
                 selectinload(Vulnerability.findings)  # type: ignore[arg-type]
                 .selectinload(Finding.package),  # type: ignore[arg-type]
+                selectinload(Vulnerability.findings)  # type: ignore[arg-type]
+                .selectinload(Finding.time_estimates),  # type: ignore[arg-type]
                 selectinload(Vulnerability.metrics),  # type: ignore[arg-type]
             )
             .order_by(Vulnerability.id)

--- a/src/routes/documents.py
+++ b/src/routes/documents.py
@@ -76,9 +76,6 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/documents/<doc_name>', methods=['GET'])
     def doc_by_name(doc_name: str) -> ResponseReturnValue:
-        ctrls = ControllersCache()
-        ctrls.packages._preload_cache()
-        templ = Templates(ctrls)
         try:
             base_mime = guess_mime_type(doc_name)
             if base_mime is None:
@@ -97,35 +94,36 @@ def init_app(app: Flask) -> None:
             except ValueError:
                 pass
 
+            # Resolve the optional project/variant scope from the "Project &
+            # Variant" selection. It applies to BOTH SBOM/VEX exports and
+            # reports (templates) so that every document only contains the
+            # in-scope data. variant_id takes precedence; project_id alone
+            # means "All variants" of that project. No selection => global.
+            variant_id = request.args.get("variant_id")
+            project_id = request.args.get("project_id")
+            scope = None
+            if variant_id:
+                variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
+                if err is not None:
+                    return err
+                scope = compute_export_scope(variant_id=variant_uuid)
+            elif project_id:
+                project_uuid, err = parse_uuid_or_400(project_id, "project_id")
+                if err is not None:
+                    return err
+                scope = compute_export_scope(project_id=project_uuid)
+
+            ctrls = ControllersCache(scope=scope)
+            ctrls.packages._preload_cache()
+
             if (
                 doc_name.startswith("CycloneDX ")
                 or doc_name == "OpenVex"
                 or doc_name.startswith("SPDX")
             ):
-                # SBOM/VEX exports are scoped to the current project/variant
-                # when the frontend passes variant_id / project_id.  Reports
-                # (templates) keep their global, unscoped data.
-                variant_id = request.args.get("variant_id")
-                project_id = request.args.get("project_id")
-                scope = None
-                if variant_id:
-                    variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
-                    if err is not None:
-                        return err
-                    scope = compute_export_scope(variant_id=variant_uuid)
-                elif project_id:
-                    project_uuid, err = parse_uuid_or_400(project_id, "project_id")
-                    if err is not None:
-                        return err
-                    scope = compute_export_scope(project_id=project_uuid)
+                return handle_sbom_exports(doc_name, ctrls, expected_mime, metadata)
 
-                if scope is not None:
-                    scoped_ctrls = ControllersCache(scope=scope)
-                    scoped_ctrls.packages._preload_cache()
-                else:
-                    scoped_ctrls = ctrls
-                return handle_sbom_exports(doc_name, scoped_ctrls, expected_mime, metadata)
-
+            templ = Templates(ctrls)
             content = templ.render(doc_name, **metadata)
 
             if base_mime == expected_mime:

--- a/src/views/templates.py
+++ b/src/views/templates.py
@@ -5,6 +5,7 @@ from jinja2 import sandbox, FileSystemLoader, ChoiceLoader
 import subprocess
 import os
 import random
+import re
 import string
 from datetime import datetime, timezone
 from typing import Any, Callable, List, Optional
@@ -299,6 +300,7 @@ class TemplatesExtensions:
         jinjaEnv.filters["filter_by_variant"] = TemplatesExtensions.filter_by_variant
         jinjaEnv.filters["filter_by_project"] = TemplatesExtensions.filter_by_project
         jinjaEnv.filters["sort_by_scan_date"] = TemplatesExtensions.sort_by_scan_date
+        jinjaEnv.filters["escape_adoc"] = TemplatesExtensions.escape_adoc
 
     @staticmethod
     def get_env_var(key: str, default: str = "") -> str:
@@ -307,6 +309,56 @@ class TemplatesExtensions:
         if prefixed is not None:
             return prefixed
         return default
+
+    # A line made only of these runs is an AsciiDoc delimited-block fence
+    # (example ``====``, listing ``----``, literal ``....``, sidebar ``****``,
+    # quote ``____``, passthrough ``++++``, comment ``////``), an open block
+    # ``--`` or a table fence (``|===``, ``,===``, ``:===``, ``!===``).
+    _ADOC_BLOCK_FENCE = re.compile(r"^(?:[=\-.*_+/]{4,}|--|[|,:!]={3,})[ \t]*$")
+
+    # A line that opens/closes a Markdown-style fenced code block (3+ backticks
+    # or tildes, optionally followed by a language). Asciidoctor honours these
+    # for Markdown compatibility, so a lone fence left by truncation would open
+    # a code block that swallows everything after it.
+    _ADOC_MD_FENCE = re.compile(r"^[`~]{3,}")
+
+    # A line that starts with ``=`` (AsciiDoc section title) or ``#`` (Markdown
+    # heading) followed by whitespace would create a spurious section/chapter
+    # and corrupt the report's heading hierarchy.
+    _ADOC_HEADING = re.compile(r"^(?:={1,6}|#{1,6})[ \t]")
+
+    @staticmethod
+    def escape_adoc(value: Optional[str]) -> str:
+        """Neutralise AsciiDoc structural markup in arbitrary free-form text.
+
+        Vulnerability descriptions are untrusted text (frequently kernel commit
+        messages containing code, lockdep splats, separator lines, Markdown
+        headings and fenced code blocks). When injected verbatim into an
+        AsciiDoc template:
+
+        * a line made of delimiter characters (``----``, ``====``, ``////`` ...)
+          or a Markdown code fence (```` ``` ````) opens a delimited block that,
+          if never closed, swallows the rest of the document. This is especially
+          easy to trigger when truncation cuts a description between a fence and
+          its matching closing delimiter;
+        * a line starting with ``=`` or ``#`` becomes a section title and breaks
+          the report's chapter hierarchy.
+
+        We defuse such lines by prefixing them with a zero-width space so
+        Asciidoctor no longer treats them as structural markup, while the
+        visible text stays unchanged.
+        """
+        if not value:
+            return ""
+        lines = value.splitlines()
+        for i, line in enumerate(lines):
+            if (
+                TemplatesExtensions._ADOC_BLOCK_FENCE.match(line)
+                or TemplatesExtensions._ADOC_MD_FENCE.match(line)
+                or TemplatesExtensions._ADOC_HEADING.match(line)
+            ):
+                lines[i] = "\u200b" + line
+        return "\n".join(lines)
 
     @staticmethod
     def filter_status(value: list, status: str | list[str]) -> list:

--- a/src/views/templates.py
+++ b/src/views/templates.py
@@ -90,10 +90,16 @@ class Templates:
         if "scan_date" not in kwargs:
             kwargs["scan_date"] = "unknown date"  # don't use actual datetime by default.
 
+        # Group every assessment by its vulnerability id once, up front. This
+        # turns the per-vulnerability loop below into a pure in-memory lookup
+        # instead of issuing one SELECT per vulnerability (the previous
+        # gets_by_vuln() call), which made large reports extremely slow.
+        assessments_by_vuln: dict[str, list] = {}
+        for assessment in kwargs["unfiltered_assessments"].values():
+            assessments_by_vuln.setdefault(assessment["vuln_id"], []).append(assessment)
+
         for vuln_obj in kwargs["unfiltered_vulnerabilities"].values():
-            vuln_assessments = []
-            for assessment in self.assessmentsCtrl.gets_by_vuln(vuln_obj['id']):
-                vuln_assessments.append(assessment.to_dict())
+            vuln_assessments = list(assessments_by_vuln.get(vuln_obj['id'], []))
 
             vuln_assessments = sorted(vuln_assessments, key=lambda x: x["timestamp"], reverse=True)  # type: ignore
             if len(vuln_assessments) >= 1:

--- a/src/views/templates/all_assessments.adoc
+++ b/src/views/templates/all_assessments.adoc
@@ -1,7 +1,7 @@
 = Vulnerabilities Report
 {{author}}
 {{export_date}}
-:toc:
+{{ ":toc:" if (vulnerabilities | as_list | length) <= 1000 else "" }}
 
 {% if client_name is defined and client_name != "" -%}
 This report is strictly confidential and restricted to {% if author is defined and author != "" %}{{author}} and {% endif %}{{client_name}}.
@@ -58,23 +58,20 @@ They are classified as follow:
 ^.^| **{{ vulnerabilities | as_list | status_ignored | length }}**
 |===
 
-You will find below the vulnerabilities found, starting by open / active vulnerabilities and in the next section thoses who are closed.
-All vulnerabilities are classed by the date of last change.
+You will find below the vulnerabilities found, grouped by assessment status and then by severity.
+Within each category, vulnerabilities are sorted by EPSS score and then by date of last change.
 
-<<<
-
-== Open vulnerabilities (classed as pending review or exploitable)
-
-{% for vuln in vulnerabilities | as_list | status_active | sort_by_epss | sort_by_last_modified %}
+{% macro vuln_block(vuln) %}
 
 [{{vuln.last_assessment.timestamp | print_iso8601}}] **{{ vuln.id }} ({{ vuln.severity.severity | capitalize }}) - EPSS: {{ "%.2f" | format(vuln.epss.score | float * 100) }} %**
 
 Impacts following packages: {{' & '.join(vuln.packages)}} +
-Reference: {{ vuln.datasource or vuln.urls[0] or "No sources found" }}
+{% set refs = (vuln.urls | reject("equalto", "") | list)[:3] -%}
+Links: {{ refs | join(' , ') if refs | length > 0 else (vuln.datasource if vuln.datasource and vuln.datasource != "unknown" else "No sources found") }} +
 
 {% if vuln.description -%}
 **Description:**
-{{ vuln.description }}
+{{ vuln.description | escape_adoc }}
 {%- endif %}
 
 **Assessment:**
@@ -90,37 +87,34 @@ Reference: {{ vuln.datasource or vuln.urls[0] or "No sources found" }}
 {%- endif %}
 
 '''
+{% endmacro %}
 
-{%- endfor %}
+{% macro severity_subsection(items, letter, label) %}
+
+=== {{ letter }}) {{ label }}
+
+{% set rows = items | sort_by_epss | sort_by_last_modified %}
+{% if rows | length == 0 %}
+_No vulnerability in this category._
+{% else %}
+{% for vuln in rows %}{{ vuln_block(vuln) }}
+{% endfor %}
+{% endif %}
+{% endmacro %}
+
+{% macro status_chapter(numeral, title, items) %}
+
+== {{ numeral }} - {{ title }}
+{{ severity_subsection(items | severity("critical"), 'a', 'Critical') }}
+{{ severity_subsection(items | severity("high"), 'b', 'High') }}
+{{ severity_subsection(items | severity("medium"), 'c', 'Medium') }}
+{{ severity_subsection(items | severity("low"), 'd', 'Low') }}
+{{ severity_subsection(items | severity("unknown"), 'e', 'Unknown') }}
 
 <<<
+{% endmacro %}
 
-== Closed vulnerabilities (classed as patched or ignored)
-
-{% for vuln in vulnerabilities | as_list | status_inactive | sort_by_epss | sort_by_last_modified %}
-
-[{{vuln.last_assessment.timestamp | print_iso8601}}] **{{ vuln.id }} ({{ vuln.severity.severity | capitalize }}) - EPSS: {{ "%.2f" | format(vuln.epss.score | float * 100) }} %**
-
-Impacts following packages: {{' & '.join(vuln.packages)}} +
-Reference: {{ vuln.datasource or vuln.urls[0] or "No sources found" }}
-
-{% if vuln.description -%}
-**Description:**
-{{ vuln.description }}
-{%- endif %}
-
-** Assessment:**
-* [{{vuln.last_assessment.timestamp | print_iso8601}}] {{vuln.last_assessment.status}} {{vuln.last_assessment.justification or ""}}
-{%- if vuln.last_assessment.status_notes != '' %}
-** Notes: {{vuln.last_assessment.status_notes}}
-{%- endif %}
-{%- if vuln.last_assessment.impact_statement != '' %}
-** Impact statement: {{vuln.last_assessment.impact_statement}}
-{%- endif %}
-{%- if vuln.last_assessment.workaround != '' %}
-** Workaround: {{vuln.last_assessment.workaround}}
-{%- endif %}
-
-'''
-
-{%- endfor %}
+{{ status_chapter('I', 'Pending Investigation', vulnerabilities | as_list | status_pending) }}
+{{ status_chapter('II', 'Exploitable', vulnerabilities | as_list | status_affected) }}
+{{ status_chapter('III', 'Fixed', vulnerabilities | as_list | status_fixed) }}
+{{ status_chapter('IV', 'Ignored or false positive', vulnerabilities | as_list | status_ignored) }}

--- a/src/views/templates/match_condition.adoc
+++ b/src/views/templates/match_condition.adoc
@@ -55,7 +55,7 @@ No vulnerabilities matched the condition. The scan passed successfully.
 
 {% if vuln.description -%}
 **Description:**
-{{ vuln.description }}
+{{ vuln.description | escape_adoc }}
 {%- endif %}
 
 {% if vuln.last_assessment is defined -%}

--- a/src/views/templates/summary.adoc
+++ b/src/views/templates/summary.adoc
@@ -66,7 +66,7 @@ The following list use EPSS ranking to outline the vulnerabilities which are mos
 **{{loop.index}}. {{ vuln.id }} ({{ vuln.severity.severity | capitalize }}) - EPSS: {{ "%.2f" | format(vuln.epss.score | float * 100) }} %**
 
 [.text-justify]
-{{ vuln.description }}
+{{ vuln.description | escape_adoc }}
 
 Reference: {{ vuln.datasource or vuln.urls[0] or "No sources found" }}
 

--- a/tests/cli_tests/test_cmd_export.py
+++ b/tests/cli_tests/test_cmd_export.py
@@ -161,6 +161,19 @@ class TestCmdExportCoverage:
             ])
         mock_eval.assert_called_once()
 
+    def test_report_does_not_rebuild_vulnerabilities_controller(self, app, tmp_path):
+        """report_command must not re-persist all vulns via from_dict (perf)."""
+        with patch("src.views.templates.Templates.render") as mock_render, \
+             patch("src.controllers.vulnerabilities.VulnerabilitiesController.from_dict") as mock_from_dict:
+            mock_render.return_value = "= Title\ncontent"
+            runner = app.test_cli_runner()
+            result = runner.invoke(args=[
+                "report", "report.adoc", "--output-dir", str(tmp_path)
+            ])
+
+        assert result.exit_code == 0, result.output
+        mock_from_dict.assert_not_called()
+
 
 class TestCmdExportSpdx2:
     def test_author_present(self, app, tmp_path, monkeypatch):

--- a/tests/unit_tests/test_controller_scope_to_dict.py
+++ b/tests/unit_tests/test_controller_scope_to_dict.py
@@ -1,0 +1,143 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for scope-aware ``to_dict()`` on the packages, vulnerabilities and
+assessments controllers.
+
+When an export/report scope is active the controllers must return ONLY the
+pre-loaded in-scope data and never fall back to the global DB set, otherwise a
+scoped report could leak another project's/variant's data.
+"""
+
+import os
+import uuid
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+from src.models.package import Package
+from src.models.vulnerability import Vulnerability
+from src.models.assessment import Assessment
+from src.controllers.packages import PackagesController
+from src.controllers.vulnerabilities import VulnerabilitiesController
+from src.controllers.assessments import AssessmentsController
+from src.helpers.export_scope import ExportScope
+
+
+@pytest.fixture()
+def app():
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": "/dev/null"})
+        with application.app_context():
+            _db.create_all()
+            yield application
+            _db.drop_all()
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+def _make_pkg(name="pkg-a", version="1.0"):
+    return Package(name, version, [], [f"pkg:generic/{name}@{version}"])
+
+
+# ---------------------------------------------------------------------------
+# PackagesController.to_dict
+# ---------------------------------------------------------------------------
+
+class TestPackagesControllerScopeToDict:
+    def test_unscoped_falls_back_to_db(self, app):
+        ctrl = PackagesController()  # no scope
+        pkg = _make_pkg("db-pkg")
+        with patch.object(Package, "get_all", return_value=[pkg]):
+            result = ctrl.to_dict()
+        assert pkg.string_id in result
+
+    def test_scoped_empty_cache_does_not_leak_db(self, app):
+        scope = ExportScope(package_ids=set(), variant_ids=set())
+        ctrl = PackagesController(scope=scope)
+        with patch.object(Package, "get_all", return_value=[_make_pkg("db-pkg")]) as get_all:
+            result = ctrl.to_dict()
+        assert result == {}
+        get_all.assert_not_called()
+
+    def test_scoped_returns_only_cached(self, app):
+        scope = ExportScope(package_ids={uuid.uuid4()}, variant_ids=set())
+        ctrl = PackagesController(scope=scope)
+        pkg = _make_pkg("scoped-pkg")
+        ctrl._cache[pkg.string_id] = pkg
+        with patch.object(Package, "get_all", return_value=[_make_pkg("db-pkg")]):
+            result = ctrl.to_dict()
+        assert list(result.keys()) == [pkg.string_id]
+
+
+# ---------------------------------------------------------------------------
+# VulnerabilitiesController.to_dict
+# ---------------------------------------------------------------------------
+
+class TestVulnerabilitiesControllerScopeToDict:
+    @patch("src.controllers.vulnerabilities.EPSS_DB")
+    def test_unscoped_falls_back_to_db(self, mock_epss, app):
+        mock_epss.return_value = MagicMock()
+        ctrl = VulnerabilitiesController(PackagesController())  # no scope
+        v_db = Vulnerability("CVE-2024-0001", ["scanner"], "url", "unknown")
+        with patch.object(Vulnerability, "get_all", return_value=[v_db]):
+            result = ctrl.to_dict()
+        assert "CVE-2024-0001" in result
+
+    @patch("src.controllers.vulnerabilities.EPSS_DB")
+    def test_scoped_empty_does_not_leak_db(self, mock_epss, app):
+        mock_epss.return_value = MagicMock()
+        scope = ExportScope(package_ids=set(), variant_ids=set())
+        ctrl = VulnerabilitiesController(PackagesController(), scope=scope)
+        v_db = Vulnerability("CVE-2024-0001", ["scanner"], "url", "unknown")
+        with patch.object(Vulnerability, "get_all", return_value=[v_db]) as get_all:
+            result = ctrl.to_dict()
+        assert result == {}
+        get_all.assert_not_called()
+
+    @patch("src.controllers.vulnerabilities.EPSS_DB")
+    def test_scoped_returns_only_inmemory(self, mock_epss, app):
+        mock_epss.return_value = MagicMock()
+        scope = ExportScope(package_ids=set(), variant_ids=set())
+        ctrl = VulnerabilitiesController(PackagesController(), scope=scope)
+        v = Vulnerability("CVE-IN-MEM", ["scanner"], "url", "unknown")
+        ctrl.vulnerabilities[v.id] = v
+        with patch.object(Vulnerability, "get_all", return_value=[
+            Vulnerability("CVE-DB-ONLY", ["scanner"], "url", "unknown")
+        ]):
+            result = ctrl.to_dict()
+        assert list(result.keys()) == ["CVE-IN-MEM"]
+
+
+# ---------------------------------------------------------------------------
+# AssessmentsController.to_dict
+# ---------------------------------------------------------------------------
+
+class TestAssessmentsControllerScopeToDict:
+    def test_unscoped_falls_back_to_db(self, app):
+        ctrl = AssessmentsController(MagicMock())  # no scope
+        a_db = Assessment.new_dto("CVE-DB", ["pkg@1.0"])
+        with patch.object(Assessment, "get_all", return_value=[a_db]):
+            result = ctrl.to_dict()
+        assert any(d["vuln_id"] == "CVE-DB" for d in result.values())
+
+    def test_scoped_filters_by_variant(self, app):
+        v1 = uuid.uuid4()
+        v2 = uuid.uuid4()
+        a1 = Assessment.new_dto("CVE-IN-SCOPE", ["pkg@1.0"])
+        a1.variant_id = v1
+        a2 = Assessment.new_dto("CVE-OUT-OF-SCOPE", ["pkg@1.0"])
+        a2.variant_id = v2
+
+        scope = ExportScope(package_ids=set(), variant_ids={v1})
+        ctrl = AssessmentsController(MagicMock(), scope=scope)
+        ctrl.assessments = {str(a1.id): a1, str(a2.id): a2}
+
+        with patch.object(Assessment, "get_all", return_value=[]):
+            result = ctrl.to_dict()
+
+        vuln_ids = {d["vuln_id"] for d in result.values()}
+        assert vuln_ids == {"CVE-IN-SCOPE"}

--- a/tests/unit_tests/test_template_extensions.py
+++ b/tests/unit_tests/test_template_extensions.py
@@ -653,3 +653,46 @@ class TestFilterPublishDateExceptions:
         result = extensions.filters["filter_by_publish_date"](vulns, "NOT-A-DATE")
         assert result == vulns
 
+
+ZWSP = "\u200b"
+
+
+class TestEscapeAdoc:
+    """escape_adoc neutralises AsciiDoc/Markdown structural markup in untrusted text."""
+
+    def test_none_and_empty_return_empty_string(self, extensions):
+        f = extensions.filters["escape_adoc"]
+        assert f(None) == ""
+        assert f("") == ""
+
+    def test_plain_text_unchanged(self, extensions):
+        f = extensions.filters["escape_adoc"]
+        text = "A normal description.\nA line with an = sign but no heading."
+        assert f(text) == text
+
+    def test_block_fence_lines_are_defused(self, extensions):
+        f = extensions.filters["escape_adoc"]
+        out = f("intro\n----\ncode\n----\nend").split("\n")
+        assert out[0] == "intro"
+        assert out[1] == ZWSP + "----"
+        assert out[3] == ZWSP + "----"
+        assert out[4] == "end"
+
+    def test_markdown_code_fence_is_defused(self, extensions):
+        f = extensions.filters["escape_adoc"]
+        out = f("```python\nx = 1\n```").split("\n")
+        assert out[0] == ZWSP + "```python"
+        assert out[2] == ZWSP + "```"
+
+    def test_headings_are_defused(self, extensions):
+        f = extensions.filters["escape_adoc"]
+        assert f("= Title") == ZWSP + "= Title"
+        assert f("## Subsection") == ZWSP + "## Subsection"
+
+    def test_short_marker_without_space_is_not_a_heading(self, extensions):
+        f = extensions.filters["escape_adoc"]
+        assert f("=no space here") == "=no space here"
+
+    def test_table_fence_is_defused(self, extensions):
+        f = extensions.filters["escape_adoc"]
+        assert f("|===") == ZWSP + "|==="

--- a/tests/unit_tests/test_templates.py
+++ b/tests/unit_tests/test_templates.py
@@ -93,6 +93,36 @@ class TestTemplatesRenderExceptions:
             assert result == "test"
 
 
+class TestRenderGroupsAssessments:
+    """render() groups assessments from to_dict() instead of a per-vuln DB query."""
+
+    def test_render_does_not_call_gets_by_vuln(self, templates_instance, pkg_ABC, vuln_123, assesment_123):
+        """The N+1 gets_by_vuln() per vulnerability must no longer be used."""
+        templates_instance.packagesCtrl.add(pkg_ABC)
+        templates_instance.vulnerabilitiesCtrl.add(vuln_123)
+        templates_instance.assessmentsCtrl.add(assesment_123)
+        templates_instance.assessmentsCtrl.gets_by_vuln = MagicMock(
+            side_effect=AssertionError("gets_by_vuln must not be called by render()")
+        )
+
+        captured = {}
+
+        def _capture(**kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+        with patch.object(templates_instance.env, 'get_template') as mock_template:
+            mock_template.return_value.render.side_effect = _capture
+            result = templates_instance.render("test.jinja2")
+
+        assert result == "ok"
+        templates_instance.assessmentsCtrl.gets_by_vuln.assert_not_called()
+        # The assessment is still correctly associated with its vulnerability.
+        rendered_vuln = captured["vulnerabilities"][vuln_123.id]
+        assert len(rendered_vuln["assessments"]) == 1
+        assert rendered_vuln["assessments"][0]["vuln_id"] == vuln_123.id
+
+
 class TestAdocToPdfErrors:
     """Test error handling in adoc_to_pdf method"""
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Export correctly respect the Project barrier (no info coming from other projects)
* Export feature gets a faster thanks to query optimization 
* Harden the report to no be corrupted with a wrong CVE description

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Export all_assessments.adoc from the web interface in "Export" tab (HTML is faster).

 The report should look clean with chapters and the description of CVEs doesn´t break the document anymore

