### PR TITLE
Fix: Reduce time to load Scan tab

### DIFF
--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -45,6 +45,43 @@ def _launch_enrichment(app):
     threading.Thread(target=_enrich_epss, name="enrichment-epss", daemon=True).start()
 
 
+def _warm_scan_list_cache(app):
+    """Pre-compute the scan-history list cache in the background.
+
+    The scan-history view runs an expensive diff/serialisation the first time
+    it is requested.  By warming the cache once the scan is finished (i.e. while
+    the frontend still shows "Loading data..."), the first click on the Scans
+    tab is served from the cache instead of paying that cost interactively.
+
+    Runs in its own daemon thread so it never blocks request handlers; any
+    failure is swallowed since the on-demand path stays fully functional.
+    """
+    def _warm():
+        with app.app_context():
+            db.session.autoflush = False
+            try:
+                from ..controllers.scans import ScanController
+                from ..controllers.projects import ProjectController
+                from ..controllers.variants import VariantController
+                from ..routes._scan_diff import serialize_list_with_diff_cached
+
+                serialize_list_with_diff_cached("all", ScanController.get_all())
+                for project in ProjectController.get_all():
+                    serialize_list_with_diff_cached(
+                        f"project:{project.id}",
+                        ScanController.get_by_project(project.id),
+                    )
+                for variant in VariantController.get_all():
+                    serialize_list_with_diff_cached(
+                        f"variant:{variant.id}",
+                        ScanController.get_by_variant(variant.id),
+                    )
+            except Exception as e:
+                print(f"[cache-warm/scan-list] {e}", flush=True)
+
+    threading.Thread(target=_warm, name="cache-warm-scan-list", daemon=True).start()
+
+
 def create_app():
     app = Flask(__name__, static_folder="../static")
     app.config.from_prefixed_env()
@@ -111,6 +148,7 @@ def create_app():
                 app._INT_SCAN_FINISHED = True
                 if not app.config.get("TESTING"):
                     _launch_enrichment(app)
+                    _warm_scan_list_cache(app)
                 return True
         return False
 

--- a/src/routes/_scan_diff.py
+++ b/src/routes/_scan_diff.py
@@ -261,6 +261,7 @@ def _global_result_id_sets(
     tool_scans: Dict[str, Scan],
     *,
     filter_tool_by_sbom_pkgs: bool = False,
+    _cache: Optional[dict] = None,
 ) -> Tuple[set[uuid.UUID], set[str], set[uuid.UUID]]:
     """Return ``(finding_ids, vuln_ids, package_ids)`` for a global result.
 
@@ -287,6 +288,13 @@ def _global_result_id_sets(
         s.id for s in tool_scans.values()
     ]
     contributing_ids = list(dict.fromkeys(contributing_ids))
+
+    cache_key = None
+    if _cache is not None:
+        cache_key = (frozenset(contributing_ids), filter_tool_by_sbom_pkgs)
+        cached = _cache.get(cache_key)
+        if cached is not None:
+            return cached
 
     sbom_pkg_ids = _packages_by_scan_ids([sbom_scan.id]).get(
         sbom_scan.id, set()
@@ -318,12 +326,16 @@ def _global_result_id_sets(
         global_fids.add(fid)
         global_vids.add(vid)
 
-    return global_fids, global_vids, sbom_pkg_ids
+    result = (global_fids, global_vids, sbom_pkg_ids)
+    if _cache is not None:
+        _cache[cache_key] = result
+    return result
 
 
 def _global_assessment_ids_for(
     sbom_scan: Optional[Scan],
     latest_tool: Dict[str, Scan],
+    _cache: Optional[dict] = None,
 ) -> set[uuid.UUID]:
     """Return the set of unique Assessment IDs visible in the global result.
 
