### PR TITLE
Feature: Add variant filtering

### DIFF
--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -120,6 +120,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
     const [selectedJustifications, setSelectedJustifications] = useState<string[]>([]);
     const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
+    const [selectedVariants, setSelectedVariants] = useState<string[]>([]);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
     const [importStatus, setImportStatus] = useState<string | null>(null);
@@ -297,11 +298,24 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
 
     const hasSupplierInfo = useMemo(() => supplierList.length > 0, [supplierList]);
 
+    const variantList = useMemo(() => {
+        const set = new Set<string>();
+        for (const a of assessments) {
+            const vids = (a as any)._variantIds ?? (a.variant_id ? [a.variant_id] : []);
+            for (const vid of vids) {
+                const name = variantNames[vid];
+                if (name) set.add(name);
+            }
+        }
+        return [...set].sort();
+    }, [assessments, variantNames]);
+
     const resetFilters = () => {
         setSearch('');
         setSelectedStatuses([]);
         setSelectedJustifications([]);
         setSelectedSuppliers([]);
+        setSelectedVariants([]);
     };
 
     const handleExportReview = useCallback(async () => {
@@ -877,6 +891,11 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             const rowSuppliers = a.packages.map(p => extractSupplierName(splitPkgId(p).supplier));
             if (!selectedSuppliers.some(s => rowSuppliers.includes(s))) return false;
         }
+        if (selectedVariants.length) {
+            const vids = (a as any)._variantIds ?? (a.variant_id ? [a.variant_id] : []);
+            const rowVariants = vids.map((vid: string) => variantNames[vid]).filter(Boolean);
+            if (!selectedVariants.some(v => rowVariants.includes(v))) return false;
+        }
         return true;
     });
 
@@ -937,6 +956,15 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                                 options={supplierList}
                                 selected={selectedSuppliers}
                                 setSelected={setSelectedSuppliers}
+                            />
+                        )}
+
+                        {variantList.length > 0 && (
+                            <FilterOption
+                                label="Variants"
+                                options={variantList}
+                                selected={selectedVariants}
+                                setSelected={setSelectedVariants}
                             />
                         )}
                     </>

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -120,7 +120,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
     const [selectedJustifications, setSelectedJustifications] = useState<string[]>([]);
     const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
-    const [selectedVariants, setSelectedVariants] = useState<string[]>([]);
+    const [deselectedVariants, setDeselectedVariants] = useState<string[]>([]);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
     const [importStatus, setImportStatus] = useState<string | null>(null);
@@ -310,12 +310,23 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         return [...set].sort();
     }, [assessments, variantNames]);
 
+    // All variants are checked by default; a variant only leaves the selection
+    // once the user explicitly unchecks it. Deriving the selection during render
+    // (instead of populating it from an effect) prevents a first-render flash.
+    const selectedVariants = useMemo(
+        () => variantList.filter(v => !deselectedVariants.includes(v)),
+        [variantList, deselectedVariants]
+    );
+    const setSelectedVariants = useCallback((values: string[]) => {
+        setDeselectedVariants(variantList.filter(v => !values.includes(v)));
+    }, [variantList]);
+
     const resetFilters = () => {
         setSearch('');
         setSelectedStatuses([]);
         setSelectedJustifications([]);
         setSelectedSuppliers([]);
-        setSelectedVariants([]);
+        setSelectedVariants(variantList);
     };
 
     const handleExportReview = useCallback(async () => {
@@ -891,10 +902,10 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             const rowSuppliers = a.packages.map(p => extractSupplierName(splitPkgId(p).supplier));
             if (!selectedSuppliers.some(s => rowSuppliers.includes(s))) return false;
         }
-        if (selectedVariants.length) {
+        {
             const vids = (a as any)._variantIds ?? (a.variant_id ? [a.variant_id] : []);
             const rowVariants = vids.map((vid: string) => variantNames[vid]).filter(Boolean);
-            if (!selectedVariants.some(v => rowVariants.includes(v))) return false;
+            if (rowVariants.length && !selectedVariants.some(v => rowVariants.includes(v))) return false;
         }
         return true;
     });

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -1,6 +1,6 @@
 import type { Package, VulnCounts, Severities } from "../handlers/packages";
 import { createColumnHelper, Row } from '@tanstack/react-table'
