### PR TITLE
feat(search): add only:<term> operator to filter by every affected package

### DIFF
--- a/frontend/src/components/TableGeneric.tsx
+++ b/frontend/src/components/TableGeneric.tsx
@@ -22,6 +22,13 @@ type Props<DataType> = {
     hasPagination?: boolean;
     onFilteredDataChange?: (filteredData: DataType[]) => void;
     onFocusedRowChange?: (rowIndex: number | null) => void;
+    /**
+     * Values checked by the `only:<term>` search operator. When provided, a row
+     * is kept only if EVERY string returned here satisfies the (optionally
+     * negated with `-`) substring condition. Used to scope the operator to a
+     * specific field, e.g. a vulnerability's SBOM-affected packages.
+     */
+    forAllValues?: (item: DataType) => string[];
 };
 /* tslint:enable:no-explicit-any */
 
@@ -38,7 +45,8 @@ function TableGeneric<DataType> ({
     updateSelected = () => {},
     hasPagination = true,
     onFilteredDataChange,
-    onFocusedRowChange
+    onFocusedRowChange,
+    forAllValues
 }: Readonly<Props<DataType>>) {
     const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 50 })
     const pageIndex = pagination.pageIndex
@@ -61,46 +69,78 @@ function TableGeneric<DataType> ({
     }, [fuseKeys, data]);
 
     const filteredData = useMemo(() => {
-        if (search && search.length > 2) {
-            const buildFuseQuery = (raw: string) => {
-                // FuseJS search query example: https://www.fusejs.io/api/query.html#use-with-extended-searching
-                const buildTermClause = (term: string) => {
-                    const isNegated = term.startsWith('-');
-                    const bare = isNegated ? term.slice(1) : term;
-                    const value = isNegated ? `!${bare}` : `'${bare}`; // exact (non-fuzzy) match
+        const buildFuseQuery = (raw: string) => {
+            // FuseJS search query example: https://www.fusejs.io/api/query.html#use-with-extended-searching
+            const buildTermClause = (term: string) => {
+                const isNegated = term.startsWith('-');
+                const bare = isNegated ? term.slice(1) : term;
+                const value = isNegated ? `!${bare}` : `'${bare}`; // exact (non-fuzzy) match
 
-                    if (fuseKeys.length === 1) {
-                        return { [fuseKeys[0]]: value };
-                    }
-
-                    if (isNegated) {
-                        return { $and: fuseKeys.map(key => ({ [key]: value })) };
-                    }
-                    return { $or: fuseKeys.map(key => ({ [key]: value })) };
-                };
-
-                // Split by | to support OR syntax (e.g. "openssl | libssl")
-                const orGroups = raw.split('|').map(group => group.trim()).filter(Boolean);
-
-                if (orGroups.length === 1) {
-                    const terms = orGroups[0].split(/\s+/).filter(Boolean);
-                    return { $and: terms.map(buildTermClause) };
+                if (fuseKeys.length === 1) {
+                    return { [fuseKeys[0]]: value };
                 }
 
-                return {
-                    $or: orGroups.map(group => {
-                        const terms = group.split(/\s+/).filter(Boolean);
-                        return { $and: terms.map(buildTermClause) };
-                    })
-                };
+                if (isNegated) {
+                    return { $and: fuseKeys.map(key => ({ [key]: value })) };
+                }
+                return { $or: fuseKeys.map(key => ({ [key]: value })) };
             };
 
-            const processedSearch = buildFuseQuery(search);
+            // Split by | to support OR syntax (e.g. "openssl | libssl")
+            const orGroups = raw.split('|').map(group => group.trim()).filter(Boolean);
 
-            return fuse.search(processedSearch).map(result => result.item);
+            if (orGroups.length === 1) {
+                const terms = orGroups[0].split(/\s+/).filter(Boolean);
+                return { $and: terms.map(buildTermClause) };
+            }
+
+            return {
+                $or: orGroups.map(group => {
+                    const terms = group.split(/\s+/).filter(Boolean);
+                    return { $and: terms.map(buildTermClause) };
+                })
+            };
+        };
+
+        // Extract `only:<text>` clauses when the consumer opts in via
+        // forAllValues.
+        let effectiveSearch = search ?? '';
+        const onlyClauses: RegExp[] = [];
+        if (forAllValues && effectiveSearch) {
+            const residual: string[] = [];
+            for (const token of effectiveSearch.split(/\s+/)) {
+                const match = /^only:(.+)$/i.exec(token);
+                if (match) {
+                    try {
+                        onlyClauses.push(new RegExp(match[1], 'i'));
+                    } catch {
+                        // Invalid regex — fall back to matching the literal text.
+                        onlyClauses.push(new RegExp(match[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
+                    }
+                } else if (token) {
+                    residual.push(token);
+                }
+            }
+            effectiveSearch = residual.join(' ');
         }
-        return data;
-    }, [search, fuse, data, fuseKeys]);
+
+        let result: DataType[];
+        if (effectiveSearch && effectiveSearch.length > 2) {
+            result = fuse.search(buildFuseQuery(effectiveSearch)).map(searchResult => searchResult.item);
+        } else {
+            result = data;
+        }
+
+        if (onlyClauses.length > 0 && forAllValues) {
+            result = result.filter(item => {
+                const values = forAllValues(item);
+                if (values.length === 0) return false; // nothing affected → cannot satisfy "every"
+                return onlyClauses.every(regex => values.every(value => regex.test(value)));
+            });
+        }
+
+        return result;
+    }, [search, fuse, data, fuseKeys, forAllValues]);
 
     const paginationSizes = useMemo(() => {
         const total = filteredData.length;

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -157,6 +157,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         { syntax: 'term1 term2', description: 'AND: both terms must match' },
         { syntax: 'term1 | term2', description: 'OR: either term matches' },
         { syntax: '-term', description: 'NOT: exclude rows with term' },
+        { syntax: 'only:text', description: 'Show a row only when all of its affected packages contain text (e.g. only:native keeps rows whose affected packages are all native)' },
     ];
 
     useEffect(() => {
@@ -1090,6 +1091,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                         }))}
                         search={search}
                         fuseKeys={["vuln_id", "packages", "simplified_status", "status_notes", "justification", "workaround", "extractedSuppliers"]}
+                        forAllValues={(row) => row.packages}
                         estimateRowHeight={50}
                         hasPagination={true}
                         hoverField="texts"

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -72,6 +72,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         { syntax: 'term1 term2', description: 'AND: both terms must match' },
         { syntax: 'term1 | term2', description: 'OR: either term matches' },
         { syntax: '-term', description: 'NOT: exclude rows with term' },
+        { syntax: 'only:text', description: 'Show only packages whose name contains text (e.g. only:native)' },
     ];
 
     const updateSearch = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
@@ -515,7 +516,7 @@ function TablePackages({ packages, onShowVulns }: Readonly<Props>) {
         </div>
 
         <div ref={tableRef}>
-            <TableGeneric fuseKeys={fuseKeys} search={search} columns={columns} data={filteredPackages} estimateRowHeight={57} />
+            <TableGeneric fuseKeys={fuseKeys} forAllValues={(pkg) => [pkg.name]} search={search} columns={columns} data={filteredPackages} estimateRowHeight={57} />
         </div>
     </>);
 }

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -415,6 +415,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         { syntax: 'term1 term2', description: 'AND: both terms must match' },
         { syntax: 'term1 | term2', description: 'OR: either term matches' },
         { syntax: '-term', description: 'NOT: exclude rows with term' },
+        { syntax: 'only:text', description: 'Show a vuln only when all of its SBOM-affected packages contain text (e.g. only:native keeps vulns whose affected packages are all native)' },
     ];
 
     const hasAnyGhsaVuln = useMemo(
@@ -1578,6 +1579,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
 
         <TableGeneric
             fuseKeys={fuseKeys}
+            forAllValues={(vuln) => (vuln.packages_current?.length ? vuln.packages_current : vuln.packages)}
             hoverField="texts"
             search={search}
             columns={columns}

--- a/frontend/tests/unit_tests/test_table_generic.tsx
+++ b/frontend/tests/unit_tests/test_table_generic.tsx
@@ -435,3 +435,86 @@ describe('TableGeneric component (direct tests to raise coverage)', () => {
     });
   }, 10000);
 });
