### PR TITLE
feat(variants): support selecting multiple variants in scope selector

### DIFF
--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -14,7 +14,7 @@ type Props = {
   setDarkMode: (mode: boolean) => void;
   defaultProject?: { id: string; name: string } | null;
   defaultVariant?: { id: string; name: string } | null;
-  onApply: (projectId: string, variantId: string, compareVariantId: string, operation: string) => void;
+  onApply: (projectId: string, variantId: string, compareVariantId: string, operation: string, variantIds: string[], multiOperation: string) => void;
 };
 
 function NavigationBar({ tab, changeTab, darkMode, setDarkMode, defaultProject, defaultVariant, onApply }: Readonly<Props>) {

--- a/frontend/src/components/ProjectVariantSelector.tsx
+++ b/frontend/src/components/ProjectVariantSelector.tsx
@@ -30,7 +30,7 @@ type Props = {
     onApply: (projectId: string, variantId: string, compareVariantId: string, operation: string, variantIds: string[], multiOperation: string) => void;
 };
 
-function ProjectVariantSelector({ defaultProject, defaultVariant, onApply }: Readonly<Props>) {
+function ProjectVariantSelector({ defaultProject, onApply }: Readonly<Props>) {
     const [isOpen, setIsOpen] = useState(false);
     const buttonRef = useRef<HTMLButtonElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
@@ -80,20 +80,17 @@ function ProjectVariantSelector({ defaultProject, defaultVariant, onApply }: Rea
     // Sync display state when default config arrives from the server
     useEffect(() => {
         if (defaultProject?.id) {
-            // Show only the configured variant (if any) on first load.
-            if (defaultVariant?.id) pendingRestoreRef.current = [defaultVariant.id];
+            // All variants are selected by default on first load.
             setSelectedProjectId(defaultProject.id);
             setAppliedProject(defaultProject.name);
         }
-    }, [defaultProject?.id, defaultProject?.name, defaultVariant?.id]);
+    }, [defaultProject?.id, defaultProject?.name]);
 
     useEffect(() => {
-        if (defaultVariant?.id) {
-            setAppliedLabel(defaultVariant.name);
-        } else if (defaultProject?.id) {
+        if (defaultProject?.id) {
             setAppliedLabel('All variants');
         }
-    }, [defaultVariant?.id, defaultVariant?.name, defaultProject?.id]);
+    }, [defaultProject?.id]);
 
     // Default the compare base / compare variant once variants are available
     useEffect(() => {
@@ -144,9 +141,8 @@ function ProjectVariantSelector({ defaultProject, defaultVariant, onApply }: Rea
     useEffect(() => {
         if (appliedScope || variants.length === 0 || !selectedProjectId) return;
         if (defaultProject?.id !== selectedProjectId) return;
-        const variantIds = (defaultVariant?.id && variants.some(v => v.id === defaultVariant.id))
-            ? [defaultVariant.id]
-            : variants.map(v => v.id);
+        // All variants are selected by default.
+        const variantIds = variants.map(v => v.id);
         applyScope({
             projectId: selectedProjectId,
             mode: 'select',
@@ -155,7 +151,7 @@ function ProjectVariantSelector({ defaultProject, defaultVariant, onApply }: Rea
             compareOp: 'difference',
             compareId: '',
         });
-    }, [variants, selectedProjectId, appliedScope, defaultProject?.id, defaultVariant?.id]);
+    }, [variants, selectedProjectId, appliedScope, defaultProject?.id]);
 
     // Restore the panel controls from the applied scope each time it opens.
     useEffect(() => {

--- a/frontend/src/components/ProjectVariantSelector.tsx
+++ b/frontend/src/components/ProjectVariantSelector.tsx
@@ -11,10 +11,23 @@ const greenTheme = true;
 const bgHoverColor = greenTheme ? 'hover:bg-cyan-700' : 'dark:hover:bg-neutral-700';
 const bgActiveColor = greenTheme ? 'bg-cyan-900' : 'dark:bg-neutral-800';
 
+type Mode = 'select' | 'compare';
+
+// Snapshot of the currently-applied (loaded) scope, used to restore the panel
+// controls to the active configuration each time it is reopened.
+type AppliedScope = {
+    projectId: string;
+    mode: Mode;
+    variantIds: string[];
+    compareBaseId: string;
+    compareOp: 'difference' | 'intersection';
+    compareId: string;
+};
+
 type Props = {
     defaultProject?: { id: string; name: string } | null;
     defaultVariant?: { id: string; name: string } | null;
-    onApply: (projectId: string, variantId: string, compareVariantId: string, operation: string) => void;
+    onApply: (projectId: string, variantId: string, compareVariantId: string, operation: string, variantIds: string[], multiOperation: string) => void;
 };
 
 function ProjectVariantSelector({ defaultProject, defaultVariant, onApply }: Readonly<Props>) {
@@ -25,46 +38,77 @@ function ProjectVariantSelector({ defaultProject, defaultVariant, onApply }: Rea
     const [projects, setProjects] = useState<Project[]>([]);
     const [variants, setVariants] = useState<Variant[]>([]);
     const [selectedProjectId, setSelectedProjectId] = useState<string>('');
-    const [selectedVariantId, setSelectedVariantId] = useState<string>('');
 
-    // Compare variants state
-    const [compareEnabled, setCompareEnabled] = useState<boolean>(false);
+    // Two mutually-exclusive modes:
+    //  - 'select': pick one or more variants; data relevant to *any* of them (union)
+    //  - 'compare': diff/intersection between a base variant and a compare variant
+    const [mode, setMode] = useState<Mode>('select');
+
+    // Select-variants mode state (all variants selected by default)
+    const [selectedVariantIds, setSelectedVariantIds] = useState<string[]>([]);
+
+    // Compare-variants mode state
+    const [compareBaseVariantId, setCompareBaseVariantId] = useState<string>('');
     const [compareOperation, setCompareOperation] = useState<'difference' | 'intersection'>('difference');
     const [selectedCompareVariantId, setSelectedCompareVariantId] = useState<string>('');
 
     // Applied (display) state — initialised from props when they arrive
     const [appliedProject, setAppliedProject] = useState<string>('');
-    const [appliedVariant, setAppliedVariant] = useState<string>('');
-    const [appliedCompareVariant, setAppliedCompareVariant] = useState<string>('');
-    const [appliedOperation, setAppliedOperation] = useState<string>('');
+    const [appliedLabel, setAppliedLabel] = useState<string>('');
+
+    // Snapshot of the scope that is actually applied/loaded. Reopening the
+    // panel restores its controls from this so the user always sees the
+    // current settings checked rather than stale, un-applied edits.
+    const [appliedScope, setAppliedScope] = useState<AppliedScope | null>(null);
+    const appliedScopeRef = useRef<AppliedScope | null>(null);
+    // Selection to apply once variants finish (re)loading for a project. Used
+    // both for the initial config scope and when reopening restores a project.
+    const pendingRestoreRef = useRef<string[] | null>(null);
+    // Mirror project/variants in refs so the open-restore effect can read the
+    // latest values without re-running on every change.
+    const variantsRef = useRef<Variant[]>([]);
+    const selectedProjectIdRef = useRef<string>('');
+
+    const applyScope = (scope: AppliedScope) => {
+        appliedScopeRef.current = scope;
+        setAppliedScope(scope);
+    };
+
+    useEffect(() => { variantsRef.current = variants; }, [variants]);
+    useEffect(() => { selectedProjectIdRef.current = selectedProjectId; }, [selectedProjectId]);
 
     // Sync display state when default config arrives from the server
     useEffect(() => {
         if (defaultProject?.id) {
+            // Show only the configured variant (if any) on first load.
+            if (defaultVariant?.id) pendingRestoreRef.current = [defaultVariant.id];
             setSelectedProjectId(defaultProject.id);
             setAppliedProject(defaultProject.name);
         }
-    }, [defaultProject?.id, defaultProject?.name]);
+    }, [defaultProject?.id, defaultProject?.name, defaultVariant?.id]);
 
     useEffect(() => {
         if (defaultVariant?.id) {
-            setSelectedVariantId(defaultVariant.id);
-            setAppliedVariant(defaultVariant.name);
+            setAppliedLabel(defaultVariant.name);
         } else if (defaultProject?.id) {
-            setSelectedVariantId('');
-            setAppliedVariant('All variants');
+            setAppliedLabel('All variants');
         }
     }, [defaultVariant?.id, defaultVariant?.name, defaultProject?.id]);
 
-    // Track previous project id to avoid clearing variant on initial default load
-    const prevProjectIdRef = useRef("");
+    // Default the compare base / compare variant once variants are available
+    useEffect(() => {
+        if (variants.length === 0) return;
+        if (!compareBaseVariantId || !variants.some(v => v.id === compareBaseVariantId)) {
+            setCompareBaseVariantId(variants[0].id);
+        }
+    }, [variants, compareBaseVariantId]);
 
     useEffect(() => {
-        if (compareEnabled && selectedCompareVariantId === selectedVariantId) {
-            const first = variants.find(v => v.id !== selectedVariantId);
+        if (selectedCompareVariantId === compareBaseVariantId) {
+            const first = variants.find(v => v.id !== compareBaseVariantId);
             setSelectedCompareVariantId(first?.id ?? '');
         }
-    }, [selectedVariantId, compareEnabled, variants, selectedCompareVariantId]);
+    }, [compareBaseVariantId, variants, selectedCompareVariantId]);
 
     // Load projects on mount
     useEffect(() => {
@@ -73,19 +117,65 @@ function ProjectVariantSelector({ defaultProject, defaultVariant, onApply }: Rea
             .catch(() => setProjects([]));
     }, []);
 
-    // Load variants when selected project changes; only clear variant on user-driven changes
+    // Load variants when selected project changes
     useEffect(() => {
         setVariants([]);
         if (!selectedProjectId) return;
-        const prev = prevProjectIdRef.current;
-        prevProjectIdRef.current = selectedProjectId;
-        if (prev !== '' && prev !== selectedProjectId) {
-            setSelectedVariantId('');
-        }
         Variants.list(selectedProjectId)
-            .then(setVariants)
+            .then(vs => {
+                setVariants(vs);
+                const restore = pendingRestoreRef.current;
+                pendingRestoreRef.current = null;
+                if (restore) {
+                    // Restore a previously-applied (or configured) selection,
+                    // keeping only the ids that still exist for this project.
+                    const valid = restore.filter(id => vs.some(v => v.id === id));
+                    setSelectedVariantIds(valid.length ? valid : vs.map(v => v.id));
+                } else {
+                    // Select Variants mode defaults to all variants selected
+                    setSelectedVariantIds(vs.map(v => v.id));
+                }
+            })
             .catch(() => setVariants([]));
     }, [selectedProjectId]);
+
+    // Establish the initial applied scope from config once variants are known,
+    // so the first reopen reflects the configured project/variant.
+    useEffect(() => {
+        if (appliedScope || variants.length === 0 || !selectedProjectId) return;
+        if (defaultProject?.id !== selectedProjectId) return;
+        const variantIds = (defaultVariant?.id && variants.some(v => v.id === defaultVariant.id))
+            ? [defaultVariant.id]
+            : variants.map(v => v.id);
+        applyScope({
+            projectId: selectedProjectId,
+            mode: 'select',
+            variantIds,
+            compareBaseId: variants[0]?.id ?? '',
+            compareOp: 'difference',
+            compareId: '',
+        });
+    }, [variants, selectedProjectId, appliedScope, defaultProject?.id, defaultVariant?.id]);
+
+    // Restore the panel controls from the applied scope each time it opens.
+    useEffect(() => {
+        if (!isOpen) return;
+        const scope = appliedScopeRef.current;
+        if (!scope) return;
+        setMode(scope.mode);
+        setCompareBaseVariantId(scope.compareBaseId);
+        setCompareOperation(scope.compareOp);
+        setSelectedCompareVariantId(scope.compareId);
+        if (scope.projectId !== selectedProjectIdRef.current) {
+            // Switching back to the applied project reloads its variants; defer
+            // the selection restore until they arrive.
+            pendingRestoreRef.current = scope.variantIds;
+            setSelectedProjectId(scope.projectId);
+        } else if (scope.mode === 'select') {
+            const valid = scope.variantIds.filter(id => variantsRef.current.some(v => v.id === id));
+            setSelectedVariantIds(valid.length ? valid : variantsRef.current.map(v => v.id));
+        }
+    }, [isOpen]);
 
     // Close panel when clicking outside
     useEffect(() => {
@@ -120,18 +210,61 @@ function ProjectVariantSelector({ defaultProject, defaultVariant, onApply }: Rea
         return { top: rect.bottom + 4, right: window.innerWidth - rect.right };
     };
 
+    const allSelected = variants.length > 0 && selectedVariantIds.length === variants.length;
+
     const handleApply = () => {
         const project = projects.find(p => p.id === selectedProjectId);
-        const variant = variants.find(v => v.id === selectedVariantId);
-        const compareVariant = variants.find(v => v.id === selectedCompareVariantId);
-        const activeCompare = compareEnabled && selectedCompareVariantId;
+
+        if (mode === 'compare' && compareBaseVariantId && selectedCompareVariantId) {
+            const base = variants.find(v => v.id === compareBaseVariantId);
+            const compareVariant = variants.find(v => v.id === selectedCompareVariantId);
+            const opSymbol = { difference: '∖', intersection: '∩' }[compareOperation];
+            setAppliedProject(project?.name ?? '');
+            setAppliedLabel(`${base?.name ?? 'All'} ${opSymbol} ${compareVariant?.name ?? ''}`);
+            applyScope({
+                projectId: selectedProjectId,
+                mode: 'compare',
+                variantIds: [],
+                compareBaseId: compareBaseVariantId,
+                compareOp: compareOperation,
+                compareId: selectedCompareVariantId,
+            });
+            onApply(selectedProjectId, compareBaseVariantId, selectedCompareVariantId, compareOperation, [], '');
+            setIsOpen(false);
+            return;
+        }
+
+        // Select Variants mode — union of the selected variants
         setAppliedProject(project?.name ?? '');
-        setAppliedVariant(selectedVariantId ? (variant?.name ?? '') : (selectedProjectId ? 'All variants' : ''));
-        setAppliedCompareVariant(activeCompare ? (compareVariant?.name ?? '') : '');
-        setAppliedOperation(activeCompare ? compareOperation : '');
-        onApply(selectedProjectId, selectedVariantId, compareEnabled ? selectedCompareVariantId : '', compareEnabled ? compareOperation : '');
+        const selectScope: AppliedScope = {
+            projectId: selectedProjectId,
+            mode: 'select',
+            variantIds: (allSelected || selectedVariantIds.length === 0)
+                ? variants.map(v => v.id)
+                : [...selectedVariantIds],
+            compareBaseId: compareBaseVariantId,
+            compareOp: compareOperation,
+            compareId: selectedCompareVariantId,
+        };
+        applyScope(selectScope);
+        if (allSelected || selectedVariantIds.length === 0) {
+            // Whole project scope
+            setAppliedLabel('All variants');
+            onApply(selectedProjectId, '', '', '', [], '');
+        } else if (selectedVariantIds.length === 1) {
+            const variant = variants.find(v => v.id === selectedVariantIds[0]);
+            setAppliedLabel(variant?.name ?? '');
+            onApply(selectedProjectId, selectedVariantIds[0], '', '', [], '');
+        } else {
+            setAppliedLabel(`${selectedVariantIds.length} variants (∪)`);
+            onApply(selectedProjectId, '', '', '', selectedVariantIds, 'union');
+        }
         setIsOpen(false);
     };
+
+    const applyDisabled = !selectedProjectId
+        || (mode === 'select' && selectedVariantIds.length === 0)
+        || (mode === 'compare' && (!compareBaseVariantId || !selectedCompareVariantId));
 
     const panelPosition = isOpen ? getPanelPosition() : { top: 0, right: 0 };
 
@@ -153,9 +286,7 @@ function ProjectVariantSelector({ defaultProject, defaultVariant, onApply }: Rea
                         {appliedProject || 'Select Project'}
                     </span>
                     <span className="text-xs font-normal opacity-75 max-w-[160px] truncate">
-                        {appliedCompareVariant
-                            ? `${appliedVariant || 'All'} ${{ difference: '∖', intersection: '∩' }[appliedOperation] ?? '∖'} ${appliedCompareVariant}`
-                            : (appliedVariant || (appliedProject ? 'All variants' : 'No variant'))}
+                        {appliedLabel || (appliedProject ? 'All variants' : 'No variant')}
                     </span>
                 </div>
                 <FontAwesomeIcon icon={faChevronDown} className="text-xs" />
@@ -184,94 +315,144 @@ function ProjectVariantSelector({ defaultProject, defaultVariant, onApply }: Rea
                         ))}
                     </select>
 
-                    {/* Variant select */}
-                    <label className="block text-sm mb-1">Variant</label>
-                    <select
-                        value={selectedVariantId}
-                        onChange={e => setSelectedVariantId(e.target.value)}
-                        disabled={!selectedProjectId}
-                        className="w-full rounded px-2 py-1 text-sm bg-cyan-800 border border-cyan-600 focus:outline-none focus:border-cyan-400 mb-4 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                        <option value="">All variants</option>
-                        {variants.map(v => (
-                            <option key={v.id} value={v.id}>{v.name}</option>
-                        ))}
-                    </select>
-
-                    {/* Compare variants section */}
-                    <div className="border-t border-cyan-700 pt-3 mb-4">
-                        <label className="flex items-center gap-2 text-sm cursor-pointer mb-2">
+                    {/* Mode selector — exclusive choice */}
+                    <div className="flex flex-col gap-1.5 mb-3">
+                        <label className="flex items-center gap-2 text-sm cursor-pointer">
                             <input
-                                type="checkbox"
-                                checked={compareEnabled}
-                                onChange={e => {
-                                    setCompareEnabled(e.target.checked);
-                                    if (e.target.checked) {
-                                        const first = variants.find(v => v.id !== selectedVariantId);
-                                        if (first) setSelectedCompareVariantId(first.id);
-                                    } else {
-                                        setSelectedCompareVariantId('');
-                                    }
-                                }}
-                                className="accent-cyan-400"
+                                type="radio"
+                                name="variant-mode"
+                                value="select"
+                                checked={mode === 'select'}
+                                onChange={() => setMode('select')}
+                                className="accent-cyan-400 shrink-0"
+                            />
+                            <span className="font-semibold">Select Variants</span>
+                        </label>
+                        <label className="flex items-center gap-2 text-sm cursor-pointer">
+                            <input
+                                type="radio"
+                                name="variant-mode"
+                                value="compare"
+                                checked={mode === 'compare'}
+                                onChange={() => setMode('compare')}
+                                className="accent-cyan-400 shrink-0"
                             />
                             <span className="font-semibold">Compare variants</span>
                         </label>
-                        {compareEnabled && (
-                            <>
-                                <div className="flex flex-col gap-1.5 mb-3">
-                                    {([
-                                        { value: 'difference',   symbol: 'Exclusion', desc: 'Only present in compared variant' },
+                    </div>
 
-                                        { value: 'intersection', symbol: 'Intersection', desc: 'common to both variants' },
-                                    ] as { value: 'difference' | 'intersection'; symbol: string; desc: string }[]).map(op => (
-                                        <label key={op.value} className="flex items-center gap-2 text-sm cursor-pointer">
-                                            <input
-                                                type="radio"
-                                                name="compare-operation"
-                                                value={op.value}
-                                                checked={compareOperation === op.value}
-                                                onChange={() => setCompareOperation(op.value)}
-                                                className="accent-cyan-400 shrink-0"
-                                            />
-                                            <span className="font-mono text-xs">{op.symbol}</span>
-                                            <span className="text-xs text-cyan-300">— {op.desc}</span>
-                                        </label>
-                                    ))}
-                                </div>
-                                <label className="block text-sm mb-1">Compare variant</label>
-                                <select
-                                    value={selectedCompareVariantId}
-                                    onChange={e => setSelectedCompareVariantId(e.target.value)}
-                                    disabled={!selectedVariantId}
-                                    className="w-full rounded px-2 py-1 text-sm bg-cyan-800 border border-cyan-600 focus:outline-none focus:border-cyan-400 disabled:opacity-50 disabled:cursor-not-allowed"
-                                >
-                                    {variants.filter(v => v.id !== selectedVariantId).map(v => (
-                                        <option key={v.id} value={v.id}>{v.name}</option>
-                                    ))}
-                                </select>
+                    {/* Select Variants mode */}
+                    {mode === 'select' && (
+                        <div className="border-t border-cyan-700 pt-3 mb-4">
+                            <div className="flex items-center justify-between mb-1">
+                                <label className="block text-sm">Variants</label>
                                 <button
                                     type="button"
-                                    onClick={() => {
-                                        const tmp = selectedVariantId;
-                                        setSelectedVariantId(selectedCompareVariantId);
-                                        setSelectedCompareVariantId(tmp);
-                                    }}
-                                    disabled={!selectedVariantId || !selectedCompareVariantId}
-                                    title="Swap variants"
-                                    className="mt-2 w-full flex items-center justify-center gap-2 py-1 rounded border border-cyan-600 text-xs text-cyan-300 hover:bg-cyan-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+                                    onClick={() => setSelectedVariantIds(
+                                        allSelected ? [] : variants.map(v => v.id)
+                                    )}
+                                    disabled={!selectedProjectId || variants.length === 0}
+                                    className="text-xs text-cyan-300 hover:text-cyan-100 disabled:opacity-40 disabled:cursor-not-allowed"
                                 >
-                                    <FontAwesomeIcon icon={faSort} />
-                                    Swap variants
+                                    {allSelected ? 'Clear all' : 'Select all'}
                                 </button>
-                            </>
-                        )}
-                    </div>
+                            </div>
+                            <div className="max-h-44 overflow-y-auto rounded border border-cyan-600 bg-cyan-800 p-2 flex flex-col gap-1">
+                                {!selectedProjectId && (
+                                    <span className="text-xs text-cyan-300">Select a project first</span>
+                                )}
+                                {selectedProjectId && variants.length === 0 && (
+                                    <span className="text-xs text-cyan-300">No variants available</span>
+                                )}
+                                {variants.map(v => (
+                                    <label key={v.id} className="flex items-center gap-2 text-sm cursor-pointer">
+                                        <input
+                                            type="checkbox"
+                                            checked={selectedVariantIds.includes(v.id)}
+                                            onChange={e => {
+                                                setSelectedVariantIds(prev =>
+                                                    e.target.checked
+                                                        ? [...prev, v.id]
+                                                        : prev.filter(id => id !== v.id)
+                                                );
+                                            }}
+                                            className="accent-cyan-400 shrink-0"
+                                        />
+                                        <span className="truncate">{v.name}</span>
+                                    </label>
+                                ))}
+                            </div>
+                            {selectedProjectId && variants.length > 0 && selectedVariantIds.length === 0 && (
+                                <p className="text-xs text-amber-300 mt-1">Select at least one variant.</p>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Compare variants mode */}
+                    {mode === 'compare' && (
+                        <div className="border-t border-cyan-700 pt-3 mb-4">
+                            <div className="flex flex-col gap-1.5 mb-3">
+                                {([
+                                    { value: 'difference', symbol: 'Exclusion', desc: 'Only present in compared variant' },
+                                    { value: 'intersection', symbol: 'Intersection', desc: 'common to both variants' },
+                                ] as { value: 'difference' | 'intersection'; symbol: string; desc: string }[]).map(op => (
+                                    <label key={op.value} className="flex items-center gap-2 text-sm cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="compare-operation"
+                                            value={op.value}
+                                            checked={compareOperation === op.value}
+                                            onChange={() => setCompareOperation(op.value)}
+                                            className="accent-cyan-400 shrink-0"
+                                        />
+                                        <span className="font-mono text-xs">{op.symbol}</span>
+                                        <span className="text-xs text-cyan-300">— {op.desc}</span>
+                                    </label>
+                                ))}
+                            </div>
+                            <label className="block text-sm mb-1">Base variant</label>
+                            <select
+                                value={compareBaseVariantId}
+                                onChange={e => setCompareBaseVariantId(e.target.value)}
+                                disabled={!selectedProjectId}
+                                className="w-full rounded px-2 py-1 text-sm bg-cyan-800 border border-cyan-600 focus:outline-none focus:border-cyan-400 mb-3 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {variants.map(v => (
+                                    <option key={v.id} value={v.id}>{v.name}</option>
+                                ))}
+                            </select>
+                            <label className="block text-sm mb-1">Compare variant</label>
+                            <select
+                                value={selectedCompareVariantId}
+                                onChange={e => setSelectedCompareVariantId(e.target.value)}
+                                disabled={!compareBaseVariantId}
+                                className="w-full rounded px-2 py-1 text-sm bg-cyan-800 border border-cyan-600 focus:outline-none focus:border-cyan-400 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {variants.filter(v => v.id !== compareBaseVariantId).map(v => (
+                                    <option key={v.id} value={v.id}>{v.name}</option>
+                                ))}
+                            </select>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    const tmp = compareBaseVariantId;
+                                    setCompareBaseVariantId(selectedCompareVariantId);
+                                    setSelectedCompareVariantId(tmp);
+                                }}
+                                disabled={!compareBaseVariantId || !selectedCompareVariantId}
+                                title="Swap variants"
+                                className="mt-2 w-full flex items-center justify-center gap-2 py-1 rounded border border-cyan-600 text-xs text-cyan-300 hover:bg-cyan-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+                            >
+                                <FontAwesomeIcon icon={faSort} />
+                                Swap variants
+                            </button>
+                        </div>
+                    )}
 
                     {/* Apply button */}
                     <button
                         onClick={handleApply}
