### PR TITLE
New page and form for AI assessment context

### DIFF
--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBox, faShieldHalved, faFileExport, faMoon, faSun, faClockRotateLeft, faClipboardCheck, faGear } from '@fortawesome/free-solid-svg-icons';
+import { faBox, faShieldHalved, faFileExport, faMoon, faSun, faClockRotateLeft, faClipboardCheck, faGear, faRobot } from '@fortawesome/free-solid-svg-icons';
 import ProjectVariantSelector from './ProjectVariantSelector';
 
 const greenTheme = true;
@@ -82,6 +82,18 @@ function NavigationBar({ tab, changeTab, darkMode, setDarkMode, defaultProject, 
         >
           <FontAwesomeIcon icon={faClipboardCheck} className="mr-1" />
           Review
+        </button>
+      </li>
+
+      {/* === AI Context === */}
+      <li className={[bgHoverColor, tab == 'ai' && bgActiveColor].join(' ')}>
+        <button
+          onClick={() => changeTab('ai')}
+          className="flex items-center h-full px-4 py-2"
+          aria-current={tab === 'ai' ? 'page' : undefined}
+        >
+          <FontAwesomeIcon icon={faRobot} className="mr-1" />
+          AI
         </button>
       </li>
 

--- a/frontend/src/handlers/context.ts
+++ b/frontend/src/handlers/context.ts
@@ -1,0 +1,105 @@
+type ProjectContext = {
+    project_id: string;
+    description: string | null;
+};
+
+type VariantContextData = {
+    variant_description: string | null;
+    environment: string | null;
+    threat_model: string | null;
+    risks: string | null;
+    other_info: string | null;
+};
+
+type VariantContext = VariantContextData & {
+    variant_id: string;
+    files: ContextFile[];
+};
+
+type MergedContext = ProjectContext & VariantContext;
+
+type ContextFile = {
+    id: string;
+    original_name: string;
+    description: string | null;
+};
+
+export type { ProjectContext, VariantContext, VariantContextData, MergedContext, ContextFile };
+
+class Context {
+    static async get(projectId: string, variantId: string): Promise<MergedContext> {
+        const url = `${import.meta.env.VITE_API_URL}/api/context?project_id=${encodeURIComponent(projectId)}&variant_id=${encodeURIComponent(variantId)}`;
+        const res = await fetch(url, { mode: 'cors' });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || `Failed to load context (${res.status})`);
+        return data as MergedContext;
+    }
+
+    static async getProject(projectId: string): Promise<ProjectContext> {
+        const res = await fetch(
+            `${import.meta.env.VITE_API_URL}/api/projects/${encodeURIComponent(projectId)}/context`,
+            { mode: 'cors' }
+        );
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || `Failed to load project context (${res.status})`);
+        return data as ProjectContext;
+    }
+
+    static async saveProject(projectId: string, description: string | null): Promise<ProjectContext> {
+        const res = await fetch(
+            `${import.meta.env.VITE_API_URL}/api/projects/${encodeURIComponent(projectId)}/context`,
+            {
+                mode: 'cors',
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ description }),
+            }
+        );
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || `Failed to save project context (${res.status})`);
+        return data as ProjectContext;
+    }
+
+    static async saveVariant(variantId: string, fields: VariantContextData): Promise<VariantContext> {
+        const res = await fetch(
+            `${import.meta.env.VITE_API_URL}/api/variants/${encodeURIComponent(variantId)}/context`,
+            {
+                mode: 'cors',
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(fields),
+            }
+        );
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || `Failed to save variant context (${res.status})`);
+        return data as VariantContext;
+    }
+
+    static async uploadFile(variantId: string, file: File, description?: string | null): Promise<ContextFile> {
+        const formData = new FormData();
+        formData.append('file', file);
+        if (description != null && description !== '') {
+            formData.append('description', description);
+        }
+        const res = await fetch(
+            `${import.meta.env.VITE_API_URL}/api/variants/${encodeURIComponent(variantId)}/context/files`,
+            { mode: 'cors', method: 'POST', body: formData }
+        );
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || `Failed to upload file (${res.status})`);
+        return data as ContextFile;
+    }
+
+    static async deleteFile(variantId: string, fileId: string): Promise<void> {
+        const res = await fetch(
+            `${import.meta.env.VITE_API_URL}/api/variants/${encodeURIComponent(variantId)}/context/files/${encodeURIComponent(fileId)}`,
+            { mode: 'cors', method: 'DELETE' }
+        );
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            throw new Error(data.error || `Failed to delete file (${res.status})`);
+        }
+    }
+}
+
+export default Context;