@@ -338,6 +350,13 @@ def _global_assessment_ids_for(
     contributing_ids = list(dict.fromkeys(contributing_ids))
     if not contributing_ids:
         return set()
+
+    cache_key = None
+    if _cache is not None:
+        cache_key = frozenset(contributing_ids)
+        cached = _cache.get(cache_key)
+        if cached is not None:
+            return cached
 
     tool_scan_ids: set[uuid.UUID] = {s.id for s in latest_tool.values()}
     sbom_pkg_ids = _packages_by_scan_ids([sbom_scan.id]).get(
@@ -363,6 +382,8 @@ def _global_assessment_ids_for(
         if sid in tool_scan_ids and pkg_id not in sbom_pkg_ids:
             continue
         result.add(aid)
+    if _cache is not None:
+        _cache[cache_key] = result
     return result
 
 
@@ -730,6 +751,11 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
     # Also track the SBOM baseline that was active at each tool scan's
     # timestamp so historical counts stay stable.
     running_src_findings: Dict[Tuple[uuid.UUID, Optional[str]], set[uuid.UUID]] = {}  # (variant_id, source) -> set
+    # Request-scoped memoization: consecutive scans share the same
+    # contributing-scan sets, so cache the expensive global-result and
+    # assessment JOIN queries keyed on the contributing scan-id set.
+    _grs_cache: Dict = {}
+    _assess_cache: Dict = {}
     result = []
     for entry in scan_data:
         scan = entry["scan"]
@@ -765,10 +791,10 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
 
             before_fids, before_vids, _ = _global_result_id_sets(
                 sbom_before, tools_before,
-                filter_tool_by_sbom_pkgs=True)
+                filter_tool_by_sbom_pkgs=True, _cache=_grs_cache)
             after_fids, after_vids, after_pkg_ids = _global_result_id_sets(
                 sbom_after, tools_after,
-                filter_tool_by_sbom_pkgs=True)
+                filter_tool_by_sbom_pkgs=True, _cache=_grs_cache)
 
             # Update running tracker (still needed by the SBOM branch)
             src_key = (scan.variant_id, scan.scan_source)
@@ -793,14 +819,14 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             base["newly_detected_findings"] = len(after_fids - before_fids)
 
             # Assessments: before/after global sets
-            before_assess = _global_assessment_ids_for(sbom_before, tools_before)
-            after_assess = _global_assessment_ids_for(sbom_after, tools_after)
+            before_assess = _global_assessment_ids_for(sbom_before, tools_before, _cache=_assess_cache)
+            after_assess = _global_assessment_ids_for(sbom_after, tools_after, _cache=_assess_cache)
             base["newly_detected_assessments"] = len(after_assess - before_assess)
 
             # Branch result = SBOM ∪ THIS tool scan only (one source)
             branch_fids, branch_vids, branch_pkg_ids = _global_result_id_sets(
                 sbom_after, {scan.scan_source or "": scan},
-                filter_tool_by_sbom_pkgs=True)
+                filter_tool_by_sbom_pkgs=True, _cache=_grs_cache)
             base["branch_finding_count"] = len(branch_fids)
             base["branch_vuln_count"] = len(branch_vids)
             base["branch_package_count"] = len(branch_pkg_ids)
@@ -809,7 +835,7 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             base["global_finding_count"] = len(after_fids)
             base["global_vuln_count"] = len(after_vids)
             base["global_package_count"] = len(after_pkg_ids)
-            base["global_assessment_count"] = _global_assessment_count(scan, variant_scans)
+            base["global_assessment_count"] = len(after_assess)
 
             base["formats"] = []
         elif prev is None:
@@ -843,11 +869,11 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             curr_scan_result_f, curr_scan_result_v, _ = (
                 _global_result_id_sets(
                     scan, latest_tool,
-                    filter_tool_by_sbom_pkgs=True))
+                    filter_tool_by_sbom_pkgs=True, _cache=_grs_cache))
             prev_sr_f, prev_sr_v, _ = (
                 _global_result_id_sets(
                     prev, latest_tool,
-                    filter_tool_by_sbom_pkgs=True))
+                    filter_tool_by_sbom_pkgs=True, _cache=_grs_cache))
 
             # --- Classify findings using scan result diffs ---
             # new + upgraded + unchanged = current scan result