-                        disabled={!selectedProjectId || (compareEnabled && (!selectedVariantId || !selectedCompareVariantId))}
+                        disabled={applyDisabled}
                         className="w-full py-1.5 rounded bg-cyan-600 hover:bg-cyan-500 disabled:opacity-40 disabled:cursor-not-allowed text-sm font-semibold transition-colors duration-150"
                         type="button"
                     >

--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -60,13 +60,17 @@ class Packages {
      * Fetch server API to list all packages
      * @returns {Promise<Package[]>} A promise that resolves to a list of packages
      */
-    static async list(variantId?: string, projectId?: string, compareVariantId?: string, operation?: string): Promise<Package[]> {
+    static async list(variantId?: string, projectId?: string, compareVariantId?: string, operation?: string, variantIds?: string[], multiOperation?: string): Promise<Package[]> {
         const url = new URL(import.meta.env.VITE_API_URL + "/api/packages", window.location.href);
         url.searchParams.set('format', 'list');
         if (variantId && compareVariantId) {
             url.searchParams.set('variant_id', variantId);
             url.searchParams.set('compare_variant_id', compareVariantId);
             if (operation) url.searchParams.set('operation', operation);
+        } else if (variantIds && variantIds.length >= 2) {
+            url.searchParams.set('variant_ids', variantIds.join(','));
+            if (multiOperation) url.searchParams.set('operation', multiOperation);
+            if (projectId) url.searchParams.set('project_id', projectId);
         } else if (variantId) {
             url.searchParams.set('variant_id', variantId);
         } else if (projectId) {

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -262,13 +262,17 @@ const asVulnerability = (data: any): Vulnerability | [] => {
 }
 
 class Vulnerabilities {
-    static async list(variantId?: string, projectId?: string, compareVariantId?: string, operation?: string): Promise<Vulnerability[]> {
+    static async list(variantId?: string, projectId?: string, compareVariantId?: string, operation?: string, variantIds?: string[], multiOperation?: string): Promise<Vulnerability[]> {
         const url = new URL(import.meta.env.VITE_API_URL + "/api/vulnerabilities", window.location.href);
         url.searchParams.set('format', 'list');
         if (variantId && compareVariantId) {
             url.searchParams.set('variant_id', variantId);
             url.searchParams.set('compare_variant_id', compareVariantId);
             if (operation) url.searchParams.set('operation', operation);
+        } else if (variantIds && variantIds.length >= 2) {
+            url.searchParams.set('variant_ids', variantIds.join(','));
+            if (multiOperation) url.searchParams.set('operation', multiOperation);
+            if (projectId) url.searchParams.set('project_id', projectId);
         } else if (variantId) {
             url.searchParams.set('variant_id', variantId);
         } else if (projectId) {

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -58,6 +58,8 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
     const [currentProjectId, setCurrentProjectId] = useState<string | undefined>(undefined);
     const [currentBaseVariantId, setCurrentBaseVariantId] = useState<string | undefined>(undefined);
     const [currentOperation, setCurrentOperation] = useState<string | undefined>(undefined);
+    const [currentVariantIds, setCurrentVariantIds] = useState<string[] | undefined>(undefined);
+    const [currentMultiOperation, setCurrentMultiOperation] = useState<string | undefined>(undefined);
 
     const triggerBanner = (message: string, type: 'error' | 'success') => {
         setBannerMessage(message);
@@ -69,19 +71,27 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         setBannerVisible(false);
     };
 
-    const loadData = useCallback((variantId?: string, projectId?: string, compareVariantId?: string, operation?: string) => {
+    const loadData = useCallback((variantId?: string, projectId?: string, compareVariantId?: string, operation?: string, variantIds?: string[], multiOperation?: string) => {
         setIsLoadingData(true);
 
-        const assessPromise: Promise<Assessment[]> = (compareVariantId && variantId)
-            ? Promise.all([
+        const multiActive = !!(variantIds && variantIds.length >= 2);
+        let assessPromise: Promise<Assessment[]>;
+        if (multiActive) {
+            assessPromise = Promise.all(
+                variantIds!.map(id => Assessments.list(id, projectId)),
+            ).then(lists => removeDuplicateAssessments(lists.flat()));
+        } else if (compareVariantId && variantId) {
+            assessPromise = Promise.all([
                 Assessments.list(variantId, projectId),
                 Assessments.list(compareVariantId, projectId),
-              ]).then(([a1, a2]) => removeDuplicateAssessments([...a1, ...a2]))
-            : Assessments.list(variantId, projectId);
+              ]).then(([a1, a2]) => removeDuplicateAssessments([...a1, ...a2]));
+        } else {
+            assessPromise = Assessments.list(variantId, projectId);
+        }
 
         Promise.allSettled([
-            Packages.list(variantId, projectId, compareVariantId, operation),
-            Vulnerabilities.list(variantId, projectId, compareVariantId, operation),
+            Packages.list(variantId, projectId, compareVariantId, operation, variantIds, multiOperation),
+            Vulnerabilities.list(variantId, projectId, compareVariantId, operation, variantIds, multiOperation),
             assessPromise,
         ]).then(([pkgsResult, vulnsResult, assessResult]) => {
             setIsLoadingData(false);
@@ -112,28 +122,33 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
             .catch(() => loadData(undefined));
     }, [loadData]);
 
-    const handleApply = useCallback((projectId: string, variantId: string, compareVariantId: string, operation: string) => {
-        const effectiveVariantId = compareVariantId || variantId || undefined;
+    const handleApply = useCallback((projectId: string, variantId: string, compareVariantId: string, operation: string, variantIds: string[], multiOperation: string) => {
+        const multiActive = !!(variantIds && variantIds.length >= 2);
+        const effectiveVariantId = multiActive ? undefined : (compareVariantId || variantId || undefined);
         setCurrentVariantId(effectiveVariantId);
         setCurrentProjectId(projectId || undefined);
         // Track origin variant and operation separately for MultiEditBar intersection logic
-        setCurrentBaseVariantId(compareVariantId ? (variantId || undefined) : undefined);
-        setCurrentOperation(compareVariantId ? (operation || undefined) : undefined);
+        setCurrentBaseVariantId((!multiActive && compareVariantId) ? (variantId || undefined) : undefined);
+        setCurrentOperation((!multiActive && compareVariantId) ? (operation || undefined) : undefined);
+        setCurrentVariantIds(multiActive ? variantIds : undefined);
+        setCurrentMultiOperation(multiActive ? (multiOperation || undefined) : undefined);
         loadData(
-            variantId || undefined,
-            variantId ? undefined : projectId || undefined,
-            compareVariantId || undefined,
-            operation || undefined,
+            multiActive ? undefined : (variantId || undefined),
+            (multiActive || !variantId) ? (projectId || undefined) : undefined,
+            multiActive ? undefined : (compareVariantId || undefined),
+            multiActive ? undefined : (operation || undefined),
+            multiActive ? variantIds : undefined,
+            multiActive ? (multiOperation || undefined) : undefined,
         );
     }, [loadData]);
 
     const handleScanComplete = useCallback(() => {
-        loadData(currentVariantId, currentVariantId ? undefined : currentProjectId);
-    }, [loadData, currentVariantId, currentProjectId]);
+        loadData(currentVariantId, currentVariantId ? undefined : currentProjectId, undefined, undefined, currentVariantIds, currentMultiOperation);
+    }, [loadData, currentVariantId, currentProjectId, currentVariantIds, currentMultiOperation]);
 
     const handleRefreshComplete = useCallback(() => {
-        loadData(currentVariantId, currentVariantId ? undefined : currentProjectId);
-    }, [loadData, currentVariantId, currentProjectId]);
+        loadData(currentVariantId, currentVariantId ? undefined : currentProjectId, undefined, undefined, currentVariantIds, currentMultiOperation);
+    }, [loadData, currentVariantId, currentProjectId, currentVariantIds, currentMultiOperation]);
 
 
     function appendAssessment(added: Assessment) {
@@ -297,7 +312,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     if (message) setLoadingMessage(message);
                     Config.get().then(config => setDefaultConfig(config)).catch(() => {});
                     setSelectorKey(k => k + 1);
-                    loadData(currentVariantId, currentVariantId ? undefined : currentProjectId);
+                    loadData(currentVariantId, currentVariantId ? undefined : currentProjectId, undefined, undefined, currentVariantIds, currentMultiOperation);
                 }} onLoadingMessage={(msg) => {
                     if (msg) {
                         setLoadingMessage(msg);

--- a/frontend/tests/unit_tests/test_project_variant_handlers.ts
+++ b/frontend/tests/unit_tests/test_project_variant_handlers.ts
@@ -380,6 +380,59 @@ describe('Packages.list with filtering params', () => {
         expect(calledUrl).toContain('variant_id=var-1');
         expect(calledUrl).not.toContain('project_id');
     });
+
+    test('list(...variantIds, multiOperation) uses variant_ids, operation and project_id', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+
+        await Packages.list(undefined, 'proj-1', undefined, undefined, ['v1', 'v2'], 'intersection');
+
+        const calledUrl = decodeURIComponent((fetchMock.mock.calls[0] as any[])[0]);
+        expect(calledUrl).toContain('variant_ids=v1,v2');
+        expect(calledUrl).toContain('operation=intersection');
+        expect(calledUrl).toContain('project_id=proj-1');
+        expect(calledUrl).not.toContain('variant_id=');
+    });
+
+    test('list(...variantIds) without multiOperation omits operation', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+
+        await Packages.list(undefined, 'proj-1', undefined, undefined, ['v1', 'v2']);
+
+        const calledUrl = decodeURIComponent((fetchMock.mock.calls[0] as any[])[0]);
+        expect(calledUrl).toContain('variant_ids=v1,v2');
+        expect(calledUrl).toContain('project_id=proj-1');
+        expect(calledUrl).not.toContain('operation=');
+    });
+
+    test('list with a single variantIds entry falls back to project scope', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+
+        await Packages.list(undefined, 'proj-1', undefined, undefined, ['v1']);
+
+        const calledUrl = decodeURIComponent((fetchMock.mock.calls[0] as any[])[0]);
+        expect(calledUrl).not.toContain('variant_ids=');
+        expect(calledUrl).toContain('project_id=proj-1');
+    });
+
+    test('compare mode takes priority over variant_ids', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+
+        await Packages.list('var-1', 'proj-1', 'var-2', 'difference', ['v1', 'v2', 'v3'], 'union');
+
+        const calledUrl = decodeURIComponent((fetchMock.mock.calls[0] as any[])[0]);
+        expect(calledUrl).toContain('variant_id=var-1');
+        expect(calledUrl).toContain('compare_variant_id=var-2');
+        expect(calledUrl).toContain('operation=difference');
+        expect(calledUrl).not.toContain('variant_ids=');
+    });
 });
 
 
@@ -441,6 +494,59 @@ describe('Vulnerabilities.list with filtering params', () => {
         const calledUrl: string = (fetchMock.mock.calls[0] as any[])[0];
         expect(calledUrl).toContain('variant_id=var-1');
         expect(calledUrl).not.toContain('project_id');
+    });
+
+    test('list(...variantIds, multiOperation) uses variant_ids, operation and project_id', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+
+        await Vulnerabilities.list(undefined, 'proj-1', undefined, undefined, ['v1', 'v2'], 'intersection');
+
+        const calledUrl = decodeURIComponent((fetchMock.mock.calls[0] as any[])[0]);
+        expect(calledUrl).toContain('variant_ids=v1,v2');
+        expect(calledUrl).toContain('operation=intersection');
+        expect(calledUrl).toContain('project_id=proj-1');
+        expect(calledUrl).not.toContain('variant_id=');
+    });
+
+    test('list(...variantIds) without multiOperation omits operation', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+
+        await Vulnerabilities.list(undefined, 'proj-1', undefined, undefined, ['v1', 'v2']);
+
+        const calledUrl = decodeURIComponent((fetchMock.mock.calls[0] as any[])[0]);
+        expect(calledUrl).toContain('variant_ids=v1,v2');
+        expect(calledUrl).toContain('project_id=proj-1');
+        expect(calledUrl).not.toContain('operation=');
+    });
+
+    test('list with a single variantIds entry falls back to project scope', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+
+        await Vulnerabilities.list(undefined, 'proj-1', undefined, undefined, ['v1']);
+
+        const calledUrl = decodeURIComponent((fetchMock.mock.calls[0] as any[])[0]);
+        expect(calledUrl).not.toContain('variant_ids=');
+        expect(calledUrl).toContain('project_id=proj-1');
+    });
+
+    test('compare mode takes priority over variant_ids', async () => {
+        fetchMock.mockImplementationOnce(() =>
+            Promise.resolve({ json: () => Promise.resolve([]) } as Response)
+        );
+
+        await Vulnerabilities.list('var-1', 'proj-1', 'var-2', 'difference', ['v1', 'v2', 'v3'], 'union');
+
+        const calledUrl = decodeURIComponent((fetchMock.mock.calls[0] as any[])[0]);
+        expect(calledUrl).toContain('variant_id=var-1');
+        expect(calledUrl).toContain('compare_variant_id=var-2');
+        expect(calledUrl).toContain('operation=difference');
+        expect(calledUrl).not.toContain('variant_ids=');
     });
 });
 

--- a/frontend/tests/unit_tests/test_project_variant_selector.tsx
+++ b/frontend/tests/unit_tests/test_project_variant_selector.tsx
@@ -34,10 +34,28 @@ const PROJECTS = [
     { id: 'proj-2', name: 'ProjectBeta' },
 ];
 
+// Three variants so the "union of a subset" path (>= 2 but not all) is testable.
 const VARIANTS_PROJ1 = [
     { id: 'var-1', name: 'default', project_id: 'proj-1' },
     { id: 'var-2', name: 'release', project_id: 'proj-1' },
+    { id: 'var-3', name: 'staging', project_id: 'proj-1' },
 ];
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+async function openPanel() {
+    const button = screen.getAllByRole('button')[0];
+    await act(async () => { fireEvent.click(button); });
+}
+
+async function selectProject(value: string) {
+    const projectSelect = screen.getAllByRole('combobox')[0];
+    await act(async () => {
+        fireEvent.change(projectSelect, { target: { value } });
+    });
+}
 
 
 describe('ProjectVariantSelector', () => {
@@ -56,18 +74,13 @@ describe('ProjectVariantSelector', () => {
     // -----------------------------------------------------------------------
 
     test('renders the trigger button', () => {
-        render(
-            <ProjectVariantSelector onApply={jest.fn()} />
-        );
-        // The button should be in the document (layer-group icon + text)
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
         const button = screen.getByRole('button');
         expect(button).toBeInTheDocument();
     });
 
     test('shows "Select Project" when no default project is provided', () => {
-        render(
-            <ProjectVariantSelector onApply={jest.fn()} />
-        );
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
         expect(screen.getByText('Select Project')).toBeInTheDocument();
     });
 
@@ -101,45 +114,28 @@ describe('ProjectVariantSelector', () => {
     // -----------------------------------------------------------------------
 
     test('dropdown panel is not visible initially', () => {
-        render(
-            <ProjectVariantSelector onApply={jest.fn()} />
-        );
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
         expect(screen.queryByText('Project & Variant')).not.toBeInTheDocument();
     });
 
     test('clicking the button opens the dropdown panel', async () => {
-        render(
-            <ProjectVariantSelector onApply={jest.fn()} />
-        );
-        const button = screen.getByRole('button');
-        await act(async () => {
-            fireEvent.click(button);
-        });
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
         expect(screen.getByText('Project & Variant')).toBeInTheDocument();
     });
 
     test('clicking the button again closes the dropdown panel', async () => {
-        render(
-            <ProjectVariantSelector onApply={jest.fn()} />
-        );
-        const button = screen.getByRole('button');
-
-        await act(async () => { fireEvent.click(button); });
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
         expect(screen.getByText('Project & Variant')).toBeInTheDocument();
-
-        await act(async () => { fireEvent.click(button); });
+        await openPanel();
         expect(screen.queryByText('Project & Variant')).not.toBeInTheDocument();
     });
 
     test('pressing Escape closes the dropdown panel', async () => {
-        render(
-            <ProjectVariantSelector onApply={jest.fn()} />
-        );
-        const button = screen.getByRole('button');
-
-        await act(async () => { fireEvent.click(button); });
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
         expect(screen.getByText('Project & Variant')).toBeInTheDocument();
-
         await act(async () => {
             fireEvent.keyDown(document, { key: 'Escape' });
         });
@@ -151,12 +147,8 @@ describe('ProjectVariantSelector', () => {
     // -----------------------------------------------------------------------
 
     test('loads and displays project options in the dropdown', async () => {
-        render(
-            <ProjectVariantSelector onApply={jest.fn()} />
-        );
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
         await waitFor(() => {
             expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
             expect(screen.getByRole('option', { name: 'ProjectBeta' })).toBeInTheDocument();
@@ -164,341 +156,372 @@ describe('ProjectVariantSelector', () => {
         expect(mockProjectsList).toHaveBeenCalledTimes(1);
     });
 
-    test('loads variants when a project is selected', async () => {
-        render(
-            <ProjectVariantSelector onApply={jest.fn()} />
-        );
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
+    test('loads variants as checkboxes (all checked) when a project is selected', async () => {
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
         await waitFor(() => {
             expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
         });
-
-        // Select ProjectAlpha
-        const projectSelect = screen.getAllByRole('combobox')[0];
-        await act(async () => {
-            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
-        });
-
+        await selectProject('proj-1');
         await waitFor(() => {
             expect(mockVariantsList).toHaveBeenCalledWith('proj-1');
-            expect(screen.getByRole('option', { name: 'default' })).toBeInTheDocument();
-            expect(screen.getByRole('option', { name: 'release' })).toBeInTheDocument();
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+            expect(screen.getByRole('checkbox', { name: 'release' })).toBeChecked();
+            expect(screen.getByRole('checkbox', { name: 'staging' })).toBeChecked();
         });
     });
 
     // -----------------------------------------------------------------------
-    // Apply button behaviour
+    // Mode selection
+    // -----------------------------------------------------------------------
+
+    test('Select Variants mode is the default and shows the variant checklist', async () => {
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        expect(screen.getByRole('radio', { name: /select variants/i })).toBeChecked();
+        expect(screen.getByRole('radio', { name: /compare variants/i })).not.toBeChecked();
+        expect(screen.getByText('Variants')).toBeInTheDocument();
+    });
+
+    test('switching to Compare variants mode shows the compare section', async () => {
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        await act(async () => {
+            fireEvent.click(screen.getByRole('radio', { name: /compare variants/i }));
+        });
+        expect(screen.getByText('Base variant')).toBeInTheDocument();
+        expect(screen.getByText('Compare variant')).toBeInTheDocument();
+    });
+
+    test('the two modes are mutually exclusive', async () => {
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        await act(async () => {
+            fireEvent.click(screen.getByRole('radio', { name: /compare variants/i }));
+        });
+        expect(screen.getByRole('radio', { name: /compare variants/i })).toBeChecked();
+        expect(screen.getByRole('radio', { name: /select variants/i })).not.toBeChecked();
+        // Variant checklist is hidden in compare mode
+        expect(screen.queryByText('Variants')).not.toBeInTheDocument();
+    });
+
+    // -----------------------------------------------------------------------
+    // Apply — Select Variants mode
     // -----------------------------------------------------------------------
 
     test('Apply button is disabled when no project is selected', async () => {
-        render(
-            <ProjectVariantSelector onApply={jest.fn()} />
-        );
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
-        const applyButton = screen.getByRole('button', { name: 'Apply' });
-        expect(applyButton).toBeDisabled();
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
     });
 
-    test('Apply button calls onApply with selected project and variant ids', async () => {
+    test('Apply with all variants selected calls onApply with project scope', async () => {
         const onApply = jest.fn();
-        render(
-            <ProjectVariantSelector onApply={onApply} />
-        );
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
+        render(<ProjectVariantSelector onApply={onApply} />);
+        await openPanel();
         await waitFor(() => {
             expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
         });
-
-        // Select project
-        const [projectSelect, variantSelect] = screen.getAllByRole('combobox');
-        await act(async () => {
-            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
-        });
-
+        await selectProject('proj-1');
         await waitFor(() => {
-            expect(screen.getByRole('option', { name: 'default' })).toBeInTheDocument();
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
         });
 
-        // Select variant
         await act(async () => {
-            fireEvent.change(variantSelect, { target: { value: 'var-1' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
         });
-
-        // Click Apply
-        const applyButton = screen.getByRole('button', { name: 'Apply' });
-        await act(async () => { fireEvent.click(applyButton); });
-
-        expect(onApply).toHaveBeenCalledWith('proj-1', 'var-1', '', '');
+        expect(onApply).toHaveBeenCalledWith('proj-1', '', '', '', [], '');
     });
 
-    test('Apply with no variant selected calls onApply with empty variant id', async () => {
+    test('Apply with a single variant selected calls onApply with that variant id', async () => {
         const onApply = jest.fn();
-        render(
-            <ProjectVariantSelector onApply={onApply} />
-        );
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
+        render(<ProjectVariantSelector onApply={onApply} />);
+        await openPanel();
         await waitFor(() => {
             expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
         });
-
-        // Select project only
-        const [projectSelect] = screen.getAllByRole('combobox');
-        await act(async () => {
-            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
         });
 
-        const applyButton = screen.getByRole('button', { name: 'Apply' });
-        await act(async () => { fireEvent.click(applyButton); });
+        // Clear all, then check only "default" (var-1)
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Clear all' }));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('checkbox', { name: 'default' }));
+        });
 
-        expect(onApply).toHaveBeenCalledWith('proj-1', '', '', '');
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+        });
+        expect(onApply).toHaveBeenCalledWith('proj-1', 'var-1', '', '', [], '');
+    });
+
+    test('Apply with a subset of variants (>= 2) calls onApply with union variantIds', async () => {
+        const onApply = jest.fn();
+        render(<ProjectVariantSelector onApply={onApply} />);
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        });
+
+        // Clear all, then select var-1 and var-2 (subset of three)
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Clear all' }));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('checkbox', { name: 'default' }));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('checkbox', { name: 'release' }));
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+        });
+        expect(onApply).toHaveBeenCalledWith('proj-1', '', '', '', ['var-1', 'var-2'], 'union');
+    });
+
+    test('Clear all disables Apply and shows a warning', async () => {
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Clear all' }));
+        });
+        expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+        expect(screen.getByText('Select at least one variant.')).toBeInTheDocument();
     });
 
     test('Apply closes the dropdown panel', async () => {
-        mockProjectsList.mockResolvedValue(PROJECTS);
         const onApply = jest.fn();
-        render(
-            <ProjectVariantSelector onApply={onApply} />
-        );
-
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
+        render(<ProjectVariantSelector onApply={onApply} />);
+        await openPanel();
         await waitFor(() => {
             expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
         });
-
-        const [projectSelect] = screen.getAllByRole('combobox');
-        await act(async () => {
-            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
         });
 
-        const applyButton = screen.getByRole('button', { name: 'Apply' });
-        await act(async () => { fireEvent.click(applyButton); });
-
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+        });
         expect(screen.queryByText('Project & Variant')).not.toBeInTheDocument();
     });
 
     // -----------------------------------------------------------------------
-    // Compare variants feature
+    // Apply — Compare variants mode
     // -----------------------------------------------------------------------
 
-    test('compare variants checkbox is not visible when panel is closed', () => {
-        render(<ProjectVariantSelector onApply={jest.fn()} />);
-        expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
-    });
-
-    test('compare variants label is present when panel is open', async () => {
-        render(<ProjectVariantSelector onApply={jest.fn()} />);
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-        expect(screen.getByText('Compare variants')).toBeInTheDocument();
-    });
-
-    test('compare section is hidden by default', async () => {
-        render(<ProjectVariantSelector onApply={jest.fn()} />);
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-        expect(screen.queryByText('Compare variant')).not.toBeInTheDocument();
-    });
-
-    test('checking Compare checkbox shows the compare section', async () => {
-        render(<ProjectVariantSelector onApply={jest.fn()} />);
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
-        const checkbox = screen.getByRole('checkbox');
-        await act(async () => { fireEvent.click(checkbox); });
-
-        expect(screen.getByText('Compare variant')).toBeInTheDocument();
-    });
-
-    test('unchecking Compare hides the compare section again', async () => {
-        render(<ProjectVariantSelector onApply={jest.fn()} />);
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
-        const checkbox = screen.getByRole('checkbox');
-        await act(async () => { fireEvent.click(checkbox); });
-        expect(screen.getByText('Compare variant')).toBeInTheDocument();
-
-        await act(async () => { fireEvent.click(checkbox); });
-        expect(screen.queryByText('Compare variant')).not.toBeInTheDocument();
-    });
-
-    test('Apply is disabled when compare enabled but no compare variant selected', async () => {
-        render(<ProjectVariantSelector onApply={jest.fn()} />);
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
-        await waitFor(() => {
-            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
-        });
-
-        const [projectSelect] = screen.getAllByRole('combobox');
-        await act(async () => {
-            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
-        });
-
-        const checkbox = screen.getByRole('checkbox');
-        await act(async () => { fireEvent.click(checkbox); });
-
-        const applyButton = screen.getByRole('button', { name: 'Apply' });
-        expect(applyButton).toBeDisabled();
-    });
-
-    test('Apply with compare calls onApply with compareVariantId and default operation', async () => {
+    test('Apply in compare mode calls onApply with base, compare and difference operation', async () => {
         const onApply = jest.fn();
         render(<ProjectVariantSelector onApply={onApply} />);
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
+        await openPanel();
         await waitFor(() => {
             expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
         });
-
-        const [projectSelect, variantSelect] = screen.getAllByRole('combobox');
-        await act(async () => {
-            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
-        });
+        await selectProject('proj-1');
         await waitFor(() => {
-            expect(screen.getByRole('option', { name: 'default' })).toBeInTheDocument();
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
         });
+
         await act(async () => {
-            fireEvent.change(variantSelect, { target: { value: 'var-1' } });
+            fireEvent.click(screen.getByRole('radio', { name: /compare variants/i }));
         });
 
-        const checkbox = screen.getByRole('checkbox');
-        await act(async () => { fireEvent.click(checkbox); });
-
-        // Compare select is the last combobox; var-1 is filtered out, so var-2 is available
-        await waitFor(() => {
-            expect(screen.getAllByRole('combobox').length).toBe(3);
-        });
-        const compareSelect = screen.getAllByRole('combobox')[2];
+        // Base defaults to var-1, compare to var-2
         await act(async () => {
-            fireEvent.change(compareSelect, { target: { value: 'var-2' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
         });
-
-        const applyButton = screen.getByRole('button', { name: 'Apply' });
-        await act(async () => { fireEvent.click(applyButton); });
-
-        expect(onApply).toHaveBeenCalledWith('proj-1', 'var-1', 'var-2', 'difference');
+        expect(onApply).toHaveBeenCalledWith('proj-1', 'var-1', 'var-2', 'difference', [], '');
     });
 
-    test('Apply with compare and intersection operation passes correct args', async () => {
+    test('Apply in compare mode with intersection operation passes correct args', async () => {
         const onApply = jest.fn();
         render(<ProjectVariantSelector onApply={onApply} />);
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
+        await openPanel();
         await waitFor(() => {
             expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
         });
-
-        const [projectSelect, variantSelect] = screen.getAllByRole('combobox');
-        await act(async () => {
-            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
-        });
+        await selectProject('proj-1');
         await waitFor(() => {
-            expect(screen.getByRole('option', { name: 'default' })).toBeInTheDocument();
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('radio', { name: /compare variants/i }));
         });
         await act(async () => {
-            fireEvent.change(variantSelect, { target: { value: 'var-1' } });
+            fireEvent.click(screen.getByRole('radio', { name: /intersection/i }));
         });
 
-        const checkbox = screen.getByRole('checkbox');
-        await act(async () => { fireEvent.click(checkbox); });
-
-        // Switch to intersection
-        const intersectionRadio = screen.getByRole('radio', { name: /intersection/i });
-        await act(async () => { fireEvent.click(intersectionRadio); });
-
-        await waitFor(() => {
-            expect(screen.getAllByRole('combobox').length).toBe(3);
-        });
-        const compareSelect = screen.getAllByRole('combobox')[2];
         await act(async () => {
-            fireEvent.change(compareSelect, { target: { value: 'var-2' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
         });
-
-        const applyButton = screen.getByRole('button', { name: 'Apply' });
-        await act(async () => { fireEvent.click(applyButton); });
-
-        expect(onApply).toHaveBeenCalledWith('proj-1', 'var-1', 'var-2', 'intersection');
+        expect(onApply).toHaveBeenCalledWith('proj-1', 'var-1', 'var-2', 'intersection', [], '');
     });
 
-    test('unchecking compare passes empty compareVariantId to onApply', async () => {
+    test('swap button swaps base and compare variants', async () => {
         const onApply = jest.fn();
         render(<ProjectVariantSelector onApply={onApply} />);
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
+        await openPanel();
         await waitFor(() => {
             expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
         });
-
-        const [projectSelect] = screen.getAllByRole('combobox');
-        await act(async () => {
-            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
         });
 
-        const checkbox = screen.getByRole('checkbox');
-        await act(async () => { fireEvent.click(checkbox); });
-        await act(async () => { fireEvent.click(checkbox); });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('radio', { name: /compare variants/i }));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByTitle('Swap variants'));
+        });
 
-        const applyButton = screen.getByRole('button', { name: 'Apply' });
-        await act(async () => { fireEvent.click(applyButton); });
-
-        expect(onApply).toHaveBeenCalledWith('proj-1', '', '', '');
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+        });
+        expect(onApply).toHaveBeenCalledWith('proj-1', 'var-2', 'var-1', 'difference', [], '');
     });
 
-    test('swap button swaps variant A and compare variant B', async () => {
+    // -----------------------------------------------------------------------
+    // Reopen restores the currently-applied scope
+    // -----------------------------------------------------------------------
+
+    test('reopening restores the applied subset of variants', async () => {
         const onApply = jest.fn();
         render(<ProjectVariantSelector onApply={onApply} />);
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
+        await openPanel();
         await waitFor(() => {
             expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
         });
-
-        const [projectSelect, variantSelect] = screen.getAllByRole('combobox');
-        await act(async () => {
-            fireEvent.change(projectSelect, { target: { value: 'proj-1' } });
-        });
+        await selectProject('proj-1');
         await waitFor(() => {
-            expect(screen.getByRole('option', { name: 'default' })).toBeInTheDocument();
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        });
+
+        // Apply only var-1 + var-2 (drop var-3)
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Clear all' }));
         });
         await act(async () => {
-            fireEvent.change(variantSelect, { target: { value: 'var-1' } });
+            fireEvent.click(screen.getByRole('checkbox', { name: 'default' }));
         });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('checkbox', { name: 'release' }));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+        });
+        expect(onApply).toHaveBeenLastCalledWith('proj-1', '', '', '', ['var-1', 'var-2'], 'union');
 
-        const checkbox = screen.getByRole('checkbox');
-        await act(async () => { fireEvent.click(checkbox); });
-
+        // Reopen — the applied selection should be restored
+        await openPanel();
         await waitFor(() => {
-            expect(screen.getAllByRole('combobox').length).toBe(3);
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
         });
-        const compareSelect = screen.getAllByRole('combobox')[2];
+        expect(screen.getByRole('checkbox', { name: 'release' })).toBeChecked();
+        expect(screen.getByRole('checkbox', { name: 'staging' })).not.toBeChecked();
+    });
+
+    test('reopening discards un-applied edits and shows the applied selection', async () => {
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        });
+
+        // Apply all variants (project scope)
         await act(async () => {
-            fireEvent.change(compareSelect, { target: { value: 'var-2' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
         });
 
-        const swapButton = screen.getByTitle('Swap variants');
-        await act(async () => { fireEvent.click(swapButton); });
+        // Reopen, uncheck one variant but DON'T apply, then close
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'staging' })).toBeChecked();
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('checkbox', { name: 'staging' }));
+        });
+        expect(screen.getByRole('checkbox', { name: 'staging' })).not.toBeChecked();
+        // Close without applying (Escape)
+        await act(async () => {
+            fireEvent.keyDown(document, { key: 'Escape' });
+        });
 
-        const applyButton = screen.getByRole('button', { name: 'Apply' });
-        await act(async () => { fireEvent.click(applyButton); });
+        // Reopen — staging should be checked again (applied scope restored)
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'staging' })).toBeChecked();
+        });
+    });
 
-        expect(onApply).toHaveBeenCalledWith('proj-1', 'var-2', 'var-1', 'difference');
+    test('reopening restores compare mode and its operation', async () => {
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('radio', { name: /compare variants/i }));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('radio', { name: /intersection/i }));
+        });
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+        });
+
+        // Reopen — compare mode + intersection should be restored
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('radio', { name: /compare variants/i })).toBeChecked();
+        });
+        expect(screen.getByRole('radio', { name: /intersection/i })).toBeChecked();
+    });
+
+    test('reopening restores the single configured variant from defaults', async () => {
+        render(
+            <ProjectVariantSelector
+                defaultProject={{ id: 'proj-1', name: 'ProjectAlpha' }}
+                defaultVariant={{ id: 'var-2', name: 'release' }}
+                onApply={jest.fn()}
+            />
+        );
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'release' })).toBeChecked();
+        });
+        // Only the configured variant should be checked, not all
+        expect(screen.getByRole('checkbox', { name: 'default' })).not.toBeChecked();
+        expect(screen.getByRole('checkbox', { name: 'staging' })).not.toBeChecked();
     });
 
     // -----------------------------------------------------------------------
