### PR TITLE
Feature(VulnModal) add Packages logic in the assessment recap

### DIFF
--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -201,16 +201,19 @@ function EditAssessment({
             return;
         }
 
-        const includeJustificationAndImpact = status == "not_affected";
+        // Justification only applies to not_affected; the impact statement
+        // applies to both not_affected and false_positive (mirrors StatusEditor).
+        const includeJustification = status == "not_affected";
+        const includeImpact = status == "not_affected" || status == "false_positive";
 
         onSaveAssessment({
             id: assessment.id,
             status,
-            justification: includeJustificationAndImpact ? justification : undefined,
+            justification: includeJustification ? justification : undefined,
             status_notes: statusNotes,
             workaround,
             // For non-impact statuses the value was folded into status_notes; clear impact_statement.
-            impact_statement: includeJustificationAndImpact ? impact : "",
+            impact_statement: includeImpact ? impact : "",
             variant_ids: selectedVariantIds.length > 0 ? selectedVariantIds : undefined,
             packages: selectedPackages.length > 0 ? selectedPackages : (availablePackages ?? [])
         });

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -19,7 +19,6 @@ import ConfirmationModal from "./ConfirmationModal";
 import EditAssessment from "./EditAssessment";
 import type { EditAssessmentData } from "./EditAssessment";
 import Variants from '../handlers/variant';
-import Packages from '../handlers/packages';
 import { formatSourceName } from '../helpers/sourceNames';
 import { useDocUrl } from '../helpers/useDocUrl';
 import { splitPkgId, formatPkgId, extractSupplierName } from '../helpers/pkgId';
@@ -112,6 +111,8 @@ type AssessmentGroup = {
     packages: string[];
 };
 
+type StatusSortKey = 'variant' | 'package' | 'status' | 'justification' | 'impact' | 'notes' | 'workaround';
+
 type VariantScopedSnapshot = {
     variantId: string;
     variantName: string;
@@ -143,6 +144,10 @@ type VariantScopedSnapshot = {
     const [selectedTargetVariantIds, setSelectedTargetVariantIds] = useState<string[]>([]);
     const [variantSnapshots, setVariantSnapshots] = useState<VariantScopedSnapshot[]>([]);
     const [variantPackageMap, setVariantPackageMap] = useState<Record<string, string[]>>({});
+    // True once the active-SBOM package list has been fetched for every variant,
+    // so deprecated packages can reliably be split into their own table.
+    const [variantPackageMapLoaded, setVariantPackageMapLoaded] = useState(false);
+    const [statusSort, setStatusSort] = useState<{ key: StatusSortKey; dir: 'asc' | 'desc' } | null>(null);
     const [snapshotVersion, setSnapshotVersion] = useState(0);
     const [submittingMessage, setSubmittingMessage] = useState<string | null>(null);
     const [editingGroup, setEditingGroup] = useState<AssessmentGroup | null>(null);
@@ -259,34 +264,46 @@ type VariantScopedSnapshot = {
         return () => { cancelled = true; };
     }, [variantId, availableVariants, vuln.id, projectId, snapshotVersion]);
 
-    // Build variant -> package compatibility map using the same source as the
-    // SBOM tab: GET /api/packages?variant_id=<id> returns the active SBOM
-    // packages for that variant, whose ids match vuln.packages entries.
     useEffect(() => {
         let cancelled = false;
+        setVariantPackageMapLoaded(false);
         if (availableVariants.length === 0) {
             setVariantPackageMap({});
+            setVariantPackageMapLoaded(true);
             return;
         }
         (async () => {
-            const entries: [string, string[]][] = await Promise.all(
-                availableVariants.map(async (variant): Promise<[string, string[]]> => {
-                    try {
-                        const pkgs = await Packages.list(variant.id);
-                        // Build the same key format as vuln.packages:
-                        // "name@version::supplier" when supplier present, else "name@version"
-                        return [variant.id, pkgs.map(p =>
-                            p.supplier ? `${p.name}@${p.version}::${p.supplier}` : `${p.name}@${p.version}`
-                        )];
-                    } catch {
-                        return [variant.id, []];
+            try {
+                const url = new URL(
+                    import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/variant-active-packages`,
+                    window.location.href
+                );
+                if (projectId) {
+                    url.searchParams.set('project_id', projectId);
+                }
+                const response = await fetch(url.toString(), { mode: 'cors' });
+                const data = response.ok ? await response.json() : [];
+                const map: Record<string, string[]> = {};
+                if (Array.isArray(data)) {
+                    for (const entry of data) {
+                        if (entry && typeof entry.variant_id === 'string' && Array.isArray(entry.active_packages)) {
+                            map[entry.variant_id] = entry.active_packages.filter((p: unknown): p is string => typeof p === 'string');
+                        }
                     }
-                })
-            );
-            if (!cancelled) setVariantPackageMap(Object.fromEntries(entries));
+                }
+                if (!cancelled) {
+                    setVariantPackageMap(map);
+                    setVariantPackageMapLoaded(true);
+                }
+            } catch {
+                if (!cancelled) {
+                    setVariantPackageMap({});
+                    setVariantPackageMapLoaded(true);
+                }
+            }
         })();
         return () => { cancelled = true; };
-    }, [availableVariants]);
+    }, [availableVariants, vuln.id, projectId]);
 
     const [hasTimeChanges, setHasTimeChanges] = useState(false);
     const [hasAssessmentChanges, setHasAssessmentChanges] = useState(false);
@@ -779,16 +796,129 @@ type VariantScopedSnapshot = {
     };
 
     const groupedAssessments = groupAssessments(vuln.assessments);
-    const currentStatusByVariant = availableVariants
-        .map(variant => {
-            const latest = allVulnAssessments
+
+    const latestAssessmentFor = (variantIdValue: string, pkg: string | null): Assessment | null =>
+        allVulnAssessments
+            .filter(a => a.variant_id === variantIdValue && (pkg === null || a.packages.includes(pkg)))
+            .reduce<Assessment | null>((best, a) => {
+                if (!best) return a;
+                return new Date(a.timestamp).getTime() > new Date(best.timestamp).getTime() ? a : best;
+            }, null);
+
+    type StatusRow = { variant: Variant; pkg: string | null; assessment: Assessment | null; deprecated: boolean };
+
+    const allStatusRows: StatusRow[] = availableVariants.flatMap((variant): StatusRow[] => {
+        const variantPkgs = variantPackageMap[variant.id] ?? [];
+        // Packages affected by this vuln that still exist in the variant's active SBOM.
+        const activeAffected = projectPackages.filter(p => variantPkgs.includes(p));
+        // Packages referenced by the variant's assessments may include older,
+        // now-deprecated versions that are no longer in the active SBOM.
+        const assessmentPkgs = [...new Set(
+            allVulnAssessments
                 .filter(a => a.variant_id === variant.id)
-                .reduce<Assessment | null>((best, a) => {
-                    if (!best) return a;
-                    return new Date(a.timestamp).getTime() > new Date(best.timestamp).getTime() ? a : best;
-                }, null);
-            return { variant, assessment: latest };
-        });
+                .flatMap(a => a.packages)
+        )];
+        const allPkgs = [...new Set([...activeAffected, ...assessmentPkgs])];
+        if (allPkgs.length === 0) {
+            return [{ variant, pkg: null, assessment: latestAssessmentFor(variant.id, null), deprecated: false }];
+        }
+        return allPkgs.slice().sort().map(pkg => ({
+            variant,
+            pkg,
+            assessment: latestAssessmentFor(variant.id, pkg),
+            // A package is deprecated once it's no longer in the variant's active
+            // SBOM. Until that list has loaded, keep it in the current table.
+            deprecated: variantPackageMapLoaded && !variantPkgs.includes(pkg),
+        }));
+    });
+
+    const currentAssessmentRows = allStatusRows.filter(r => !r.deprecated);
+    const deprecatedAssessmentRows = allStatusRows.filter(r => r.deprecated);
+
+    // Value used to compare two rows for a given sortable column.
+    const statusSortValue = (row: StatusRow, key: StatusSortKey): string => {
+        switch (key) {
+            case 'variant': return row.variant.name ?? '';
+            case 'package': return row.pkg ? formatPkgId(row.pkg) : '';
+            case 'status': return row.assessment?.simplified_status ?? 'No status';
+            case 'justification': return row.assessment?.justification ?? '';
+            case 'impact': return row.assessment?.impact_statement ?? '';
+            case 'notes': return row.assessment?.status_notes ?? '';
+            case 'workaround': return row.assessment?.workaround ?? '';
+        }
+    };
+
+    const sortStatusRows = (rows: StatusRow[]): StatusRow[] =>
+        statusSort
+            ? rows.slice().sort((a, b) => {
+                const cmp = statusSortValue(a, statusSort.key)
+                    .localeCompare(statusSortValue(b, statusSort.key), undefined, { sensitivity: 'base' });
+                return statusSort.dir === 'asc' ? cmp : -cmp;
+            })
+            : rows;
+
+    const toggleStatusSort = (key: StatusSortKey) => {
+        setStatusSort(prev =>
+            prev?.key === key
+                ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+                : { key, dir: 'asc' }
+        );
+    };
+
+    const statusSortColumns: { key: StatusSortKey; label: string }[] = [
+        { key: 'variant', label: 'Variant' },
+        { key: 'package', label: 'Package' },
+        { key: 'status', label: 'Status' },
+        { key: 'justification', label: 'Justification' },
+        { key: 'impact', label: 'Impact' },
+        { key: 'notes', label: 'Notes' },
+        { key: 'workaround', label: 'Workaround' },
+    ];
+
+    const renderStatusTable = (rows: StatusRow[]) => (
+        <div className="overflow-x-auto">
+            <table className="w-full text-sm text-left border-collapse">
+                <thead>
+                    <tr className="text-gray-400 border-b border-gray-600">
+                        {statusSortColumns.map((col, idx) => (
+                            <th
+                                key={col.key}
+                                className={`py-1 font-semibold cursor-pointer select-none hover:text-gray-200 ${idx < statusSortColumns.length - 1 ? 'pr-3' : ''}`}
+                                onClick={() => toggleStatusSort(col.key)}
+                                aria-sort={statusSort?.key === col.key ? (statusSort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+                            >
+                                {col.label}
+                                <span className="ml-1 text-xs">
+                                    {statusSort?.key === col.key ? (statusSort.dir === 'asc' ? '▲' : '▼') : ''}
+                                </span>
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.map(({ variant, pkg, assessment }) => (
+                        <tr key={`${variant.id}::${pkg ?? ''}`} className="border-b border-gray-700 last:border-0 align-top">
+                            <td className="py-1.5 pr-3">
+                                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 whitespace-nowrap">
+                                    {variant.name}
+                                </span>
+                            </td>
+                            <td className="py-1.5 pr-3 text-gray-300 whitespace-nowrap">{pkg ? formatPkgId(pkg) : '—'}</td>
+                            <td className="py-1.5 pr-3">
+                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full font-medium whitespace-nowrap ${statusBadgeClass(assessment?.simplified_status ?? 'No status')}`}>
+                                    {assessment?.simplified_status ?? 'No status'}
+                                </span>
+                            </td>
+                            <td className="py-1.5 pr-3 text-gray-300 whitespace-pre-line">{assessment?.justification || '—'}</td>
+                            <td className="py-1.5 pr-3 text-gray-300 whitespace-pre-line">{assessment?.impact_statement || '—'}</td>
+                            <td className="py-1.5 pr-3 text-gray-300 whitespace-pre-line">{assessment?.status_notes || '—'}</td>
+                            <td className="py-1.5 text-gray-300 whitespace-pre-line">{assessment?.workaround || '—'}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
 
     const bothRefreshed = isGhsaVuln
         ? refreshedList.includes('GHSA')
@@ -1409,43 +1539,16 @@ type VariantScopedSnapshot = {
 
                         <div className="mt-6">
                             <h3 className="font-bold mb-2">Assessments</h3>
-                            {currentStatusByVariant.length > 0 && (
+                            {currentAssessmentRows.length > 0 && (
                                 <div className="mb-4 p-3 rounded-lg bg-gray-800/70 border border-gray-600">
-                                    <h4 className="font-semibold text-gray-200 mb-2">Current status by variant</h4>
-                                    <div className="overflow-x-auto">
-                                        <table className="w-full text-sm text-left border-collapse">
-                                            <thead>
-                                                <tr className="text-gray-400 border-b border-gray-600">
-                                                    <th className="py-1 pr-3 font-semibold">Variant</th>
-                                                    <th className="py-1 pr-3 font-semibold">Status</th>
-                                                    <th className="py-1 pr-3 font-semibold">Justification</th>
-                                                    <th className="py-1 pr-3 font-semibold">Impact</th>
-                                                    <th className="py-1 pr-3 font-semibold">Notes</th>
-                                                    <th className="py-1 font-semibold">Workaround</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                {currentStatusByVariant.map(({ variant, assessment }) => (
-                                                    <tr key={variant.id} className="border-b border-gray-700 last:border-0 align-top">
-                                                        <td className="py-1.5 pr-3">
-                                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 whitespace-nowrap">
-                                                                {variant.name}
-                                                            </span>
-                                                        </td>
-                                                        <td className="py-1.5 pr-3">
-                                                            <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full font-medium whitespace-nowrap ${statusBadgeClass(assessment?.simplified_status ?? 'No status')}`}>
-                                                                {assessment?.simplified_status ?? 'No status'}
-                                                            </span>
-                                                        </td>
-                                                        <td className="py-1.5 pr-3 text-gray-300 whitespace-pre-line">{assessment?.justification || '—'}</td>
-                                                        <td className="py-1.5 pr-3 text-gray-300 whitespace-pre-line">{assessment?.impact_statement || '—'}</td>
-                                                        <td className="py-1.5 pr-3 text-gray-300 whitespace-pre-line">{assessment?.status_notes || '—'}</td>
-                                                        <td className="py-1.5 text-gray-300 whitespace-pre-line">{assessment?.workaround || '—'}</td>
-                                                    </tr>
-                                                ))}
-                                            </tbody>
-                                        </table>
-                                    </div>
+                                    <h4 className="font-semibold text-gray-200 mb-2">Current assessments</h4>
+                                    {renderStatusTable(sortStatusRows(currentAssessmentRows))}
+                                </div>
+                            )}
+                            {deprecatedAssessmentRows.length > 0 && (
+                                <div className="mb-4 p-3 rounded-lg bg-gray-800/70 border border-gray-600">
+                                    <h4 className="font-semibold text-gray-200 mb-2">Deprecated assessments</h4>
+                                    {renderStatusTable(sortStatusRows(deprecatedAssessmentRows))}
                                 </div>
                             )}
                             <h4 className="font-semibold text-gray-200 mb-2">Assessment history</h4>

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -517,14 +517,17 @@ type VariantScopedSnapshot = {
             }
 
             if (!anyError) {
-                if (vuln.assessments.length > 0) {
-                    const sortedAssessments = [...vuln.assessments].sort(
-                        (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-                    );
-                    vuln.simplified_status = sortedAssessments[0].simplified_status;
-                }
+                const updatedAssessments = [...vuln.assessments];
+                const statusSummary = buildStatusSummary(updatedAssessments);
+                vuln.simplified_status = statusSummary.dominant_status;
+                vuln.status_summary = statusSummary;
 
-                patchVuln(vuln.id, vuln);
+                patchVuln(vuln.id, {
+                    ...vuln,
+                    assessments: updatedAssessments,
+                    simplified_status: statusSummary.dominant_status,
+                    status_summary: statusSummary,
+                });
                 showMessage("Assessment deleted successfully!", "success");
             }
         }
@@ -697,13 +700,16 @@ type VariantScopedSnapshot = {
         }
 
         if (!anyError) {
-            const latest = vuln.assessments.slice().sort(
-                (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-            )[0];
-            if (latest) {
-                vuln.simplified_status = latest.simplified_status;
-            }
-            patchVuln(vuln.id, vuln);
+            const updatedAssessments = [...vuln.assessments];
+            const statusSummary = buildStatusSummary(updatedAssessments);
+            vuln.simplified_status = statusSummary.dominant_status;
+            vuln.status_summary = statusSummary;
+            patchVuln(vuln.id, {
+                ...vuln,
+                assessments: updatedAssessments,
+                simplified_status: statusSummary.dominant_status,
+                status_summary: statusSummary,
+            });
             showMessage('Assessment updated successfully!', 'success');
         }
 

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -23,7 +23,7 @@ import { formatSourceName } from '../helpers/sourceNames';
 import { useDocUrl } from '../helpers/useDocUrl';
 import { splitPkgId, formatPkgId, extractSupplierName } from '../helpers/pkgId';
 import type { Variant } from '../handlers/variant';
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import NvdRefreshHandler from "../handlers/nvdRefresh";
 import EpssRefreshHandler from "../handlers/epssRefresh";
 import GhsaRefreshHandler from "../handlers/ghsaRefresh";
@@ -140,6 +140,7 @@ type VariantScopedSnapshot = {
     const [groupToDelete, setGroupToDelete] = useState<AssessmentGroup | null>(null);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [availableVariants, setAvailableVariants] = useState<Variant[]>([]);
+    const [variantsLoadedForVulnId, setVariantsLoadedForVulnId] = useState<string | null>(null);
     const [allVulnAssessments, setAllVulnAssessments] = useState<Assessment[]>([]);
     const [selectedTargetVariantIds, setSelectedTargetVariantIds] = useState<string[]>([]);
     const [variantSnapshots, setVariantSnapshots] = useState<VariantScopedSnapshot[]>([]);
@@ -159,21 +160,27 @@ type VariantScopedSnapshot = {
     // Fetch variants that have a finding for this specific vulnerability,
     // filtered to the current project when a projectId is provided.
     useEffect(() => {
+        const controller = new AbortController();
         setAvailableVariants([]);
-        Variants.listByVuln(vuln.id).then(variants => {
+        setVariantsLoadedForVulnId(null);
+        Variants.listByVuln(vuln.id, controller.signal).then(variants => {
+            if (controller.signal.aborted) return;
             if (projectId) {
                 setAvailableVariants(variants.filter(v => v.project_id === projectId));
             } else {
                 setAvailableVariants(variants);
             }
+            setVariantsLoadedForVulnId(vuln.id);
         }).catch(() => {});
+        return () => controller.abort();
     }, [vuln.id, projectId]);
 
     // Fetch ALL assessments for this vuln (unfiltered) so variant tags are
     // complete even when a variant filter is active in the explorer.
     useEffect(() => {
+        const controller = new AbortController();
         setAllVulnAssessments([]);
-        fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/assessments`, { mode: 'cors' })
+        fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/assessments`, { mode: 'cors', signal: controller.signal })
             .then(r => r.json())
             .then((data: any[]) => {
                 if (Array.isArray(data)) {
@@ -181,6 +188,7 @@ type VariantScopedSnapshot = {
                 }
             })
             .catch(() => {});
+        return () => controller.abort();
     }, [vuln.id]);
 
     // In all-variants mode, default to all variant targets for custom CVSS/time edits.
@@ -192,12 +200,21 @@ type VariantScopedSnapshot = {
         setSelectedTargetVariantIds(availableVariants.map(v => v.id));
     }, [variantId, vuln.id, availableVariants]);
 
+    const variantIdsKey = useMemo(
+        () => availableVariants.map(v => v.id).sort().join(','),
+        [availableVariants]
+    );
+
     // Build per-variant snapshots so the modal can show where custom CVSS and
     // effort differ across variants directly in all-variants mode.
     useEffect(() => {
-        let cancelled = false;
+        const controller = new AbortController();
+        const signal = controller.signal;
         if (variantId || availableVariants.length === 0) {
             setVariantSnapshots([]);
+            return;
+        }
+        if (variantsLoadedForVulnId !== vuln.id) {
             return;
         }
 
@@ -212,14 +229,14 @@ type VariantScopedSnapshot = {
                 if (projectId) {
                     url.searchParams.set('project_id', projectId);
                 }
-                const response = await fetch(url.toString(), { mode: 'cors' });
+                const response = await fetch(url.toString(), { mode: 'cors', signal });
                 if (!response.ok) {
-                    if (!cancelled) setVariantSnapshots([]);
+                    if (!signal.aborted) setVariantSnapshots([]);
                     return;
                 }
                 const data = await response.json();
                 if (!Array.isArray(data)) {
-                    if (!cancelled) setVariantSnapshots([]);
+                    if (!signal.aborted) setVariantSnapshots([]);
                     return;
                 }
 
@@ -253,23 +270,30 @@ type VariantScopedSnapshot = {
                         };
                     });
 
-                if (!cancelled) {
+                if (!signal.aborted) {
                     setVariantSnapshots(snapshots);
                 }
             } catch {
-                if (!cancelled) setVariantSnapshots([]);
+                if (!signal.aborted) setVariantSnapshots([]);
             }
         })();
 
-        return () => { cancelled = true; };
-    }, [variantId, availableVariants, vuln.id, projectId, snapshotVersion]);
+        return () => { controller.abort(); };
+    // availableVariants is read inside but the fetch is intentionally keyed off
+    // the stable variantIdsKey memo, not the array identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [variantId, variantIdsKey, variantsLoadedForVulnId, vuln.id, projectId, snapshotVersion]);
 
     useEffect(() => {
-        let cancelled = false;
+        const controller = new AbortController();
+        const signal = controller.signal;
         setVariantPackageMapLoaded(false);
         if (availableVariants.length === 0) {
             setVariantPackageMap({});
             setVariantPackageMapLoaded(true);
+            return;
+        }
+        if (variantsLoadedForVulnId !== vuln.id) {
             return;
         }
         (async () => {
@@ -281,7 +305,7 @@ type VariantScopedSnapshot = {
                 if (projectId) {
                     url.searchParams.set('project_id', projectId);
                 }
-                const response = await fetch(url.toString(), { mode: 'cors' });
+                const response = await fetch(url.toString(), { mode: 'cors', signal });
                 const data = response.ok ? await response.json() : [];
                 const map: Record<string, string[]> = {};
                 if (Array.isArray(data)) {
@@ -291,19 +315,22 @@ type VariantScopedSnapshot = {
                         }
                     }
                 }
-                if (!cancelled) {
+                if (!signal.aborted) {
                     setVariantPackageMap(map);
                     setVariantPackageMapLoaded(true);
                 }
             } catch {
-                if (!cancelled) {
+                if (!signal.aborted) {
                     setVariantPackageMap({});
                     setVariantPackageMapLoaded(true);
                 }
             }
         })();
-        return () => { cancelled = true; };
-    }, [availableVariants, vuln.id, projectId]);
+        return () => { controller.abort(); };
+    // availableVariants.length is read inside but the fetch is intentionally
+    // keyed off the stable variantIdsKey memo, not the array identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [variantIdsKey, variantsLoadedForVulnId, vuln.id, projectId]);
 
     const [hasTimeChanges, setHasTimeChanges] = useState(false);
     const [hasAssessmentChanges, setHasAssessmentChanges] = useState(false);

--- a/frontend/src/handlers/variant.ts
+++ b/frontend/src/handlers/variant.ts
@@ -66,10 +66,10 @@ class Variants {
         ) as Variant[];
     }
 
-    static async listByVuln(vulnId: string): Promise<Variant[]> {
+    static async listByVuln(vulnId: string, signal?: AbortSignal): Promise<Variant[]> {
         const response = await fetch(
             import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vulnId)}/variants`,
-            { mode: "cors" }
+            { mode: "cors", signal }
         );
         if (!response.ok) return [];
         const data = await response.json();

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -254,10 +254,41 @@ describe('EditAssessment Component', () => {
             justification: undefined,
             status_notes: 'test notes',
             workaround: 'test workaround',
-            impact_statement: '',
+            // The impact statement (reasoning) must be preserved for false_positive,
+            // not wiped, since the impact textarea is shown and editable for it.
+            impact_statement: 'test impact',
             packages: [],
             variant_ids: undefined
         });
+    });
+
+    test('preserves an edited impact statement for false_positive status', async () => {
+        const fpAssessment: Assessment = {
+            ...mockAssessment,
+            status: 'false_positive',
+            impact_statement: 'original reason'
+        };
+
+        render(
+            <EditAssessment
+                assessment={fpAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+            />
+        );
+
+        const user = userEvent.setup();
+        const impactField = screen.getByPlaceholderText(/Why this vulnerability is not exploitable/i);
+        await user.clear(impactField);
+        await user.type(impactField, 'updated reason');
+
+        await user.click(screen.getByText('Save Changes'));
+
+        expect(mockOnSave).toHaveBeenCalledWith(expect.objectContaining({
+            status: 'false_positive',
+            impact_statement: 'updated reason',
+            justification: undefined,
+        }));
     });
 
     test('modifies input fields and detects changes', async () => {

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2035,6 +2035,127 @@ describe('Vulnerability Modal', () => {
         expect(patchVuln).toHaveBeenCalled();
     });
 
+    test('recomputes the status summary after deleting an assessment', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce('', { status: 200 }); // DELETE response
+
+        const patchVuln = jest.fn();
+        // Two variants with different statuses: deleting the "Exploitable" one
+        // must leave a summary dominated by the remaining "Not affected" variant.
+        const vulnWithTwoVariants = {
+            ...vulnerability,
+            simplified_status: 'Exploitable',
+            assessments: [
+                {
+                    id: 'assess-not-affected',
+                    vuln_id: 'CVE-2010-1234',
+                    packages: ['aaabbbccc@1.0.0'],
+                    status: 'not_affected',
+                    simplified_status: 'Not affected',
+                    justification: 'vulnerable_code_not_present',
+                    impact_statement: '',
+                    status_notes: '',
+                    workaround: '',
+                    timestamp: '2021-01-01T00:00:00Z',
+                    origin: 'custom',
+                    responses: [],
+                    variant_id: 'var-1'
+                },
+                {
+                    id: 'assess-exploitable',
+                    vuln_id: 'CVE-2010-1234',
+                    packages: ['aaabbbccc@1.0.0'],
+                    status: 'affected',
+                    simplified_status: 'Exploitable',
+                    justification: '',
+                    impact_statement: '',
+                    status_notes: '',
+                    workaround: '',
+                    timestamp: '2021-06-01T00:00:00Z',
+                    origin: 'custom',
+                    responses: [],
+                    variant_id: 'var-2'
+                }
+            ]
+        };
+
+        render(<VulnModal vuln={vulnWithTwoVariants} isEditing={true} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={patchVuln} />);
+
+        const user = userEvent.setup();
+        // The most recent group (var-2 / Exploitable) sorts first in the history.
+        const deleteBtns = screen.getAllByTitle(/delete assessment/i);
+        await user.click(deleteBtns[0]);
+        await user.click(screen.getByText(/yes, delete/i));
+
+        await screen.findByText(/assessment deleted successfully/i);
+
+        // The recomputed summary drops the deleted variant and reflects the
+        // remaining "Not affected" assessment (no active status left).
+        expect(patchVuln).toHaveBeenCalledWith('CVE-2010-1234', expect.objectContaining({
+            simplified_status: 'Not affected',
+            status_summary: expect.objectContaining({
+                dominant_status: 'Not affected',
+                has_active_status: false,
+                total_assessments: 1,
+            }),
+        }));
+    });
+
+    test('breaks down the current status by variant and package', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'var-1', name: 'Production', project_id: 'proj1' }
+        ]));
+        // A single variant with an assessment on the active package plus an
+        // assessment on an older package version that is no longer shipped.
+        fetchMock.mockResponseOnce(JSON.stringify([
+            {
+                id: 'assess-current', vuln_id: 'CVE-2010-1234', packages: ['pkgA@1.0.0'],
+                status: 'affected', simplified_status: 'Exploitable', justification: '',
+                impact_statement: '', status_notes: '', workaround: '',
+                timestamp: '2025-06-01T00:00:00Z', origin: 'custom', responses: [], variant_id: 'var-1'
+            },
+            {
+                id: 'assess-old', vuln_id: 'CVE-2010-1234', packages: ['pkgOld@0.9.0'],
+                status: 'fixed', simplified_status: 'Fixed', justification: '',
+                impact_statement: '', status_notes: '', workaround: '',
+                timestamp: '2025-01-01T00:00:00Z', origin: 'custom', responses: [], variant_id: 'var-1'
+            }
+        ]));
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variant-snapshots
+        // Only pkgA is still active in the variant; pkgOld is deprecated.
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { variant_id: 'var-1', active_packages: ['pkgA@1.0.0'] }
+        ]));
+
+        const multiPkgVuln: Vulnerability = {
+            ...vulnerability,
+            packages: ['pkgA@1.0.0'],
+            packages_current: [],
+            assessments: [],
+        };
+
+        render(<VulnModal vuln={multiPkgVuln} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} projectId="proj1" />);
+
+        // Wait for the deprecated split to appear once variant-active-packages loads.
+        const deprecatedHeading = await screen.findByText('Deprecated assessments');
+        const deprecated = deprecatedHeading.parentElement as HTMLElement;
+        // The stale package version is broken out into the deprecated table.
+        expect(within(deprecated).getByText('pkgOld@0.9.0')).toBeInTheDocument();
+        expect(within(deprecated).getByText('Fixed')).toBeInTheDocument();
+        expect(within(deprecated).queryByText('pkgA@1.0.0')).not.toBeInTheDocument();
+
+        // The active (variant, package) pair stays in the current table.
+        const current = screen.getByText('Current assessments').parentElement as HTMLElement;
+        expect(within(current).getByText('pkgA@1.0.0')).toBeInTheDocument();
+        expect(within(current).getByText('Exploitable')).toBeInTheDocument();
+        expect(within(current).queryByText('pkgOld@0.9.0')).not.toBeInTheDocument();
+        // Production appears as the variant tag in the current table.
+        expect(within(current).getByText('Production')).toBeInTheDocument();
+    });
+
     test('adding assessment to multiple variants shows multi-variant success message', async () => {
         fetchMock.resetMocks();
         // Variants endpoint returns two variants
@@ -2044,8 +2165,7 @@ describe('Vulnerability Modal', () => {
         ]));
         fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
         fetchMock.mockResponseOnce(JSON.stringify([])); // batch variant snapshots (single fetch)
-        fetchMock.mockResponseOnce(JSON.stringify([])); // packages fetch for v1 (variantPackageMap effect)
-        fetchMock.mockResponseOnce(JSON.stringify([])); // packages fetch for v2 (variantPackageMap effect)
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variant-active-packages (single request for variantPackageMap)
         // Single batch POST returns one record per (package, variant) pair
         fetchMock.mockResponseOnce(JSON.stringify({
             status: 'success',
@@ -2212,10 +2332,17 @@ describe('Vulnerability Modal', () => {
                 timestamp: '2025-01-01T00:00:00Z', origin: 'custom', responses: [], variant_id: 'var-2'
             }
         ]));
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variant-snapshots
+        // Both variants still ship the affected package, so their rows stay in
+        // the current (non-deprecated) table.
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { variant_id: 'var-1', active_packages: ['aaabbbccc@1.0.0'] },
+            { variant_id: 'var-2', active_packages: ['aaabbbccc@1.0.0'] }
+        ]));
 
         render(<VulnModal vuln={{ ...vulnerability, assessments: [] }} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
-        const recapHeading = await screen.findByText('Current status by variant');
+        const recapHeading = await screen.findByText('Current assessments');
         const recap = recapHeading.parentElement as HTMLElement;
         // Production reflects its most recent assessment (Not affected), not the older Exploitable
         expect(within(recap).getByText('Production')).toBeInTheDocument();
@@ -2240,10 +2367,17 @@ describe('Vulnerability Modal', () => {
                 timestamp: '2025-01-01T00:00:00Z', origin: 'custom', responses: [], variant_id: 'var-1'
             }
         ]));
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variant-snapshots
+        // Both variants still ship the affected package; var-2 has no assessment
+        // yet, so its row surfaces as "No status" in the current table.
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { variant_id: 'var-1', active_packages: ['aaabbbccc@1.0.0'] },
+            { variant_id: 'var-2', active_packages: ['aaabbbccc@1.0.0'] }
+        ]));
 
         render(<VulnModal vuln={{ ...vulnerability, assessments: [] }} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
-        const recapHeading = await screen.findByText('Current status by variant');
+        const recapHeading = await screen.findByText('Current assessments');
         const recap = recapHeading.parentElement as HTMLElement;
         // Staging has no assessment yet, so it is flagged as "No status"
         expect(within(recap).getByText('Staging')).toBeInTheDocument();
@@ -2566,18 +2700,16 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
 
     test('builds variantPackageMap and disables packages absent from the selected variant', async () => {
         fetchMock.resetMocks();
-        // Route fetches by URL so the per-variant package lookups resolve
-        // regardless of effect ordering.
+        // Route fetches by URL so the single variant-active-packages lookup
+        // resolves regardless of effect ordering.
         fetchMock.mockResponse((req) => {
             const url = req.url;
-            if (url.includes('/api/packages')) {
-                if (url.includes('variant_id=v1')) {
-                    return Promise.resolve(JSON.stringify([{ name: 'pkgA', version: '1.0.0' }]));
-                }
-                if (url.includes('variant_id=v2')) {
-                    return Promise.resolve(JSON.stringify([{ name: 'pkgB', version: '1.0.0' }]));
-                }
-                return Promise.resolve(JSON.stringify([]));
+            if (url.includes('/variant-active-packages')) {
+                // Single request returns each variant's active packages.
+                return Promise.resolve(JSON.stringify([
+                    { variant_id: 'v1', active_packages: ['pkgA@1.0.0'] },
+                    { variant_id: 'v2', active_packages: ['pkgB@1.0.0'] },
+                ]));
             }
             if (url.includes('/variants') && !url.includes('/variant-snapshots')) {
                 // Variants.listByVuln
@@ -2633,8 +2765,8 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         fetchMock.resetMocks();
         fetchMock.mockResponse((req) => {
             const url = req.url;
-            if (url.includes('/api/packages')) {
-                // Simulate the package lookup failing for every variant.
+            if (url.includes('/variant-active-packages')) {
+                // Simulate the single active-packages lookup failing.
                 return Promise.reject(new Error('packages unavailable'));
             }
             if (url.includes('/variants') && !url.includes('/variant-snapshots')) {

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2806,7 +2806,68 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         expect(packageCheckbox('pkgA@1.0.0').disabled).toBe(false);
         expect(packageCheckbox('pkgB@1.0.0').disabled).toBe(false);
     });
+
+    test('navigating between vulns fetches each variant endpoint once per vuln', async () => {
+        fetchMock.resetMocks();
+        const counts: Record<string, number> = {
+            snapshots: 0,
+            activePackages: 0,
+            variants: 0,
+        };
+        fetchMock.mockResponse((req) => {
+            const url = req.url;
+            if (url.includes('/variant-snapshots')) {
+                counts.snapshots += 1;
+                return Promise.resolve(JSON.stringify([]));
+            }
+            if (url.includes('/variant-active-packages')) {
+                counts.activePackages += 1;
+                return Promise.resolve(JSON.stringify([]));
+            }
+            if (url.includes('/variants')) {
+                counts.variants += 1;
+                return Promise.resolve(JSON.stringify([
+                    { id: 'v1', name: 'Variant Alpha', project_id: 'proj1' },
+                ]));
+            }
+            // assessments and any other GETs
+            return Promise.resolve(JSON.stringify([]));
+        });
+
+        const vuln1: Vulnerability = { ...vulnerability, id: 'CVE-1000-0001' };
+        const vuln2: Vulnerability = { ...vulnerability, id: 'CVE-1000-0002' };
+
+        const { rerender } = render(
+            <VulnModal vuln={vuln1} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} projectId="proj1" />
+        );
+
+        // Wait until the first vuln has resolved its variant-derived endpoints.
+        await waitFor(() => {
+            expect(counts.snapshots).toBe(1);
+            expect(counts.activePackages).toBe(1);
+        });
+
+        // Navigate to the next vuln (arrow navigation changes the prop, no remount).
+        rerender(
+            <VulnModal vuln={vuln2} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} projectId="proj1" />
+        );
+
+        // The second vuln must trigger exactly one more call to each endpoint —
+        // not two (which happened before the variantsLoadedForVulnId guard, when
+        // the effects fired once with the stale variant set and again after the
+        // new variants loaded).
+        await waitFor(() => {
+            expect(counts.snapshots).toBe(2);
+            expect(counts.activePackages).toBe(2);
+        });
+
+        // Give any erroneous stale-set fetch a chance to land, then assert it did not.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(counts.snapshots).toBe(2);
+        expect(counts.activePackages).toBe(2);
+    });
 });
+
 
 // ---------------------------------------------------------------------------
 // Refresh button (NVD + EPSS for CVEs, GHSA for GHSA advisories)

--- a/src/helpers/active_scans.py
+++ b/src/helpers/active_scans.py
@@ -132,14 +132,25 @@ def active_sbom_scan_ids_for_project(project_uuid: uuid.UUID) -> list[uuid.UUID]
 # Active package IDs (from SBOM scans only)
 # ------------------------------------------------------------------
 
-def active_package_ids_for_scans(scan_ids: list[uuid.UUID]) -> set[uuid.UUID]:
+def active_package_ids_for_scans(
+    scan_ids: list[uuid.UUID],
+    restrict_to_package_ids: set[uuid.UUID] | None = None,
+) -> set[uuid.UUID]:
     """Return the set of package IDs present in the SBOM documents of *scan_ids*.
 
     Packages listed by SBOM scans form the "active" package set.
     Tool-scan findings for packages outside this set are stale
     (the package was upgraded or removed) and should be excluded.
+
+    When *restrict_to_package_ids* is provided, only those package IDs are
+    considered — the query filters on them in SQL instead of loading the whole
+    SBOM package set into memory. Callers that only need to test membership of
+    a small, known set of packages should pass it to avoid fetching thousands
+    of rows per scan.
     """
     if not scan_ids:
+        return set()
+    if restrict_to_package_ids is not None and not restrict_to_package_ids:
         return set()
     # Filter to SBOM-type scans only
     sbom_scan_ids = [
@@ -153,10 +164,13 @@ def active_package_ids_for_scans(scan_ids: list[uuid.UUID]) -> set[uuid.UUID]:
     ]
     if not sbom_scan_ids:
         return set()
-    rows = db.session.execute(
+    query = (
         db.select(SBOMPackage.package_id)
         .join(SBOMDocument, SBOMDocument.id == SBOMPackage.sbom_document_id)
         .where(SBOMDocument.scan_id.in_(sbom_scan_ids))
         .distinct()
-    ).all()
+    )
+    if restrict_to_package_ids is not None:
+        query = query.where(SBOMPackage.package_id.in_(restrict_to_package_ids))
+    rows = db.session.execute(query).all()
     return {r[0] for r in rows}

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -582,6 +582,58 @@ def init_app(app: Flask) -> None:
                     })
         return variants_out, 200
 
+    @app.route('/api/vulnerabilities/<vuln_id>/variant-active-packages')
+    def list_variant_active_packages(vuln_id: str) -> ResponseReturnValue:
+        """For each variant affected by this vulnerability, return the subset of
+        the vulnerability's packages still present in that variant's active SBOM.
+
+        Lets the front-end classify deprecated (variant, package) pairs in a
+        single request instead of one ``/api/packages`` call per variant.
+        """
+        from ..models.observation import Observation
+        from ..models.scan import Scan
+        from ..models.variant import Variant as DBVariant
+        from ..helpers.active_scans import (
+            active_sbom_scan_ids_for_variant,
+            active_package_ids_for_scans,
+        )
+
+        project_uuid: UUID | None = None
+        project_id = request.args.get('project_id')
+        if project_id:
+            project_uuid, err = parse_uuid_or_400(project_id, "project_id")
+            if err:
+                return err
+
+        findings = Finding.get_by_vulnerability(vuln_id)
+        # package_id -> string_id for the packages affected by this vulnerability
+        pkg_string_by_id: dict[UUID, str] = {}
+        for f in findings:
+            if f.package_id and f.package:
+                pkg_string_by_id[f.package_id] = f.package.string_id
+
+        # Distinct variants with a finding for this vuln (Observation -> Scan -> Variant)
+        seen_variant_ids: set[UUID] = set()
+        variant_ids: list[UUID] = []
+        for finding in findings:
+            for obs in Observation.get_by_finding(finding.id):
+                scan = db.session.get(Scan, obs.scan_id)
+                if scan is None or scan.variant_id in seen_variant_ids:
+                    continue
+                seen_variant_ids.add(scan.variant_id)
+                if project_uuid is not None:
+                    variant = db.session.get(DBVariant, scan.variant_id)
+                    if variant is None or variant.project_id != project_uuid:
+                        continue
+                variant_ids.append(scan.variant_id)
+
+        result = []
+        for vid in variant_ids:
+            active_ids = active_package_ids_for_scans(active_sbom_scan_ids_for_variant(vid))
+            active_packages = [sid for pid, sid in pkg_string_by_id.items() if pid in active_ids]
+            result.append({"variant_id": str(vid), "active_packages": active_packages})
+        return result, 200
+
     @app.route("/api/vulnerabilities/<vuln_id>/assessments", methods=["POST"])
     def add_assessment(vuln_id: str) -> ResponseReturnValue:
         payload_data = request.get_json()

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -628,8 +628,12 @@ def init_app(app: Flask) -> None:
                 variant_ids.append(scan.variant_id)
 
         result = []
+        vuln_pkg_ids = set(pkg_string_by_id.keys())
         for vid in variant_ids:
-            active_ids = active_package_ids_for_scans(active_sbom_scan_ids_for_variant(vid))
+            active_ids = active_package_ids_for_scans(
+                active_sbom_scan_ids_for_variant(vid),
+                restrict_to_package_ids=vuln_pkg_ids,
+            )
             active_packages = [sid for pid, sid in pkg_string_by_id.items() if pid in active_ids]
             result.append({"variant_id": str(vid), "active_packages": active_packages})
         return result, 200

--- a/tests/unit_tests/test_package_db.py
+++ b/tests/unit_tests/test_package_db.py
@@ -120,6 +120,57 @@ def test_active_package_ids_for_scans_returns_empty_for_empty_input(app):
     assert active_package_ids_for_scans([]) == set()
 
 
+def test_active_package_ids_for_scans_restrict_filters_to_requested(app):
+    """restrict_to_package_ids narrows the result to the requested package ids."""
+    from src.helpers.active_scans import active_package_ids_for_scans
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+
+    project = Project.create("restrict-proj")
+    variant = Variant.create("restrict-variant", project.id)
+    sbom_scan = Scan.create("sbom", variant.id, scan_type="sbom")
+    document = SBOMDocument.create("sbom.json", "test", sbom_scan.id)
+    pkg_a = Package.create("pkg-a", "1.0.0")
+    pkg_b = Package.create("pkg-b", "2.0.0")
+    SBOMPackage.create(document.id, pkg_a.id)
+    SBOMPackage.create(document.id, pkg_b.id)
+    _db.session.flush()
+
+    # Without restriction: both packages are active.
+    assert active_package_ids_for_scans([sbom_scan.id]) == {pkg_a.id, pkg_b.id}
+
+    # With restriction: only the requested (present) package is returned.
+    assert active_package_ids_for_scans(
+        [sbom_scan.id], restrict_to_package_ids={pkg_a.id}
+    ) == {pkg_a.id}
+
+    # A restriction listing a package absent from the SBOM yields an empty set.
+    absent = Package.create("pkg-c", "3.0.0")
+    assert active_package_ids_for_scans(
+        [sbom_scan.id], restrict_to_package_ids={absent.id}
+    ) == set()
+
+
+def test_active_package_ids_for_scans_restrict_empty_returns_empty(app):
+    """An empty restriction set short-circuits to an empty result."""
+    from src.helpers.active_scans import active_package_ids_for_scans
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+
+    project = Project.create("restrict-empty-proj")
+    variant = Variant.create("restrict-empty-variant", project.id)
+    sbom_scan = Scan.create("sbom", variant.id, scan_type="sbom")
+    document = SBOMDocument.create("sbom.json", "test", sbom_scan.id)
+    pkg = Package.create("pkg-x", "1.0.0")
+    SBOMPackage.create(document.id, pkg.id)
+    _db.session.flush()
+
+    assert active_package_ids_for_scans(
+        [sbom_scan.id], restrict_to_package_ids=set()
+    ) == set()
+
+
+
 def test_find_or_create_openembedded_collapses_into_blank_supplier(app):
     """An OpenEmbedded supplier resolves to the same row as the blank one."""
     pkg_oe = Package.find_or_create("busybox", "1.36.1", supplier="OpenEmbedded ()")

--- a/tests/webapp_tests/test_vuln_assess_coverage.py
+++ b/tests/webapp_tests/test_vuln_assess_coverage.py
@@ -110,6 +110,44 @@ class TestAssessmentsProjectIdPaths:
         assert resp.status_code == 400
 
 
+class TestVariantActivePackages:
+    """GET /api/vulnerabilities/<vuln_id>/variant-active-packages."""
+
+    def test_returns_list_per_variant(self, client):
+        """Real vuln → list of {variant_id, active_packages} entries."""
+        resp = client.get("/api/vulnerabilities/CVE-2020-35492/variant-active-packages")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert isinstance(data, list)
+        for entry in data:
+            assert isinstance(entry["variant_id"], str)
+            assert isinstance(entry["active_packages"], list)
+            assert all(isinstance(p, str) for p in entry["active_packages"])
+
+    def test_project_id_filter(self, client):
+        """project_id filters variants without error."""
+        proj_id = "11111111-1111-1111-1111-111111111111"
+        resp = client.get(
+            f"/api/vulnerabilities/CVE-2020-35492/variant-active-packages?project_id={proj_id}"
+        )
+        assert resp.status_code == 200
+        assert isinstance(json.loads(resp.data), list)
+
+    def test_invalid_project_id(self, client):
+        """Invalid project UUID → 400."""
+        resp = client.get(
+            "/api/vulnerabilities/CVE-2020-35492/variant-active-packages?project_id=not-a-uuid"
+        )
+        assert resp.status_code == 400
+
+    def test_unknown_vuln_returns_empty(self, client):
+        """Unknown vuln → empty list."""
+        resp = client.get("/api/vulnerabilities/CVE-0000-00000/variant-active-packages")
+        assert resp.status_code == 200
+        assert json.loads(resp.data) == []
+
+
+
 class TestAssessmentsExportCustomData:
     """Lines 597, 624, 627: export-custom-data endpoint."""
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Update VulnModal to add the package column in the recap of the current assessments
* Add a new array "Deprecated Assessments" for old assessments based on deprecated SBOM elements

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

<img width="1754" height="692" alt="image" src="https://github.com/user-attachments/assets/a2fa8a16-2587-4375-a2d0-df98be569911" />

<img width="1751" height="639" alt="image" src="https://github.com/user-attachments/assets/806ffb82-2755-4bcf-a334-73d9887cd0eb" />

