### PR TITLE
feat(vuln-modal): recap current assessment status per variant

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -70,6 +70,39 @@ const statusBadgeClass = (status: string): string => {
     }
 };
 
+const originLabel = (origin: string): string => {
+    switch (origin) {
+        case 'custom':
+            return 'User';
+        case 'sbom':
+            return 'SBOM';
+        default:
+            return origin ? formatSourceName(origin) : 'Unknown';
+    }
+};
+
+const originBadgeClass = (origin: string): string => {
+    switch (origin) {
+        case 'custom':
+            return 'bg-slate-200 text-slate-800 dark:bg-slate-600 dark:text-slate-100';
+        case 'sbom':
+            return 'bg-blue-200 text-blue-900 dark:bg-blue-800 dark:text-blue-100';
+        case 'scc':
+            return 'bg-sky-100 text-sky-800 dark:bg-sky-900 dark:text-sky-300';
+        case 'grype':
+            return 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300';
+        case 'yocto_cve_check':
+            return 'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-300';
+        case 'nvd':
+        case 'nvd_cpe':
+            return 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300';
+        case 'osv':
+            return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300';
+        default:
+            return 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
+    }
+};
+
 
 
 type AssessmentGroup = {
@@ -1412,11 +1445,19 @@ type VariantScopedSnapshot = {
                                     const firstAssess = group.assessments[0]; // Use first assessment for content
                                     const isNewlyAdded = group.assessments.some(assess => newAssessmentIds.has(assess.id));
                                     const isBeingEdited = editingAssessmentId === firstAssess.id;
+                                    const groupOrigins = [...new Set(group.assessments.map(a => a.origin).filter(Boolean))];
 
                                     return (
                                         <li key={encodeURIComponent(group.key)} className={`mb-10 ms-4 ${isNewlyAdded ? 'new-element-glow' : ''}`}>
                                             <div className="absolute w-3 h-3 bg-gray-200 rounded-full mt-1.5 -start-1.5 border border-gray-800 bg-gray-800"></div>
-                                            <time className="mb-1 text-sm font-normal leading-none text-gray-400">{dt.toLocaleString(undefined, dt_options)}</time>
+                                            <div className="mb-2 flex flex-wrap items-center gap-2">
+                                                <time className="text-sm font-normal leading-none text-gray-400">{dt.toLocaleString(undefined, dt_options)}</time>
+                                                {groupOrigins.map(origin => (
+                                                    <span key={origin} className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${originBadgeClass(origin)}`} title={`Assessment origin: ${origin}`}>
+                                                        {originLabel(origin)}
+                                                    </span>
+                                                ))}
+                                            </div>
                                             <div className="text-sm mb-2 flex flex-wrap gap-1">
                                                 {group.packages.map(pkg => {
                                                     const { nameVersion, supplier } = splitPkgId(pkg);

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -53,6 +53,24 @@ const dt_options: Intl.DateTimeFormatOptions = {
     timeZoneName: 'shortOffset'
 };
 
+// Tailwind classes for a simplified-status badge, matching the palette used
+// across the app (red = exploitable, amber = pending, green = not affected).
+const statusBadgeClass = (status: string): string => {
+    switch (status) {
+        case 'Exploitable':
+            return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300';
+        case 'Pending Assessment':
+            return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300';
+        case 'Not affected':
+            return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300';
+        case 'Fixed':
+            return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300';
+        default:
+            return 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
+    }
+};
+
+
 
 type AssessmentGroup = {
     key: string;
@@ -722,6 +740,16 @@ type VariantScopedSnapshot = {
     };
 
     const groupedAssessments = groupAssessments(vuln.assessments);
+    const currentStatusByVariant = availableVariants
+        .map(variant => {
+            const latest = allVulnAssessments
+                .filter(a => a.variant_id === variant.id)
+                .reduce<Assessment | null>((best, a) => {
+                    if (!best) return a;
+                    return new Date(a.timestamp).getTime() > new Date(best.timestamp).getTime() ? a : best;
+                }, null);
+            return { variant, assessment: latest };
+        });
 
     const bothRefreshed = isGhsaVuln
         ? refreshedList.includes('GHSA')
@@ -1320,6 +1348,46 @@ type VariantScopedSnapshot = {
 
                         <div className="mt-6">
                             <h3 className="font-bold mb-2">Assessments</h3>
+                            {currentStatusByVariant.length > 0 && (
+                                <div className="mb-4 p-3 rounded-lg bg-gray-800/70 border border-gray-600">
+                                    <h4 className="font-semibold text-gray-200 mb-2">Current status by variant</h4>
+                                    <div className="overflow-x-auto">
+                                        <table className="w-full text-sm text-left border-collapse">
+                                            <thead>
+                                                <tr className="text-gray-400 border-b border-gray-600">
+                                                    <th className="py-1 pr-3 font-semibold">Variant</th>
+                                                    <th className="py-1 pr-3 font-semibold">Status</th>
+                                                    <th className="py-1 pr-3 font-semibold">Justification</th>
+                                                    <th className="py-1 pr-3 font-semibold">Impact</th>
+                                                    <th className="py-1 pr-3 font-semibold">Notes</th>
+                                                    <th className="py-1 font-semibold">Workaround</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {currentStatusByVariant.map(({ variant, assessment }) => (
+                                                    <tr key={variant.id} className="border-b border-gray-700 last:border-0 align-top">
+                                                        <td className="py-1.5 pr-3">
+                                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 whitespace-nowrap">
+                                                                {variant.name}
+                                                            </span>
+                                                        </td>
+                                                        <td className="py-1.5 pr-3">
+                                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full font-medium whitespace-nowrap ${statusBadgeClass(assessment?.simplified_status ?? 'No status')}`}>
+                                                                {assessment?.simplified_status ?? 'No status'}
+                                                            </span>
+                                                        </td>
+                                                        <td className="py-1.5 pr-3 text-gray-300 whitespace-pre-line">{assessment?.justification || '—'}</td>
+                                                        <td className="py-1.5 pr-3 text-gray-300 whitespace-pre-line">{assessment?.impact_statement || '—'}</td>
+                                                        <td className="py-1.5 pr-3 text-gray-300 whitespace-pre-line">{assessment?.status_notes || '—'}</td>
+                                                        <td className="py-1.5 text-gray-300 whitespace-pre-line">{assessment?.workaround || '—'}</td>
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            )}
+                            <h4 className="font-semibold text-gray-200 mb-2">Assessment history</h4>
                             <ol className="relative border-s border-gray-800">
                                 {isEditing && (
                                     <li className="ms-4 text-white pb-8">

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -148,7 +148,40 @@ describe('Vulnerability Modal', () => {
         expect(impact).toBeInTheDocument();
         expect(status_notes).toBeInTheDocument();
         expect(workaround).toBeInTheDocument();
+        // The assessment origin ("custom") is surfaced as a "User" tag
+        expect(screen.getByText('User')).toBeInTheDocument();
     })
+
+    test('assessment history tags an SBOM-sourced assessment', async () => {
+        const sbomVuln = {
+            ...vulnerability,
+            assessments: [{
+                ...vulnerability.assessments[0],
+                id: 'assessment-sbom',
+                origin: 'sbom'
+            }]
+        };
+        render(<VulnModal vuln={sbomVuln} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        expect(await screen.findByText('SBOM')).toBeInTheDocument();
+        expect(screen.queryByText('User')).not.toBeInTheDocument();
+    })
+
+    test('assessment history shows sbom-cve-check for the scc origin', async () => {
+        const sccVuln = {
+            ...vulnerability,
+            assessments: [{
+                ...vulnerability.assessments[0],
+                id: 'assessment-scc',
+                origin: 'scc'
+            }]
+        };
+        render(<VulnModal vuln={sccVuln} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        expect(await screen.findByText('sbom-cve-check')).toBeInTheDocument();
+        expect(screen.queryByText('Scc')).not.toBeInTheDocument();
+    })
+
 
     test('closing button', async () => {
         // ARRANGE

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2145,9 +2145,79 @@ describe('Vulnerability Modal', () => {
 
         render(<VulnModal vuln={vulnWithVariantAssessments} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
-        // Wait for variant tags to render
-        await screen.findByText('Production');
-        expect(screen.getByText('Staging')).toBeInTheDocument();
+        // Wait for variant tags to render (variant names now appear both in the
+        // per-variant recap and on the assessment history entries)
+        expect((await screen.findAllByText('Production')).length).toBeGreaterThan(0);
+        expect(screen.getAllByText('Staging').length).toBeGreaterThan(0);
+    });
+
+    test('recap shows the latest status for each variant', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'var-1', name: 'Production', project_id: 'proj1' },
+            { id: 'var-2', name: 'Staging', project_id: 'proj1' }
+        ]));
+        // var-1 has two assessments; the most recent one is "Not affected".
+        // var-2 has a single "Exploitable" assessment.
+        fetchMock.mockResponseOnce(JSON.stringify([
+            {
+                id: 'assess-v1-old', vuln_id: 'CVE-2010-1234', packages: ['aaabbbccc@1.0.0'],
+                status: 'affected', simplified_status: 'Exploitable', justification: '',
+                impact_statement: '', status_notes: '', workaround: '',
+                timestamp: '2025-01-01T00:00:00Z', origin: 'custom', responses: [], variant_id: 'var-1'
+            },
+            {
+                id: 'assess-v1-new', vuln_id: 'CVE-2010-1234', packages: ['aaabbbccc@1.0.0'],
+                status: 'not_affected', simplified_status: 'Not affected', justification: 'vulnerable_code_not_present',
+                impact_statement: '', status_notes: '', workaround: '',
+                timestamp: '2025-06-01T00:00:00Z', origin: 'custom', responses: [], variant_id: 'var-1'
+            },
+            {
+                id: 'assess-v2', vuln_id: 'CVE-2010-1234', packages: ['aaabbbccc@1.0.0'],
+                status: 'affected', simplified_status: 'Exploitable', justification: '',
+                impact_statement: '', status_notes: '', workaround: '',
+                timestamp: '2025-01-01T00:00:00Z', origin: 'custom', responses: [], variant_id: 'var-2'
+            }
+        ]));
+
+        render(<VulnModal vuln={{ ...vulnerability, assessments: [] }} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const recapHeading = await screen.findByText('Current status by variant');
+        const recap = recapHeading.parentElement as HTMLElement;
+        // Production reflects its most recent assessment (Not affected), not the older Exploitable
+        expect(within(recap).getByText('Production')).toBeInTheDocument();
+        expect(within(recap).getByText('Not affected')).toBeInTheDocument();
+        // Staging is Exploitable
+        expect(within(recap).getByText('Staging')).toBeInTheDocument();
+        expect(within(recap).getByText('Exploitable')).toBeInTheDocument();
+    });
+
+    test('recap shows "No status" for affected variants without an assessment', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'var-1', name: 'Production', project_id: 'proj1' },
+            { id: 'var-2', name: 'Staging', project_id: 'proj1' }
+        ]));
+        // Only var-1 has an assessment; var-2 is affected but not yet assessed.
+        fetchMock.mockResponseOnce(JSON.stringify([
+            {
+                id: 'assess-v1', vuln_id: 'CVE-2010-1234', packages: ['aaabbbccc@1.0.0'],
+                status: 'affected', simplified_status: 'Exploitable', justification: '',
+                impact_statement: '', status_notes: '', workaround: '',
+                timestamp: '2025-01-01T00:00:00Z', origin: 'custom', responses: [], variant_id: 'var-1'
+            }
+        ]));
+
+        render(<VulnModal vuln={{ ...vulnerability, assessments: [] }} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const recapHeading = await screen.findByText('Current status by variant');
+        const recap = recapHeading.parentElement as HTMLElement;
+        // Staging has no assessment yet, so it is flagged as "No status"
+        expect(within(recap).getByText('Staging')).toBeInTheDocument();
+        expect(within(recap).getByText('No status')).toBeInTheDocument();
+        // Production keeps its actual status
+        expect(within(recap).getByText('Production')).toBeInTheDocument();
+        expect(within(recap).getByText('Exploitable')).toBeInTheDocument();
     });
 
     test('projectId prop filters variants to only show those from the current project', async () => {


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

*The assessment history can be long, making the up-to-date status per variant hard to spot. Add a "Current status by variant" table above the history that lists, for each variant, its most recent assessment: status, justification, impact, notes and workaround.
Label the timeline below as "Assessment history" to separate it from the recap.

*  tag each assessment history entry with its origin. Show a colour-coded origin badge next to every assessment in the history timeline.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open any vulnerability

<img width="1798" height="465" alt="image" src="https://github.com/user-attachments/assets/981b9f90-ca7a-40d1-9c70-bee7bf78490d" />

<img width="1826" height="843" alt="image" src="https://github.com/user-attachments/assets/383ee70f-20af-42dd-8b2b-8825ece41ea2" />