--- a/frontend/src/pages/AIContext.tsx
+++ b/frontend/src/pages/AIContext.tsx
@@ -1,0 +1,449 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark, faSpinner, faRobot } from "@fortawesome/free-solid-svg-icons";
+import type { Project } from "../handlers/project";
+import type { Variant } from "../handlers/variant";
+import Context from "../handlers/context";
+import type { ContextFile, VariantContextData } from "../handlers/context";
+import MessageBanner from "../components/MessageBanner";
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+// Throwing fetch helpers for selector loads (existing handlers swallow HTTP errors)
+async function fetchProjectList(): Promise<Project[]> {
+    const res = await fetch(import.meta.env.VITE_API_URL + "/api/projects", { mode: "cors" });
+    if (!res.ok) throw new Error(`Failed to load projects (${res.status})`);
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+    return data.filter((p: any) => typeof p?.id === "string" && typeof p?.name === "string") as Project[];
+}
+
+async function fetchVariantList(projectId: string): Promise<Variant[]> {
+    const res = await fetch(
+        import.meta.env.VITE_API_URL + `/api/projects/${encodeURIComponent(projectId)}/variants`,
+        { mode: "cors" }
+    );
+    if (!res.ok) throw new Error(`Failed to load variants (${res.status})`);
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+    return data.filter(
+        (v: any) => typeof v?.id === "string" && typeof v?.name === "string" && typeof v?.project_id === "string"
+    ) as Variant[];
+}
+
+function AIContext() {
+    const unmountedRef = useRef(false);
+    useEffect(() => {
+        unmountedRef.current = false;
+        return () => { unmountedRef.current = true; };
+    }, []);
+
+    // Selectors
+    const [projects, setProjects] = useState<Project[]>([]);
+    const [variants, setVariants] = useState<Variant[]>([]);
+    const [selectedProjectId, setSelectedProjectId] = useState<string>('');
+    const [selectedVariantId, setSelectedVariantId] = useState<string>('');
+
+    // Form fields
+    const [description, setDescription] = useState<string>('');
+    const [variantDescription, setVariantDescription] = useState<string>('');
+    const [environment, setEnvironment] = useState<string>('');
+    const [threatModel, setThreatModel] = useState<string>('');
+    const [risks, setRisks] = useState<string>('');
+    const [otherInfo, setOtherInfo] = useState<string>('');
+    const [files, setFiles] = useState<ContextFile[]>([]);
+    const [fileDescription, setFileDescription] = useState<string>('');
+
+    // UI state
+    const [busy, setBusy] = useState(false);
+    const [fileError, setFileError] = useState<string | null>(null);
+    const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+    const [bannerMsg, setBannerMsg] = useState<string>('');
+    const [bannerType, setBannerType] = useState<'success' | 'error'>('success');
+    const [bannerVisible, setBannerVisible] = useState(false);
+
+    const showBanner = (msg: string, type: 'success' | 'error') => {
+        setBannerMsg(msg);
+        setBannerType(type);
+        setBannerVisible(true);
+    };
+
+    // Load projects on mount
+    useEffect(() => {
+        fetchProjectList().then(ps => {
+            if (!unmountedRef.current) setProjects(ps);
+        }).catch((e: any) => {
+            if (!unmountedRef.current) showBanner(e?.message || "Failed to load projects.", "error");
+        });
+     
+    }, []);
+
+    const clearVariantFields = () => {
+        setVariantDescription('');
+        setEnvironment('');
+        setThreatModel('');
+        setRisks('');
+        setOtherInfo('');
+        setFiles([]);
+        setFileDescription('');
+    };
+
+    // Load variants when project changes
+    useEffect(() => {
+        setVariants([]);
+        setSelectedVariantId('');
+        clearVariantFields();
+        if (!selectedProjectId) return;
+        fetchVariantList(selectedProjectId).then(vs => {
+            if (!unmountedRef.current) setVariants(vs);
+        }).catch((e: any) => {
+            if (!unmountedRef.current) showBanner(e?.message || "Failed to load variants.", "error");
+        });
+     
+    }, [selectedProjectId]);
+
+    // Load context when selections change
+    const loadContext = useCallback(() => {
+        if (!selectedProjectId) return;
+        if (selectedVariantId) {
+            Context.get(selectedProjectId, selectedVariantId)
+                .then(ctx => {
+                    if (unmountedRef.current) return;
+                    setDescription(ctx.description ?? '');
+                    setVariantDescription(ctx.variant_description ?? '');
+                    setEnvironment(ctx.environment ?? '');
+                    setThreatModel(ctx.threat_model ?? '');
+                    setRisks(ctx.risks ?? '');
+                    setOtherInfo(ctx.other_info ?? '');
+                    setFiles(ctx.files);
+                }).catch((e: any) => {
+                    if (!unmountedRef.current)
+                        showBanner(e?.message || "Failed to load context.", "error");
+                });
+        } else {
+            // Variant cleared or not yet selected — clear variant-bound fields
+            clearVariantFields();
+            Context.getProject(selectedProjectId)
+                .then(ctx => {
+                    if (unmountedRef.current) return;
+                    setDescription(ctx.description ?? '');
+                }).catch((e: any) => {
+                    if (!unmountedRef.current)
+                        showBanner(e?.message || "Failed to load project context.", "error");
+                });
+        }
+    }, [selectedProjectId, selectedVariantId]);
+
+    useEffect(() => {
+        loadContext();
+    }, [loadContext]);
+
+    const validate = (): boolean => {
+        const errors: Record<string, string> = {};
+        if (!description.trim()) {
+            errors.description = "Project Description is required.";
+        }
+        if (selectedVariantId && !threatModel.trim()) {
+            errors.threatModel = "Threat Model is required.";
+        }
+        setValidationErrors(errors);
+        return Object.keys(errors).length === 0;
+    };
+
+    const handleSave = async () => {
+        if (!selectedProjectId || busy) return;
+        if (!validate()) return;
+        setBusy(true);
+        try {
+            await Context.saveProject(selectedProjectId, description.trim() || null);
+        } catch (e: any) {
+            if (!unmountedRef.current) showBanner(e?.message || "Failed to save project context.", "error");
+            setBusy(false);
+            return;
+        }
+        if (selectedVariantId) {
+            const fields: VariantContextData = {
+                variant_description: variantDescription.trim() || null,
+                environment: environment.trim() || null,
+                threat_model: threatModel.trim() || null,
+                risks: risks.trim() || null,
+                other_info: otherInfo.trim() || null,
+            };
+            try {
+                await Context.saveVariant(selectedVariantId, fields);
+            } catch (e: any) {
+                if (!unmountedRef.current)
+                    showBanner(
+                        `Project context saved, but variant context failed: ${e?.message ?? "unknown error"}`,
+                        "error"
+                    );
+                setBusy(false);
+                return;
+            }
+        }
+        if (!unmountedRef.current) {
+            showBanner("Context saved successfully.", "success");
+            setBusy(false);
+        }
+    };
+
+    const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = '';
+        if (!file || !selectedVariantId) return;
+        setFileError(null);
+        if (file.size > MAX_FILE_BYTES) {
+            setFileError("File exceeds the 10 MB maximum size.");
+            return;
+        }
+        const desc = fileDescription.trim() || null;
+        try {
+            const uploaded = await Context.uploadFile(selectedVariantId, file, desc);
+            if (!unmountedRef.current) {
+                setFiles(prev => [...prev, uploaded]);
+                setFileDescription('');
+            }
+        } catch (e: any) {
+            if (!unmountedRef.current) setFileError(e?.message || "Upload failed.");
+        }
+    };
+
+    const handleDeleteFile = async (fileId: string) => {
+        if (!selectedVariantId) return;
+        try {
+            await Context.deleteFile(selectedVariantId, fileId);
+            if (!unmountedRef.current) setFiles(prev => prev.filter(f => f.id !== fileId));
+        } catch (e: any) {
+            if (!unmountedRef.current) showBanner(e?.message || "Failed to delete file.", "error");
+        }
+    };
+
+    const variantSelected = Boolean(selectedVariantId);
+    const projectSelected = Boolean(selectedProjectId);
+    const labelClass = "block text-sm text-zinc-300 mb-1";
+    const inputClass =
+        "w-full rounded px-2 py-1.5 text-sm bg-slate-900/60 border border-slate-600 text-white focus:outline-none focus:border-cyan-400 disabled:opacity-40 disabled:cursor-not-allowed";
+    const textareaClass = inputClass + " resize-y min-h-[80px]";
+    const selectClass =
+        "rounded px-2 py-1.5 text-sm bg-slate-900/60 border border-slate-600 text-white focus:outline-none focus:border-cyan-400 disabled:opacity-40 disabled:cursor-not-allowed";
+    const btnPrimary =
+        "px-4 py-2 rounded-lg bg-cyan-800 hover:bg-cyan-700 focus:ring-4 focus:outline-none focus:ring-blue-800 text-white text-sm font-semibold disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150";
+    const cardHeader =
+        "bg-gradient-to-r from-slate-700 to-slate-800 px-4 py-2.5 flex items-center gap-2 rounded-t-lg border-b border-slate-600/60";
+    const cardBody =
+        "bg-slate-800/60 p-4 rounded-b-lg ring-1 ring-slate-700/70 shadow-lg shadow-black/20 space-y-4";
+
+    return (
+        <div className="w-full space-y-6">
+            <MessageBanner
+                type={bannerType}
+                message={bannerMsg}
+                isVisible={bannerVisible}
+                onClose={() => setBannerVisible(false)}
+            />
+
+            <h1 className="text-3xl font-bold text-white mb-2">AI Assessment Context</h1>
+
+            <div>
+                <div className={cardHeader}>
+                    <FontAwesomeIcon icon={faRobot} className="text-cyan-400" />
+                    <h2 className="text-xl font-bold text-white">Context</h2>
+                </div>
+                <div className={cardBody}>
+
+            {/* Selectors */}
+            <div className="flex gap-4 flex-wrap">
+                <div>
+                    <label className={labelClass} htmlFor="ai-project-select">Project</label>
+                    <select
+                        id="ai-project-select"
+                        aria-label="Project"
+                        className={selectClass}
+                        value={selectedProjectId}
+                        onChange={e => setSelectedProjectId(e.target.value)}
+                    >
+                        <option value="">— Select project —</option>
+                        {projects.map(p => (
+                            <option key={p.id} value={p.id}>{p.name}</option>
+                        ))}
+                    </select>
+                </div>
+                <div>
+                    <label className={labelClass} htmlFor="ai-variant-select">Variant</label>
+                    <select
+                        id="ai-variant-select"
+                        aria-label="Variant"
+                        className={selectClass}
+                        value={selectedVariantId}
+                        onChange={e => setSelectedVariantId(e.target.value)}
+                        disabled={!projectSelected || variants.length === 0}
+                    >
+                        <option value="">— Select variant —</option>
+                        {variants.map(v => (
+                            <option key={v.id} value={v.id}>{v.name}</option>
+                        ))}
+                    </select>
+                </div>
+            </div>
+
+            {/* Project Description */}
+            <div>
+                <label className={labelClass} htmlFor="ai-project-description">
+                    Project Description <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                    id="ai-project-description"
+                    aria-label="Project Description"
+                    className={textareaClass}
+                    value={description}
+                    onChange={e => setDescription(e.target.value)}
+                    disabled={!projectSelected}
+                    placeholder={projectSelected ? "Describe your project..." : "Select a project first"}
+                />
+                {validationErrors.description && (
+                    <p className="text-red-500 text-xs mt-1">{validationErrors.description}</p>
+                )}
+            </div>
+
+            {/* Variant Description */}
+            <div>
+                <label className={labelClass} htmlFor="ai-variant-description">Variant Description</label>
+                <textarea
+                    id="ai-variant-description"
+                    aria-label="Variant Description"
+                    className={textareaClass}
+                    value={variantDescription}
+                    onChange={e => setVariantDescription(e.target.value)}
+                    disabled={!variantSelected}
+                    placeholder={variantSelected ? "Describe this variant..." : "Select a variant to enable"}
+                />
+            </div>
+
+            {/* Environment */}
+            <div>
+                <label className={labelClass} htmlFor="ai-environment">Environment</label>
+                <textarea
+                    id="ai-environment"
+                    aria-label="Environment"
+                    className={textareaClass}
+                    value={environment}
+                    onChange={e => setEnvironment(e.target.value)}
+                    disabled={!variantSelected}
+                    placeholder={variantSelected ? "e.g. runtime environment details" : "Select a variant to enable"}
+                />
+            </div>
+
+            {/* Threat Model */}
+            <div>
+                <label className={labelClass} htmlFor="ai-threat-model">
+                    Threat Model <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                    id="ai-threat-model"
+                    aria-label="Threat Model"
+                    className={textareaClass}
+                    value={threatModel}
+                    onChange={e => setThreatModel(e.target.value)}
+                    disabled={!variantSelected}
+                    placeholder={variantSelected ? "Describe the threat criteria for CVEs..." : "Select a variant to enable"}
+                />
+                {validationErrors.threatModel && (
+                    <p className="text-red-500 text-xs mt-1">{validationErrors.threatModel}</p>
+                )}
+            </div>
+
+            {/* Risks */}
+            <div>
+                <label className={labelClass} htmlFor="ai-risks">Risks</label>
+                <textarea
+                    id="ai-risks"
+                    aria-label="Risks"
+                    className={textareaClass}
+                    value={risks}
+                    onChange={e => setRisks(e.target.value)}
+                    disabled={!variantSelected}
+                    placeholder={variantSelected ? "Describe known risks..." : "Select a variant to enable"}
+                />
+            </div>
+
+            {/* Other Information */}
+            <div>
+                <label className={labelClass} htmlFor="ai-other-info">Other Information</label>
+                <textarea
+                    id="ai-other-info"
+                    aria-label="Other Information"
+                    className={textareaClass}
+                    value={otherInfo}
+                    onChange={e => setOtherInfo(e.target.value)}
+                    disabled={!variantSelected}
+                    placeholder={variantSelected ? "Any additional context..." : "Select a variant to enable"}
+                />
+            </div>
+
+            {/* Supplemental Files */}
+            <div>
+                <label className={labelClass} htmlFor="ai-files">
+                    Supplemental Files <span className="text-neutral-400 font-normal">(10 MB each)</span>
+                </label>
+                <input
+                    id="ai-file-description"
+                    aria-label="File Description"
+                    type="text"
+                    className={inputClass + " mb-2"}
+                    value={fileDescription}
+                    onChange={e => setFileDescription(e.target.value)}
+                    disabled={!variantSelected}
+                    placeholder={variantSelected ? "Optional description for the next uploaded file" : "Select a variant to enable"}
+                />
+                <input
+                    id="ai-files"
+                    aria-label="Supplemental Files"
+                    type="file"
+                    className="text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled={!variantSelected}
+                    onChange={handleFileChange}
+                />
+                {fileError && <p className="text-red-500 text-xs mt-1">{fileError}</p>}
+                {files.length > 0 && (
+                    <ul className="mt-2 flex flex-col gap-2">
+                        {files.map(f => (
+                            <li key={f.id} className="flex items-start gap-1 bg-slate-900/60 border border-slate-600 rounded px-2 py-1.5 text-sm text-white">
+                                <div className="flex flex-col">
+                                    <span>{f.original_name}</span>
+                                    {f.description && (
+                                        <span className="text-xs text-zinc-400">{f.description}</span>
+                                    )}
+                                </div>
+                                <button
+                                    type="button"
+                                    aria-label={`Delete ${f.original_name}`}
+                                    onClick={() => handleDeleteFile(f.id)}
+                                    className="ml-auto text-zinc-400 hover:text-red-400"
+                                >
+                                    <FontAwesomeIcon icon={faXmark} />
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+                </div>
+
+                {/* Save */}
+                <div>
+                    <button
+                        type="button"
+                        onClick={handleSave}
+                        disabled={!projectSelected || busy}
+                        className={btnPrimary + " flex items-center gap-2"}
+                    >
+                        {busy && <FontAwesomeIcon icon={faSpinner} spin />}
+                        Save
+                    </button>
+                </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default AIContext;

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -15,6 +15,7 @@ import ScanHistory from "./ScanHistory";
 import Review from './Review';
 import type { AssessmentMutation } from './Review';
 import Settings from './Settings';
+import AIContext from './AIContext';
 import Assessments, { removeDuplicateAssessments, STATUS_VEX_TO_GRAPH } from '../handlers/assessments';
 import Config from "../handlers/config";
 import type { AppConfig } from "../handlers/config";
@@ -27,6 +28,7 @@ const tabLabels: Record<string, string> = {
         review: 'Review',
         exports: 'Export',
         settings: 'Settings',
+        ai: 'AI Context',
 };
 
 type Props = {
@@ -307,6 +309,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                         setLoadingMessage("Loading data...");
                     }
                 }} />}
+                {tab === 'ai' && <AIContext />}
             </div>
             </main>
             <footer>

--- a/frontend/tests/unit_tests/test_ai_context_page.tsx
+++ b/frontend/tests/unit_tests/test_ai_context_page.tsx
@@ -1,0 +1,513 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import "@testing-library/jest-dom";
+import fetchMock from 'jest-fetch-mock';
+fetchMock.enableMocks();
+// @ts-expect-error TS6133
+import React from 'react';
+
+import AIContext from '../../src/pages/AIContext';
+
+beforeEach(() => fetchMock.resetMocks());
+
+function mockProjectsAndVariants() {
+    // Projects list
+    fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+}
+
+describe('AIContext page', () => {
+
+    test('renders project and variant dropdowns', async () => {
+        mockProjectsAndVariants();
+        render(<AIContext />);
+        expect(await screen.findByLabelText("Project")).toBeInTheDocument();
+    });
+
+    test('project description textarea is disabled when no project selected', async () => {
+        mockProjectsAndVariants();
+        render(<AIContext />);
+        await screen.findByLabelText("Project");
+        const descField = screen.getByLabelText("Project Description");
+        expect(descField).toBeDisabled();
+    });
+
+    test('project description is enabled after project selection', async () => {
+        // Projects list
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        // Variants.list('p1') called when project changes
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        // getProject call
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: 'existing desc' }));
+
+        render(<AIContext />);
+        // Wait for projects to load, then select a project
+        await screen.findByRole('option', { name: 'Project A' });
+        const projectSelect = screen.getByLabelText("Project");
+        fireEvent.change(projectSelect, { target: { value: 'p1' } });
+
+        await waitFor(() => {
+            const descField = screen.getByLabelText("Project Description");
+            expect(descField).not.toBeDisabled();
+        });
+    });
+
+    test('variant-bound fields are disabled when no variant selected', async () => {
+        // Projects list
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        // Variants.list('p1')
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        // getProject call after project selection
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        const projectSelect = screen.getByLabelText("Project");
+        fireEvent.change(projectSelect, { target: { value: 'p1' } });
+
+        await waitFor(() => {
+            const threatModel = screen.getByLabelText(/threat model/i);
+            expect(threatModel).toBeDisabled();
+        });
+    });
+
+    test('save button is disabled when no project selected', async () => {
+        mockProjectsAndVariants();
+        render(<AIContext />);
+        await screen.findByLabelText("Project");
+        const saveBtn = screen.getByRole('button', { name: /save/i });
+        expect(saveBtn).toBeDisabled();
+    });
+
+    test('save button calls saveProject when project-only save', async () => {
+        // Projects list
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        // Variants.list('p1')
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        // getProject
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        // saveProject response
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: 'My proj' }));
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        const projectSelect = screen.getByLabelText("Project");
+        fireEvent.change(projectSelect, { target: { value: 'p1' } });
+
+        const descField = await screen.findByLabelText("Project Description");
+        await waitFor(() => expect(descField).not.toBeDisabled());
+        fireEvent.change(descField, { target: { value: 'My proj' } });
+
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+        await waitFor(() => {
+            const calls = fetchMock.mock.calls;
+            const putCall = calls.find(c =>
+                typeof c[0] === 'string' && c[0].includes('/api/projects/p1/context') &&
+                (c[1] as RequestInit)?.method === 'PUT'
+            );
+            expect(putCall).toBeDefined();
+        });
+    });
+
+    test('shows validation error when project description is empty on save', async () => {
+        // Projects list
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        // Variants.list('p1')
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        // getProject
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        const projectSelect = screen.getByLabelText("Project");
+        fireEvent.change(projectSelect, { target: { value: 'p1' } });
+
+        const descField = await screen.findByLabelText("Project Description");
+        await waitFor(() => expect(descField).not.toBeDisabled());
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/project description.*required/i)).toBeInTheDocument();
+        });
+    });
+
+    test('file input is disabled when no variant selected', async () => {
+        // Projects list
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        // Variants.list('p1')
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        // getProject
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        const projectSelect = screen.getByLabelText("Project");
+        fireEvent.change(projectSelect, { target: { value: 'p1' } });
+
+        await waitFor(() => {
+            const fileInput = screen.getByLabelText(/supplemental files/i);
+            expect(fileInput).toBeDisabled();
+        });
+    });
+
+    test('shows error banner when project load fails', async () => {
+        fetchMock.mockRejectOnce(new Error('Network error'));
+        render(<AIContext />);
+        await waitFor(() => {
+            expect(screen.getByText(/network error/i)).toBeInTheDocument();
+        });
+    });
+
+    test('saves variant context when variant is selected', async () => {
+        // Projects list
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        // Variants list
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
+        // getProject after project select
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        // Context.get after variant select
+        fetchMock.mockResponseOnce(JSON.stringify({
+            project_id: 'p1', description: null,
+            variant_id: 'v1', variant_description: null,
+            environment: null, threat_model: null,
+            risks: null, other_info: null, files: [],
+        }));
+        // saveProject response
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: 'Desc' }));
+        // saveVariant response
+        fetchMock.mockResponseOnce(JSON.stringify({
+            variant_id: 'v1', variant_description: null, environment: null,
+            threat_model: 'High', risks: null, other_info: null, files: [],
+        }));
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+
+        // Wait for variant option to appear
+        await screen.findByRole('option', { name: 'Variant 1' });
+        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
+
+        // Wait for context to load (threat model enabled)
+        await waitFor(() => expect(screen.getByLabelText(/threat model/i)).not.toBeDisabled());
+
+        fireEvent.change(screen.getByLabelText("Project Description"), { target: { value: 'Desc' } });
+        fireEvent.change(screen.getByLabelText(/threat model/i), { target: { value: 'High' } });
+
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+        await waitFor(() => {
+            const calls = fetchMock.mock.calls;
+            const variantPut = calls.find(c =>
+                typeof c[0] === 'string' && c[0].includes('/api/variants/v1/context') &&
+                (c[1] as RequestInit)?.method === 'PUT'
+            );
+            expect(variantPut).toBeDefined();
+        });
+    });
+
+    test('shows success banner after successful save', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: 'Saved' }));
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+
+        await waitFor(() => expect(screen.getByLabelText("Project Description")).not.toBeDisabled());
+        fireEvent.change(screen.getByLabelText("Project Description"), { target: { value: 'My project' } });
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/context saved successfully/i)).toBeInTheDocument();
+        });
+    });
+
+    test('shows error banner when save fails', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        // saveProject fails
+        fetchMock.mockResponseOnce(JSON.stringify({ error: 'Server error' }), { status: 500 });
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+
+        await waitFor(() => expect(screen.getByLabelText("Project Description")).not.toBeDisabled());
+        fireEvent.change(screen.getByLabelText("Project Description"), { target: { value: 'Desc' } });
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/server error/i)).toBeInTheDocument();
+        });
+    });
+
+    test('file upload adds file to list', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        // Context.get after variant select
+        fetchMock.mockResponseOnce(JSON.stringify({
+            project_id: 'p1', description: null, variant_id: 'v1',
+            variant_description: null, environment: null, threat_model: null,
+            risks: null, other_info: null, files: [],
+        }));
+        // upload response
+        fetchMock.mockResponseOnce(JSON.stringify({ id: 'f1', original_name: 'doc.pdf' }), { status: 201 });
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+        await screen.findByRole('option', { name: 'Variant 1' });
+        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
+
+        await waitFor(() => expect(screen.getByLabelText(/supplemental files/i)).not.toBeDisabled());
+
+        const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
+        fireEvent.change(screen.getByLabelText(/supplemental files/i), { target: { files: [file] } });
+
+        await waitFor(() => {
+            expect(screen.getByText('doc.pdf')).toBeInTheDocument();
+        });
+    });
+
+    test('file upload sends and displays description', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        fetchMock.mockResponseOnce(JSON.stringify({
+            project_id: 'p1', description: null, variant_id: 'v1',
+            variant_description: null, environment: null, threat_model: null,
+            risks: null, other_info: null, files: [],
+        }));
+        fetchMock.mockResponseOnce(
+            JSON.stringify({ id: 'f1', original_name: 'doc.pdf', description: 'design notes' }),
+            { status: 201 }
+        );
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+        await screen.findByRole('option', { name: 'Variant 1' });
+        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
+
+        await waitFor(() => expect(screen.getByLabelText(/supplemental files/i)).not.toBeDisabled());
+
+        fireEvent.change(screen.getByLabelText("File Description"), { target: { value: 'design notes' } });
+        const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
+        fireEvent.change(screen.getByLabelText(/supplemental files/i), { target: { files: [file] } });
+
+        await waitFor(() => {
+            expect(screen.getByText('design notes')).toBeInTheDocument();
+        });
+
+        const uploadCall = fetchMock.mock.calls.find(c => String(c[0]).includes('/context/files') && c[1]?.method === 'POST');
+        expect(uploadCall).toBeDefined();
+        const body = uploadCall![1]!.body as FormData;
+        expect(body.get('description')).toBe('design notes');
+
+        // description input resets after successful upload
+        expect(screen.getByLabelText("File Description")).toHaveValue('');
+    });
+
+    test('delete file button removes file from list', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        fetchMock.mockResponseOnce(JSON.stringify({
+            project_id: 'p1', description: null, variant_id: 'v1',
+            variant_description: null, environment: null, threat_model: null,
+            risks: null, other_info: null,
+            files: [{ id: 'f1', original_name: 'existing.txt' }],
+        }));
+        // delete response
+        fetchMock.mockResponseOnce('', { status: 204 });
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+        await screen.findByRole('option', { name: 'Variant 1' });
+        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
+
+        await screen.findByText('existing.txt');
+        fireEvent.click(screen.getByRole('button', { name: /delete existing\.txt/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByText('existing.txt')).not.toBeInTheDocument();
+        });
+    });
+
+    test('clears variant fields when project changes', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        fetchMock.mockResponseOnce(JSON.stringify({
+            project_id: 'p1', description: null, variant_id: 'v1',
+            variant_description: 'Old desc', environment: null, threat_model: 'TM',
+            risks: null, other_info: null, files: [],
+        }));
+        // Switch project: new variants list (empty), new getProject
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+        await screen.findByRole('option', { name: 'Variant 1' });
+        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
+
+        // Wait for threat model to be populated
+        await waitFor(() => {
+            const tm = screen.getByLabelText(/threat model/i) as HTMLTextAreaElement;
+            expect(tm.value).toBe('TM');
+        });
+
+        // Now change project — variant fields should clear
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: '' } });
+
+        await waitFor(() => {
+            const tm = screen.getByLabelText(/threat model/i) as HTMLTextAreaElement;
+            expect(tm.value).toBe('');
+        });
+    });
+
+    function setupWithVariant() {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        fetchMock.mockResponseOnce(JSON.stringify({
+            project_id: 'p1', description: null, variant_id: 'v1',
+            variant_description: null, environment: null, threat_model: null,
+            risks: null, other_info: null, files: [],
+        }));
+    }
+
+    async function selectProjectAndVariant() {
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+        await screen.findByRole('option', { name: 'Variant 1' });
+        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
+        await waitFor(() => expect(screen.getByLabelText(/supplemental files/i)).not.toBeDisabled());
+    }
+
+    test('shows error banner when variant save fails', async () => {
+        setupWithVariant();
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: 'D' }));
+        fetchMock.mockResponseOnce(JSON.stringify({ error: 'Variant save failed' }), { status: 500 });
+
+        render(<AIContext />);
+        await selectProjectAndVariant();
+
+        fireEvent.change(screen.getByLabelText("Project Description"), { target: { value: 'Desc' } });
+        fireEvent.change(screen.getByLabelText(/threat model/i), { target: { value: 'TM' } });
+        fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/variant context failed/i)).toBeInTheDocument();
+        });
+    });
+
+    test('shows file size error when file is too large', async () => {
+        setupWithVariant();
+        render(<AIContext />);
+        await selectProjectAndVariant();
+
+        const largeFile = new File([new ArrayBuffer(11 * 1024 * 1024)], 'big.bin');
+        Object.defineProperty(largeFile, 'size', { value: 11 * 1024 * 1024 });
+        fireEvent.change(screen.getByLabelText(/supplemental files/i), { target: { files: [largeFile] } });
+
+        await waitFor(() => {
+            expect(screen.getByText(/10 MB maximum/i)).toBeInTheDocument();
+        });
+    });
+
+    test('shows error when file upload fails', async () => {
+        setupWithVariant();
+        fetchMock.mockResponseOnce(JSON.stringify({ error: 'Upload failed on server' }), { status: 500 });
+
+        render(<AIContext />);
+        await selectProjectAndVariant();
+
+        const file = new File(['data'], 'test.txt');
+        fireEvent.change(screen.getByLabelText(/supplemental files/i), { target: { files: [file] } });
+
+        await waitFor(() => {
+            expect(screen.getByText(/upload failed on server/i)).toBeInTheDocument();
+        });
+    });
+
+    test('shows error banner when delete file fails', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        fetchMock.mockResponseOnce(JSON.stringify({
+            project_id: 'p1', description: null, variant_id: 'v1',
+            variant_description: null, environment: null, threat_model: null,
+            risks: null, other_info: null,
+            files: [{ id: 'f1', original_name: 'keep.txt' }],
+        }));
+        fetchMock.mockResponseOnce(JSON.stringify({ error: 'Delete failed' }), { status: 500 });
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+        await screen.findByRole('option', { name: 'Variant 1' });
+        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
+        await screen.findByText('keep.txt');
+
+        fireEvent.click(screen.getByRole('button', { name: /delete keep\.txt/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/delete failed/i)).toBeInTheDocument();
+        });
+    });
+
+    test('can type in variant-bound fields after variant selected', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        // project selection triggers: variants list + Context.getProject
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        // variant selection triggers: Context.get
+        fetchMock.mockResponseOnce(JSON.stringify({
+            project_id: 'p1', description: null, variant_id: 'v1',
+            variant_description: null, environment: null, threat_model: null, risks: null, other_info: null, files: []
+        }));
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+        await screen.findByRole('option', { name: 'Variant 1' });
+        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("Variant Description")).not.toBeDisabled();
+        });
+
+        fireEvent.change(screen.getByLabelText("Variant Description"), { target: { value: 'New variant desc' } });
+        fireEvent.change(screen.getByLabelText("Environment"), { target: { value: 'Linux runtime' } });
+        fireEvent.change(screen.getByLabelText("Risks"), { target: { value: 'Some risk' } });
+        fireEvent.change(screen.getByLabelText("Other Information"), { target: { value: 'Extra info' } });
+
+        expect(screen.getByLabelText("Variant Description")).toHaveValue('New variant desc');
+        expect(screen.getByLabelText("Environment")).toHaveValue('Linux runtime');
+        expect(screen.getByLabelText("Risks")).toHaveValue('Some risk');
+        expect(screen.getByLabelText("Other Information")).toHaveValue('Extra info');
+    });
+
+    test('shows error banner when variant load fails', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        fetchMock.mockRejectOnce(new Error('Variant fetch error'));
+        // getProject may also fail — provide a response to avoid noise
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+
+        await waitFor(() => {
+            expect(document.querySelector('[role="alert"]')).toBeInTheDocument();
+        });
+    });
+});