-import { useMemo, useState, useRef, useEffect } from "react";
+import { useMemo, useState, useRef, useEffect, useCallback } from "react";
 import SeverityTag from "../components/SeverityTag";
 import TableGeneric from "../components/TableGeneric";
 import debounce from 'lodash-es/debounce';
@@ -52,7 +52,10 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
     const [selectedSbomDocs, setSelectedSbomDocs] = useState<string[]>([]);
     const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
-    const [selectedVariants, setSelectedVariants] = useState<string[]>([]);
+    // Track variants the user has explicitly unchecked. All variants (including
+    // any discovered later) are considered selected unless present here, which
+    // avoids a first-render flash where variant rows briefly disappear.
+    const [deselectedVariants, setDeselectedVariants] = useState<string[]>([]);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
     const tableRef = useRef<HTMLDivElement>(null); // ref to table container to allow adjustment of filter box height
@@ -177,12 +180,23 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         return acc.sort();
     }, []), [packages])
 
+    // All variants are checked by default; a variant only leaves the selection
+    // once the user explicitly unchecks it. Deriving the selection during render
+    // (instead of populating it from an effect) prevents a first-render flash.
+    const selectedVariants = useMemo(
+        () => variants_list.filter(v => !deselectedVariants.includes(v)),
+        [variants_list, deselectedVariants]
+    );
+    const setSelectedVariants = useCallback((values: string[]) => {
+        setDeselectedVariants(variants_list.filter(v => !values.includes(v)));
+    }, [variants_list]);
+
     const resetFilters = () => {
         setSearch('');
         setSelectedSources([]);
         setSelectedSbomDocs([]);
         setSelectedSuppliers([]);
-        setSelectedVariants([]);
+        setSelectedVariants(variants_list);
         setShowSeverity(false);
         setVisibleColumns(defaultVisibleColumns);
     }
@@ -392,7 +406,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
             if (selectedSuppliers.length && !selectedSuppliers.includes(extractSupplierName(el.supplier))) {
                 return false;
             }
-            if (selectedVariants.length && !selectedVariants.some(variant => el.variants.includes(variant))) {
+            if (el.variants.length && !selectedVariants.some(variant => el.variants.includes(variant))) {
                 return false;
             }
             return true;

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -52,6 +52,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
     const [selectedSbomDocs, setSelectedSbomDocs] = useState<string[]>([]);
     const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
+    const [selectedVariants, setSelectedVariants] = useState<string[]>([]);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
     const tableRef = useRef<HTMLDivElement>(null); // ref to table container to allow adjustment of filter box height
@@ -168,11 +169,20 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         return acc.sort();
     }, []), [packages])
 
+    const variants_list = useMemo(() => packages.reduce((acc: string[], pkg) => {
+        for (const variant of pkg.variants) {
+            if (variant !== '' && !acc.includes(variant))
+                acc.push(variant);
+        }
+        return acc.sort();
+    }, []), [packages])
+
     const resetFilters = () => {
         setSearch('');
         setSelectedSources([]);
         setSelectedSbomDocs([]);
         setSelectedSuppliers([]);
+        setSelectedVariants([]);
         setShowSeverity(false);
         setVisibleColumns(defaultVisibleColumns);
     }
@@ -382,9 +392,12 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
             if (selectedSuppliers.length && !selectedSuppliers.includes(extractSupplierName(el.supplier))) {
                 return false;
             }
+            if (selectedVariants.length && !selectedVariants.some(variant => el.variants.includes(variant))) {
+                return false;
+            }
             return true;
         });