@@ -507,16 +530,133 @@ describe('ProjectVariantSelector', () => {
 
     test('renders gracefully when Projects.list rejects', async () => {
         mockProjectsList.mockRejectedValue(new Error('Network error'));
-
-        render(
-            <ProjectVariantSelector onApply={jest.fn()} />
-        );
-        const button = screen.getByRole('button');
-        await act(async () => { fireEvent.click(button); });
-
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
         await waitFor(() => {
-            // No project options (beside the placeholder) should appear
             expect(screen.queryByRole('option', { name: 'ProjectAlpha' })).not.toBeInTheDocument();
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Panel interactions
+    // -----------------------------------------------------------------------
+
+    test('clicking outside the panel closes it', async () => {
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        expect(screen.getByText('Project & Variant')).toBeInTheDocument();
+
+        await act(async () => {
+            fireEvent.mouseDown(document.body);
+        });
+        expect(screen.queryByText('Project & Variant')).not.toBeInTheDocument();
+    });
+
+    test('switching to Compare and back to Select restores the variant checklist', async () => {
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('radio', { name: /compare variants/i }));
+        });
+        expect(screen.queryByText('Variants')).not.toBeInTheDocument();
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('radio', { name: /select variants/i }));
+        });
+        expect(screen.getByText('Variants')).toBeInTheDocument();
+    });
+
+    test('Select all re-checks every variant after clearing', async () => {
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Clear all' }));
+        });
+        expect(screen.getByRole('checkbox', { name: 'default' })).not.toBeChecked();
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
+        });
+        expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        expect(screen.getByRole('checkbox', { name: 'release' })).toBeChecked();
+        expect(screen.getByRole('checkbox', { name: 'staging' })).toBeChecked();
+    });
+
+    test('changing base and compare variant selects updates the applied scope', async () => {
+        const onApply = jest.fn();
+        render(<ProjectVariantSelector onApply={onApply} />);
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('radio', { name: /compare variants/i }));
+        });
+
+        // Combobox order in compare mode: [0]=project, [1]=base, [2]=compare
+        const combos = screen.getAllByRole('combobox');
+        await act(async () => {
+            fireEvent.change(combos[1], { target: { value: 'var-2' } });
+        });
+        await act(async () => {
+            fireEvent.change(screen.getAllByRole('combobox')[2], { target: { value: 'var-3' } });
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+        });
+        expect(onApply).toHaveBeenCalledWith('proj-1', 'var-2', 'var-3', 'difference', [], '');
+    });
+
+    test('reopening after switching project without applying restores the applied project', async () => {
+        const onApply = jest.fn();
+        render(<ProjectVariantSelector onApply={onApply} />);
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+        await selectProject('proj-1');
+        await waitFor(() => {
+            expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        });
+
+        // Apply proj-1 (all variants)
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+        });
+
+        // Reopen, switch the project dropdown to proj-2 but DON'T apply, then close
+        await openPanel();
+        await selectProject('proj-2');
+        await act(async () => {
+            fireEvent.keyDown(document, { key: 'Escape' });
+        });
+
+        // Reopen — the applied project (proj-1) should be restored
+        await openPanel();
+        await waitFor(() => {
+            expect((screen.getAllByRole('combobox')[0] as HTMLSelectElement).value).toBe('proj-1');
         });
     });
 });