--- a/src/controllers/context.py
+++ b/src/controllers/context.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import uuid
+from typing import Optional
+
+from ..models.project import Project
+from ..models.variant import Variant
+from ..models.project_context import ProjectContext
+from ..models.variant_context import VariantContext
+from ._base import ensure_uuid
+
+
+class ProjectContextController:
+
+    @staticmethod
+    def _get_project(project_id: uuid.UUID | str) -> Project:
+        pid = ensure_uuid(project_id)
+        project = Project.get_by_id(pid)
+        if project is None:
+            raise ValueError(f"Project {project_id} not found.")
+        return project
+
+    @staticmethod
+    def get_or_create(project_id: uuid.UUID | str) -> ProjectContext:
+        pid = ensure_uuid(project_id)
+        ProjectContextController._get_project(pid)
+        existing = ProjectContext.get_by_project(pid)
+        if existing is not None:
+            return existing
+        return ProjectContext.upsert(pid, description=None)
+
+    @staticmethod
+    def upsert(
+        project_id: uuid.UUID | str,
+        description: Optional[str] = None,
+    ) -> ProjectContext:
+        pid = ensure_uuid(project_id)
+        ProjectContextController._get_project(pid)
+        return ProjectContext.upsert(pid, description=description)
+
+    @staticmethod
+    def serialize(pc: ProjectContext) -> dict:
+        return pc.to_dict()
+
+
+class VariantContextController:
+
+    @staticmethod
+    def _get_variant(variant_id: uuid.UUID | str) -> Variant:
+        vid = ensure_uuid(variant_id)
+        variant = Variant.get_by_id(vid)
+        if variant is None:
+            raise ValueError(f"Variant {variant_id} not found.")
+        return variant
+
+    @staticmethod
+    def get_or_create(variant_id: uuid.UUID | str) -> VariantContext:
+        vid = ensure_uuid(variant_id)
+        VariantContextController._get_variant(vid)
+        existing = VariantContext.get_by_variant(vid)
+        if existing is not None:
+            return existing
+        return VariantContext.upsert(vid)
+
+    @staticmethod
+    def upsert(
+        variant_id: uuid.UUID | str,
+        variant_description: Optional[str] = None,
+        environment: Optional[str] = None,
+        threat_model: Optional[str] = None,
+        risks: Optional[str] = None,
+        other_info: Optional[str] = None,
+    ) -> VariantContext:
+        vid = ensure_uuid(variant_id)
+        VariantContextController._get_variant(vid)
+        return VariantContext.upsert(
+            vid,
+            variant_description=variant_description,
+            environment=environment,
+            threat_model=threat_model,
+            risks=risks,
+            other_info=other_info,
+        )
+
+    @staticmethod
+    def serialize(vc: VariantContext) -> dict:
+        return vc.to_dict()