-    }, [packages, selectedSources, selectedSbomDocs, selectedSuppliers]);
+    }, [packages, selectedSources, selectedSbomDocs, selectedSuppliers, selectedVariants]);
 
     return (<>
         <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2">
@@ -459,6 +472,15 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
                 selected={selectedSbomDocs}
                 setSelected={setSelectedSbomDocs}
             />
+
+            {variants_list.length > 0 && (
+                <FilterOption
+                    label="Variants"
+                    options={variants_list}
+                    selected={selectedVariants}
+                    setSelected={setSelectedVariants}
+                />
+            )}
 
             <div className="ml-4">
                 <ToggleSwitch

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -353,6 +353,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
     const [selectedPackages, setSelectedPackages] = useState<string[]>([]);
+    const [selectedVariants, setSelectedVariants] = useState<string[]>([]);
     const [publishedDateFilterType, setPublishedDateFilterType] = useState<string>('');
     const [publishedDateValue, setPublishedDateValue] = useState<string>('');
     const [publishedDaysValue, setPublishedDaysValue] = useState<string>('');
@@ -575,6 +576,14 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         () => sources_list.map(formatSourceName),
         [sources_list]
     );
+
+    const variants_list = useMemo(() => vulnerabilities.reduce((acc: string[], vuln) => {
+        vuln.variants.forEach(variant => {
+            if (!acc.includes(variant) && variant != '')
+                acc.push(variant)
+        });
+        return acc.sort();
+    }, []), [vulnerabilities])
 
     const handleEditClick = useCallback((vuln: Vulnerability) => {
         const index = searchFilteredData.findIndex(v => v.id === vuln.id);
@@ -1039,6 +1048,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             }
             if (selectedSources.length && !selectedSources.some(src => el.found_by.includes(src))) return false;
             if (selectedPackages.length && !selectedPackages.some(pkg => el.packages_current.includes(pkg))) return false;
+            if (selectedVariants.length && !selectedVariants.some(variant => el.variants.includes(variant))) return false;
 
             // Published date filter
             if (publishedDateFilterType && el.published) {
@@ -1130,7 +1140,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
 
             return true;
         });
-    }, [vulnerabilities, selectedSeverities, selectedStatuses, selectedSources, selectedPackages, publishedDateFilterType, publishedDateValue, publishedDaysValue, publishedDateFrom, publishedDateTo, showCustomSeverityFilter, severityRange, showCustomEpssFilter, epssRange, selectedAttackVectors, selectedFirstScanDates]);
+    }, [vulnerabilities, selectedSeverities, selectedStatuses, selectedSources, selectedPackages, selectedVariants, publishedDateFilterType, publishedDateValue, publishedDaysValue, publishedDateFrom, publishedDateTo, showCustomSeverityFilter, severityRange, showCustomEpssFilter, epssRange, selectedAttackVectors, selectedFirstScanDates]);
 
     const selectedVulns = useMemo(() => {
         return Object.entries(selectedRows).flatMap(([id, selected]) => selected ? [id] : [])
@@ -1158,6 +1168,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         setSelectedSeverities([]);
         setSelectedStatuses([]);
         setSelectedPackages([]);
+        setSelectedVariants([]);
         setPublishedDateFilterType('');
         setPublishedDateValue('');
         setPublishedDaysValue('');
@@ -1369,6 +1380,15 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 selected={selectedStatuses}
                 setSelected={setSelectedStatuses}
             />
+
+            {variants_list.length > 0 && (
+                <FilterOption
+                    label="Variants"
+                    options={variants_list}
+                    selected={selectedVariants}
+                    setSelected={setSelectedVariants}
+                />
+            )}
 
             {/* Published Date Filter Dropdown */}
             <PublishedDateFilter

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -353,7 +353,10 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
     const [selectedPackages, setSelectedPackages] = useState<string[]>([]);
-    const [selectedVariants, setSelectedVariants] = useState<string[]>([]);
+    // Track variants the user has explicitly unchecked. All variants (including
+    // any discovered later) are considered selected unless present here, which
+    // avoids a first-render flash where variant rows briefly disappear.
+    const [deselectedVariants, setDeselectedVariants] = useState<string[]>([]);
     const [publishedDateFilterType, setPublishedDateFilterType] = useState<string>('');
     const [publishedDateValue, setPublishedDateValue] = useState<string>('');
     const [publishedDaysValue, setPublishedDaysValue] = useState<string>('');
@@ -584,6 +587,17 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         });
         return acc.sort();
     }, []), [vulnerabilities])