--- a/src/routes/_scan_diff.py
+++ b/src/routes/_scan_diff.py
@@ -716,7 +716,7 @@ def _global_result_full(
 # ---------------------------------------------------------------------------
 
 # In-memory cache of the (expensive) serialised scan-history list, keyed by
-# request scope ("all", "project:<id>", "variant:<id>").  
+# request scope ("all", "project:<id>", "variant:<id>").
 _LIST_CACHE_LOCK = threading.Lock()
 _LIST_CACHE: Dict[str, Tuple[frozenset, List[dict]]] = {}
 
@@ -744,6 +744,21 @@ def serialize_list_with_diff_cached(scope_key: str, scans: list[Scan]) -> List[d
     with _LIST_CACHE_LOCK:
         _LIST_CACHE[scope_key] = (fingerprint, payload)
     return payload
+
+
+def invalidate_scan_list_cache() -> None:
+    """Drop every cached scan-history list.
+
+    The cache fingerprint only tracks the set of scans (add / delete / rename),
+    so it does NOT notice changes to the per-scan assessment counts shown in the
+    list view.  Those counts include automated (non-custom) assessments, so when
+    a non-custom assessment is edited or deleted its scan's counts change while
+    the fingerprint stays the same.  Callers must invalidate the cache in that
+    case.  Custom (manually-created) assessments are excluded from the view and
+    therefore never require invalidation.
+    """
+    with _LIST_CACHE_LOCK:
+        _LIST_CACHE.clear()
 
 
 def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:

--- a/src/routes/_scan_diff.py
+++ b/src/routes/_scan_diff.py
@@ -18,12 +18,11 @@ from ..models.package import Package
 from ..extensions import db
 
 import uuid
+import threading
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
 from ._scan_queries import (
-    _findings_by_scan_ids,
-    _vulns_by_scan_ids,
     _packages_by_scan_ids,
     _package_rows,
     _variant_info,
@@ -256,12 +255,72 @@ def _contributing_scans_at(scan: Scan, all_variant_scans: list[Scan]) -> Tuple[O
     return sbom_scan, latest_tool
 
 
+def _observation_rows_by_scan(
+    scan_ids: List[uuid.UUID],
+) -> Dict[uuid.UUID, List[Tuple[uuid.UUID, uuid.UUID, str]]]:
+    """Pre-fetch ``{scan_id: [(finding_id, package_id, vulnerability_id), …]}``.
+
+    A single JOIN query over all scans so that the per-scan global-result
+    helper can compute its finding/vuln sets in memory instead of issuing
+    one query per contributing-scan set.
+    """
+    result: Dict[uuid.UUID, List[Tuple[uuid.UUID, uuid.UUID, str]]] = {}
+    if not scan_ids:
+        return result
+    rows = db.session.execute(
+        db.select(
+            Observation.scan_id,
+            Observation.finding_id,
+            Finding.package_id,
+            Finding.vulnerability_id,
+        )
+        .join(Finding, Finding.id == Observation.finding_id)
+        .where(Observation.scan_id.in_(scan_ids))
+    ).all()
+    for sid, fid, pkg_id, vid in rows:
+        result.setdefault(sid, []).append((fid, pkg_id, vid))
+    return result
+
+
+def _global_assessment_rows_by_scan(
+    scan_ids: List[uuid.UUID],
+) -> Dict[uuid.UUID, List[Tuple[uuid.UUID, uuid.UUID]]]:
+    """Pre-fetch ``{scan_id: [(assessment_id, package_id), …]}`` for all scans.
+
+    Mirrors the per-set query in :func:`_global_assessment_ids_for` but runs
+    once for the whole scan list.  Custom (manually-created) assessments are
+    excluded, matching the per-set query.
+    """
+    from ..models.assessment import Assessment
+
+    result: Dict[uuid.UUID, List[Tuple[uuid.UUID, uuid.UUID]]] = {}
+    if not scan_ids:
+        return result
+    rows = db.session.execute(
+        db.select(Assessment.id, Observation.scan_id, Finding.package_id)
+        .select_from(Observation)
+        .join(Finding, Finding.id == Observation.finding_id)
+        .join(Assessment, Assessment.finding_id == Finding.id)
+        .join(Scan, Scan.id == Observation.scan_id)
+        .where(
+            Observation.scan_id.in_(scan_ids),
+            Assessment.variant_id == Scan.variant_id,
+            Assessment.origin != "custom",
+        )
+    ).all()
+    for aid, sid, pkg_id in rows:
+        result.setdefault(sid, []).append((aid, pkg_id))
+    return result
+
+
 def _global_result_id_sets(
     sbom_scan: Optional[Scan],
     tool_scans: Dict[str, Scan],
     *,
     filter_tool_by_sbom_pkgs: bool = False,
     _cache: Optional[dict] = None,
+    _obs_prefetch: Optional[Dict[uuid.UUID, list]] = None,
+    _pkg_prefetch: Optional[Dict[uuid.UUID, set]] = None,
 ) -> Tuple[set[uuid.UUID], set[str], set[uuid.UUID]]:
     """Return ``(finding_ids, vuln_ids, package_ids)`` for a global result.
 
@@ -298,33 +357,41 @@ def _global_result_id_sets(
 
     sbom_pkg_ids = _packages_by_scan_ids([sbom_scan.id]).get(
         sbom_scan.id, set()
-    )
+    ) if _pkg_prefetch is None else _pkg_prefetch.get(sbom_scan.id, set())
 
     if filter_tool_by_sbom_pkgs:
         tool_scan_ids: set[uuid.UUID] = {s.id for s in tool_scans.values()}
     else:
         tool_scan_ids = set()  # empty → no filtering
 
-    finding_rows = db.session.execute(
-        db.select(
-            Observation.scan_id,
-            Observation.finding_id,
-            Finding.package_id,
-            Finding.vulnerability_id,
-        )
-        .join(Finding, Finding.id == Observation.finding_id)
-        .where(Observation.scan_id.in_(contributing_ids))
-    ).all()
-
     global_fids: set[uuid.UUID] = set()
     global_vids: set[str] = set()
-    for sid, fid, pkg_id, vid in finding_rows:
-        # When filtering is enabled, skip tool-scan findings whose
-        # package is not in the active SBOM.
-        if sid in tool_scan_ids and pkg_id not in sbom_pkg_ids:
-            continue
-        global_fids.add(fid)
-        global_vids.add(vid)
+
+    if _obs_prefetch is not None:
+        for sid in contributing_ids:
+            for fid, pkg_id, vid in _obs_prefetch.get(sid, ()):
+                if sid in tool_scan_ids and pkg_id not in sbom_pkg_ids:
+                    continue
+                global_fids.add(fid)
+                global_vids.add(vid)
+    else:
+        finding_rows = db.session.execute(
+            db.select(
+                Observation.scan_id,
+                Observation.finding_id,
+                Finding.package_id,
+                Finding.vulnerability_id,
+            )
+            .join(Finding, Finding.id == Observation.finding_id)
+            .where(Observation.scan_id.in_(contributing_ids))
+        ).all()
+        for sid, fid, pkg_id, vid in finding_rows:
+            # When filtering is enabled, skip tool-scan findings whose
+            # package is not in the active SBOM.
+            if sid in tool_scan_ids and pkg_id not in sbom_pkg_ids:
+                continue
+            global_fids.add(fid)
+            global_vids.add(vid)
 
     result = (global_fids, global_vids, sbom_pkg_ids)
     if _cache is not None:
@@ -336,6 +403,8 @@ def _global_assessment_ids_for(
     sbom_scan: Optional[Scan],
     latest_tool: Dict[str, Scan],
     _cache: Optional[dict] = None,
+    _obs_prefetch: Optional[Dict[uuid.UUID, list]] = None,
+    _pkg_prefetch: Optional[Dict[uuid.UUID, set]] = None,
 ) -> set[uuid.UUID]:
     """Return the set of unique Assessment IDs visible in the global result.
 
@@ -359,29 +428,38 @@ def _global_assessment_ids_for(
             return cached
 
     tool_scan_ids: set[uuid.UUID] = {s.id for s in latest_tool.values()}
-    sbom_pkg_ids = _packages_by_scan_ids([sbom_scan.id]).get(
-        sbom_scan.id, set()
-    ) if sbom_scan else set()
-
-    rows = db.session.execute(
-        db.select(Assessment.id, Observation.scan_id, Finding.package_id)
-        .select_from(Observation)
-        .join(Finding, Finding.id == Observation.finding_id)
-        .join(Assessment, Assessment.finding_id == Finding.id)
-        .join(Scan, Scan.id == Observation.scan_id)
-        .where(
-            Observation.scan_id.in_(contributing_ids),
-            Assessment.variant_id == Scan.variant_id,
-            Assessment.origin != "custom",
-        )
-    ).all()
+    if _pkg_prefetch is not None:
+        sbom_pkg_ids = _pkg_prefetch.get(sbom_scan.id, set()) if sbom_scan else set()
+    else:
+        sbom_pkg_ids = _packages_by_scan_ids([sbom_scan.id]).get(
+            sbom_scan.id, set()
+        ) if sbom_scan else set()
 
     result: set[uuid.UUID] = set()
-    for aid, sid, pkg_id in rows:
-        # Skip tool-scan assessments whose finding's package is not in the SBOM
-        if sid in tool_scan_ids and pkg_id not in sbom_pkg_ids:
-            continue
-        result.add(aid)
+    if _obs_prefetch is not None:
+        for sid in contributing_ids:
+            for aid, pkg_id in _obs_prefetch.get(sid, ()):
+                if sid in tool_scan_ids and pkg_id not in sbom_pkg_ids:
+                    continue
+                result.add(aid)
+    else:
+        rows = db.session.execute(
+            db.select(Assessment.id, Observation.scan_id, Finding.package_id)
+            .select_from(Observation)
+            .join(Finding, Finding.id == Observation.finding_id)
+            .join(Assessment, Assessment.finding_id == Finding.id)
+            .join(Scan, Scan.id == Observation.scan_id)
+            .where(
+                Observation.scan_id.in_(contributing_ids),
+                Assessment.variant_id == Scan.variant_id,
+                Assessment.origin != "custom",
+            )
+        ).all()
+        for aid, sid, pkg_id in rows:
+            # Skip tool-scan assessments whose finding's package is not in SBOM
+            if sid in tool_scan_ids and pkg_id not in sbom_pkg_ids:
+                continue
+            result.add(aid)
     if _cache is not None:
         _cache[cache_key] = result
     return result
@@ -637,14 +715,55 @@ def _global_result_full(
 # List-view serialisation with diff badges
 # ---------------------------------------------------------------------------
 
+# In-memory cache of the (expensive) serialised scan-history list, keyed by
+# request scope ("all", "project:<id>", "variant:<id>").  
+_LIST_CACHE_LOCK = threading.Lock()
+_LIST_CACHE: Dict[str, Tuple[frozenset, List[dict]]] = {}
+
+
+def _scan_list_fingerprint(scans: list[Scan]) -> frozenset:
+    """Order-independent fingerprint capturing scan add / delete / rename."""
+    return frozenset(
+        (s.id, s.description, s.timestamp) for s in scans
+    )
+
+
+def serialize_list_with_diff_cached(scope_key: str, scans: list[Scan]) -> List[dict]:
+    """Return the serialised scan-history list for *scans*, cached per *scope_key*.
+
+    The heavy diff computation runs once and its result is reused for later
+    requests until the underlying set of scans changes (import / delete /
+    rename), matching an application reload.
+    """
+    fingerprint = _scan_list_fingerprint(scans)
+    with _LIST_CACHE_LOCK:
+        entry = _LIST_CACHE.get(scope_key)
+        if entry is not None and entry[0] == fingerprint:
+            return entry[1]
+    payload = _serialize_list_with_diff(scans)
+    with _LIST_CACHE_LOCK:
+        _LIST_CACHE[scope_key] = (fingerprint, payload)
+    return payload
+
+
 def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
     if not scans:
         return []
 
     scan_ids = [s.id for s in scans]
-    findings_map = _findings_by_scan_ids(scan_ids)
+    # One combined observation query supplies per-scan findings, vulns and the
+    # (finding, package, vuln) rows consumed by the global-result helper below,
+    # replacing three separate Observation scans.
+    _obs_prefetch = _observation_rows_by_scan(scan_ids)
+    findings_map: Dict[uuid.UUID, set[uuid.UUID]] = {
+        sid: {r[0] for r in rows} for sid, rows in _obs_prefetch.items()
+    }
+    vulns_map: Dict[uuid.UUID, set[str]] = {
+        sid: {r[2] for r in rows} for sid, rows in _obs_prefetch.items()
+    }
     packages_map = _packages_by_scan_ids(scan_ids)
-    vulns_map = _vulns_by_scan_ids(scan_ids)
+    # Assessment rows (per scan) for the global-assessment helper.
+    _assess_prefetch = _global_assessment_rows_by_scan(scan_ids)
     prev_map = _prev_scan_map(scans)
     variant_map = _variant_info(list({s.variant_id for s in scans}))
     assessments_map = _assessments_by_scan(scans)
@@ -791,10 +910,12 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
 
             before_fids, before_vids, _ = _global_result_id_sets(
                 sbom_before, tools_before,
-                filter_tool_by_sbom_pkgs=True, _cache=_grs_cache)
+                filter_tool_by_sbom_pkgs=True, _cache=_grs_cache,
+                _obs_prefetch=_obs_prefetch, _pkg_prefetch=packages_map)
             after_fids, after_vids, after_pkg_ids = _global_result_id_sets(
                 sbom_after, tools_after,
-                filter_tool_by_sbom_pkgs=True, _cache=_grs_cache)
+                filter_tool_by_sbom_pkgs=True, _cache=_grs_cache,
+                _obs_prefetch=_obs_prefetch, _pkg_prefetch=packages_map)
 
             # Update running tracker (still needed by the SBOM branch)
             src_key = (scan.variant_id, scan.scan_source)
@@ -819,14 +940,19 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             base["newly_detected_findings"] = len(after_fids - before_fids)
 
             # Assessments: before/after global sets
-            before_assess = _global_assessment_ids_for(sbom_before, tools_before, _cache=_assess_cache)
-            after_assess = _global_assessment_ids_for(sbom_after, tools_after, _cache=_assess_cache)
+            before_assess = _global_assessment_ids_for(
+                sbom_before, tools_before, _cache=_assess_cache,
+                _obs_prefetch=_assess_prefetch, _pkg_prefetch=packages_map)
+            after_assess = _global_assessment_ids_for(
+                sbom_after, tools_after, _cache=_assess_cache,
+                _obs_prefetch=_assess_prefetch, _pkg_prefetch=packages_map)
             base["newly_detected_assessments"] = len(after_assess - before_assess)
 
             # Branch result = SBOM ∪ THIS tool scan only (one source)
             branch_fids, branch_vids, branch_pkg_ids = _global_result_id_sets(
                 sbom_after, {scan.scan_source or "": scan},
-                filter_tool_by_sbom_pkgs=True, _cache=_grs_cache)
+                filter_tool_by_sbom_pkgs=True, _cache=_grs_cache,
+                _obs_prefetch=_obs_prefetch, _pkg_prefetch=packages_map)
             base["branch_finding_count"] = len(branch_fids)
             base["branch_vuln_count"] = len(branch_vids)
             base["branch_package_count"] = len(branch_pkg_ids)
@@ -869,11 +995,13 @@ def _serialize_list_with_diff(scans: list[Scan]) -> list[dict]:
             curr_scan_result_f, curr_scan_result_v, _ = (
                 _global_result_id_sets(
                     scan, latest_tool,
-                    filter_tool_by_sbom_pkgs=True, _cache=_grs_cache))
+                    filter_tool_by_sbom_pkgs=True, _cache=_grs_cache,
+                    _obs_prefetch=_obs_prefetch, _pkg_prefetch=packages_map))
             prev_sr_f, prev_sr_v, _ = (
                 _global_result_id_sets(
                     prev, latest_tool,
-                    filter_tool_by_sbom_pkgs=True, _cache=_grs_cache))
+                    filter_tool_by_sbom_pkgs=True, _cache=_grs_cache,
+                    _obs_prefetch=_obs_prefetch, _pkg_prefetch=packages_map))
 
             # --- Classify findings using scan result diffs ---
             # new + upgraded + unchanged = current scan result

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -12,6 +12,7 @@ from ..models.vulnerability import Vulnerability as DBVuln
 from ..models.variant import Variant as DBVariant
 from ._scan_helpers import parse_uuid_or_400
 from ._scan_queries import VulnerabilityText, fetch_vulnerabilities_texts
