### PR TITLE
fix(table): stop filtered rows blinking

### DIFF
--- a/frontend/src/components/TableGeneric.tsx
+++ b/frontend/src/components/TableGeneric.tsx
@@ -68,6 +68,9 @@ function TableGeneric<DataType> ({
         });
     }, [fuseKeys, data]);
 
+    const forAllValuesRef = useRef(forAllValues);
+    forAllValuesRef.current = forAllValues;
+
     const filteredData = useMemo(() => {
         const buildFuseQuery = (raw: string) => {
             // FuseJS search query example: https://www.fusejs.io/api/query.html#use-with-extended-searching
@@ -104,9 +107,10 @@ function TableGeneric<DataType> ({
 
         // Extract `only:<text>` clauses when the consumer opts in via
         // forAllValues.
+        const forAll = forAllValuesRef.current;
         let effectiveSearch = search ?? '';
         const onlyClauses: RegExp[] = [];
-        if (forAllValues && effectiveSearch) {
+        if (forAll && effectiveSearch) {
             const residual: string[] = [];
             for (const token of effectiveSearch.split(/\s+/)) {
                 const match = /^only:(.+)$/i.exec(token);
@@ -131,16 +135,16 @@ function TableGeneric<DataType> ({
             result = data;
         }
 
-        if (onlyClauses.length > 0 && forAllValues) {
+        if (onlyClauses.length > 0 && forAll) {
             result = result.filter(item => {
-                const values = forAllValues(item);
+                const values = forAll(item);
                 if (values.length === 0) return false; // nothing affected → cannot satisfy "every"
                 return onlyClauses.every(regex => values.every(value => regex.test(value)));
             });
         }
 
         return result;
-    }, [search, fuse, data, fuseKeys, forAllValues]);
+    }, [search, fuse, data, fuseKeys]);
 
     const paginationSizes = useMemo(() => {
         const total = filteredData.length;

--- a/frontend/tests/unit_tests/test_table_generic.tsx
+++ b/frontend/tests/unit_tests/test_table_generic.tsx
@@ -2,6 +2,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import { useState } from 'react';
 
 import TableGeneric from '../../src/components/TableGeneric';
 
@@ -516,5 +517,123 @@ describe('TableGeneric only:<regex> operator (forAllValues)', () => {
     // "g++" is not a valid regex → treated as the literal string "g++"
     expect(await screen.findByRole('cell', { name: /^cppA$/ })).toBeInTheDocument();
     expect(screen.queryByRole('cell', { name: /^cppB$/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('TableGeneric filteredData stability (blink regression)', () => {
+  type PkgRow = { id: string; packages: string[] };
+
+  const pkgColumns = [
+    {
+      accessorKey: 'id',
+      header: 'ID',
+      cell: (info: any) => info.getValue(),
+      size: 200,
+    },
+  ];
+
+  const stableData: PkgRow[] = [
+    { id: 'vulnA', packages: ['linux-yocto-native', 'busybox-native'] },
+    { id: 'vulnB', packages: ['linux-yocto', 'busybox-native'] },
+  ];
+
+  // Reference-stable so only forAllValues identity varies between renders,
+  // isolating the regression the fix targets.
+  const stableFuseKeys = ['id', 'packages'];
+
+  // Harness that mimics how real tables pass forAllValues: as an inline arrow
+  // whose identity changes on every render. A "bump" button forces an unrelated
+  // re-render (e.g. showing a hover tooltip) without touching search/data.
+  function Harness({ probe }: { probe: (row: PkgRow) => void }) {
+    const [, setBump] = useState(0);
+    return (
+      <>
+        <button onClick={() => setBump(n => n + 1)}>bump</button>
+        <TableGeneric<PkgRow>
+          columns={pkgColumns}
+          data={stableData}
+          fuseKeys={stableFuseKeys}
+          // New identity on every render, delegating to a stable probe so we can
+          // count how many times the filter memo actually evaluated the rows.
+          forAllValues={(row) => { probe(row); return row.packages; }}
+          search="only:-native"
+          tableHeight="auto"
+          hasPagination={false}
+        />
+      </>
+    );
+  }
+
+  test('does not recompute filtered rows when only forAllValues identity changes', async () => {
+    const probe = jest.fn();
+
+    render(<Harness probe={probe} />);
+
+    // Initial filter settles: only:-native keeps vulnA (all packages -native).
+    await waitFor(() => {
+      expect(screen.getByRole('cell', { name: /^vulnA$/ })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('cell', { name: /^vulnB$/ })).not.toBeInTheDocument();
+
+    // Filter memo ran at least once, invoking forAllValues for each row.
+    expect(probe.mock.calls.length).toBeGreaterThan(0);
+    const probeCallsAfterMount = probe.mock.calls.length;
+
+    // Trigger several unrelated re-renders (each supplies a fresh forAllValues arrow).
+    const user = userEvent.setup();
+    const bumpBtn = screen.getByRole('button', { name: 'bump' });
+    await user.click(bumpBtn);
+    await user.click(bumpBtn);
+    await user.click(bumpBtn);
+
+    // The filtered result must not be recomputed: forAllValues is not called
+    // again just because its identity (or an unrelated state) changed.
+    expect(probe.mock.calls.length).toBe(probeCallsAfterMount);
+
+    // The filter is still correct after the churn.
+    expect(screen.getByRole('cell', { name: /^vulnA$/ })).toBeInTheDocument();
+    expect(screen.queryByRole('cell', { name: /^vulnB$/ })).not.toBeInTheDocument();
+  });
+
+  test('uses the latest forAllValues closure when the filter recomputes', async () => {
+    // The fix stores forAllValues in a ref; when search actually changes, the
+    // memo must read the current closure, not a stale one.
+    function ClosureHarness() {
+      const [invert, setInvert] = useState(false);
+      const [search, setSearch] = useState('only:-native');
+      return (
+        <>
+          <button onClick={() => { setInvert(true); setSearch('only:native'); }}>swap</button>
+          <TableGeneric<PkgRow>
+            columns={pkgColumns}
+            data={stableData}
+            fuseKeys={['id', 'packages']}
+            // Latest closure flips the values it exposes for the only: check.
+            forAllValues={(row) => invert ? row.packages.map(p => p.replace('-native', '')) : row.packages}
+            search={search}
+            tableHeight="auto"
+            hasPagination={false}
+          />
+        </>
+      );
+    }
+
+    render(<ClosureHarness />);
+
+    // only:-native + original closure → vulnA kept.
+    await waitFor(() => {
+      expect(screen.getByRole('cell', { name: /^vulnA$/ })).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'swap' }));
+
+    // After swap: search only:native + inverted closure (which strips "-native"),
+    // so no package contains "native" → vulnA is now excluded. This only holds if
+    // the memo read the updated closure via the ref.
+    await waitFor(() => {
+      expect(screen.queryByRole('cell', { name: /^vulnA$/ })).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole('cell', { name: /^vulnB$/ })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The filteredData memo listed forAllValues in its dependency array, but every table passes it as an inline arrow, so its identity changed on each render. Any unrelated re-render (e.g. showing a hover tooltip over an ID cell) re-ran fuse.search and returned a new array, making the virtualized table constantly re-render/re-measure.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change


Type a word in the search bar and overlay a vulnerability in "ID" column. 

With this fix, it doesn´t blink anymore and the vulnerability can be correctly open with a click on it

<img width="941" height="322" alt="image" src="https://github.com/user-attachments/assets/af2016ba-954e-4615-a467-e716a0be1ce8" />