--- a/frontend/tests/unit_tests/test_project_variant_selector.tsx
+++ b/frontend/tests/unit_tests/test_project_variant_selector.tsx
@@ -96,7 +96,7 @@ describe('ProjectVariantSelector', () => {
         });
     });
 
-    test('shows default variant name when both defaultProject and defaultVariant are supplied', async () => {
+    test('shows "All variants" by default even when defaultVariant is supplied', async () => {
         render(
             <ProjectVariantSelector
                 defaultProject={{ id: 'proj-1', name: 'ProjectAlpha' }}
@@ -105,7 +105,7 @@ describe('ProjectVariantSelector', () => {
             />
         );
         await waitFor(() => {
-            expect(screen.getByText('default')).toBeInTheDocument();
+            expect(screen.getByText('All variants')).toBeInTheDocument();
         });
     });
 
@@ -507,7 +507,7 @@ describe('ProjectVariantSelector', () => {
         expect(screen.getByRole('radio', { name: /intersection/i })).toBeChecked();
     });
 
-    test('reopening restores the single configured variant from defaults', async () => {
+    test('all variants are checked by default even when defaultVariant is supplied', async () => {
         render(
             <ProjectVariantSelector
                 defaultProject={{ id: 'proj-1', name: 'ProjectAlpha' }}
@@ -519,9 +519,9 @@ describe('ProjectVariantSelector', () => {
         await waitFor(() => {
             expect(screen.getByRole('checkbox', { name: 'release' })).toBeChecked();
         });
-        // Only the configured variant should be checked, not all
-        expect(screen.getByRole('checkbox', { name: 'default' })).not.toBeChecked();
-        expect(screen.getByRole('checkbox', { name: 'staging' })).not.toBeChecked();
+        // All variants should be checked by default, not just the configured one
+        expect(screen.getByRole('checkbox', { name: 'default' })).toBeChecked();
+        expect(screen.getByRole('checkbox', { name: 'staging' })).toBeChecked();
     });
 
     // -----------------------------------------------------------------------

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -43,12 +43,14 @@ def init_app(app: Flask) -> None:
             operation = request.args.get('operation', 'difference')
 
             def _pkg_ids_for_variant(variant_uuid: uuid.UUID) -> set[uuid.UUID]:
+                scan_ids = active_sbom_scan_ids_for_variant(variant_uuid)
+                if not scan_ids:
+                    return set()
                 return set(db.session.execute(
                     db.select(Package.id)
                     .join(SBOMPackage, Package.id == SBOMPackage.package_id)
                     .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
-                    .join(Scan, SBOMDocument.scan_id == Scan.id)
-                    .where(Scan.variant_id == variant_uuid)
+                    .where(SBOMDocument.scan_id.in_(scan_ids))
                     .distinct()
                 ).scalars().all())
 
@@ -63,21 +65,24 @@ def init_app(app: Flask) -> None:
                 ).scalars().all()) if result_ids else []
             else:  # difference (default): packages in compare but NOT in base
                 exclude_ids = list(_pkg_ids_for_variant(base_uuid))
-                pkg_ids_sub = (
-                    db.select(Package.id)
-                    .join(SBOMPackage, Package.id == SBOMPackage.package_id)
-                    .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
-                    .join(Scan, SBOMDocument.scan_id == Scan.id)
-                    .where(Scan.variant_id == compare_uuid)
-                    .distinct()
-                )
-                if exclude_ids:
-                    pkg_ids_sub = pkg_ids_sub.where(~Package.id.in_(exclude_ids))
-                pkgs = list(db.session.execute(
-                    db.select(Package)
-                    .where(Package.id.in_(pkg_ids_sub))
-                    .order_by(Package.name)
-                ).scalars().all())
+                compare_scan_ids = active_sbom_scan_ids_for_variant(compare_uuid)
+                if not compare_scan_ids:
+                    pkgs = []
+                else:
+                    pkg_ids_sub = (
+                        db.select(Package.id)
+                        .join(SBOMPackage, Package.id == SBOMPackage.package_id)
+                        .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+                        .where(SBOMDocument.scan_id.in_(compare_scan_ids))
+                        .distinct()
+                    )
+                    if exclude_ids:
+                        pkg_ids_sub = pkg_ids_sub.where(~Package.id.in_(exclude_ids))
+                    pkgs = list(db.session.execute(
+                        db.select(Package)
+                        .where(Package.id.in_(pkg_ids_sub))
+                        .order_by(Package.name)
+                    ).scalars().all())
             active_scan_ids = []  # compare mode: do not restrict by scan
         elif variant_ids:
             # Multi-variant mode: union or intersection of the packages present
@@ -94,12 +99,14 @@ def init_app(app: Flask) -> None:
             operation = request.args.get('operation', 'union')
 
             def _multi_pkg_ids_for_variant(variant_uuid: uuid.UUID) -> set[uuid.UUID]:
+                scan_ids = active_sbom_scan_ids_for_variant(variant_uuid)
+                if not scan_ids:
+                    return set()
                 return set(db.session.execute(
                     db.select(Package.id)
                     .join(SBOMPackage, Package.id == SBOMPackage.package_id)
                     .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
-                    .join(Scan, SBOMDocument.scan_id == Scan.id)
-                    .where(Scan.variant_id == variant_uuid)
+                    .where(SBOMDocument.scan_id.in_(scan_ids))
                     .distinct()
                 ).scalars().all())
 

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -28,6 +28,7 @@ def init_app(app: Flask) -> None:
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
         compare_variant_id = request.args.get('compare_variant_id')
+        variant_ids = request.args.get('variant_ids')
         if variant_id and compare_variant_id:
             base_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:
@@ -78,6 +79,48 @@ def init_app(app: Flask) -> None:
                     .order_by(Package.name)
                 ).scalars().all())
             active_scan_ids = []  # compare mode: do not restrict by scan
+        elif variant_ids:
+            # Multi-variant mode: union or intersection of the packages present
+            # in two or more selected variants.
+            raw_ids = [s.strip() for s in variant_ids.split(',') if s.strip()]
+            parsed_uuids: list[uuid.UUID] = []
+            for raw_id in raw_ids:
+                parsed, err = parse_uuid_or_400(raw_id, "variant_ids")
+                if err:
+                    return err
+                if parsed is None:
+                    return {"error": "Internal error"}, 500
+                parsed_uuids.append(parsed)
+            operation = request.args.get('operation', 'union')
+
+            def _multi_pkg_ids_for_variant(variant_uuid: uuid.UUID) -> set[uuid.UUID]:
+                return set(db.session.execute(
+                    db.select(Package.id)
+                    .join(SBOMPackage, Package.id == SBOMPackage.package_id)
+                    .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+                    .join(Scan, SBOMDocument.scan_id == Scan.id)
+                    .where(Scan.variant_id == variant_uuid)
+                    .distinct()
+                ).scalars().all())
+
+            id_sets = [_multi_pkg_ids_for_variant(u) for u in parsed_uuids]
+            if not id_sets:
+                multi_result_ids: list[uuid.UUID] = []
+            elif operation == 'intersection':
+                multi_result_ids = list(set.intersection(*id_sets))
+            else:  # union (default)
+                multi_result_ids = list(set.union(*id_sets))
+            pkgs = list(db.session.execute(
+                db.select(Package)
+                .where(Package.id.in_(multi_result_ids))
+                .order_by(Package.name)
+            ).scalars().all()) if multi_result_ids else []
+            # Restrict enrichment to the active SBOM scans of the selected variants
+            active_scan_ids = [
+                sid
+                for parsed in parsed_uuids
+                for sid in active_sbom_scan_ids_for_variant(parsed)
+            ]
         elif variant_id:
             variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -66,6 +66,24 @@ def _sbom_pkg_filter(pkg_ids: set[uuid.UUID]) -> "ColumnElement[bool] | None":
     )
 
 
+def _vuln_ids_for_scans(scan_ids: list[uuid.UUID]) -> set[str]:
+    """Vuln IDs from *scan_ids*, filtering tool scans to active SBOM packages."""
+    if not scan_ids:
+        return set()
+    _pkg_ids = active_package_ids_for_scans(scan_ids)
+    q = (
+        db.select(Vulnerability.id)
+        .join(Finding, Vulnerability.id == Finding.vulnerability_id)
+        .join(Observation, Finding.id == Observation.finding_id)
+        .join(Scan, Observation.scan_id == Scan.id)
+        .where(Observation.scan_id.in_(scan_ids))
+    )
+    _flt = _sbom_pkg_filter(_pkg_ids)
+    if _flt is not None:
+        q = q.where(_flt)
+    return set(db.session.execute(q.distinct()).scalars().all())
+
+
 # Formats that are exclusively vulnerability scanners (never pure package BOMs)
 # Mapping from SBOMDocument.format to the found_by string exposed by the API
 _FORMAT_TO_FOUND_BY: dict[str, str] = {
@@ -281,6 +299,7 @@ def init_app(app: Flask) -> None:
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
         compare_variant_id = request.args.get('compare_variant_id')
+        variant_ids = request.args.get('variant_ids')
         variant_scoped_overrides: dict[str, _ScopedOverrides] = {}
         current_scan_ids: list[uuid.UUID] = []
         records: list[Vulnerability] = []
@@ -307,23 +326,6 @@ def init_app(app: Flask) -> None:
                 selectinload(Vulnerability.findings).selectinload(Finding.time_estimates),
                 selectinload(Vulnerability.metrics),
             )
-
-            def _vuln_ids_for_scans(scan_ids: list[uuid.UUID]) -> set[str]:
-                """Vuln IDs from *scan_ids*, filtering tool scans to active packages."""
-                if not scan_ids:
-                    return set()
-                _pkg_ids = active_package_ids_for_scans(scan_ids)
-                q = (
-                    db.select(Vulnerability.id)
-                    .join(Finding, Vulnerability.id == Finding.vulnerability_id)
-                    .join(Observation, Finding.id == Observation.finding_id)
-                    .join(Scan, Observation.scan_id == Scan.id)
-                    .where(Observation.scan_id.in_(scan_ids))
-                )
-                _flt = _sbom_pkg_filter(_pkg_ids)
-                if _flt is not None:
-                    q = q.where(_flt)
-                return set(db.session.execute(q.distinct()).scalars().all())
 
             base_ids = _vuln_ids_for_scans(base_latest_ids)
             operation = request.args.get('operation', 'difference')
@@ -360,6 +362,43 @@ def init_app(app: Flask) -> None:
                         query = query.where(~Vulnerability.id.in_(list(base_ids)))
                     records = list(db.session.execute(query).scalars().all())
             variant_scoped_overrides = _variant_scoped_metrics_and_effort_overrides(records, compare_uuid)
+        elif variant_ids:
+            # Multi-variant mode: union or intersection of the vulnerabilities
+            # present in two or more selected variants.
+            raw_ids = [s.strip() for s in variant_ids.split(',') if s.strip()]
+            parsed_uuids: list[uuid.UUID] = []
+            for raw_id in raw_ids:
+                parsed, err = parse_uuid_or_400(raw_id, "variant_ids")
+                if err:
+                    return err
+                if parsed is None:
+                    return {"error": "Internal error"}, 500
+                parsed_uuids.append(parsed)
+            operation = request.args.get('operation', 'union')
+            _scope_variant = None
+            _scope_project = None
+            opts = (
+                selectinload(Vulnerability.findings).selectinload(Finding.package),
+                selectinload(Vulnerability.findings).selectinload(Finding.time_estimates),
+                selectinload(Vulnerability.metrics),
+            )
+            per_variant_scan_ids = {u: active_scan_ids_for_variant(u) for u in parsed_uuids}
+            current_scan_ids = []
+            for _ids in per_variant_scan_ids.values():
+                current_scan_ids.extend(_ids)
+            id_sets = [_vuln_ids_for_scans(per_variant_scan_ids[u]) for u in parsed_uuids]
+            if not id_sets:
+                result_ids: list = []
+            elif operation == 'intersection':
+                result_ids = list(set.intersection(*id_sets))
+            else:  # union (default)
+                result_ids = list(set.union(*id_sets))
+            records = list(db.session.execute(
+                select(Vulnerability)
+                .options(*opts)
+                .where(Vulnerability.id.in_(result_ids))
+                .order_by(Vulnerability.id)
+            ).scalars().all()) if result_ids else []
         elif variant_id:
             variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:

--- a/tests/webapp_tests/test_project_variant_endpoints.py
+++ b/tests/webapp_tests/test_project_variant_endpoints.py
@@ -599,6 +599,72 @@ class TestPackagesFiltering:
         )
         assert response.status_code == 400
 
+    # Multi-variant tests:
+    # VariantA has cairo@1.16.0, VariantB has busybox@1.35.0 (no common package).
+
+    def test_packages_multi_union_returns_all_selected(self, client_and_data):
+        """union([VA, VB]): packages present in any selected variant → cairo + busybox."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        variant_b_id = data["variant_b_id"]
+        response = client.get(
+            f"/api/packages?format=list"
+            f"&variant_ids={variant_a_id},{variant_b_id}"
+            f"&operation=union"
+        )
+        assert response.status_code == 200
+        names = [p["name"] for p in json.loads(response.data)]
+        assert "cairo" in names
+        assert "busybox" in names
+
+    def test_packages_multi_default_operation_is_union(self, client_and_data):
+        """Omitting operation defaults to union."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        variant_b_id = data["variant_b_id"]
+        response = client.get(
+            f"/api/packages?format=list&variant_ids={variant_a_id},{variant_b_id}"
+        )
+        assert response.status_code == 200
+        names = [p["name"] for p in json.loads(response.data)]
+        assert "cairo" in names
+        assert "busybox" in names
+
+    def test_packages_multi_intersection_empty_when_no_common(self, client_and_data):
+        """intersection([VA, VB]): no common package → empty."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        variant_b_id = data["variant_b_id"]
+        response = client.get(
+            f"/api/packages?format=list"
+            f"&variant_ids={variant_a_id},{variant_b_id}"
+            f"&operation=intersection"
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data) == []
+
+    def test_packages_multi_intersection_same_variant(self, client_and_data):
+        """intersection([VA, VA]): identical sets → all of VA's packages."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        response = client.get(
+            f"/api/packages?format=list"
+            f"&variant_ids={variant_a_id},{variant_a_id}"
+            f"&operation=intersection"
+        )
+        assert response.status_code == 200
+        names = [p["name"] for p in json.loads(response.data)]
+        assert "cairo" in names
+
+    def test_packages_multi_invalid_uuid(self, client_and_data):
+        """Invalid UUID inside variant_ids returns 400."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        response = client.get(
+            f"/api/packages?variant_ids={variant_a_id},not-a-uuid"
+        )
+        assert response.status_code == 400
+
 
 # ===========================================================================
 # /api/vulnerabilities  — variant / project filtering
@@ -789,6 +855,75 @@ class TestVulnerabilitiesFiltering:
             f"/api/vulnerabilities?format=list"
             f"&variant_id=not-a-uuid"
             f"&compare_variant_id={variant_a_id}"
+        )
+        assert response.status_code == 400
+
+    # Multi-variant tests:
+    # VariantA has CVE-2020-35492, VariantB has no vulnerabilities.
+
+    def test_vulnerabilities_multi_union_returns_all_selected(self, client_and_data):
+        """union([VA, VB]): vulns in any selected variant → CVE-2020-35492."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        variant_b_id = data["variant_b_id"]
+        url = (
+            f"/api/vulnerabilities?format=list"
+            f"&variant_ids={variant_a_id},{variant_b_id}"
+            f"&operation=union"
+        )
+        response = client.get(url)
+        assert response.status_code == 200
+        ids = [v["id"] for v in response.get_json()]
+        assert "CVE-2020-35492" in ids
+
+    def test_vulnerabilities_multi_default_operation_is_union(self, client_and_data):
+        """Omitting operation defaults to union."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        variant_b_id = data["variant_b_id"]
+        url = (
+            f"/api/vulnerabilities?format=list"
+            f"&variant_ids={variant_a_id},{variant_b_id}"
+        )
+        response = client.get(url)
+        assert response.status_code == 200
+        ids = [v["id"] for v in response.get_json()]
+        assert "CVE-2020-35492" in ids
+
+    def test_vulnerabilities_multi_intersection_empty_when_no_common(self, client_and_data):
+        """intersection([VA, VB]): no common vuln → empty."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        variant_b_id = data["variant_b_id"]
+        url = (
+            f"/api/vulnerabilities?format=list"
+            f"&variant_ids={variant_a_id},{variant_b_id}"
+            f"&operation=intersection"
+        )
+        response = client.get(url)
+        assert response.status_code == 200
+        assert response.get_json() == []
+
+    def test_vulnerabilities_multi_intersection_same_variant(self, client_and_data):
+        """intersection([VA, VA]): identical sets → all of VA's vulns."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        url = (
+            f"/api/vulnerabilities?format=list"
+            f"&variant_ids={variant_a_id},{variant_a_id}"
+            f"&operation=intersection"
+        )
+        response = client.get(url)
+        assert response.status_code == 200
+        ids = [v["id"] for v in response.get_json()]
+        assert "CVE-2020-35492" in ids
+
+    def test_vulnerabilities_multi_invalid_uuid(self, client_and_data):
+        """Invalid UUID inside variant_ids returns 400."""
+        client, data = client_and_data
+        variant_a_id = data["variant_a_id"]
+        response = client.get(
+            f"/api/vulnerabilities?format=list&variant_ids={variant_a_id},bad-uuid"
         )
         assert response.status_code == 400
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Replace the scope selector with two mutually-exclusive modes: 'Select Variants' (all selected by default, union semantics for any subset) and 'Compare variants' (unchanged difference/intersection). Selecting multiple variants loads data relevant to at least one of them via a new variant_ids query param (union/intersection) on /api/packages and /api/vulnerabilities.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Play with the new menu:

<img width="327" height="437" alt="image" src="https://github.com/user-attachments/assets/d6fc7d68-be3a-4405-8962-ae63cca65c7f" />

