### PR TITLE
Fix: Reduce post-assessment loading time from twenty sec to less than a second

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -766,50 +766,54 @@ type VariantScopedSnapshot = {
 
         setSubmittingMessage('Adding assessment...');
         try {
-        for (const vid of variantIds) {
-            const body = vid ? { ...baseContent, variant_id: vid, timestamp: sharedTimestamp } : { ...baseContent, timestamp: sharedTimestamp };
-            const response = await fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/assessments`, {
-                method: 'POST',
-                mode: 'cors',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(body)
-            });
-            const data = await response.json();
-            if (data?.status === 'success') {
-                // Backend returns an array (one record per package); support legacy single too
-                const rawList: unknown[] = Array.isArray(data?.assessments)
-                    ? data.assessments
-                    : (data?.assessment ? [data.assessment] : []);
-                for (const raw of rawList) {
-                    const casted = asAssessment(raw);
-                    if (!Array.isArray(casted) && typeof casted === 'object') {
-                        successCount++;
-                        lastCasted = casted;
-                        if (casted.variant_id) touchedVariantIds.add(casted.variant_id);
-                        for (const pkg of casted.packages ?? []) touchedPackages.add(pkg);
+        // Post every variant in a single batch request
+        const items = variantIds.map(vid =>
+            vid
+                ? { ...baseContent, variant_id: vid, timestamp: sharedTimestamp }
+                : { ...baseContent, timestamp: sharedTimestamp }
+        );
+        const response = await fetch(import.meta.env.VITE_API_URL + `/api/assessments/batch`, {
+            method: 'POST',
+            mode: 'cors',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ assessments: items })
+        });
+        const data = await response.json();
+        if (data?.status === 'success') {
+            // Backend returns one record per (package, variant) pair.
+            const rawList: unknown[] = Array.isArray(data?.assessments) ? data.assessments : [];
+            for (const raw of rawList) {
+                const casted = asAssessment(raw);
+                if (!Array.isArray(casted) && typeof casted === 'object') {
+                    successCount++;
+                    lastCasted = casted;
+                    if (casted.variant_id) touchedVariantIds.add(casted.variant_id);
+                    for (const pkg of casted.packages ?? []) touchedPackages.add(pkg);
 
-                        // Highlight the very first created assessment
-                        if (successCount === 1) {
-                            setNewAssessmentIds(prev => new Set(prev).add(casted.id));
-                            setTimeout(() => {
-                                setNewAssessmentIds(prev => {
-                                    const newSet = new Set(prev);
-                                    newSet.delete(casted.id);
-                                    return newSet;
-                                });
-                            }, 5500);
-                        }
-
-                        appendAssessment(casted);
-                        vuln.assessments.push(casted);
-                        // Keep allVulnAssessments in sync so variant tags appear immediately
-                        setAllVulnAssessments(prev => [...prev, casted]);
-                        vuln.simplified_status = casted.simplified_status;
+                    // Highlight the very first created assessment
+                    if (successCount === 1) {
+                        setNewAssessmentIds(prev => new Set(prev).add(casted.id));
+                        setTimeout(() => {
+                            setNewAssessmentIds(prev => {
+                                const newSet = new Set(prev);
+                                newSet.delete(casted.id);
+                                return newSet;
+                            });
+                        }, 5500);
                     }
+
+                    appendAssessment(casted);
+                    vuln.assessments.push(casted);
+                    // Keep allVulnAssessments in sync so variant tags appear immediately
+                    setAllVulnAssessments(prev => [...prev, casted]);
+                    vuln.simplified_status = casted.simplified_status;
                 }
-            } else {
-                showMessage(`Failed to add assessment: HTTP code ${Number(response?.status)} | ${escape(JSON.stringify(data))}`, 'error');
             }
+            if (Array.isArray(data?.errors) && data.errors.length > 0) {
+                showMessage(`Some assessments failed: ${escape(JSON.stringify(data.errors))}`, 'error');
+            }
+        } else {
+            showMessage(`Failed to add assessment: HTTP code ${Number(response?.status)} | ${escape(JSON.stringify(data))}`, 'error');
         }
 
         if (lastCasted) {

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -176,7 +176,7 @@ describe('Vulnerability Modal', () => {
             Promise.resolve({
                 json: () => Promise.resolve({
                     "status": "success",
-                    "assessment": {
+                    "assessments": [{
                         id: '00-0-0-0-000-00',
                         vuln_id: vulnerability.id,
                         packages: vulnerability.packages,
@@ -186,7 +186,7 @@ describe('Vulnerability Modal', () => {
                         timestamp: '2021-01-02T00:00:00Z',
                         origin: 'custom',
                         responses: []
-                    }
+                    }]
                 })
             } as Response)
         );
@@ -2013,42 +2013,41 @@ describe('Vulnerability Modal', () => {
         fetchMock.mockResponseOnce(JSON.stringify([])); // batch variant snapshots (single fetch)
         fetchMock.mockResponseOnce(JSON.stringify([])); // packages fetch for v1 (variantPackageMap effect)
         fetchMock.mockResponseOnce(JSON.stringify([])); // packages fetch for v2 (variantPackageMap effect)
-        // Two POST responses for two variants
+        // Single batch POST returns one record per (package, variant) pair
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
-            assessment: {
-                id: 'new-assess-v1',
-                vuln_id: 'CVE-2010-1234',
-                packages: ['aaabbbccc@1.0.0'],
-                status: 'affected',
-                simplified_status: 'Exploitable',
-                justification: '',
-                impact_statement: '',
-                status_notes: 'multi test',
-                workaround: '',
-                timestamp: '2026-01-01T00:00:00Z',
-                origin: 'custom',
-                responses: [],
-                variant_id: 'v1'
-            }
-        }));
-        fetchMock.mockResponseOnce(JSON.stringify({
-            status: 'success',
-            assessment: {
-                id: 'new-assess-v2',
-                vuln_id: 'CVE-2010-1234',
-                packages: ['aaabbbccc@1.0.0'],
-                status: 'affected',
-                simplified_status: 'Exploitable',
-                justification: '',
-                impact_statement: '',
-                status_notes: 'multi test',
-                workaround: '',
-                timestamp: '2026-01-01T00:00:00Z',
-                origin: 'custom',
-                responses: [],
-                variant_id: 'v2'
-            }
+            assessments: [
+                {
+                    id: 'new-assess-v1',
+                    vuln_id: 'CVE-2010-1234',
+                    packages: ['aaabbbccc@1.0.0'],
+                    status: 'affected',
+                    simplified_status: 'Exploitable',
+                    justification: '',
+                    impact_statement: '',
+                    status_notes: 'multi test',
+                    workaround: '',
+                    timestamp: '2026-01-01T00:00:00Z',
+                    origin: 'custom',
+                    responses: [],
+                    variant_id: 'v1'
+                },
+                {
+                    id: 'new-assess-v2',
+                    vuln_id: 'CVE-2010-1234',
+                    packages: ['aaabbbccc@1.0.0'],
+                    status: 'affected',
+                    simplified_status: 'Exploitable',
+                    justification: '',
+                    impact_statement: '',
+                    status_notes: 'multi test',
+                    workaround: '',
+                    timestamp: '2026-01-01T00:00:00Z',
+                    origin: 'custom',
+                    responses: [],
+                    variant_id: 'v2'
+                }
+            ]
         }));
 
         const appendCb = jest.fn();

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -722,9 +722,12 @@ def init_app(app: Flask) -> None:
                         if finding is None:
                             finding = Finding.get_or_create(db_pkg.id, vuln_id)
                             finding_cache[f_key] = finding
-                        # Always create a new record — never overwrite an existing assessment
+                        # Always create a new record — never overwrite an existing assessment.
+                        # Honour the per-item timestamp so rows added for the same action
+                        # (e.g. one assessment across several variants) share a value.
                         db_a = _create_assessment_record(
-                            assessment, finding.id, variant_id)
+                            assessment, finding.id, variant_id,
+                            timestamp=getattr(assessment, 'timestamp', None))
                         results.append(db_a.to_dict())
                     except Exception as e:
                         errors.append({"vuln_id": vuln_id, "error": str(e)})

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -7,9 +7,6 @@ from uuid import UUID
 
 from ..models import Assessment as DBAssessment, Package, Finding
 from ..models.assessment import STATUS_TO_SIMPLIFIED
-from ..views.openvex import OpenVex
-from ..controllers import ControllersCache
-from ..helpers.verbose import verbose
 from ..extensions import db, batch_session
 from ..models.vulnerability import Vulnerability as DBVuln
 from ..models.variant import Variant as DBVariant
@@ -28,8 +25,6 @@ from ..helpers.assessment_io import (
 from flask import request, Flask
 from flask.typing import ResponseReturnValue
 from sqlalchemy import select
-
-OPENVEX_FILE = "/scan/outputs/openvex.json"
 
 _SCANNER_AUTHORS = {
     "nvd",
@@ -91,25 +86,8 @@ def _create_assessment_record(
 
 def init_app(app: Flask) -> None:
 
-    if "OPENVEX_FILE" not in app.config:
-        app.config["OPENVEX_FILE"] = OPENVEX_FILE
-
     def _get_all_db_assessments() -> list["DBAssessment"]:
         return DBAssessment.get_all()
-
-    def _save_openvex() -> None:
-        """Re-generate and save the OpenVEX file from current DB state."""
-        try:
-            import json
-
-            ctrls = ControllersCache()
-            ctrls.packages._preload_cache()
-
-            vex = OpenVex(ctrls)
-            with open(app.config["OPENVEX_FILE"], "w") as f:
-                f.write(json.dumps(vex.to_dict(), indent=2))
-        except Exception as e:
-            verbose(f"[_save_openvex] {e}")
 
     @app.route('/api/assessments')
     def index_assess() -> ResponseReturnValue:
@@ -262,7 +240,6 @@ def init_app(app: Flask) -> None:
                     "errors": total_errors,
                 }, 400
 
-            _save_openvex()
             return {
                 "status": "success",
                 "imported": len(total_created),
@@ -295,7 +272,6 @@ def init_app(app: Flask) -> None:
                 }, 400
 
             created, errors, skipped = _import_openvex_statements(data["statements"], variant.id)
-            _save_openvex()
             return {"status": "success", "imported": len(created), "skipped": skipped, "errors": errors}, 200
 
         return {"error": "Unsupported file type. Please upload a .json or .tar.gz file."}, 400
@@ -556,8 +532,6 @@ def init_app(app: Flask) -> None:
         variant_by_name = build_variant_by_name_map()
         result = import_custom_data(data, variant_by_name, variant_id)
 
-        _save_openvex()
-
         status_code = 200 if result["status"] == "success" else 400
         return result, status_code
 
@@ -661,7 +635,6 @@ def init_app(app: Flask) -> None:
         if not created:
             return {"error": "No valid package found"}, 400
 
-        _save_openvex()
         response_body = {"status": "success", "assessments": created, "assessment": created[0]}
         return response_body, 200
 
@@ -742,8 +715,6 @@ def init_app(app: Flask) -> None:
         if errors:
             response["errors"] = errors
             response["error_count"] = len(errors)
-        if results:
-            _save_openvex()
         return response, 200 if results else 400
 
     @app.route("/api/assessments/<assessment_id>", methods=["PUT", "PATCH"])
@@ -795,7 +766,6 @@ def init_app(app: Flask) -> None:
             workaround=getattr(mem_assess, "workaround", None),
             responses=list(mem_assess.responses or []),
         )
-        _save_openvex()
         return {"status": "success", "assessment": existing.to_dict()}, 200
 
     @app.route("/api/assessments/<assessment_id>", methods=["DELETE"])
@@ -804,7 +774,6 @@ def init_app(app: Flask) -> None:
         if existing is None:
             return {"error": "Assessment not found"}, 404
         existing.delete()
-        _save_openvex()
         return {"status": "success", "message": "Assessment deleted successfully"}, 200
 
 

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -62,22 +62,6 @@ def _prune_upload_status() -> None:
         _upload_status.pop(uid, None)
 
 
-def _regenerate_openvex(app: Flask) -> None:
-    """Re-generate and save the OpenVEX file from current DB state."""
-    try:
-        from ..views.openvex import OpenVex
-        from ..controllers import ControllersCache
-
-        openvex_file = app.config.get("OPENVEX_FILE", "/scan/outputs/openvex.json")
-        ctrls = ControllersCache()
-        ctrls.packages._preload_cache()
-        vex = OpenVex(ctrls)
-        with open(openvex_file, "w") as f:
-            f.write(json.dumps(vex.to_dict(), indent=2))
-    except Exception as e:
-        verbose(f"[_regenerate_openvex] {e}")
-
-
 def _retry_on_lock(fn: Callable[[], T], max_retries: int = 5, delay: float = 0.5) -> T:
     """Call *fn* and retry up to *max_retries* times on SQLite 'database is locked'.
 
@@ -590,9 +574,6 @@ def init_app(app: Flask) -> None:
                     commit=False,
                 )
                 copied += 1
-
-        if copied:
-            _regenerate_openvex(app)
 
         return jsonify({
             "copied": copied,

--- a/tests/webapp_tests/test_assessments_coverage.py
+++ b/tests/webapp_tests/test_assessments_coverage.py
@@ -504,22 +504,6 @@ def test_update_assessment_updates_last_update(client):
     assert data["assessment"]["last_update"] >= original_last_update
 
 
-# Test verifying that OpenVEX file is updated after assessment changes
-def test_update_assessment_updates_openvex_file(client, init_files):
-    """Test that OpenVEX file is updated when assessment is modified"""
-    # Create assessment
-    response = client.post("/api/vulnerabilities/CVE-2021-99999/assessments", json={
-        'packages': ['test@1.0.0'],
-        'status': 'affected'
-    })
-    assert response.status_code == 200
-    
-    # Check that OpenVEX file was created/updated
-    assert init_files["openvex"].exists()
-    openvex_content = json.loads(init_files["openvex"].read_text())
-    assert "statements" in openvex_content
-
-
 def test_post_assessment_invalid_timestamp(client):
     """POST with an unparseable timestamp string falls back silently (lines 257-258)."""
     response = client.post("/api/vulnerabilities/CVE-2020-35492/assessments", json={
@@ -527,26 +511,6 @@ def test_post_assessment_invalid_timestamp(client):
         "status": "affected",
         "timestamp": "not-a-valid-timestamp",
     })
-    assert response.status_code == 200
-
-
-def test_save_openvex_exception_is_silenced(client, monkeypatch):
-    """_save_openvex silently ignores write errors (lines 41-42)."""
-    import builtins
-    real_open = builtins.open
-
-    def fail_on_write(path, mode="r", **kwargs):
-        # path can be str or pathlib.Path — use str() for consistent matching
-        if "openvex" in str(path) and "w" in str(mode):
-            raise PermissionError("no write access")
-        return real_open(path, mode, **kwargs)
-
-    monkeypatch.setattr("builtins.open", fail_on_write)
-
-    response = client.post("/api/vulnerabilities/CVE-2020-35492/assessments", json={
-        "packages": ["cairo@1.16.0"], "status": "affected"
-    })
-    # Despite the write failure, the API should still succeed
     assert response.status_code == 200
 
 

--- a/tests/webapp_tests/test_post_endpoints.py
+++ b/tests/webapp_tests/test_post_endpoints.py
@@ -293,27 +293,3 @@ def test_delete_assessment_not_found(client):
     
     data = json.loads(response.data)
     assert data["error"] == "Assessment not found"
-
-
-def test_delete_assessment_updates_openvex_file(app, client):
-    # Create an assessment for a vulnerability not already present
-    response = client.post("/api/vulnerabilities/CVE-1999-54321/assessments", json={
-        'packages': ['abc@1.2.3'],
-        'status': 'exploitable',
-        'status_notes': 'Assessment to be deleted'
-    })
-    assert response.status_code == 200
-    assessment_id = json.loads(response.data)["assessment"]["id"]
-
-    # The OpenVEX output file should now reference this vulnerability
-    openvex_path = app.config["OPENVEX_FILE"]
-    with open(openvex_path) as f:
-        assert "CVE-1999-54321" in f.read()
-
-    # Delete the assessment
-    response = client.delete(f"/api/assessments/{assessment_id}")
-    assert response.status_code == 200
-
-    # The OpenVEX file must be regenerated without the deleted assessment
-    with open(openvex_path) as f:
-        assert "CVE-1999-54321" not in f.read()

--- a/tests/webapp_tests/test_settings_endpoints.py
+++ b/tests/webapp_tests/test_settings_endpoints.py
@@ -942,19 +942,6 @@ class TestProcessSBOMBackground:
 
             assert _upload_status[upload_id]["status"] == "error"
 
-    def test_regenerate_openvex_handles_exception(self, app, tmp_path):
-        """_regenerate_openvex() must swallow OpenVEX generation failures."""
-        from src.routes.settings import _regenerate_openvex
-
-        out_file = tmp_path / "openvex.json"
-        app.config["OPENVEX_FILE"] = str(out_file)
-
-        with patch("src.views.openvex.OpenVex.to_dict", side_effect=RuntimeError("boom")):
-            _regenerate_openvex(app)
-
-        assert out_file.exists()
-        assert out_file.stat().st_size == 0
-
 
 # ---------------------------------------------------------------------------
 # NVD API key endpoint


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

- Batch multi-variant adds into one request. Post all variants in a single /api/assessments/batch call to the backend
- Remove legacy OpenVEX file-writing artifact. Drop the auto-written /scan/outputs/openvex.json that predates the
database implementation.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Setup:

```
docker build -t sfl:assess
export VULNSCOUT_IMAGE="sfl:assess"
./vulnscout stop
./vulnscout --serve --dev
```

Create/Edit an assessment. The loading time goes from 20 seconds (without this fix) to less than a second (with this change)