+from ._scan_diff import invalidate_scan_list_cache
 from ..helpers.assessment_io import (
     build_openvex_archive,
     is_openvex_doc,
@@ -727,6 +728,8 @@ def init_app(app: Flask) -> None:
         if existing is None:
             return {"error": "Assessment not found"}, 404
 
+        was_non_custom = (existing.origin or "") != "custom"
+
         # Reconstruct Assessment DTO for validation
         mem_assess = DBAssessment.from_dict(existing.to_dict())
 
@@ -766,6 +769,10 @@ def init_app(app: Flask) -> None:
             workaround=getattr(mem_assess, "workaround", None),
             responses=list(mem_assess.responses or []),
         )
+        # Editing an automated assessment removes it from the scan-history
+        # counts (it becomes custom-origin), so refresh the cached list view.
+        if was_non_custom:
+            invalidate_scan_list_cache()
         return {"status": "success", "assessment": existing.to_dict()}, 200
 
     @app.route("/api/assessments/<assessment_id>", methods=["DELETE"])
@@ -773,7 +780,12 @@ def init_app(app: Flask) -> None:
         existing = DBAssessment.get_by_id(assessment_id)
         if existing is None:
             return {"error": "Assessment not found"}, 404
+        # A non-custom assessment contributes to the scan-history counts, so
+        # its removal must invalidate the cached list view.
+        was_non_custom = (existing.origin or "") != "custom"
         existing.delete()