+
+    // All variants are checked by default; a variant only leaves the selection
+    // once the user explicitly unchecks it. Deriving the selection during render
+    // (instead of populating it from an effect) prevents a first-render flash.
+    const selectedVariants = useMemo(
+        () => variants_list.filter(v => !deselectedVariants.includes(v)),
+        [variants_list, deselectedVariants]
+    );
+    const setSelectedVariants = useCallback((values: string[]) => {
+        setDeselectedVariants(variants_list.filter(v => !values.includes(v)));
+    }, [variants_list]);
 
     const handleEditClick = useCallback((vuln: Vulnerability) => {
         const index = searchFilteredData.findIndex(v => v.id === vuln.id);
@@ -1048,7 +1062,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             }
             if (selectedSources.length && !selectedSources.some(src => el.found_by.includes(src))) return false;
             if (selectedPackages.length && !selectedPackages.some(pkg => el.packages_current.includes(pkg))) return false;
-            if (selectedVariants.length && !selectedVariants.some(variant => el.variants.includes(variant))) return false;
+            if (el.variants.length && !selectedVariants.some(variant => el.variants.includes(variant))) return false;
 
             // Published date filter
             if (publishedDateFilterType && el.published) {
@@ -1168,7 +1182,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         setSelectedSeverities([]);
         setSelectedStatuses([]);
         setSelectedPackages([]);
-        setSelectedVariants([]);
+        setSelectedVariants(variants_list);
         setPublishedDateFilterType('');
         setPublishedDateValue('');
         setPublishedDaysValue('');

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -336,24 +336,24 @@ describe('Packages Table', () => {
         const variants_btn = await screen.getByRole('button', { name: /^variants$/i });
         await user.click(variants_btn);
 
-        // ACT: select "variant-a"
+        // All variants are checked by default. ACT: uncheck "variant-a"
         const variantACheckbox = await screen.getByRole('checkbox', { name: /variant-a/i });
         await user.click(variantACheckbox);
 
-        // xxxyyyzzz is only in variant-b, so it must disappear
+        // aaabbbccc is only in variant-a, so it must disappear
         await waitFor(() => {
-            expect(document.body.innerHTML).not.toContain('xxxyyyzzz');
+            expect(document.body.innerHTML).not.toContain('aaabbbccc');
         }, { timeout: 2000 });
 
-        // aaabbbccc (variant-a) and dddeeefff (variant-a + variant-b) remain
-        expect(screen.getAllByRole('cell', { name: /aaabbbccc/ }).length).toBeGreaterThan(0);
+        // xxxyyyzzz (variant-b) and dddeeefff (variant-a + variant-b) remain
+        expect(screen.getAllByRole('cell', { name: /xxxyyyzzz/ }).length).toBeGreaterThan(0);
         expect(screen.getAllByRole('cell', { name: /dddeeefff/ }).length).toBeGreaterThan(0);
 
-        // REVERT CHANGE: uncheck "variant-a"
+        // REVERT CHANGE: re-check "variant-a"
         await user.click(variantACheckbox);
 
         await waitFor(() => {
-            expect(screen.getAllByRole('cell', { name: /xxxyyyzzz/ }).length).toBeGreaterThan(0);
+            expect(screen.getAllByRole('cell', { name: /aaabbbccc/ }).length).toBeGreaterThan(0);
         });
     })
 

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -321,6 +321,50 @@ describe('Packages Table', () => {
         });
     })
 
