### PR TITLE
fix: published-date filter when dates exist

### DIFF
--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -158,17 +158,21 @@ type PublishedDateFilterProps = {
     setDateFrom: (value: string) => void;
     setDateTo: (value: string) => void;
     nvdProgress: NVDProgress | null;
+    hasAnyPublishedDate: boolean;
 };
 
 function PublishedDateFilter({
     filterType, dateValue, daysValue, dateFrom, dateTo,
     setFilterType, setDateValue, setDaysValue, setDateFrom, setDateTo,
-    nvdProgress
+    nvdProgress, hasAnyPublishedDate
 }: Readonly<PublishedDateFilterProps>) {
     const [isOpen, setIsOpen] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
 
-    const isDisabled = !nvdProgress || nvdProgress.in_progress || nvdProgress.phase !== 'completed';
+    // Disabled only while NVD is actively syncing, or when there is no
+    // published-date data at all (neither from NVD nor any other scan).
+    const nvdReady = !!nvdProgress && !nvdProgress.in_progress && nvdProgress.phase === 'completed';
+    const isDisabled = (nvdProgress?.in_progress ?? false) || (!nvdReady && !hasAnyPublishedDate);
     const hasActiveFilter = filterType !== '' && (dateValue || daysValue || (dateFrom && dateTo));
 
     useEffect(() => {
@@ -206,7 +210,9 @@ function PublishedDateFilter({
                         ? 'bg-sky-950'
                         : 'bg-sky-900 hover:bg-sky-950'
                 } text-white`}
-                title={isDisabled ? 'NVD sync in progress' : 'Filter by published date'}
+                title={isDisabled
+                    ? (nvdProgress?.in_progress ? 'NVD sync in progress' : 'No published dates available')
+                    : 'Filter by published date'}
             >
                 Published Date
                 {hasActiveFilter && <span className="ml-1 bg-sky-700 px-1 rounded text-xs">✓</span>}
@@ -413,6 +419,14 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
 
     const hasAnyGhsaVuln = useMemo(
         () => vulnerabilities.some(v => v.id?.toUpperCase().startsWith('GHSA-')),
+        [vulnerabilities]
+    );
+
+    // Published dates can come from sources other than NVD (e.g. an
+    // sbom-cve-check scan). When at least one vulnerability already has a
+    // published date, the filter is usable even if NVD has never synced.
+    const hasAnyPublishedDate = useMemo(
+        () => vulnerabilities.some(v => !!v.published),
         [vulnerabilities]
     );
 
@@ -1368,6 +1382,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 setDateFrom={setPublishedDateFrom}
                 setDateTo={setPublishedDateTo}
                 nvdProgress={nvdProgress}
+                hasAnyPublishedDate={hasAnyPublishedDate}
             />
 
             {/* More Filters dropdown — EPSS Range, Attack Vector, First Scan Date */}

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -1322,14 +1322,27 @@ describe('Vulnerability Table', () => {
     // Published Date Feature Tests
     // =========================================================================
 
-    test('published date filter button is disabled when NVD sync is not completed', async () => {
-        // NVD progress mock defaults to phase: 'idle', which means not completed
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+    test('published date filter button is disabled when NVD sync is not completed and no published dates exist', async () => {
+        // NVD progress mock defaults to phase: 'idle' (not completed). With no
+        // vulnerability carrying a published date, the filter has nothing to act on.
+        const noPublished = vulnerabilities.map(v => ({ ...v, published: undefined }));
+        render(<TableVulnerabilities vulnerabilities={noPublished} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         const publishedDateBtn = await screen.getByRole('button', { name: /published date/i });
         expect(publishedDateBtn).toBeInTheDocument();
         expect(publishedDateBtn).toBeDisabled();
-        expect(publishedDateBtn).toHaveAttribute('title', 'NVD sync in progress');
+        expect(publishedDateBtn).toHaveAttribute('title', 'No published dates available');
+    });
+
+    test('published date filter button is enabled when a published date exists even if NVD has not synced', async () => {
+        // NVD progress mock defaults to 'idle' (not completed), but the fixture
+        // vulnerabilities carry published dates (e.g. from an sbom-cve-check scan).
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const publishedDateBtn = await screen.getByRole('button', { name: /published date/i });
+        expect(publishedDateBtn).toBeInTheDocument();
+        expect(publishedDateBtn).not.toBeDisabled();
+        expect(publishedDateBtn).toHaveAttribute('title', 'Filter by published date');
     });
 
     test('published date filter button is enabled when NVD sync is completed', async () => {
@@ -1344,6 +1357,49 @@ describe('Vulnerability Table', () => {
         });
 
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        await waitFor(() => {
+            const publishedDateBtn = screen.getByRole('button', { name: /published date/i });
+            expect(publishedDateBtn).not.toBeDisabled();
+            expect(publishedDateBtn).toHaveAttribute('title', 'Filter by published date');
+        });
+    });
+
+    test('published date filter button is disabled while NVD sync is in progress even when published dates exist', async () => {
+        // An active NVD sync takes priority: the button is disabled and shows
+        // the sync tooltip, regardless of already-available published dates.
+        const NVDProgressHandler = require('../../src/handlers/nvd_progress').default;
+        NVDProgressHandler.getProgress.mockResolvedValueOnce({
+            in_progress: true,
+            phase: 'downloading',
+            current: 10,
+            total: 100,
+            message: 'Downloading',
+        });
+
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        await waitFor(() => {
+            const publishedDateBtn = screen.getByRole('button', { name: /published date/i });
+            expect(publishedDateBtn).toBeDisabled();
+            expect(publishedDateBtn).toHaveAttribute('title', 'NVD sync in progress');
+        });
+    });
+
+    test('published date filter button is enabled when NVD sync is completed even without published dates', async () => {
+        // A completed NVD sync makes the filter usable on its own, independent
+        // of whether the loaded vulnerabilities carry published dates.
+        const NVDProgressHandler = require('../../src/handlers/nvd_progress').default;
+        NVDProgressHandler.getProgress.mockResolvedValueOnce({
+            in_progress: false,
+            phase: 'completed',
+            current: 100,
+            total: 100,
+            message: 'Done',
+        });
+
+        const noPublished = vulnerabilities.map(v => ({ ...v, published: undefined }));
+        render(<TableVulnerabilities vulnerabilities={noPublished} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         await waitFor(() => {
             const publishedDateBtn = screen.getByRole('button', { name: /published date/i });


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The published-date filter was disabled whenever NVD had not completed a sync, even though published dates can come from other sources (e.g. an sbom-cve-check scan)..

- TableVulnerabilities: compute hasAnyPublishedDate from the loaded vulnerabilities and pass it to PublishedDateFilter.
- PublishedDateFilter: disable only while NVD is actively syncing, or when no published-date data exists at all. Update the tooltip to distinguish "NVD sync in progress" from "No published dates available".

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Load Published date via any other way (e.g: sbom-cve-check), then the Published Date button is available as a valid filter