+        if was_non_custom:
+            invalidate_scan_list_cache()
         return {"status": "success", "message": "Assessment deleted successfully"}, 200
 
 

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -40,7 +40,7 @@ from ._scan_diff import (
     _global_result_id_sets,
     _global_assessment_ids_for,
     _global_result_full,
-    _serialize_list_with_diff,
+    serialize_list_with_diff_cached,
 )
 
 
@@ -59,6 +59,7 @@ from ._scan_queries import (  # noqa: F401  — re-exports
 from ._scan_diff import (  # noqa: F401  — re-exports
     _classify_finding_changes,
     _prev_scan_map,
+    _serialize_list_with_diff,
 )
 
 
@@ -286,7 +287,7 @@ def init_app(app: Flask) -> None:
     @app.route('/api/scans')
     def list_all_scans() -> ResponseReturnValue:
         scans = ScanController.get_all()
-        result = _serialize_list_with_diff(scans)
+        result = serialize_list_with_diff_cached("all", scans)
         return jsonify(result)
 
     @app.route('/api/projects/<project_id>/scans')
@@ -295,7 +296,7 @@ def init_app(app: Flask) -> None:
         if project is None:
             return jsonify({"error": "Project not found"}), 404
         scans = ScanController.get_by_project(project_id)
-        result = _serialize_list_with_diff(scans)
+        result = serialize_list_with_diff_cached(f"project:{project_id}", scans)
         return jsonify(result)
 
     @app.route('/api/variants/<variant_id>/scans')
@@ -304,7 +305,7 @@ def init_app(app: Flask) -> None:
         if variant is None:
             return jsonify({"error": "Variant not found"}), 404
         scans = ScanController.get_by_variant(variant_id)
-        result = _serialize_list_with_diff(scans)
+        result = serialize_list_with_diff_cached(f"variant:{variant_id}", scans)
         return jsonify(result)
 
     @app.route('/api/scans/<scan_id>', methods=['PATCH'])

--- a/tests/webapp_tests/test_scan_cache_diff.py
+++ b/tests/webapp_tests/test_scan_cache_diff.py
@@ -740,6 +740,59 @@ class TestSerializeListWithDiffCached:
 
 
 # ===================================================================
+# _scan_diff.py — invalidate_scan_list_cache
+# ===================================================================
+
+class TestInvalidateScanListCache:
+    """Explicit invalidation drops every cached scope so the next call
+    recomputes, even when the scan fingerprint is unchanged."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        from src.routes import _scan_diff
+        with _scan_diff._LIST_CACHE_LOCK:
+            _scan_diff._LIST_CACHE.clear()
+        yield
+        with _scan_diff._LIST_CACHE_LOCK:
+            _scan_diff._LIST_CACHE.clear()
+
+    def test_invalidate_forces_recompute(self, app, ids):
+        from src.routes._scan_diff import (
+            serialize_list_with_diff_cached, invalidate_scan_list_cache,
+        )
+        from src.controllers.scans import ScanController
+
+        with app.app_context():
+            scans = ScanController.get_all()
+            first = serialize_list_with_diff_cached("all", scans)
+            # Same scans → cache hit without invalidation.
+            assert serialize_list_with_diff_cached("all", scans) is first
+            invalidate_scan_list_cache()
+            # After invalidation the identical scan set is recomputed.
+            recomputed = serialize_list_with_diff_cached("all", scans)
+            assert recomputed is not first
+            assert recomputed == first
+
+    def test_invalidate_clears_all_scopes(self, app, ids):
+        from src.routes import _scan_diff
+        from src.routes._scan_diff import (
+            serialize_list_with_diff_cached, invalidate_scan_list_cache,
+        )
+        from src.controllers.scans import ScanController
+
+        with app.app_context():
+            scans = ScanController.get_all()
+            serialize_list_with_diff_cached("all", scans)
+            serialize_list_with_diff_cached(
+                f"variant:{ids['variant_id']}", scans)
+            with _scan_diff._LIST_CACHE_LOCK:
+                assert len(_scan_diff._LIST_CACHE) == 2
+            invalidate_scan_list_cache()
+            with _scan_diff._LIST_CACHE_LOCK:
+                assert _scan_diff._LIST_CACHE == {}
+
+
+# ===================================================================
 # _scan_diff.py — prefetch helpers
 # ===================================================================
 

--- a/tests/webapp_tests/test_scan_cache_diff.py
+++ b/tests/webapp_tests/test_scan_cache_diff.py
@@ -622,3 +622,169 @@ class TestAssessmentGlobalAndList:
         assert "assessments_added" in data
         assert "assessments_removed" in data
         assert "assessments_unchanged" in data
+
+
+# ===================================================================
+# _scan_diff.py — _scan_list_fingerprint (cache invalidation key)
+# ===================================================================
+
+class TestScanListFingerprint:
+    """The fingerprint drives cache invalidation for the scan-history list."""
+
+    @staticmethod
+    def _scan(id_, description, timestamp):
+        from types import SimpleNamespace
+        return SimpleNamespace(id=id_, description=description, timestamp=timestamp)
+
+    def test_order_independent(self):
+        from src.routes._scan_diff import _scan_list_fingerprint
+        a = self._scan(1, "a", 100)
+        b = self._scan(2, "b", 200)
+        assert _scan_list_fingerprint([a, b]) == _scan_list_fingerprint([b, a])
+
+    def test_changes_when_scan_added_or_removed(self):
+        from src.routes._scan_diff import _scan_list_fingerprint
+        a = self._scan(1, "a", 100)
+        b = self._scan(2, "b", 200)
+        assert _scan_list_fingerprint([a, b]) != _scan_list_fingerprint([a])
+
+    def test_changes_on_rename(self):
+        from src.routes._scan_diff import _scan_list_fingerprint
+        before = [self._scan(1, "old name", 100)]
+        after = [self._scan(1, "new name", 100)]
+        assert _scan_list_fingerprint(before) != _scan_list_fingerprint(after)
+
+    def test_changes_on_timestamp(self):
+        from src.routes._scan_diff import _scan_list_fingerprint
+        before = [self._scan(1, "a", 100)]
+        after = [self._scan(1, "a", 200)]
+        assert _scan_list_fingerprint(before) != _scan_list_fingerprint(after)
+
+
+# ===================================================================
+# _scan_diff.py — serialize_list_with_diff_cached (per-scope cache)
+# ===================================================================
+
+class TestSerializeListWithDiffCached:
+    """The cached wrapper must match the uncached output and only recompute
+    when the underlying set of scans changes."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        from src.routes import _scan_diff
+        with _scan_diff._LIST_CACHE_LOCK:
+            _scan_diff._LIST_CACHE.clear()
+        yield
+        with _scan_diff._LIST_CACHE_LOCK:
+            _scan_diff._LIST_CACHE.clear()
+
+    def test_output_matches_uncached(self, app, ids):
+        from src.routes._scan_diff import (
+            _serialize_list_with_diff, serialize_list_with_diff_cached,
+        )
+        from src.controllers.scans import ScanController
+
+        with app.app_context():
+            scans = ScanController.get_all()
+            expected = _serialize_list_with_diff(scans)
+            cached = serialize_list_with_diff_cached("all", scans)
+            assert cached == expected
+
+    def test_second_call_returns_cached_object(self, app, ids):
+        from src.routes._scan_diff import serialize_list_with_diff_cached
+        from src.controllers.scans import ScanController
+
+        with app.app_context():
+            scans = ScanController.get_all()
+            first = serialize_list_with_diff_cached("all", scans)
+            second = serialize_list_with_diff_cached("all", scans)
+            # Same scan set → cache hit → the very same list object is returned.
+            assert second is first
+
+    def test_scopes_are_isolated(self, app, ids):
+        from src.routes._scan_diff import serialize_list_with_diff_cached
+        from src.controllers.scans import ScanController
+
+        with app.app_context():
+            scans = ScanController.get_all()
+            all_scope = serialize_list_with_diff_cached("all", scans)
+            variant_scope = serialize_list_with_diff_cached(
+                f"variant:{ids['variant_id']}", scans)
+            # Different scope keys are computed independently…
+            assert variant_scope is not all_scope
+            # …but over the same scans they yield equal content.
+            assert variant_scope == all_scope
+
+    def test_recomputes_when_scan_set_changes(self, app, ids):
+        from src.routes._scan_diff import serialize_list_with_diff_cached
+        from src.controllers.scans import ScanController
+
+        with app.app_context():
+            scans = ScanController.get_all()
+            first = serialize_list_with_diff_cached("all", scans)
+            # Drop a scan → fingerprint changes → recompute (new object).
+            reduced = serialize_list_with_diff_cached("all", scans[:-1])
+            assert reduced is not first
+            assert len(reduced) == len(first) - 1
+
+    def test_recomputes_after_rename(self, app, ids):
+        from src.routes._scan_diff import serialize_list_with_diff_cached
+        from src.controllers.scans import ScanController
+
+        with app.app_context():
+            scans = ScanController.get_all()
+            first = serialize_list_with_diff_cached("all", scans)
+            scans[0].description = "renamed for cache test"
+            renamed = serialize_list_with_diff_cached("all", scans)
+            assert renamed is not first
+
+
+# ===================================================================
+# _scan_diff.py — prefetch helpers
+# ===================================================================
+
+class TestObservationRowsByScan:
+    """_observation_rows_by_scan batches finding/package/vuln rows per scan."""
+
+    def test_empty_input_returns_empty(self, app):
+        from src.routes._scan_diff import _observation_rows_by_scan
+        with app.app_context():
+            assert _observation_rows_by_scan([]) == {}
+
+    def test_rows_grouped_by_scan(self, app, ids):
+        from src.routes._scan_diff import _observation_rows_by_scan
+        with app.app_context():
+            sbom_a = uuid.UUID(ids["sbom_a_id"])
+            tool = uuid.UUID(ids["tool_scan_id"])
+            rows = _observation_rows_by_scan([sbom_a, tool])
+
+            # First SBOM: openssl@1.1.0 → CVE-2020-0001
+            a_vulns = {vid for (_fid, _pkg, vid) in rows[sbom_a]}
+            a_pkgs = {pkg for (_fid, pkg, _vid) in rows[sbom_a]}
+            assert a_vulns == {"CVE-2020-0001"}
+            assert uuid.UUID(ids["pkg_old_id"]) in a_pkgs
+
+            # Tool scan: two findings (new-version pkg + soon-removed pkg)
+            t_vulns = {vid for (_fid, _pkg, vid) in rows[tool]}
+            assert t_vulns == {"CVE-2021-9999", "CVE-2021-8888"}
+
+
+class TestGlobalAssessmentRowsByScan:
+    """_global_assessment_rows_by_scan excludes custom-origin assessments."""
+
+    def test_empty_input_returns_empty(self, app):
+        from src.routes._scan_diff import _global_assessment_rows_by_scan
+        with app.app_context():
+            assert _global_assessment_rows_by_scan([]) == {}
+
+    def test_excludes_custom_origin(self, app, ids):
+        from src.routes._scan_diff import _global_assessment_rows_by_scan
+        with app.app_context():
+            tool = uuid.UUID(ids["tool_scan_id"])
+            rows = _global_assessment_rows_by_scan([tool])
+            pkg_ids = {pkg for (_aid, pkg) in rows.get(tool, [])}
+
+            # The sbom-origin assessment (on the new-version package) counts…
+            assert uuid.UUID(ids["pkg_new_id"]) in pkg_ids
+            # …the custom-origin assessment (on the removed package) does not.
+            assert uuid.UUID(ids["pkg_removed_id"]) not in pkg_ids


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

-Speed up scan-tab list serialization. The scan history list recomputed global results per scan, issuing a JOIN
query per contributing-scan set plus separate observation scans for findings and vulns.

-Cache scan-tab list and finish prefetch refactor. The scan history list is expensive to serialize (per-scan global-result
diffs). Its content only changes when scans are imported, deleted or
renamed, so recomputing it on every request is wasteful.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Go on the Scan tab, should be faster to load the first time. Then, move to another tab and come back to Scan tab. 
Should be very fast thanks to the cache