+    test('filter by variant', async () => {
+        // ARRANGE: packages spread across two variants
+        const packagesWithVariants: Package[] = [
+            { ...packages[0], variants: ['variant-a'] },
+            { ...packages[1], variants: ['variant-b'] },
+            { ...packages[2], variants: ['variant-a', 'variant-b'] },
+        ];
+        render(<TablePackages packages={packagesWithVariants} />);
+
+        const user = userEvent.setup();
+
+        // Open the "Variants" filter dropdown
+        const variants_btn = await screen.getByRole('button', { name: /^variants$/i });
+        await user.click(variants_btn);
+
+        // ACT: select "variant-a"
+        const variantACheckbox = await screen.getByRole('checkbox', { name: /variant-a/i });
+        await user.click(variantACheckbox);
+
+        // xxxyyyzzz is only in variant-b, so it must disappear
+        await waitFor(() => {
+            expect(document.body.innerHTML).not.toContain('xxxyyyzzz');
+        }, { timeout: 2000 });
+
+        // aaabbbccc (variant-a) and dddeeefff (variant-a + variant-b) remain
+        expect(screen.getAllByRole('cell', { name: /aaabbbccc/ }).length).toBeGreaterThan(0);
+        expect(screen.getAllByRole('cell', { name: /dddeeefff/ }).length).toBeGreaterThan(0);
+
+        // REVERT CHANGE: uncheck "variant-a"
+        await user.click(variantACheckbox);
+
+        await waitFor(() => {
+            expect(screen.getAllByRole('cell', { name: /xxxyyyzzz/ }).length).toBeGreaterThan(0);
+        });
+    })
+
+    test('variant filter is hidden when no package has variants', async () => {
+        // ARRANGE: the default packages have no variants
+        render(<TablePackages packages={packages} />);
+
+        // ASSERT: the "Variants" filter button is not rendered
+        expect(screen.queryByRole('button', { name: /^variants$/i })).toBeNull();
+    })
+
     test('reset filters button clears all filters', async () => {
         // ARRANGE
         render(<TablePackages packages={packages} />);

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -607,14 +607,18 @@ describe('Vulnerability Table', () => {
         expect(variantBtn).toBeInTheDocument();
         await user.click(variantBtn);
 
+        // All variants are checked by default; unchecking variant-a removes rows
+        // that belong only to variant-a (the first vuln). Rows that also belong to
+        // variant-b stay visible.
         const variantCheckbox = await screen.getByRole('checkbox', { name: 'variant-a' });
+        expect(variantCheckbox).toBeChecked();
         await user.click(variantCheckbox);
 
         await waitFor(() => {
-            expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).toBeNull();
+            expect(screen.queryByRole('cell', {name: /CVE-2010-1234/})).toBeNull();
         }, { timeout: 5000 });
 
-        expect(await screen.getByRole('cell', {name: /CVE-2010-1234/})).toBeInTheDocument();
+        expect(await screen.getByRole('cell', {name: /CVE-2018-5678/})).toBeInTheDocument();
         expect(await screen.getByRole('cell', {name: /CVE-2024-56730/})).toBeInTheDocument();
     })
 

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -594,6 +594,37 @@ describe('Vulnerability Table', () => {
         expect(pkg_xyz).toBeInTheDocument();
     })
 
+    test('filter by variant', async () => {
+        // ARRANGE
+        const vulnerabilitiesWithVariants = vulnerabilities.map((vuln, index) => ({
+            ...vuln,
+            variants: index === 0 ? ['variant-a'] : index === 1 ? ['variant-b'] : ['variant-a', 'variant-b']
+        }));
+        render(<TableVulnerabilities vulnerabilities={vulnerabilitiesWithVariants} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const user = userEvent.setup();
+        const variantBtn = await screen.getByRole('button', { name: /^variants$/i });
+        expect(variantBtn).toBeInTheDocument();
+        await user.click(variantBtn);
+
+        const variantCheckbox = await screen.getByRole('checkbox', { name: 'variant-a' });
+        await user.click(variantCheckbox);
+
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).toBeNull();
+        }, { timeout: 5000 });
+
+        expect(await screen.getByRole('cell', {name: /CVE-2010-1234/})).toBeInTheDocument();
+        expect(await screen.getByRole('cell', {name: /CVE-2024-56730/})).toBeInTheDocument();
+    })
+
+    test('variant filter is hidden when no vulnerability has variants', async () => {
+        // ARRANGE
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        expect(screen.queryByRole('button', { name: /^variants$/i })).toBeNull();
+    })
+
     test('filter out Exploitable', async () => {
         // ARRANGE
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Add new filters on SBOM, Vulnerability, and Review tab. Uncheck a variant would remove all elements which are only affected by variant inactives 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Play with the variant filter in SBOM, Vulnerability, and Review tab
<img width="1566" height="280" alt="image" src="https://github.com/user-attachments/assets/79ae2827-5636-47fd-b37b-8e1623888096" />