+
+describe('TableGeneric only:<regex> operator (forAllValues)', () => {
+  type PkgRow = { id: string; packages: string[] };
+
+  const pkgColumns = [
+    {
+      accessorKey: 'id',
+      header: 'ID',
+      cell: (info: any) => info.getValue(),
+      size: 200,
+    },
+  ];
+
+  const onlyData: PkgRow[] = [
+    { id: 'vulnA', packages: ['linux-yocto-native', 'busybox-native'] },
+    { id: 'vulnB', packages: ['linux-yocto', 'busybox-native'] },
+    { id: 'vulnC', packages: [] },
+  ];
+
+  const renderOnly = (search: string) =>
+    render(
+      <TableGeneric<PkgRow>
+        columns={pkgColumns}
+        data={onlyData}
+        fuseKeys={['id', 'packages']}
+        forAllValues={(row) => row.packages}
+        search={search}
+        tableHeight="auto"
+        hasPagination={false}
+      />
+    );
+
+  test('keeps only rows whose every affected value matches the regex', async () => {
+    renderOnly('only:-native');
+
+    // vulnA: every package matches /-native/i → kept
+    expect(await screen.findByRole('cell', { name: /^vulnA$/ })).toBeInTheDocument();
+    // vulnB: linux-yocto does not match → excluded
+    expect(screen.queryByRole('cell', { name: /^vulnB$/ })).not.toBeInTheDocument();
+    // vulnC: no affected packages → cannot satisfy "every" → excluded
+    expect(screen.queryByRole('cell', { name: /^vulnC$/ })).not.toBeInTheDocument();
+  });
+
+  test('regex is case-insensitive and anchors are supported', async () => {
+    renderOnly('only:^linux');
+
+    // vulnA first package is busybox-native as well → not every matches ^linux → excluded
+    expect(screen.queryByRole('cell', { name: /^vulnA$/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('cell', { name: /^vulnB$/ })).not.toBeInTheDocument();
+  });
+
+  test('combines a residual fuzzy search term with the only: clause', async () => {
+    renderOnly('vuln only:-native');
+
+    // residual "vuln" matches all ids, only: narrows to vulnA
+    expect(await screen.findByRole('cell', { name: /^vulnA$/ })).toBeInTheDocument();
+    expect(screen.queryByRole('cell', { name: /^vulnB$/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('cell', { name: /^vulnC$/ })).not.toBeInTheDocument();
+  });
+
+  test('invalid regex falls back to a literal match', async () => {
+    const cppData: PkgRow[] = [
+      { id: 'cppA', packages: ['g++', 'libstdg++'] },
+      { id: 'cppB', packages: ['gcc'] },
+    ];
+
+    render(
+      <TableGeneric<PkgRow>
+        columns={pkgColumns}
+        data={cppData}
+        fuseKeys={['id', 'packages']}
+        forAllValues={(row) => row.packages}
+        search="only:g++"
+        tableHeight="auto"
+        hasPagination={false}
+      />
+    );
+
+    // "g++" is not a valid regex → treated as the literal string "g++"
+    expect(await screen.findByRole('cell', { name: /^cppA$/ })).toBeInTheDocument();
+    expect(screen.queryByRole('cell', { name: /^cppB$/ })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Introduce an "only:<regex>" search operator that keeps a row only when every value returned by the new forAllValues accessor matches the given case-insensitive regex. Rows with no affected values are excluded, and an invalid regex falls back to a literal match.

Wire the operator into the Vulnerabilities tab (SBOM-affected packages), the SBOM/Packages tab (package name) and the Review tab (affected packages), and document it in each search-syntax help panel.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

<img width="1312" height="313" alt="image" src="https://github.com/user-attachments/assets/6775afcd-76d9-4a60-8f9a-796be43fc534" />

<img width="1006" height="836" alt="image" src="https://github.com/user-attachments/assets/f872abee-4ee2-40cd-b231-82a2867bb15b" />