--- a/src/migrations/versions/r4a5b6c7d8e9_add_context_tables.py
+++ b/src/migrations/versions/r4a5b6c7d8e9_add_context_tables.py
@@ -1,0 +1,58 @@
+"""add project_context, variant_context, context_files tables
+
+Revision ID: r4a5b6c7d8e9
+Revises: q3f4a5b6c7d8
+Create Date: 2026-06-29 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'r4a5b6c7d8e9'
+down_revision = 'q3f4a5b6c7d8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'project_context',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('project_id', sa.Uuid(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(['project_id'], ['projects.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('project_id', name='uq_project_context_project'),
+    )
+    op.create_table(
+        'variant_context',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('variant_id', sa.Uuid(), nullable=False),
+        sa.Column('variant_description', sa.Text(), nullable=True),
+        sa.Column('environment', sa.Text(), nullable=True),
+        sa.Column('threat_model', sa.Text(), nullable=True),
+        sa.Column('risks', sa.Text(), nullable=True),
+        sa.Column('other_info', sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(['variant_id'], ['variants.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('variant_id', name='uq_variant_context_variant'),
+    )
+    op.create_table(
+        'context_files',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('variant_context_id', sa.Uuid(), nullable=False),
+        sa.Column('original_name', sa.String(), nullable=False),
+        sa.Column('file_path', sa.String(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ['variant_context_id'], ['variant_context.id'], ondelete='CASCADE'
+        ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+
+def downgrade():
+    op.drop_table('context_files')
+    op.drop_table('variant_context')
+    op.drop_table('project_context')

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -17,3 +17,5 @@ from .metrics import Metrics
 from .cvss import CVSS
 from .sbom_observation import SBOMObservation
 from .iso8601_duration import Iso8601Duration
+from .project_context import ProjectContext
+from .variant_context import VariantContext, ContextFile

--- a/src/models/project.py
+++ b/src/models/project.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if typing.TYPE_CHECKING:
     from .variant import Variant
+    from .project_context import ProjectContext
 
 
 class Project(Base):
@@ -26,6 +27,11 @@ class Project(Base):
     variants: Mapped[list["Variant"]] = relationship(
         back_populates="project",
         cascade="all, delete-orphan"
+    )
+    context: Mapped["ProjectContext | None"] = relationship(
+        back_populates="project",
+        cascade="all, delete-orphan",
+        uselist=False,
     )
 
     def __repr__(self) -> str:

--- a/src/models/project_context.py
+++ b/src/models/project_context.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import uuid
+import typing
+
+from ..extensions import db, Base
+from sqlalchemy import ForeignKey, UniqueConstraint, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if typing.TYPE_CHECKING:
+    from .project import Project
+
+
+class ProjectContext(Base):
+    """Stores AI assessment context tied to a project."""
+
+    __tablename__ = "project_context"
+    __table_args__ = (UniqueConstraint("project_id", name="uq_project_context_project"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    project: Mapped["Project"] = relationship(back_populates="context")
+
+    def to_dict(self) -> dict:
+        return {
+            "project_id": str(self.project_id),
+            "description": self.description,
+        }
+
+    # ------------------------------------------------------------------
+    # CRUD helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_by_project(project_id: uuid.UUID) -> "ProjectContext | None":
+        return db.session.execute(
+            db.select(ProjectContext).where(ProjectContext.project_id == project_id)
+        ).scalar_one_or_none()
+
+    @staticmethod
+    def upsert(project_id: uuid.UUID, description: str | None = None) -> "ProjectContext":
+        existing = ProjectContext.get_by_project(project_id)
+        if existing is not None:
+            existing.description = description
+            db.session.commit()
+            return existing
+        pc = ProjectContext(project_id=project_id, description=description)
+        db.session.add(pc)
+        db.session.commit()
+        return pc

--- a/src/models/variant.py
+++ b/src/models/variant.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 if typing.TYPE_CHECKING:
     from ..models import Project, Scan, Assessment, TimeEstimate, Metrics
+    from .variant_context import VariantContext
 
 
 class Variant(Base):
@@ -44,6 +45,11 @@ class Variant(Base):
     metrics: Mapped[list["Metrics"]] = relationship(
         back_populates="variant",
         cascade="all, delete-orphan"
+    )
+    context: Mapped["VariantContext | None"] = relationship(
+        back_populates="variant",
+        cascade="all, delete-orphan",
+        uselist=False,
     )
 
     def __repr__(self) -> str:

--- a/src/models/variant_context.py
+++ b/src/models/variant_context.py
@@ -1,0 +1,196 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import os
+import uuid
+import shutil
+import logging
+import typing
+
+from ..extensions import db, Base
+from sqlalchemy import ForeignKey, UniqueConstraint, Text, event
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if typing.TYPE_CHECKING:
+    from .variant import Variant
+
+logger = logging.getLogger(__name__)
+
+
+def _get_cache_dir() -> str:
+    return os.getenv("VULNSCOUT_CACHE_DIR", "/cache/vulnscout")
+
+
+def _delete_context_dir(variant_context_id: uuid.UUID) -> None:
+    """Best-effort deletion of the context file directory for a VariantContext."""
+    dir_path = os.path.join(_get_cache_dir(), "context-files", str(variant_context_id))
+    try:
+        if os.path.isdir(dir_path):
+            shutil.rmtree(dir_path)
+    except OSError as exc:
+        logger.warning("Could not delete context dir %s: %s", dir_path, exc)
+
+
+class ContextFile(Base):
+    """Supplemental file attached to a variant's context."""
+
+    __tablename__ = "context_files"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    variant_context_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("variant_context.id", ondelete="CASCADE"), nullable=False
+    )
+    original_name: Mapped[str]
+    file_path: Mapped[str]
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    variant_context: Mapped["VariantContext"] = relationship(back_populates="files")
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "original_name": self.original_name,
+            "description": self.description,
+        }
+
+    # ------------------------------------------------------------------
+    # CRUD helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create(
+        variant_context_id: uuid.UUID, original_name: str, file_path: str,
+        description: str | None = None, id: uuid.UUID | None = None
+    ) -> "ContextFile":
+        cf = ContextFile(
+            id=id or uuid.uuid4(),
+            variant_context_id=variant_context_id,
+            original_name=original_name,
+            file_path=file_path,
+            description=description,
+        )
+        db.session.add(cf)
+        db.session.commit()
+        return cf
+
+    @staticmethod
+    def count_for_variant_context(variant_context_id: uuid.UUID) -> int:
+        return db.session.execute(
+            db.select(db.func.count()).select_from(ContextFile).where(
+                ContextFile.variant_context_id == variant_context_id
+            )
+        ).scalar_one()
+
+    @staticmethod
+    def get_by_id_and_variant_context(
+        file_id: uuid.UUID, variant_context_id: uuid.UUID
+    ) -> "ContextFile | None":
+        return db.session.execute(
+            db.select(ContextFile).where(
+                ContextFile.id == file_id,
+                ContextFile.variant_context_id == variant_context_id,
+            )
+        ).scalar_one_or_none()
+
+
+class VariantContext(Base):
+    """Stores AI assessment context tied to a variant."""
+
+    __tablename__ = "variant_context"
+    __table_args__ = (UniqueConstraint("variant_id", name="uq_variant_context_variant"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    variant_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("variants.id", ondelete="CASCADE"), nullable=False
+    )
+    variant_description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    environment: Mapped[str | None] = mapped_column(Text, nullable=True)
+    threat_model: Mapped[str | None] = mapped_column(Text, nullable=True)
+    risks: Mapped[str | None] = mapped_column(Text, nullable=True)
+    other_info: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    variant: Mapped["Variant"] = relationship(back_populates="context")
+    files: Mapped[list["ContextFile"]] = relationship(
+        back_populates="variant_context",
+        cascade="all, delete-orphan",
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "variant_id": str(self.variant_id),
+            "variant_description": self.variant_description,
+            "environment": self.environment,
+            "threat_model": self.threat_model,
+            "risks": self.risks,
+            "other_info": self.other_info,
+            "files": [f.to_dict() for f in self.files],
+        }
+
+    # ------------------------------------------------------------------
+    # CRUD helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_by_variant(variant_id: uuid.UUID) -> "VariantContext | None":
+        return db.session.execute(
+            db.select(VariantContext).where(VariantContext.variant_id == variant_id)
+        ).scalar_one_or_none()
+
+    @staticmethod
+    def upsert(
+        variant_id: uuid.UUID,
+        variant_description: str | None = None,
+        environment: str | None = None,
+        threat_model: str | None = None,
+        risks: str | None = None,
+        other_info: str | None = None,
+    ) -> "VariantContext":
+        existing = VariantContext.get_by_variant(variant_id)
+        if existing is not None:
+            existing.variant_description = variant_description
+            existing.environment = environment
+            existing.threat_model = threat_model
+            existing.risks = risks
+            existing.other_info = other_info
+            db.session.commit()
+            return existing
+        vc = VariantContext(
+            variant_id=variant_id,
+            variant_description=variant_description,
+            environment=environment,
+            threat_model=threat_model,
+            risks=risks,
+            other_info=other_info,
+        )
+        db.session.add(vc)
+        db.session.commit()
+        return vc
+
+
+# ---------------------------------------------------------------------------
+# SQLAlchemy events — post-commit filesystem cleanup
+# ---------------------------------------------------------------------------
+# We use a two-step pattern to guarantee DB is committed before FS cleanup:
+#   1. after_delete mapper event: record the context dir path in Session.info
+#   2. after_commit session event: perform the actual FS deletion
+# This avoids deleting files before the commit finalises.
+
+@event.listens_for(VariantContext, "after_delete")
+def _on_variant_context_deleted(mapper, connection, target: VariantContext) -> None:
+    from ..extensions import db
+    session = db.session
+    if 'pending_context_cleanups' not in session.info:
+        session.info['pending_context_cleanups'] = []
+    dir_path = os.path.join(_get_cache_dir(), "context-files", str(target.id))
+    session.info['pending_context_cleanups'].append(dir_path)
+
+
+@event.listens_for(db.session, "after_commit")
+def _cleanup_after_commit(session) -> None:
+    paths = session.info.pop('pending_context_cleanups', [])
+    for dir_path in paths:
+        try:
+            if os.path.isdir(dir_path):
+                shutil.rmtree(dir_path)
+        except OSError as exc:
+            logger.warning("Could not delete context dir %s: %s", dir_path, exc)

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -16,6 +16,7 @@ from .scan_triggers import init_app as init_scan_triggers_app
 from .config import init_app as init_config_app
 from .settings import init_app as init_settings_app
 from .frontpage import init_app as init_front_app
+from .context import init_app as init_context_app
 
 
 def init_app(app):
@@ -33,6 +34,7 @@ def init_app(app):
     init_bulk_refresh_app(app)
     init_config_app(app)
     init_settings_app(app)
+    init_context_app(app)
     # keep front endpoint at the end
     init_front_app(app)
     return app

--- a/src/routes/context.py
+++ b/src/routes/context.py
@@ -1,0 +1,199 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import os
+import uuid
+import logging
+
+from flask import jsonify, request
+
+from ..controllers.context import ProjectContextController, VariantContextController
+from ..models.project import Project
+from ..models.variant import Variant
+from ..models.variant_context import VariantContext, ContextFile
+from ..routes._scan_helpers import parse_uuid_or_400
+
+logger = logging.getLogger(__name__)
+
+MAX_FILE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _get_cache_dir() -> str:
+    return os.getenv("VULNSCOUT_CACHE_DIR", "/cache/vulnscout")
+
+
+def init_app(app):
+
+    @app.route('/api/context', methods=['GET'])
+    def get_merged_context():
+        project_id_str = request.args.get('project_id', '')
+        variant_id_str = request.args.get('variant_id', '')
+
+        project_uuid, err = parse_uuid_or_400(project_id_str, 'project_id')
+        if err:
+            return err
+        assert project_uuid is not None
+        variant_uuid, err = parse_uuid_or_400(variant_id_str, 'variant_id')
+        if err:
+            return err
+        assert variant_uuid is not None
+
+        project = Project.get_by_id(project_uuid)
+        if project is None:
+            return jsonify({"error": "Project not found"}), 404
+        variant = Variant.get_by_id(variant_uuid)
+        if variant is None:
+            return jsonify({"error": "Variant not found"}), 404
+        if variant.project_id != project_uuid:
+            return jsonify({"error": "Variant does not belong to the specified project"}), 400
+
+        from ..models.project_context import ProjectContext
+        pc = ProjectContext.get_by_project(project_uuid)
+        vc = VariantContext.get_by_variant(variant_uuid)
+
+        return jsonify({
+            "project_id": str(project_uuid),
+            "description": pc.description if pc else None,
+            "variant_id": str(variant_uuid),
+            "variant_description": vc.variant_description if vc else None,
+            "environment": vc.environment if vc else None,
+            "threat_model": vc.threat_model if vc else None,
+            "risks": vc.risks if vc else None,
+            "other_info": vc.other_info if vc else None,
+            "files": [f.to_dict() for f in vc.files] if vc else [],
+        })
+
+    @app.route('/api/projects/<project_id>/context', methods=['GET'])
+    def get_project_context(project_id):
+        project_uuid, err = parse_uuid_or_400(project_id, 'project_id')
+        if err:
+            return err
+        assert project_uuid is not None
+        project = Project.get_by_id(project_uuid)
+        if project is None:
+            return jsonify({"error": "Project not found"}), 404
+        from ..models.project_context import ProjectContext
+        pc = ProjectContext.get_by_project(project_uuid)
+        return jsonify({
+            "project_id": str(project_uuid),
+            "description": pc.description if pc else None,
+        })
+
+    @app.route('/api/projects/<project_id>/context', methods=['PUT'])
+    def put_project_context(project_id):
+        project_uuid, err = parse_uuid_or_400(project_id, 'project_id')
+        if err:
+            return err
+        assert project_uuid is not None
+        body = request.get_json(silent=True) or {}
+        try:
+            pc = ProjectContextController.upsert(
+                project_uuid, description=body.get('description')
+            )
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 404
+        return jsonify(ProjectContextController.serialize(pc))
+
+    @app.route('/api/variants/<variant_id>/context', methods=['PUT'])
+    def put_variant_context(variant_id):
+        variant_uuid, err = parse_uuid_or_400(variant_id, 'variant_id')
+        if err:
+            return err
+        assert variant_uuid is not None
+        body = request.get_json(silent=True) or {}
+        try:
+            vc = VariantContextController.upsert(
+                variant_uuid,
+                variant_description=body.get('variant_description'),
+                environment=body.get('environment'),
+                threat_model=body.get('threat_model'),
+                risks=body.get('risks'),
+                other_info=body.get('other_info'),
+            )
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 404
+        return jsonify(VariantContextController.serialize(vc))
+
+    @app.route('/api/variants/<variant_id>/context/files', methods=['POST'])
+    def post_context_file(variant_id):
+        variant_uuid, err = parse_uuid_or_400(variant_id, 'variant_id')
+        if err:
+            return err
+        assert variant_uuid is not None
+
+        variant = Variant.get_by_id(variant_uuid)
+        if variant is None:
+            return jsonify({"error": "Variant not found"}), 404
+
+        file = request.files.get('file')
+        if file is None or file.filename == '':
+            return jsonify({"error": "No file provided"}), 400
+
+        file.seek(0, 2)
+        size = file.tell()
+        file.seek(0)
+        if size > MAX_FILE_BYTES:
+            max_mb = MAX_FILE_BYTES // (1024 * 1024)
+            return jsonify({"error": f"File exceeds maximum size of {max_mb} MB"}), 400
+
+        vc = VariantContext.get_by_variant(variant_uuid)
+        if vc is None:
+            vc = VariantContext.upsert(variant_uuid)
+
+        description = request.form.get('description')
+        if description is not None:
+            description = description.strip() or None
+
+        file_id = uuid.uuid4()
+        original_name = os.path.basename(file.filename.replace('\\', '/'))
+
+        dest_dir = os.path.join(_get_cache_dir(), "context-files", str(vc.id))
+        try:
+            os.makedirs(dest_dir, exist_ok=True)
+            file_path = os.path.join(dest_dir, str(file_id))
+            file.save(file_path)
+        except OSError as exc:
+            logger.error("Failed to save uploaded file: %s", exc)
+            return jsonify({"error": "Failed to store file on server"}), 500
+
+        cf = ContextFile.create(
+            vc.id, original_name=original_name, file_path=file_path,
+            description=description, id=file_id
+        )
+        return jsonify(cf.to_dict()), 201
+
+    @app.route('/api/variants/<variant_id>/context/files/<file_id>', methods=['DELETE'])
+    def delete_context_file(variant_id, file_id):
+        variant_uuid, err = parse_uuid_or_400(variant_id, 'variant_id')
+        if err:
+            return err
+        assert variant_uuid is not None
+        file_uuid, err = parse_uuid_or_400(file_id, 'file_id')
+        if err:
+            return err
+        assert file_uuid is not None
+
+        variant = Variant.get_by_id(variant_uuid)
+        if variant is None:
+            return jsonify({"error": "Variant not found"}), 404
+
+        vc = VariantContext.get_by_variant(variant_uuid)
+        if vc is None:
+            return jsonify({"error": "File not found"}), 404
+
+        cf = ContextFile.get_by_id_and_variant_context(file_uuid, vc.id)
+        if cf is None:
+            return jsonify({"error": "File not found"}), 404
+
+        file_path = cf.file_path
+        from ..extensions import db
+        db.session.delete(cf)
+        db.session.commit()
+
+        try:
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+        except OSError as exc:
+            logger.warning("Could not delete file %s: %s", file_path, exc)
+
+        return '', 204

--- a/tests/unit_tests/test_context.py
+++ b/tests/unit_tests/test_context.py
@@ -1,0 +1,480 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import os
+import uuid
+import pytest
+from unittest.mock import patch
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+from src.models.project import Project
+from src.models.variant import Variant
+
+
+@pytest.fixture()
+def app():
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": "/dev/null"})
+        # Mark scan as finished so the /api middleware allows all requests.
+        application._INT_SCAN_FINISHED = True
+        with application.app_context():
+            _db.create_all()
+            yield application
+            _db.drop_all()
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def project(app):
+    return Project.create("TestProject")
+
+
+@pytest.fixture()
+def variant(app, project):
+    return Variant.create("TestVariant", project.id)
+
+
+# ---------------------------------------------------------------------------
+# ProjectContext model
+# ---------------------------------------------------------------------------
+
+class TestProjectContextModel:
+
+    def test_create_project_context(self, app, project):
+        from src.models.project_context import ProjectContext
+        pc = ProjectContext.upsert(project.id, description="A test project.")
+        assert pc.project_id == project.id
+        assert pc.description == "A test project."
+
+    def test_upsert_updates_existing(self, app, project):
+        from src.models.project_context import ProjectContext
+        ProjectContext.upsert(project.id, description="First")
+        pc = ProjectContext.upsert(project.id, description="Second")
+        assert pc.description == "Second"
+        assert _db.session.execute(_db.select(ProjectContext)).scalars().all().__len__() == 1
+
+    def test_upsert_none_clears_description(self, app, project):
+        from src.models.project_context import ProjectContext
+        ProjectContext.upsert(project.id, description="Something")
+        pc = ProjectContext.upsert(project.id, description=None)
+        assert pc.description is None
+
+    def test_get_by_project_returns_none_when_missing(self, app, project):
+        from src.models.project_context import ProjectContext
+        assert ProjectContext.get_by_project(project.id) is None
+
+    def test_cascade_delete_with_project(self, app, project):
+        from src.models.project_context import ProjectContext
+        ProjectContext.upsert(project.id, description="will be deleted")
+        project.delete()
+        assert _db.session.execute(_db.select(ProjectContext)).scalars().all() == []
+
+    def test_to_dict(self, app, project):
+        from src.models.project_context import ProjectContext
+        pc = ProjectContext.upsert(project.id, description="desc")
+        d = pc.to_dict()
+        assert d["project_id"] == str(project.id)
+        assert d["description"] == "desc"
+
+
+# ---------------------------------------------------------------------------
+# VariantContext model
+# ---------------------------------------------------------------------------
+
+class TestVariantContextModel:
+
+    def test_create_variant_context(self, app, variant):
+        from src.models.variant_context import VariantContext
+        vc = VariantContext.upsert(variant.id, threat_model="High CVE severity")
+        assert vc.variant_id == variant.id
+        assert vc.threat_model == "High CVE severity"
+        assert vc.environment is None
+
+    def test_upsert_replaces_all_fields(self, app, variant):
+        from src.models.variant_context import VariantContext
+        VariantContext.upsert(variant.id, threat_model="Old", environment="Linux")
+        vc = VariantContext.upsert(variant.id, threat_model="New", environment=None)
+        assert vc.threat_model == "New"
+        assert vc.environment is None
+
+    def test_get_by_variant(self, app, variant):
+        from src.models.variant_context import VariantContext
+        assert VariantContext.get_by_variant(variant.id) is None
+        VariantContext.upsert(variant.id)
+        assert VariantContext.get_by_variant(variant.id) is not None
+
+    def test_cascade_delete_with_variant(self, app, variant, project):
+        from src.models.variant_context import VariantContext
+        with patch("src.models.variant_context._delete_context_dir"):
+            VariantContext.upsert(variant.id)
+            variant.delete()
+            assert _db.session.execute(_db.select(VariantContext)).scalars().all() == []
+
+    def test_to_dict(self, app, variant):
+        from src.models.variant_context import VariantContext
+        vc = VariantContext.upsert(variant.id, threat_model="T", risks="R")
+        d = vc.to_dict()
+        assert d["variant_id"] == str(variant.id)
+        assert d["threat_model"] == "T"
+        assert d["risks"] == "R"
+        assert d["files"] == []
+
+
+# ---------------------------------------------------------------------------
+# ContextFile model
+# ---------------------------------------------------------------------------
+
+class TestContextFileModel:
+
+    def test_create_context_file(self, app, variant, tmp_path):
+        from src.models.variant_context import VariantContext, ContextFile
+        vc = VariantContext.upsert(variant.id)
+        fake_path = str(tmp_path / "somefile")
+        cf = ContextFile.create(vc.id, original_name="report.pdf", file_path=fake_path)
+        assert cf.variant_context_id == vc.id
+        assert cf.original_name == "report.pdf"
+        assert cf.file_path == fake_path
+        assert cf.description is None
+
+    def test_create_context_file_with_description(self, app, variant, tmp_path):
+        from src.models.variant_context import VariantContext, ContextFile
+        vc = VariantContext.upsert(variant.id)
+        cf = ContextFile.create(
+            vc.id, original_name="report.pdf", file_path=str(tmp_path / "f"),
+            description="a spec"
+        )
+        assert cf.description == "a spec"
+        assert cf.to_dict()["description"] == "a spec"
+
+    def test_count_for_variant_context(self, app, variant, tmp_path):
+        from src.models.variant_context import VariantContext, ContextFile
+        vc = VariantContext.upsert(variant.id)
+        assert ContextFile.count_for_variant_context(vc.id) == 0
+        ContextFile.create(vc.id, "a.txt", str(tmp_path / "a"))
+        assert ContextFile.count_for_variant_context(vc.id) == 1
+
+    def test_get_by_id_and_variant_context(self, app, variant, tmp_path):
+        from src.models.variant_context import VariantContext, ContextFile
+        vc = VariantContext.upsert(variant.id)
+        cf = ContextFile.create(vc.id, "b.txt", str(tmp_path / "b"))
+        assert ContextFile.get_by_id_and_variant_context(cf.id, vc.id) is not None
+        assert ContextFile.get_by_id_and_variant_context(uuid.uuid4(), vc.id) is None
+
+    def test_cascade_delete_with_variant_context(self, app, variant, tmp_path):
+        from src.models.variant_context import VariantContext, ContextFile
+        with patch("src.models.variant_context._delete_context_dir"):
+            vc = VariantContext.upsert(variant.id)
+            ContextFile.create(vc.id, "c.txt", str(tmp_path / "c"))
+            variant.delete()
+            assert _db.session.execute(_db.select(ContextFile)).scalars().all() == []
+
+
+# ---------------------------------------------------------------------------
+# Controllers
+# ---------------------------------------------------------------------------
+
+class TestProjectContextController:
+
+    def test_get_or_create_project_context(self, app, project):
+        from src.controllers.context import ProjectContextController
+        result = ProjectContextController.get_or_create(str(project.id))
+        assert result.project_id == project.id
+
+    def test_upsert_saves_description(self, app, project):
+        from src.controllers.context import ProjectContextController
+        result = ProjectContextController.upsert(str(project.id), description="My project")
+        assert result.description == "My project"
+
+    def test_upsert_invalid_uuid_raises(self, app):
+        from src.controllers.context import ProjectContextController
+        with pytest.raises(ValueError):
+            ProjectContextController.upsert("not-a-uuid", description="x")
+
+    def test_get_raises_on_missing_project(self, app):
+        from src.controllers.context import ProjectContextController
+        with pytest.raises(ValueError):
+            ProjectContextController.upsert(str(uuid.uuid4()), description="x")
+
+    def test_serialize(self, app, project):
+        from src.controllers.context import ProjectContextController
+        pc = ProjectContextController.upsert(str(project.id), description="desc")
+        d = ProjectContextController.serialize(pc)
+        assert d["description"] == "desc"
+        assert "project_id" in d
+
+
+class TestVariantContextController:
+
+    def test_upsert_creates_variant_context(self, app, variant):
+        from src.controllers.context import VariantContextController
+        vc = VariantContextController.upsert(
+            str(variant.id),
+            threat_model="Any CVSS >= 7.0",
+        )
+        assert vc.threat_model == "Any CVSS >= 7.0"
+
+    def test_upsert_full_replacement(self, app, variant):
+        from src.controllers.context import VariantContextController
+        VariantContextController.upsert(str(variant.id), environment="Linux 6.1")
+        vc = VariantContextController.upsert(str(variant.id), environment=None)
+        assert vc.environment is None
+
+    def test_get_or_create_creates_row(self, app, variant):
+        from src.controllers.context import VariantContextController
+        vc = VariantContextController.get_or_create(str(variant.id))
+        assert vc.variant_id == variant.id
+
+    def test_serialize(self, app, variant):
+        from src.controllers.context import VariantContextController
+        vc = VariantContextController.upsert(str(variant.id), risks="Risk A")
+        d = VariantContextController.serialize(vc)
+        assert d["risks"] == "Risk A"
+        assert d["files"] == []
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+class TestGetMergedContext:
+
+    def test_returns_nulls_when_no_context_rows(self, client, project, variant):
+        resp = client.get(
+            f"/api/context?project_id={project.id}&variant_id={variant.id}"
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["project_id"] == str(project.id)
+        assert data["description"] is None
+        assert data["variant_id"] == str(variant.id)
+        assert data["threat_model"] is None
+        assert data["files"] == []
+
+    def test_returns_saved_values(self, client, project, variant):
+        from src.models.project_context import ProjectContext
+        from src.models.variant_context import VariantContext
+        ProjectContext.upsert(project.id, description="proj desc")
+        VariantContext.upsert(variant.id, threat_model="CVSS >= 7")
+        resp = client.get(
+            f"/api/context?project_id={project.id}&variant_id={variant.id}"
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["description"] == "proj desc"
+        assert data["threat_model"] == "CVSS >= 7"
+
+    def test_400_when_project_id_missing(self, client, variant):
+        resp = client.get(f"/api/context?variant_id={variant.id}")
+        assert resp.status_code == 400
+
+    def test_400_when_variant_id_missing(self, client, project):
+        resp = client.get(f"/api/context?project_id={project.id}")
+        assert resp.status_code == 400
+
+    def test_400_when_invalid_uuid(self, client):
+        resp = client.get("/api/context?project_id=bad&variant_id=alsobad")
+        assert resp.status_code == 400
+
+    def test_404_when_project_not_found(self, client, variant):
+        resp = client.get(
+            f"/api/context?project_id={uuid.uuid4()}&variant_id={variant.id}"
+        )
+        assert resp.status_code == 404
+
+    def test_404_when_variant_not_found(self, client, project):
+        resp = client.get(
+            f"/api/context?project_id={project.id}&variant_id={uuid.uuid4()}"
+        )
+        assert resp.status_code == 404
+
+    def test_400_when_variant_not_in_project(self, client, project):
+        other_project = Project.create("OtherProject")
+        other_variant = Variant.create("OtherVariant", other_project.id)
+        resp = client.get(
+            f"/api/context?project_id={project.id}&variant_id={other_variant.id}"
+        )
+        assert resp.status_code == 400
+
+
+class TestGetProjectContext:
+
+    def test_returns_null_description_when_no_row(self, client, project):
+        resp = client.get(f"/api/projects/{project.id}/context")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["project_id"] == str(project.id)
+        assert data["description"] is None
+
+    def test_returns_saved_description(self, client, project):
+        from src.models.project_context import ProjectContext
+        ProjectContext.upsert(project.id, description="hello")
+        resp = client.get(f"/api/projects/{project.id}/context")
+        assert resp.status_code == 200
+        assert resp.get_json()["description"] == "hello"
+
+    def test_404_when_project_not_found(self, client):
+        resp = client.get(f"/api/projects/{uuid.uuid4()}/context")
+        assert resp.status_code == 404
+
+
+class TestPutProjectContext:
+
+    def test_upsert_creates_row(self, client, project):
+        resp = client.put(
+            f"/api/projects/{project.id}/context",
+            json={"description": "My project"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["description"] == "My project"
+
+    def test_upsert_updates_existing(self, client, project):
+        client.put(f"/api/projects/{project.id}/context", json={"description": "Old"})
+        resp = client.put(
+            f"/api/projects/{project.id}/context", json={"description": "New"}
+        )
+        assert resp.get_json()["description"] == "New"
+
+    def test_null_description_clears_field(self, client, project):
+        client.put(f"/api/projects/{project.id}/context", json={"description": "X"})
+        resp = client.put(
+            f"/api/projects/{project.id}/context", json={"description": None}
+        )
+        assert resp.get_json()["description"] is None
+
+    def test_404_when_project_not_found(self, client):
+        resp = client.put(
+            f"/api/projects/{uuid.uuid4()}/context", json={"description": "x"}
+        )
+        assert resp.status_code == 404
+
+
+class TestPutVariantContext:
+
+    def test_upsert_creates_row(self, client, variant):
+        resp = client.put(
+            f"/api/variants/{variant.id}/context",
+            json={"threat_model": "CVSS >= 7"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["threat_model"] == "CVSS >= 7"
+
+    def test_full_replacement_nulls_omitted_fields(self, client, variant):
+        client.put(
+            f"/api/variants/{variant.id}/context",
+            json={"threat_model": "T", "environment": "Linux"},
+        )
+        resp = client.put(
+            f"/api/variants/{variant.id}/context",
+            json={"threat_model": "T2"},
+        )
+        assert resp.get_json()["environment"] is None
+
+    def test_404_when_variant_not_found(self, client):
+        resp = client.put(
+            f"/api/variants/{uuid.uuid4()}/context",
+            json={"threat_model": "x"},
+        )
+        assert resp.status_code == 404
+
+
+class TestPostContextFile:
+
+    def test_upload_file(self, client, variant, tmp_path):
+        with patch("src.routes.context._get_cache_dir", return_value=str(tmp_path)):
+            from io import BytesIO
+            data = {"file": (BytesIO(b"content"), "report.pdf")}
+            resp = client.post(
+                f"/api/variants/{variant.id}/context/files",
+                data=data,
+                content_type="multipart/form-data",
+            )
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["original_name"] == "report.pdf"
+        assert "id" in body
+        assert body["description"] is None
+
+    def test_upload_file_with_description(self, client, variant, tmp_path):
+        with patch("src.routes.context._get_cache_dir", return_value=str(tmp_path)):
+            from io import BytesIO
+            data = {"file": (BytesIO(b"content"), "report.pdf"), "description": "spec sheet"}
+            resp = client.post(
+                f"/api/variants/{variant.id}/context/files",
+                data=data,
+                content_type="multipart/form-data",
+            )
+        assert resp.status_code == 201
+        assert resp.get_json()["description"] == "spec sheet"
+
+    def test_blank_description_stored_as_null(self, client, variant, tmp_path):
+        with patch("src.routes.context._get_cache_dir", return_value=str(tmp_path)):
+            from io import BytesIO
+            data = {"file": (BytesIO(b"content"), "report.pdf"), "description": "   "}
+            resp = client.post(
+                f"/api/variants/{variant.id}/context/files",
+                data=data,
+                content_type="multipart/form-data",
+            )
+        assert resp.status_code == 201
+        assert resp.get_json()["description"] is None
+
+    def test_400_when_no_file(self, client, variant):
+        resp = client.post(
+            f"/api/variants/{variant.id}/context/files",
+            data={},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 400
+
+    def test_no_file_count_limit(self, client, variant, tmp_path):
+        with patch("src.routes.context._get_cache_dir", return_value=str(tmp_path)):
+            from io import BytesIO
+            for i in range(5):
+                resp = client.post(
+                    f"/api/variants/{variant.id}/context/files",
+                    data={"file": (BytesIO(b"x"), f"file{i}.txt")},
+                    content_type="multipart/form-data",
+                )
+                assert resp.status_code == 201
+
+    def test_404_when_variant_not_found(self, client):
+        from io import BytesIO
+        resp = client.post(
+            f"/api/variants/{uuid.uuid4()}/context/files",
+            data={"file": (BytesIO(b"x"), "f.txt")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 404
+
+
+class TestDeleteContextFile:
+
+    def _upload(self, client, variant, tmp_path):
+        from io import BytesIO
+        with patch("src.routes.context._get_cache_dir", return_value=str(tmp_path)):
+            resp = client.post(
+                f"/api/variants/{variant.id}/context/files",
+                data={"file": (BytesIO(b"data"), "doc.txt")},
+                content_type="multipart/form-data",
+            )
+        return resp.get_json()["id"]
+
+    def test_delete_removes_file_and_db_row(self, client, variant, tmp_path):
+        file_id = self._upload(client, variant, tmp_path)
+        resp = client.delete(f"/api/variants/{variant.id}/context/files/{file_id}")
+        assert resp.status_code == 204
+
+    def test_404_when_file_not_found(self, client, variant):
+        resp = client.delete(
+            f"/api/variants/{variant.id}/context/files/{uuid.uuid4()}"
+        )
+        assert resp.status_code == 404


### PR DESCRIPTION
### Changes proposed in this pull request:

* Add a page and form to enter project and variant-related context for AI assessment. The purpose of this page and form is to enable the AI agent to fetch the project and variant context from VulnScout through [vulnscout-mcp](https://github.com/savoirfairelinux/vulnscout-mcp) to help assess vulnerabilities.

> `vulnscout-mcp` has also been updated for this change. See associated PR: https://github.com/savoirfairelinux/vulnscout-mcp/pull/1

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

The new page can be accessed via the AI tab in the top nav bar.

<img width="921" height="922" alt="image" src="https://github.com/user-attachments/assets/6cd1ed98-1975-48f5-86a5-467327e7a3f9" />

<img width="915" height="331" alt="image" src="https://github.com/user-attachments/assets/c81c9e2c-3546-4f4e-bafd-4aa0d526cb9f" />

### Additional notes

The project context input field is enabled when a project is selected. Other input fields can be modified when a variant is selected.

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


