### PR TITLE
Add local database for NVD

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -760,6 +760,89 @@ Exports all visible scans, optionally filtered by variant or project.
 
 ---
 
+## NVD Refresh
+
+These endpoints update cached NVD data (description, CVSS scores, references) for vulnerabilities already present in the database. Unlike the NVD scan, refresh does not create new findings — it only enriches existing `Vulnerability` records.
+
+All refresh endpoints accept a `mode` field to select the NVD data source:
+
+- **`local`** (default) — reads from the local NVD-FKIE advisory database; no network calls, no API key needed.
+- **`api`** — queries the NVD REST API v2; requires network access and honours the `NVD_API_KEY` environment variable.
+
+### Refresh a Single CVE
+
+```
+POST /api/vulnerabilities/<cve_id>/nvd-refresh
+```
+
+Fetches NVD data for the given CVE and updates the stored description, CVSS scores, and references.
+
+**Request body:**
+```json
+{ "mode": "local" }
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | string | `"local"` (default) or `"api"`. |
+
+**Response:** Updated vulnerability object.
+
+**Error responses:**
+
+| Code | `error_code` | Condition |
+|------|--------------|-----------|
+| `503` | `unavailable` | Local mode: CVE not found in the local database. API mode: NVD API unreachable or returned no data. |
+| `429` | `rate_limited` | API mode only: NVD rate limit exceeded. |
+| `401`/`403` | `unauthorized` | API mode only: API key rejected by NVD. |
+
+### Bulk NVD Refresh
+
+```
+POST /api/vulnerabilities/bulk-nvd-refresh
+```
+
+Triggers an asynchronous bulk refresh of NVD data for a list of CVE IDs. Returns `202 Accepted` immediately and runs in a background thread.
+
+**Request body:**
+```json
+{
+  "cve_ids": ["CVE-2024-1234", "CVE-2024-5678"],
+  "mode": "local"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cve_ids` | array of strings | CVE identifiers to refresh. Must match the pattern `CVE-YYYY-NNNNN`. |
+| `mode` | string | `"local"` (default) — no rate limit cap. `"api"` — capped at 1000 CVEs per request. |
+
+**Response:** `202 Accepted`
+```json
+{ "status": "started", "total": 42 }
+```
+
+Returns `409 Conflict` if a bulk refresh is already in progress. Returns `400` if `cve_ids` is empty or contains no valid identifiers, or if `mode` is `"api"` and more than 1000 IDs are supplied.
+
+Progress can be polled via `GET /api/nvd/progress`.
+
+### Cancel Bulk NVD Refresh
+
+```
+POST /api/vulnerabilities/cancel-nvd-refresh
+```
+
+Requests cancellation of an in-progress bulk NVD refresh. The running refresh stops after completing its current CVE.
+
+**Response:**
+```json
+{ "status": "cancelled" }
+```
+
+Returns `404` if no refresh is currently running.
+
+---
+
 ## Scan Triggers
 
 These endpoints trigger asynchronous vulnerability scans for a specific variant. Each returns `202 Accepted` immediately; use the corresponding `/status` endpoint to poll progress.
@@ -807,7 +890,16 @@ Status values: `"idle"` (no scan started), `"running"`, `"done"`, `"error"`.
 POST /api/variants/<variant_id>/nvd-scan
 ```
 
-For every active package with CPE identifiers, queries the NVD CVE API and creates findings for any matched CVEs. Respects the `NVD_API_KEY` environment variable for higher rate limits.
+Triggers a CVE scan for the given variant. Supports two modes controlled by the `?mode` query parameter:
+
+- **`local`** (default) — uses the local NVD-FKIE advisory database via the sbom-cve-check engine; no network calls, no rate limits.
+- **`api`** — queries the NVD REST API v2 using CPE identifiers from packages; honours the `NVD_API_KEY` environment variable and rate limits.
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `mode` | string | `"local"` (default) or `"api"` — selects the NVD data source. |
 
 **Response:** `202 Accepted`
 ```json
@@ -820,7 +912,7 @@ For every active package with CPE identifiers, queries the NVD CVE API and creat
 GET /api/variants/<variant_id>/nvd-scan/status
 ```
 
-Same response shape as Grype status. `total` is the number of unique CPEs to query, `done_count` tracks progress.
+Same response shape as Grype status. In local mode `total` is the number of active packages; in API mode it is the number of unique CPEs to query. `done_count` advances per package or CPE respectively.
 
 ### Trigger OSV Scan
 
@@ -851,7 +943,7 @@ POST /api/variants/<variant_id>/sbom-cve-check-scan
 
 Runs a CVE scan powered by the sbom-cve-check engine. For every active package, the engine looks up candidate advisories from locally-cloned NVD-FKIE and CVEList V5 databases, applies product-name aliasing, evaluates version ranges locally, and records findings as a tool scan. No network calls are made during matching.
 
-The databases live at `SBOM_CVE_CHECK_DATABASES_DIR` inside the container (default: `/cache/vulnscout/sbom_cve_check_databases`, inside the cache volume next to `vulnscout.db`). Set `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` on the host to use a shared clone mounted at `/sbom_cve_check_databases` instead. Set `SBOM_CVE_CHECK_AUTO_UPDATE=1` to let the engine clone the databases on first use and fetch fresh advisories before every scan.
+The databases live at `SBOM_CVE_CHECK_DATABASES_DIR` inside the container (default: `/cache/vulnscout/local_databases`, inside the cache volume next to `vulnscout.db`). Set `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` on the host to use a shared clone mounted at `/local_databases` instead. Set `SBOM_CVE_CHECK_AUTO_UPDATE=1` to let the engine clone the databases on first use and fetch fresh advisories before every scan.
 
 **Response:** `202 Accepted`
 ```json

--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -136,7 +136,7 @@ The following paths inside the container are relevant:
 | `/scan/src/views/templates/` | Built-in report templates |
 | `/cache/vulnscout/vulnscout.db` | SQLite database |
 | `/etc/vulnscout/config.env` | Persistent configuration file |
-| `/cache/vulnscout/sbom_cve_check_databases/` | Local sbom-cve-check advisory database clones (NVD-FKIE + CVEList), stored inside the cache volume next to `vulnscout.db`. Override the host path with `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` (then mounted at `/sbom_cve_check_databases`) |
+| `/cache/vulnscout/local_databases/` | Local sbom-cve-check advisory database clones (NVD-FKIE + CVEList), stored inside the cache volume next to `vulnscout.db`. Override the host path with `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` (then mounted at `/local_databases`) |
 | `/scan/status.txt` | Scan progress status (used by the web UI) |
 
 ---
@@ -178,7 +178,7 @@ docker exec vulnscout /scan/src/entrypoint.sh \
   --perform-sbom-cve-check-scan
 ```
 
-> By default the sbom-cve-check databases live in `/cache/vulnscout/sbom_cve_check_databases` (inside the cache volume, next to `vulnscout.db`); set `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` to use a shared host clone mounted at `/sbom_cve_check_databases` instead. With `SBOM_CVE_CHECK_AUTO_UPDATE=1` the databases are cloned automatically on first use and refreshed before every scan.
+> By default the sbom-cve-check databases live in `/cache/vulnscout/local_databases` (inside the cache volume, next to `vulnscout.db`); set `$VULNSCOUT_SBOM_CVE_CHECK_DB_DIR` to use a shared host clone mounted at `/local_databases` instead. With `SBOM_CVE_CHECK_AUTO_UPDATE=1` the databases are cloned automatically on first use and refreshed before every scan.
 
 **Set persistent configuration:**
 ```bash

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -585,7 +585,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                                                         onChange={() => setNvdRefreshMode("local")}
                                                         className="accent-cyan-500"
                                                     />
-                                                    <span className="text-neutral-200">Local</span>
+                                                    <span className="text-neutral-200">Git repository</span>
                                                 </label>
                                                 <label className="flex items-center gap-1.5 cursor-pointer text-xs">
                                                     <input

--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -47,6 +47,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
     const [euvdCancelling, setEuvdCancelling] = useState<boolean>(false)
     const [refreshMenuOpen, setRefreshMenuOpen] = useState<boolean>(false)
     const [selectedRefreshTypes, setSelectedRefreshTypes] = useState<Set<'nvd' | 'epss' | 'ghsa' | 'euvd'>>(new Set(['nvd', 'epss', 'ghsa', 'euvd']))
+    const [nvdRefreshMode, setNvdRefreshMode] = useState<"local" | "api">("local")
     const refreshMenuRef = useRef<HTMLDivElement>(null)
     const loadingLabel = selectedVulns.length === 1 ? 'Editing selected CVE...' : 'Editing selected CVEs...'
     const hasSelection = selectedVulns.length >= 1
@@ -135,7 +136,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
         const promises: Promise<void>[] = [];
         if (selectedRefreshTypes.has('nvd') && !nvdInProgress && hasCveIds) {
             promises.push(
-                BulkNvdRefreshHandler.trigger(selectedCveIds).then(res => {
+                BulkNvdRefreshHandler.trigger(selectedCveIds, nvdRefreshMode).then(res => {
                     if (res) triggerBanner(`NVD refresh started for ${res.total} CVE(s)`, 'success', 'nvd', true);
                     else triggerBanner('Failed to start NVD refresh', 'error', 'nvd');
                 }).catch(() => triggerBanner('Failed to start NVD refresh', 'error', 'nvd'))
@@ -569,6 +570,37 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                                             >{nvdCancelling ? 'Cancelling…' : 'Cancel'}</button>
                                         )}
                                     </div>
+
+                                    {/* NVD data source radio (shown when NVD is selected and not in progress) */}
+                                    {selectedRefreshTypes.has('nvd') && !nvdInProgress && (
+                                        <div className="px-1 py-1.5 border-t border-sky-800/40 mt-1">
+                                            <div className="text-xs text-sky-300 mb-1">NVD data source:</div>
+                                            <div className="flex gap-3">
+                                                <label className="flex items-center gap-1.5 cursor-pointer text-xs">
+                                                    <input
+                                                        type="radio"
+                                                        name="nvd-refresh-mode"
+                                                        value="local"
+                                                        checked={nvdRefreshMode === "local"}
+                                                        onChange={() => setNvdRefreshMode("local")}
+                                                        className="accent-cyan-500"
+                                                    />
+                                                    <span className="text-neutral-200">Local</span>
+                                                </label>
+                                                <label className="flex items-center gap-1.5 cursor-pointer text-xs">
+                                                    <input
+                                                        type="radio"
+                                                        name="nvd-refresh-mode"
+                                                        value="api"
+                                                        checked={nvdRefreshMode === "api"}
+                                                        onChange={() => setNvdRefreshMode("api")}
+                                                        className="accent-cyan-500"
+                                                    />
+                                                    <span className="text-neutral-200">NVD REST API</span>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    )}
 
                                     {/* EPSS row */}
                                     <div className="flex items-center justify-between py-1 px-1 rounded hover:bg-sky-900/40">

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -343,6 +343,7 @@ type VariantScopedSnapshot = {
     const [refreshing, setRefreshing] = useState(false);
     const [refreshError, setRefreshError] = useState<string | null>(null);
     const [refreshedList, setRefreshedList] = useState<string[]>([]);
+    const [nvdMode, setNvdMode] = useState<"local" | "api">("local");
 
     const modalRef = useRef<HTMLDivElement>(null);
     const shortcutButtonRef = useRef<HTMLButtonElement>(null);
@@ -458,7 +459,7 @@ type VariantScopedSnapshot = {
                 }
             } else {
                 const [nvdResult, epssResult] = await Promise.allSettled([
-                    NvdRefreshHandler.triggerSingleRefresh(vuln.id),
+                    NvdRefreshHandler.triggerSingleRefresh(vuln.id, nvdMode),
                     EpssRefreshHandler.triggerSingleRefresh(vuln.id),
                 ]);
 
@@ -470,8 +471,12 @@ type VariantScopedSnapshot = {
                         errors.push(nvdValue.apiKeyConfigured
                             ? "NVD rate-limited. Your NVD API key may be exhausted, please try again later."
                             : "NVD rate-limited. Set NVD API key in settings to reduce throttling.");
+                    } else if (nvdValue?.kind === "error" && nvdValue.code === "unauthorized") {
+                        errors.push("NVD API key rejected. Check your key in Settings.");
                     } else {
-                        errors.push("NVD API unavailable");
+                        errors.push(nvdMode === "api"
+                            ? "NVD API unavailable. Try again or switch to Local mode."
+                            : "NVD data unavailable. Try again or run an sbom-cve-check scan.");
                     }
                 }
                 if (epssResult.status === "rejected" || epssResult.value === null) {
@@ -514,7 +519,7 @@ type VariantScopedSnapshot = {
         } finally {
             setRefreshing(false);
         }
-    }, [vuln, patchVuln]);
+    }, [vuln, patchVuln, nvdMode]);
 
     const handleEditAssessment = (assessmentId: string, group: AssessmentGroup) => {
         setEditingAssessmentId(assessmentId);
@@ -1308,7 +1313,36 @@ type VariantScopedSnapshot = {
                             </div>
 
                             {!readOnly && (
-                                <div className="flex items-center gap-2">
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    {!isGhsaVuln && (
+                                        <span className="flex items-center gap-1.5 text-xs text-gray-400">
+                                            NVD source:
+                                            <label className="flex items-center gap-1 cursor-pointer">
+                                                <input
+                                                    type="radio"
+                                                    name={`nvd-mode-${vuln.id}`}
+                                                    value="local"
+                                                    checked={nvdMode === "local"}
+                                                    onChange={() => setNvdMode("local")}
+                                                    disabled={refreshing}
+                                                    className="accent-cyan-500"
+                                                />
+                                                <span className="text-gray-300">Local</span>
+                                            </label>
+                                            <label className="flex items-center gap-1 cursor-pointer">
+                                                <input
+                                                    type="radio"
+                                                    name={`nvd-mode-${vuln.id}`}
+                                                    value="api"
+                                                    checked={nvdMode === "api"}
+                                                    onChange={() => setNvdMode("api")}
+                                                    disabled={refreshing}
+                                                    className="accent-cyan-500"
+                                                />
+                                                <span className="text-gray-300">API</span>
+                                            </label>
+                                        </span>
+                                    )}
                                     <button
                                         onClick={handleRefresh}
                                         disabled={refreshing}

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -1334,7 +1334,7 @@ type VariantScopedSnapshot = {
                                                     disabled={refreshing}
                                                     className="accent-cyan-500"
                                                 />
-                                                <span className="text-gray-300">Local</span>
+                                                <span className="text-gray-300">Git repository</span>
                                             </label>
                                             <label className="flex items-center gap-1 cursor-pointer">
                                                 <input

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -289,8 +289,15 @@ type VariantScopedSnapshot = {
         const signal = controller.signal;
         setVariantPackageMapLoaded(false);
         if (availableVariants.length === 0) {
-            setVariantPackageMap({});
-            setVariantPackageMapLoaded(true);
+            // Only mark as loaded once we know variants have been resolved.
+            // If variants are still loading (variantsLoadedForVulnId !== vuln.id),
+            // keep variantPackageMapLoaded = false to avoid a premature
+            // "all packages deprecated" flash when the map is empty but
+            // variants haven't arrived yet.
+            if (variantsLoadedForVulnId === vuln.id) {
+                setVariantPackageMap({});
+                setVariantPackageMapLoaded(true);
+            }
             return;
         }
         if (variantsLoadedForVulnId !== vuln.id) {

--- a/frontend/src/handlers/bulkRefresh.ts
+++ b/frontend/src/handlers/bulkRefresh.ts
@@ -12,14 +12,14 @@ export interface BulkRefreshResponse {
 }
 
 export class BulkNvdRefreshHandler {
-    static async trigger(cveIds: string[]): Promise<BulkRefreshResponse | null> {
+    static async trigger(cveIds: string[], mode: "local" | "api" = "local"): Promise<BulkRefreshResponse | null> {
         const url = `${import.meta.env.VITE_API_URL}/api/vulnerabilities/bulk-nvd-refresh`;
         try {
             const response = await fetch(url, {
                 method: "POST",
                 mode: "cors",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ cve_ids: cveIds }),
+                body: JSON.stringify({ cve_ids: cveIds, mode }),
             });
             if (!response.ok) return null;
             return response.json().catch(() => null);

--- a/frontend/src/handlers/nvdRefresh.ts
+++ b/frontend/src/handlers/nvdRefresh.ts
@@ -14,9 +14,17 @@ export type NvdRefreshError = {
 export type NvdRefreshResult = NvdRefreshSuccess | NvdRefreshError;
 
 class NvdRefreshHandler {
-    static async triggerSingleRefresh(cveId: string): Promise<NvdRefreshResult> {
+    static async triggerSingleRefresh(
+        cveId: string,
+        mode: "local" | "api" = "local",
+    ): Promise<NvdRefreshResult> {
         const url = `${import.meta.env.VITE_API_URL}/api/vulnerabilities/${encodeURIComponent(cveId)}/nvd-refresh`;
-        const response = await fetch(url, { method: "POST", mode: "cors" });
+        const response = await fetch(url, {
+            method: "POST",
+            mode: "cors",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mode }),
+        });
         if (!response.ok) {
             const body = await response.json().catch(() => null);
             const code = body?.error_code === "rate_limited"

--- a/frontend/src/handlers/nvdScanState.ts
+++ b/frontend/src/handlers/nvdScanState.ts
@@ -10,7 +10,7 @@ import { ScanStateManager } from "./scanStateManager";
 export type { ScanEntryState as NvdState, ScanManagerSnapshot } from "./scanStateManager";
 
 const manager = new ScanStateManager(
-    (vid, opts) => ScansHandler.triggerNvdScan(vid, opts.excludeKernel ?? true),
+    (vid, opts) => ScansHandler.triggerNvdScan(vid, opts.excludeKernel ?? true, opts.nvdMode ?? "local"),
     (vid) => ScansHandler.getNvdScanStatus(vid),
     "NVD",
 );

--- a/frontend/src/handlers/scanStateManager.ts
+++ b/frontend/src/handlers/scanStateManager.ts
@@ -29,6 +29,8 @@ export type ScanManagerSnapshot = readonly ScanEntryState[];
 export type ScanTriggerOptions = {
     /** Exclude kernel companion packages from scanner inputs (default true). */
     excludeKernel?: boolean;
+    /** NVD data source: "local" (default) uses local NVD-FKIE DB; "api" uses NVD REST API. */
+    nvdMode?: "local" | "api";
 };
 
 // Status response shape returned by the backend polling endpoints

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -243,9 +243,9 @@ class ScansHandler {
         return await response.json();
     }
 
-    static async triggerNvdScan(variantId: string, excludeKernel: boolean = true): Promise<{ ok: boolean; error?: string }> {
+    static async triggerNvdScan(variantId: string, excludeKernel: boolean = true, nvdMode: "local" | "api" = "local"): Promise<{ ok: boolean; error?: string }> {
         const response = await fetch(
-            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/nvd-scan?exclude_kernel=${excludeKernel}`,
+            import.meta.env.VITE_API_URL + `/api/variants/${encodeURIComponent(variantId)}/nvd-scan?exclude_kernel=${excludeKernel}&mode=${nvdMode}`,
             { method: 'POST', mode: 'cors' }
         );
         if (response.ok || response.status === 202) return { ok: true };

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1124,6 +1124,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     // Scan options
     const [excludeKernel, setExcludeKernel] = useState(true);
     const [showKernelHelp, setShowKernelHelp] = useState(false);
+    const [nvdScanMode, setNvdScanMode] = useState<"local" | "api">("local");
     const scanMenuRef = useRef<HTMLDivElement>(null);
 
     // Global Grype scan state — survives tab switches (per-variant)
@@ -1327,7 +1328,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
             .map(v => ({ id: v.id, name: v.name }));
         if (variants.length === 0 || selectedScanTypes.size === 0) return;
         setScanMenuOpen(false);
-        const opts = { excludeKernel };
+        const opts = { excludeKernel, nvdMode: nvdScanMode };
         const promises: Promise<void>[] = [];
         if (selectedScanTypes.has('grype')) promises.push(triggerScan(variants, opts));
         if (selectedScanTypes.has('nvd')) promises.push(nvdTriggerScan(variants, opts));
@@ -1560,19 +1561,47 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                         { key: 'osv', label: 'OSV', icon: faLeaf, color: 'green' },
                                         { key: 'scc', label: 'sbom-cve-check', icon: faCrosshairs, color: 'sky' },
                                     ] as const).map(({ key, label, icon, color }) => (
-                                        <label
-                                            key={key}
-                                            className="flex items-center gap-2 py-1 px-1 rounded hover:bg-sky-900/40 cursor-pointer text-sm"
-                                        >
-                                            <input
-                                                type="checkbox"
-                                                checked={selectedScanTypes.has(key)}
-                                                onChange={() => toggleScanType(key)}
-                                                className="rounded accent-cyan-500"
-                                            />
-                                            <FontAwesomeIcon icon={icon} className={`text-${color}-400 w-4`} />
-                                            <span className="text-neutral-200">{label}</span>
-                                        </label>
+                                        <div key={key}>
+                                            <label className="flex items-center gap-2 py-1 px-1 rounded hover:bg-sky-900/40 cursor-pointer text-sm">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={selectedScanTypes.has(key)}
+                                                    onChange={() => toggleScanType(key)}
+                                                    className="rounded accent-cyan-500"
+                                                />
+                                                <FontAwesomeIcon icon={icon} className={`text-${color}-400 w-4`} />
+                                                <span className="text-neutral-200">{label}</span>
+                                            </label>
+                                            {key === 'nvd' && selectedScanTypes.has('nvd') && (
+                                                <div className="ml-6 mt-1 mb-1 pl-2 border-l border-orange-700/50">
+                                                    <div className="text-xs font-semibold text-sky-300 mb-1">NVD data source</div>
+                                                    <div className="flex gap-3">
+                                                        <label className="flex items-center gap-1.5 cursor-pointer text-sm">
+                                                            <input
+                                                                type="radio"
+                                                                name="nvd-scan-mode"
+                                                                value="local"
+                                                                checked={nvdScanMode === "local"}
+                                                                onChange={() => setNvdScanMode("local")}
+                                                                className="accent-cyan-500"
+                                                            />
+                                                            <span className="text-neutral-200">Local</span>
+                                                        </label>
+                                                        <label className="flex items-center gap-1.5 cursor-pointer text-sm">
+                                                            <input
+                                                                type="radio"
+                                                                name="nvd-scan-mode"
+                                                                value="api"
+                                                                checked={nvdScanMode === "api"}
+                                                                onChange={() => setNvdScanMode("api")}
+                                                                className="accent-cyan-500"
+                                                            />
+                                                            <span className="text-neutral-200">NVD REST API</span>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                            )}
+                                        </div>
                                     ))}
                                 </div>
 

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1585,7 +1585,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                                                                 onChange={() => setNvdScanMode("local")}
                                                                 className="accent-cyan-500"
                                                             />
-                                                            <span className="text-neutral-200">Local</span>
+                                                            <span className="text-neutral-200">Git repository</span>
                                                         </label>
                                                         <label className="flex items-center gap-1.5 cursor-pointer text-sm">
                                                             <input

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -10,7 +10,6 @@ import {
   faTriangleExclamation,
   faTrash,
   faXmark,
-  faKey,
   faPenToSquare,
   faBug,
 } from "@fortawesome/free-solid-svg-icons";
@@ -19,9 +18,8 @@ import type { Project } from "../handlers/project";
 import Variants from "../handlers/variant";
 import type { Variant } from "../handlers/variant";
 import Config from "../handlers/config";
-import ConfirmationModal from "../components/ConfirmationModal";
-import MessageBanner from "../components/MessageBanner";
 import NvdApiKey from "../handlers/nvdApiKey";
+import ConfirmationModal from "../components/ConfirmationModal";
 
 type Props = {
   onDataChanged?: (message?: string) => void;
@@ -64,6 +62,15 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
   const [grypeMemlimitInput, setGrypeMemlimitInput] = useState("");
   const [grypeMemlimitBusy, setGrypeMemlimitBusy] = useState(false);
   const [grypeMemlimitMsg, setGrypeMemlimitMsg] = useState<{ text: string; type: "success" | "error" } | null>(null);
+
+  // ---- NVD API Key ----
+  const [nvdKeyInput, setNvdKeyInput] = useState("");
+  const [nvdMaskedKey, setNvdMaskedKey] = useState("");
+  const [nvdHasKey, setNvdHasKey] = useState(false);
+  const [nvdBusy, setNvdBusy] = useState(false);
+  const [nvdMsg, setNvdMsg] = useState<{ text: string; type: "success" | "error" } | null>(null);
+  const [nvdEditing, setNvdEditing] = useState(false);
+  const [confirmRemoveNvdKey, setConfirmRemoveNvdKey] = useState(false);
 
   useEffect(() => {
     Config.get()
@@ -129,6 +136,68 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
   useEffect(() => {
     loadProjects();
   }, [loadProjects]);
+
+  // Load NVD API key status on mount
+  useEffect(() => {
+    NvdApiKey.get()
+      .then((data) => {
+        if (unmountedRef.current) return;
+        setNvdHasKey(data.has_key);
+        setNvdMaskedKey(data.masked_key);
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleSaveNvdKey = async () => {
+    if (nvdBusy || !nvdKeyInput.trim()) return;
+    setNvdBusy(true);
+    setNvdMsg(null);
+    try {
+      const result = await NvdApiKey.set(nvdKeyInput.trim());
+      if (unmountedRef.current) return;
+      if (!result.ok) {
+        setNvdMsg({ text: result.error ?? "Failed to save NVD API key.", type: "error" });
+      } else {
+        setNvdHasKey(result.has_key);
+        setNvdMaskedKey(result.masked_key);
+        setNvdKeyInput("");
+        setNvdEditing(false);
+        setNvdMsg({
+          text: result.warning ?? "NVD API key saved.",
+          type: result.warning ? "error" : "success",
+        });
+      }
+    } catch {
+      if (unmountedRef.current) return;
+      setNvdMsg({ text: "Failed to save NVD API key.", type: "error" });
+    } finally {
+      if (!unmountedRef.current) setNvdBusy(false);
+    }
+  };
+
+  const handleRemoveNvdKey = async () => {
+    setConfirmRemoveNvdKey(false);
+    setNvdBusy(true);
+    setNvdMsg(null);
+    try {
+      const result = await NvdApiKey.remove();
+      if (unmountedRef.current) return;
+      if (!result.ok) {
+        setNvdMsg({ text: result.error ?? "Failed to remove NVD API key.", type: "error" });
+      } else {
+        setNvdHasKey(false);
+        setNvdMaskedKey("");
+        setNvdKeyInput("");
+        setNvdEditing(false);
+        setNvdMsg({ text: "NVD API key removed.", type: "success" });
+      }
+    } catch {
+      if (unmountedRef.current) return;
+      setNvdMsg({ text: "Failed to remove NVD API key.", type: "error" });
+    } finally {
+      if (!unmountedRef.current) setNvdBusy(false);
+    }
+  };
 
   // ---- Manage Projects ----
   const [renameProjectId, setRenameProjectId] = useState<string>("");
@@ -370,68 +439,6 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
     }
   };
 
-  // ---- NVD API Key ----
-  const [nvdKeyInput, setNvdKeyInput] = useState("");
-  const [nvdMaskedKey, setNvdMaskedKey] = useState("");
-  const [nvdHasKey, setNvdHasKey] = useState(false);
-  const [nvdBusy, setNvdBusy] = useState(false);
-  const [nvdMsg, setNvdMsg] = useState<{ text: string; type: "success" | "error" } | null>(null);
-  const [nvdEditing, setNvdEditing] = useState(false);
-  const [confirmDeleteNvdKey, setConfirmDeleteNvdKey] = useState(false);
-
-  useEffect(() => {
-    NvdApiKey.get()
-      .then(data => {
-        setNvdHasKey(data.has_key);
-        setNvdMaskedKey(data.masked_key);
-      })
-      .catch((e) => {
-        console.error(e instanceof Error ? e.message : String(e));
-      });
-  }, []);
-
-  const handleSaveNvdKey = async () => {
-    setNvdBusy(true);
-    setNvdMsg(null);
-    try {
-      const data = await NvdApiKey.set(nvdKeyInput);
-      if (!data.ok) {
-        setNvdMsg({ text: data.error || "Failed to save API key", type: "error" });
-      } else {
-        setNvdHasKey(data.has_key);
-        setNvdMaskedKey(data.masked_key);
-        setNvdKeyInput("");
-        setNvdEditing(false);
-        setNvdMsg({ text: data.has_key ? "API key saved." : "API key removed.", type: "success" });
-      }
-    } catch (e) {
-      setNvdMsg({ text: e instanceof Error ? e.message : String(e), type: "error" });
-    } finally {
-      setNvdBusy(false);
-    }
-  };
-
-  const handleRemoveNvdKey = async () => {
-    setConfirmDeleteNvdKey(false);
-    setNvdBusy(true);
-    setNvdMsg(null);
-    try {
-      const data = await NvdApiKey.remove();
-      if (data.ok) {
-        setNvdHasKey(data.has_key);
-        setNvdMaskedKey(data.masked_key);
-        setNvdKeyInput("");
-        setNvdMsg({ text: "API key removed.", type: "success" });
-      } else {
-        setNvdMsg({ text: data.error || "Failed to remove API key", type: "error" });
-      }
-    } catch (e) {
-      setNvdMsg({ text: e instanceof Error ? e.message : String(e), type: "error" });
-    } finally {
-      setNvdBusy(false);
-    }
-  };
-
   // ---- Styles ----
   const inputClass =
     "w-full rounded px-2 py-1.5 text-sm bg-slate-900/60 border border-slate-600 text-white focus:outline-none focus:border-cyan-400";
@@ -590,82 +597,66 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         {/* ======== NVD API Key ======== */}
         <section aria-labelledby="settings-heading-nvd">
           <div className={cardHeader}>
-            <FontAwesomeIcon icon={faKey} className="text-cyan-400" aria-hidden="true" />
+            <FontAwesomeIcon icon={faFolderOpen} className="text-cyan-400" aria-hidden="true" />
             <h2 id="settings-heading-nvd" className="text-xl font-bold text-white">NVD API Key</h2>
           </div>
-          <div className={cardBody + " space-y-4"}>
+          <div className={cardBody + " space-y-3"}>
             <p id="nvd-key-description" className="text-zinc-400 text-sm">
-              An NVD API key increases the rate limit for vulnerability enrichment from 5 to 50 requests per 30 seconds.
-              Get a free key at{" "}
+              An NVD API key increases the rate limit for vulnerability enrichment from 5 to 50 requests per 30 seconds
+              when using NVD REST API mode. Required only when NVD data source is set to <strong>NVD REST API</strong>.{' '}
               <a
+                className="text-cyan-400 hover:text-cyan-300 underline"
                 href="https://nvd.nist.gov/developers/request-an-api-key"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-cyan-400 hover:text-cyan-300 underline"
               >
                 nvd.nist.gov
-              </a>.
+              </a>
             </p>
-
-            {/* -- Feedback -- */}
             {nvdMsg && (
-              <MessageBanner
-                type={nvdMsg.type}
-                message={nvdMsg.text}
-                isVisible={true}
-                onClose={() => setNvdMsg(null)}
-              />
+              <div className={`text-sm rounded px-3 py-2 ${nvdMsg.type === "success" ? "bg-green-900/40 text-green-300" : "bg-red-900/40 text-red-300"}`}>
+                {nvdMsg.text}
+              </div>
             )}
-
             {nvdHasKey && !nvdEditing ? (
-              <>
-                {/* -- Key is set: show masked key + modify / remove buttons -- */}
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-zinc-300">NVD API key:</span>
-                  <code className="text-sm text-zinc-300 bg-slate-900 px-2 py-0.5 rounded font-mono">{nvdMaskedKey}</code>
-                </div>
-
-                <div className="flex items-center gap-3 pt-1">
-                  <button
-                    onClick={() => { setNvdEditing(true); setNvdKeyInput(""); setNvdMsg(null); }}
-                    className={btnPrimary}
-                  >
-                    <FontAwesomeIcon icon={faPenToSquare} className="mr-1" aria-hidden="true" />
-                    Modify
-                  </button>
-                  <button
-                    onClick={() => setConfirmDeleteNvdKey(true)}
-                    disabled={nvdBusy}
-                    className="px-4 py-2 rounded-lg bg-red-900 hover:bg-red-800 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
-                  >
-                    <FontAwesomeIcon icon={faTrash} className="mr-1" aria-hidden="true" />
-                    Remove
-                  </button>
-                </div>
-              </>
+              <div className="flex items-center gap-3 flex-wrap">
+                <span className="text-sm text-zinc-300">NVD API key:</span>
+                <code className="text-sm text-zinc-300 bg-slate-900 px-2 py-0.5 rounded font-mono">{nvdMaskedKey}</code>
+                <button
+                  type="button"
+                  onClick={() => { setNvdEditing(true); setNvdMsg(null); }}
+                  disabled={nvdBusy}
+                  className={btnPrimary + " text-xs py-1 px-3"}
+                >
+                  Change
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmRemoveNvdKey(true)}
+                  disabled={nvdBusy}
+                  className="px-3 py-1 rounded text-xs font-semibold bg-red-800 hover:bg-red-700 text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  Remove
+                </button>
+              </div>
             ) : (
-              <>
-                {/* -- No key or editing: show input field -- */}
-                <div className="space-y-2">
-                  <label htmlFor="nvd-api-key-input" className="block text-sm text-zinc-300 font-semibold">
-                    {nvdEditing ? "New API Key" : "API Key"}
-                  </label>
-                  <input
-                    id="nvd-api-key-input"
-                    type="password"
-                    value={nvdKeyInput}
-                    onChange={e => setNvdKeyInput(e.target.value)}
-                    placeholder="Paste your NVD API key..."
-                    className={inputClass}
-                    disabled={nvdBusy}
-                    autoComplete="off"
-                    aria-required="true"
-                    aria-describedby="nvd-key-description"
-                  />
-                </div>
-
-                <div className="flex items-center gap-3 pt-1">
+              <div className="space-y-2">
+                <label htmlFor="nvd-api-key-input" className="block text-sm text-zinc-300 font-semibold">
+                  {nvdEditing ? "New API Key" : "API Key"}
+                </label>
+                <input
+                  id="nvd-api-key-input"
+                  type="password"
+                  value={nvdKeyInput}
+                  onChange={(e) => setNvdKeyInput(e.target.value)}
+                  placeholder="Paste your NVD API key..."
+                  className={inputClass}
+                  disabled={nvdBusy}
+                  aria-describedby="nvd-key-description"
+                />
+                <div className="flex items-center gap-2">
                   <button
+                    type="button"
                     onClick={handleSaveNvdKey}
                     disabled={nvdBusy || !nvdKeyInput.trim()}
                     className={btnPrimary}
@@ -676,24 +667,26 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
                     ) : (
                       <FontAwesomeIcon icon={faCheck} className="mr-1" aria-hidden="true" />
                     )}
-                    Save
+                    Save key
                   </button>
                   {nvdEditing && (
                     <button
+                      type="button"
                       onClick={() => { setNvdEditing(false); setNvdKeyInput(""); setNvdMsg(null); }}
-                      className="px-4 py-2 rounded-lg bg-slate-600 hover:bg-slate-500 text-white text-sm font-medium transition-colors duration-150"
+                      disabled={nvdBusy}
+                      className="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm font-semibold disabled:opacity-40 transition-colors"
                     >
-                      <FontAwesomeIcon icon={faXmark} className="mr-1" aria-hidden="true" />
                       Cancel
                     </button>
                   )}
                 </div>
-              </>
+              </div>
             )}
           </div>
         </section>
-        </>
-        )}
+
+        </>)
+        }
 
         {/* ======== Projects Settings tab ======== */}
         {activeTab === "projects" && (
@@ -1278,14 +1271,14 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         onCancel={() => setConfirmDeleteVariant(false)}
       />
       <ConfirmationModal
-        isOpen={confirmDeleteNvdKey}
+        isOpen={confirmRemoveNvdKey}
         title="Remove NVD API Key"
-        message="Are you sure you want to remove the NVD API key? Vulnerability enrichment will fall back to the lower rate limit."
-        confirmText="Yes, remove"
+        message="Are you sure you want to remove the NVD API key? Vulnerability enrichment will fall back to the lower rate limit when using NVD REST API mode."
+        confirmText="Remove"
         cancelText="Cancel"
         showTitleIcon={true}
         onConfirm={handleRemoveNvdKey}
-        onCancel={() => setConfirmDeleteNvdKey(false)}
+        onCancel={() => setConfirmRemoveNvdKey(false)}
       />
     </div>
   );

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -20,6 +20,7 @@ import type { Variant } from "../handlers/variant";
 import Config from "../handlers/config";
 import NvdApiKey from "../handlers/nvdApiKey";
 import ConfirmationModal from "../components/ConfirmationModal";
+import MessageBanner from "../components/MessageBanner";
 
 type Props = {
   onDataChanged?: (message?: string) => void;

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -457,13 +457,15 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     useRefreshProgressEffect(ghsaProgress, 'GHSA', prevGhsaInProgress, prevGhsaPhase, prevGhsaStartedAt, setGhsaBanner, onRefreshComplete, 'advisories');
     useRefreshProgressEffect(euvdProgress, 'EUVD', prevEuvdInProgress, prevEuvdPhase, prevEuvdStartedAt, setEuvdBanner, onRefreshComplete, 'CVEs');
 
-    const fetchAllProgress = useCallback(async () => {
-        const shouldPollGhsa = hasAnyGhsaVuln || Boolean(ghsaProgress?.in_progress);
+    const fetchAllProgress = useCallback(async (forceAll = false) => {
+        const shouldPollGhsa = forceAll || hasAnyGhsaVuln || Boolean(ghsaProgress?.in_progress);
+        const shouldPollEpss = forceAll || Boolean(epssProgress?.in_progress);
+        const shouldPollEuvd = forceAll || Boolean(euvdProgress?.in_progress);
         const [nvd, epss, ghsa, euvd] = await Promise.allSettled([
             NVDProgressHandler.getProgress(),
-            EPSSProgressHandler.getProgress(),
+            shouldPollEpss ? EPSSProgressHandler.getProgress() : Promise.resolve(null),
             shouldPollGhsa ? GHSAProgressHandler.getProgress() : Promise.resolve(null),
-            EUVDProgressHandler.getProgress(),
+            shouldPollEuvd ? EUVDProgressHandler.getProgress() : Promise.resolve(null),
         ]);
         if (nvd.status === 'fulfilled') setNvdProgress(nvd.value);
         else console.error('Failed to fetch NVD refresh progress:', nvd.reason);
@@ -473,13 +475,13 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         else console.error('Failed to fetch GHSA refresh progress:', ghsa.reason);
         if (euvd.status === 'fulfilled') setEuvdProgress(euvd.value);
         else console.error('Failed to fetch EUVD refresh progress:', euvd.reason);
-    }, [hasAnyGhsaVuln, ghsaProgress?.in_progress]);
+    }, [hasAnyGhsaVuln, ghsaProgress?.in_progress, epssProgress?.in_progress, euvdProgress?.in_progress]);
 
     // Fetch once on mount so we can recover progress if a refresh was already running.
     useEffect(() => {
         if (!hasFetchedProgressOnce.current) {
             hasFetchedProgressOnce.current = true;
-            void fetchAllProgress();
+            void fetchAllProgress(true);
         }
     }, [fetchAllProgress]);
 
@@ -516,7 +518,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
         // without idle background polling. This relies on an explicit flag
         // rather than parsing the user-facing banner text.
         if (source && refreshActivity) {
-            void fetchAllProgress();
+            void fetchAllProgress(true);
         }
     };
 

--- a/frontend/tests/handlers/bulkRefresh.test.ts
+++ b/frontend/tests/handlers/bulkRefresh.test.ts
@@ -38,7 +38,7 @@ describe("BulkNvdRefreshHandler.trigger", () => {
             expect.objectContaining({
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ cve_ids: cveIds }),
+                body: JSON.stringify({ cve_ids: cveIds, mode: "local" }),
             }),
         );
     });
@@ -526,5 +526,41 @@ describe("BulkEuvdRefreshCancelHandler.trigger", () => {
         } as unknown as Response);
         const result = await BulkEuvdRefreshCancelHandler.trigger();
         expect(result).toBeNull();
+    });
+});
+
+describe("BulkNvdRefreshHandler.trigger — mode parameter", () => {
+    it("sends mode:local by default", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkResponse({ status: "started", total: 1 }));
+        await BulkNvdRefreshHandler.trigger(["CVE-2024-0001"]);
+        const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.mode).toBe("local");
+    });
+
+    it("sends mode:api when explicitly passed", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkResponse({ status: "started", total: 1 }));
+        await BulkNvdRefreshHandler.trigger(["CVE-2024-0001"], "api");
+        const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.mode).toBe("api");
+    });
+
+    it("sends mode:local when explicitly passed", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkResponse({ status: "started", total: 1 }));
+        await BulkNvdRefreshHandler.trigger(["CVE-2024-0001"], "local");
+        const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.mode).toBe("local");
+    });
+
+    it("includes cve_ids and mode together in the body", async () => {
+        mockFetch.mockResolvedValueOnce(makeOkResponse({ status: "started", total: 2 }));
+        const ids = ["CVE-2024-0001", "CVE-2024-0002"];
+        await BulkNvdRefreshHandler.trigger(ids, "api");
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/vulnerabilities/bulk-nvd-refresh"),
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ cve_ids: ids, mode: "api" }),
+            }),
+        );
     });
 });

--- a/frontend/tests/handlers/nvdApiKey.test.ts
+++ b/frontend/tests/handlers/nvdApiKey.test.ts
@@ -1,0 +1,155 @@
+import NvdApiKey from "../../src/handlers/nvdApiKey";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as typeof fetch;
+
+beforeEach(() => {
+    mockFetch.mockReset();
+});
+
+describe("NvdApiKey.get", () => {
+    it("returns has_key:false and empty masked_key when server returns no key", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ has_key: false, masked_key: "" }),
+        } as Response);
+
+        const result = await NvdApiKey.get();
+        expect(result.has_key).toBe(false);
+        expect(result.masked_key).toBe("");
+    });
+
+    it("returns has_key:true and masked key when server has a key", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ has_key: true, masked_key: "abcd****mnop" }),
+        } as Response);
+
+        const result = await NvdApiKey.get();
+        expect(result.has_key).toBe(true);
+        expect(result.masked_key).toBe("abcd****mnop");
+    });
+
+    it("returns has_key:false on json() failure (fallback)", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            json: async () => { throw new Error("bad json"); },
+        } as unknown as Response);
+
+        const result = await NvdApiKey.get();
+        expect(result.has_key).toBe(false);
+        expect(result.masked_key).toBe("");
+    });
+
+    it("hits the correct URL", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ has_key: false, masked_key: "" }),
+        } as Response);
+
+        await NvdApiKey.get();
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/config/nvd-api-key"),
+            expect.objectContaining({ mode: "cors" }),
+        );
+    });
+});
+
+describe("NvdApiKey.set", () => {
+    it("returns ok:true, has_key:true and masked_key on success", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ status: "ok", has_key: true, masked_key: "abcd****mnop" }),
+        } as Response);
+
+        const result = await NvdApiKey.set("abcdefghijklmnop");
+        expect(result.ok).toBe(true);
+        expect(result.has_key).toBe(true);
+        expect(result.masked_key).toBe("abcd****mnop");
+    });
+
+    it("sends a PUT request with the api_key in the body", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ status: "ok", has_key: true, masked_key: "abcd****" }),
+        } as Response);
+
+        await NvdApiKey.set("test-api-key");
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/config/nvd-api-key"),
+            expect.objectContaining({
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ api_key: "test-api-key" }),
+            }),
+        );
+    });
+
+    it("returns ok:false and error message on 400", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 400,
+            json: async () => ({ error: "Invalid NVD API key" }),
+        } as Response);
+
+        const result = await NvdApiKey.set("bad-key");
+        expect(result.ok).toBe(false);
+        expect(result.error).toBe("Invalid NVD API key");
+    });
+
+    it("returns ok:false and no error on json() failure", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            json: async () => { throw new Error("server error"); },
+        } as unknown as Response);
+
+        const result = await NvdApiKey.set("some-key");
+        expect(result.ok).toBe(false);
+        expect(result.error).toBeUndefined();
+    });
+
+    it("returns warning when server includes one", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                status: "ok",
+                has_key: true,
+                masked_key: "abcd****",
+                warning: "Probe returned HTTP 503, key saved anyway",
+            }),
+        } as Response);
+
+        const result = await NvdApiKey.set("uncertain-key");
+        expect(result.ok).toBe(true);
+        expect(result.warning).toContain("503");
+    });
+});
+
+describe("NvdApiKey.remove", () => {
+    it("sends api_key:'' to remove the key", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ status: "ok", has_key: false, masked_key: "" }),
+        } as Response);
+
+        const result = await NvdApiKey.remove();
+        expect(result.ok).toBe(true);
+        expect(result.has_key).toBe(false);
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/config/nvd-api-key"),
+            expect.objectContaining({
+                method: "PUT",
+                body: JSON.stringify({ api_key: "" }),
+            }),
+        );
+    });
+});

--- a/frontend/tests/handlers/nvdRefresh.test.ts
+++ b/frontend/tests/handlers/nvdRefresh.test.ts
@@ -113,3 +113,111 @@ describe("NvdRefreshHandler.triggerSingleRefresh", () => {
         }
     });
 });
+
+describe("NvdRefreshHandler.triggerSingleRefresh — mode parameter", () => {
+    it("sends mode:local by default in the request body", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                vulnerabilities: [{
+                    id: "CVE-2024-0001",
+                    found_by: [], datasource: "nvd", namespace: "nvd",
+                    aliases: [], related_vulnerabilities: [], urls: [],
+                    texts: {}, fix: {},
+                    severity: { severity: "high", min_score: 8.1, max_score: 8.1, cvss: [] },
+                    epss: {}, effort: {}, advisories: [], packages: [],
+                }]
+            }),
+        } as Response);
+
+        await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001");
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/vulnerabilities/CVE-2024-0001/nvd-refresh"),
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({ mode: "local" }),
+            }),
+        );
+    });
+
+    it("sends mode:api when explicitly passed", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                vulnerabilities: [{
+                    id: "CVE-2024-0002",
+                    found_by: [], datasource: "nvd", namespace: "nvd",
+                    aliases: [], related_vulnerabilities: [], urls: [],
+                    texts: {}, fix: {},
+                    severity: { severity: "medium", min_score: 5.0, max_score: 5.0, cvss: [] },
+                    epss: {}, effort: {}, advisories: [], packages: [],
+                }]
+            }),
+        } as Response);
+
+        await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0002", "api");
+
+        const callArg = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+        expect(callArg.mode).toBe("api");
+    });
+
+    it("returns kind:error code:rate_limited on 429 in api mode", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 429,
+            json: async () => ({ error_code: "rate_limited", api_key_configured: true }),
+        } as Response);
+
+        const result = await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001", "api");
+        expect(result.kind).toBe("error");
+        if (result.kind === "error") {
+            expect(result.code).toBe("rate_limited");
+        }
+    });
+
+    it("returns kind:error code:unauthorized on 401 in api mode", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 401,
+            json: async () => ({ error_code: "unauthorized", api_key_configured: true }),
+        } as Response);
+
+        const result = await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001", "api");
+        expect(result.kind).toBe("error");
+        if (result.kind === "error") {
+            expect(result.code).toBe("unauthorized");
+        }
+    });
+
+    it("returns kind:error code:unavailable on 503 in api mode", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 503,
+            json: async () => ({ error_code: "unavailable", api_key_configured: false }),
+        } as Response);
+
+        const result = await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001", "api");
+        expect(result.kind).toBe("error");
+        if (result.kind === "error") {
+            expect(result.code).toBe("unavailable");
+            expect(result.apiKeyConfigured).toBe(false);
+        }
+    });
+
+    it("returns kind:error code:unavailable on 503 in local mode", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 503,
+            json: async () => ({ error_code: "unavailable" }),
+        } as Response);
+
+        const result = await NvdRefreshHandler.triggerSingleRefresh("CVE-2024-0001", "local");
+        expect(result.kind).toBe("error");
+        if (result.kind === "error") {
+            expect(result.code).toBe("unavailable");
+        }
+    });
+});

--- a/frontend/tests/handlers/scans.nvdMode.test.ts
+++ b/frontend/tests/handlers/scans.nvdMode.test.ts
@@ -1,0 +1,63 @@
+import ScansHandler from "../../src/handlers/scans";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as typeof fetch;
+
+beforeEach(() => {
+    mockFetch.mockReset();
+});
+
+describe("ScansHandler.triggerNvdScan — mode parameter", () => {
+    const variantId = "variant-uuid-1234";
+
+    it("appends mode=local by default", async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 202, json: async () => ({}) } as Response);
+        await ScansHandler.triggerNvdScan(variantId);
+        const url: string = mockFetch.mock.calls[0][0];
+        expect(url).toContain("mode=local");
+    });
+
+    it("appends mode=local when explicitly passed", async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 202, json: async () => ({}) } as Response);
+        await ScansHandler.triggerNvdScan(variantId, true, "local");
+        const url: string = mockFetch.mock.calls[0][0];
+        expect(url).toContain("mode=local");
+    });
+
+    it("appends mode=api when api is passed", async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 202, json: async () => ({}) } as Response);
+        await ScansHandler.triggerNvdScan(variantId, true, "api");
+        const url: string = mockFetch.mock.calls[0][0];
+        expect(url).toContain("mode=api");
+    });
+
+    it("also includes exclude_kernel in the URL", async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 202, json: async () => ({}) } as Response);
+        await ScansHandler.triggerNvdScan(variantId, false, "api");
+        const url: string = mockFetch.mock.calls[0][0];
+        expect(url).toContain("exclude_kernel=false");
+        expect(url).toContain("mode=api");
+    });
+
+    it("returns ok:true on 202", async () => {
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 202, json: async () => ({}) } as Response);
+        const result = await ScansHandler.triggerNvdScan(variantId, true, "local");
+        expect(result.ok).toBe(true);
+    });
+
+    it("returns ok:false on 409 with error message", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 409,
+            json: async () => ({ error: "already in progress" }),
+        } as Response);
+        const result = await ScansHandler.triggerNvdScan(variantId, true, "api");
+        expect(result.ok).toBe(false);
+        expect(result.error).toContain("already in progress");
+    });
+
+    it("returns ok:false when fetch rejects", async () => {
+        mockFetch.mockRejectedValueOnce(new Error("network down"));
+        await expect(ScansHandler.triggerNvdScan(variantId)).rejects.toThrow("network down");
+    });
+});

--- a/frontend/tests/unit_tests/test_multi_edit_bar.tsx
+++ b/frontend/tests/unit_tests/test_multi_edit_bar.tsx
@@ -353,7 +353,7 @@ describe('MultiEditBar', () => {
         });
 
         expect(mockHideBanner).toHaveBeenCalledTimes(1);
-        expect(mockBulkNvdTrigger).toHaveBeenCalledWith(['CVE-2024-0001', 'CVE-2024-0002']);
+        expect(mockBulkNvdTrigger).toHaveBeenCalledWith(['CVE-2024-0001', 'CVE-2024-0002'], 'local');
         expect(mockBulkEpssTrigger).toHaveBeenCalledWith(['CVE-2024-0001', 'CVE-2024-0002']);
         expect(mockBulkEuvdTrigger).toHaveBeenCalledWith(['CVE-2024-0001', 'CVE-2024-0002']);
     });
@@ -415,7 +415,7 @@ describe('MultiEditBar', () => {
         });
 
         await waitFor(() => {
-            expect(mockBulkNvdTrigger).toHaveBeenCalledWith(['CVE-2024-0001', 'CVE-2024-0002']);
+            expect(mockBulkNvdTrigger).toHaveBeenCalledWith(['CVE-2024-0001', 'CVE-2024-0002'], 'local');
         });
         expect(mockBulkEpssTrigger).not.toHaveBeenCalled();
     });

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2686,7 +2686,7 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
 
     test('renders NVD source selector defaulting to Local mode', () => {
         render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-        const localRadio = screen.getByRole('radio', { name: 'Local' });
+        const localRadio = screen.getByRole('radio', { name: 'Git repository' });
         const apiRadio = screen.getByRole('radio', { name: 'API' });
         expect(localRadio).toBeChecked();
         expect(apiRadio).not.toBeChecked();
@@ -2726,8 +2726,8 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         const user = userEvent.setup();
 
         await user.click(screen.getByRole('radio', { name: 'API' }));
-        await user.click(screen.getByRole('radio', { name: 'Local' }));
-        expect(screen.getByRole('radio', { name: 'Local' })).toBeChecked();
+        await user.click(screen.getByRole('radio', { name: 'Git repository' }));
+        expect(screen.getByRole('radio', { name: 'Git repository' })).toBeChecked();
 
         await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
 

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2684,6 +2684,116 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         });
     });
 
+    test('renders NVD source selector defaulting to Local mode', () => {
+        render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const localRadio = screen.getByRole('radio', { name: 'Local' });
+        const apiRadio = screen.getByRole('radio', { name: 'API' });
+        expect(localRadio).toBeChecked();
+        expect(apiRadio).not.toBeChecked();
+    });
+
+    test('switching NVD source to API sends mode "api" to the nvd-refresh endpoint', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify({ vulnerabilities: [updatedVulnPayload] })); // nvd-refresh
+        fetchMock.mockResponseOnce(JSON.stringify({ vulnerabilities: [updatedVulnPayload] })); // epss-refresh
+
+        render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        const apiRadio = screen.getByRole('radio', { name: 'API' });
+        await user.click(apiRadio);
+        expect(apiRadio).toBeChecked();
+
+        await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
+
+        await waitFor(() => {
+            const nvdCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/nvd-refresh'));
+            expect(nvdCall).toBeDefined();
+            expect(JSON.parse(String(nvdCall![1]!.body))).toEqual({ mode: 'api' });
+        });
+    });
+
+    test('switching back to Local mode sends mode "local" to the nvd-refresh endpoint', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify({ vulnerabilities: [updatedVulnPayload] })); // nvd-refresh
+        fetchMock.mockResponseOnce(JSON.stringify({ vulnerabilities: [updatedVulnPayload] })); // epss-refresh
+
+        render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        await user.click(screen.getByRole('radio', { name: 'API' }));
+        await user.click(screen.getByRole('radio', { name: 'Local' }));
+        expect(screen.getByRole('radio', { name: 'Local' })).toBeChecked();
+
+        await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
+
+        await waitFor(() => {
+            const nvdCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/nvd-refresh'));
+            expect(nvdCall).toBeDefined();
+            expect(JSON.parse(String(nvdCall![1]!.body))).toEqual({ mode: 'local' });
+        });
+    });
+
+    test('shows API-key-rejected message when NVD returns unauthorized', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce(
+            JSON.stringify({ error: 'unauthorized', error_code: 'unauthorized' }),
+            { status: 401 }
+        ); // nvd-refresh
+        fetchMock.mockResponseOnce(JSON.stringify({ vulnerabilities: [updatedVulnPayload] })); // epss-refresh
+
+        render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        await user.click(screen.getByRole('radio', { name: 'API' }));
+        await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
+
+        await waitFor(() => {
+            expect(screen.getByText(/NVD API key rejected/i)).toBeInTheDocument();
+        });
+    });
+
+    test('shows API-mode hint when NVD is unavailable in API mode', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce('Service Unavailable', { status: 503 }); // nvd-refresh
+        fetchMock.mockResponseOnce(JSON.stringify({ vulnerabilities: [updatedVulnPayload] })); // epss-refresh
+
+        render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        await user.click(screen.getByRole('radio', { name: 'API' }));
+        await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
+
+        await waitFor(() => {
+            expect(screen.getByText(/NVD API unavailable.*switch to Local/i)).toBeInTheDocument();
+        });
+    });
+
+    test('shows local-mode hint when NVD data is unavailable in Local mode', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce('Service Unavailable', { status: 503 }); // nvd-refresh
+        fetchMock.mockResponseOnce(JSON.stringify({ vulnerabilities: [updatedVulnPayload] })); // epss-refresh
+
+        render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
+
+        await waitFor(() => {
+            expect(screen.getByText(/NVD data unavailable.*sbom-cve-check/i)).toBeInTheDocument();
+        });
+    });
+
     test('clears success cue and error when navigating to a different vulnerability', async () => {
         fetchMock.resetMocks();
         fetchMock.mockResponse(JSON.stringify([])); // all fetches return empty

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2640,7 +2640,7 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
 
         await waitFor(() => {
-            expect(screen.getByText(/NVD API unavailable.*EPSS API unavailable/i)).toBeInTheDocument();
+            expect(screen.getByText(/NVD.*unavailable.*EPSS API unavailable/i)).toBeInTheDocument();
         });
     });
 
@@ -2695,7 +2695,7 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         rerender(<VulnModal vuln={vuln2} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         expect(screen.queryByText('Updated')).not.toBeInTheDocument();
-        expect(screen.queryByText(/NVD API unavailable/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/NVD.*unavailable/i)).not.toBeInTheDocument();
     });
 
     test('builds variantPackageMap and disables packages absent from the selected variant', async () => {
@@ -2996,7 +2996,7 @@ describe('Refresh button', () => {
         await user.click(screen.getByTitle(/Refresh from NVD & EPSS/i));
 
         await waitFor(() => {
-            expect(screen.getByText(/NVD API unavailable/i)).toBeInTheDocument();
+            expect(screen.getByText(/NVD.*unavailable/i)).toBeInTheDocument();
         });
         expect(patchVuln).not.toHaveBeenCalled();
     });

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -41,6 +41,15 @@ jest.mock('../../src/handlers/euvd_progress', () => ({
     },
 }));
 
+// Mock GHSAProgressHandler to prevent unwanted fetch calls
+jest.mock('../../src/handlers/ghsa_progress', () => ({
+    __esModule: true,
+    default: {
+        getProgress: jest.fn().mockResolvedValue(null),
+        getProgressPercentage: jest.fn().mockReturnValue(0),
+    },
+}));
+
 
 const getDOMRect = (width: number, height: number) => ({
     width,

--- a/src/bin/cmd_vuln_scan.py
+++ b/src/bin/cmd_vuln_scan.py
@@ -2,14 +2,15 @@
 # SPDX-License-Identifier: GPL-3.0-only
 """Vulnerability scanning commands: ``flask nvd-scan`` and ``flask osv-scan``."""
 
+from ..controllers.scc_engine import get_engine
 from ..controllers.nvd_db import NVD_DB
+from ..controllers.nvd_persist import persist_nvd_cve
 from ..controllers.osv_client import OSVClient
 from ..models.scan import Scan as ScanModel
 from ..models.finding import Finding as FindingModel
 from ..models.observation import Observation
 from ..models.vulnerability import Vulnerability as VulnModel
 from ..models.metrics import Metrics as MetricsModel
-from ..models.cvss import CVSS
 from ..models.assessment import Assessment, STATUS_TO_SIMPLIFIED
 from ..models.package import Package
 from ..extensions import db as _db
@@ -18,7 +19,6 @@ from ..helpers.active_scans import active_sbom_scan_ids_for_variant, active_pack
 from ..helpers.scan_filters import filter_scannable_packages
 from ._common import DEFAULT_VARIANT_NAME, resolve_project_variant
 import click
-import os
 import uuid
 from datetime import datetime, timezone
 from sqlalchemy import inspect as sa_inspect
@@ -100,25 +100,34 @@ def _persist_finding(pkg_id, vuln_id, scan_id, variant_uuid, origin: str,
 @click.option("--project", "-p", required=True, help="Project name.")
 @click.option("--variant", "-v", default=None,
               help=f"Variant name (defaults to '{DEFAULT_VARIANT_NAME}').")
+@click.option("--mode", "-m", default="local", type=click.Choice(["local", "api"]),
+              help="NVD backend: 'local' (default, uses local NVD-FKIE DB) or 'api' (NVD REST API).")
 @with_appcontext
-def nvd_scan_command(project: str, variant: str | None) -> None:
-    """Run an NVD CPE-based vulnerability scan for the given project/variant.
+def nvd_scan_command(project: str, variant: str | None, mode: str) -> None:
+    """Run an NVD-based vulnerability scan for the given project/variant.
 
-    Queries the NVD API for every CPE found in the variant's active packages
-    and creates findings/observations in a new tool scan.
+    With ``--mode local`` (default) the local NVD-FKIE advisory database is
+    used (no network required). With ``--mode api`` the NVD REST API v2 is
+    queried per CPE (network required; set NVD_API_KEY for higher rate limits).
+    The result is stored as a tool scan with source ``nvd``.
     """
     project_obj, variant_obj = resolve_project_variant(project, variant, create=True)
     variant_uuid = variant_obj.id
 
-    nvd_api_key = os.getenv("NVD_API_KEY")
-    nvd = NVD_DB(nvd_api_key=nvd_api_key)
-
     packages = _resolve_active_packages(variant_uuid)
 
-    # Collect CPE names from packages
-    # Accept any CPE with a non-wildcard product (parts[4]).
-    # Wildcard part/vendor/version are handled via virtualMatchString.
-    cpe_to_pkgs: dict = {}
+    if mode == "api":
+        _nvd_scan_api(variant_uuid, packages)
+    else:
+        _nvd_scan_local(variant_uuid, packages)
+
+
+def _nvd_scan_api(variant_uuid, packages) -> None:
+    """NVD scan using the NVD REST API v2 (CPE-based)."""
+    import os as _os
+    nvd = NVD_DB(nvd_api_key=_os.getenv("NVD_API_KEY"))
+
+    cpe_to_pkgs: dict[str, list] = {}
     for pkg in packages:
         for cpe in (pkg.cpe or []):
             parts = cpe.split(":")
@@ -126,18 +135,15 @@ def nvd_scan_command(project: str, variant: str | None) -> None:
                 cpe_to_pkgs.setdefault(cpe, []).append(pkg)
 
     if not cpe_to_pkgs:
-        raise click.ClickException(
-            "No packages with valid CPE identifiers"
-        )
+        raise click.ClickException("No packages with valid CPE identifiers")
 
+    total_cpes = len(cpe_to_pkgs)
     click.echo(
-        f"Found {len(packages)} packages with "
-        f"{len(cpe_to_pkgs)} unique CPEs to query"
+        f"Found {len(packages)} packages with {total_cpes} unique CPEs to query"
     )
 
     scan = _create_tool_scan(variant_uuid, "nvd")
-    total_cpes = len(cpe_to_pkgs)
-    cves_found: set = set()
+    cves_found: set[str] = set()
     observation_pairs: set = set()
     assessed_findings: set = set()
 
@@ -147,106 +153,67 @@ def nvd_scan_command(project: str, variant: str | None) -> None:
             cpe_parts = cpe_name.split(":")
             has_wildcards = (
                 len(cpe_parts) >= 6
-                and (cpe_parts[2] == "*"
-                     or cpe_parts[3] == "*"
-                     or cpe_parts[5] == "*")
+                and (cpe_parts[2] == "*" or cpe_parts[3] == "*" or cpe_parts[5] == "*")
             )
             nvd_vulns = nvd.api_get_cves_by_cpe(
-                cpe_name,
-                results_per_page=100,
-                use_virtual_match=has_wildcards,
+                cpe_name, results_per_page=100, use_virtual_match=has_wildcards,
             )
-        except Exception as e:
-            click.echo(
-                f"[{idx}/{total_cpes}] ERROR {cpe_name}: {str(e)[:200]}",
-                err=True,
-            )
+        except Exception as exc:
+            click.echo(f"[{idx}/{total_cpes}] ERROR {cpe_name}: {str(exc)[:200]}", err=True)
             continue
 
         cpe_cves = [
-            v.get("cve", {}).get("id", "")
-            for v in nvd_vulns if v.get("cve", {}).get("id")
+            v.get("cve", {}).get("id", "") for v in nvd_vulns if v.get("cve", {}).get("id")
         ]
-        _echo_query_results(idx, total_cpes, cpe_name, cpe_cves, "CVE(s)", "no CVEs")
+        _echo_query_results(idx, total_cpes, cpe_name, cpe_cves, noun="CVE(s)", no_results="no CVEs")
 
         for nvd_vuln in nvd_vulns:
             cve = nvd_vuln.get("cve", {})
             cve_id = cve.get("id", "")
             if not cve_id:
                 continue
-
             cves_found.add(cve_id)
             details = NVD_DB.extract_cve_details(cve)
 
-            existing_vuln = _db.session.get(VulnModel, cve_id.upper())
-            if existing_vuln is None:
-                existing_vuln = VulnModel.create_record(
-                    id=cve_id,
-                    description=details.get("description"),
-                    status=details.get("status"),
-                    publish_date=details.get("publish_date"),
-                    attack_vector=details.get("attack_vector"),
-                    links=details.get("links"),
-                    weaknesses=details.get("weaknesses"),
-                    nvd_last_modified=details.get("nvd_last_modified"),
-                )
-                existing_vuln.add_found_by("nvd")
-            else:
-                existing_vuln.add_found_by("nvd")
-                _update = {}
-                if not existing_vuln.description and details.get("description"):
-                    _update["description"] = details["description"]
-                if not existing_vuln.status and details.get("status"):
-                    _update["status"] = details["status"]
-                if not existing_vuln.publish_date and details.get("publish_date"):
-                    _update["publish_date"] = details["publish_date"]
-                if not existing_vuln.attack_vector and details.get("attack_vector"):
-                    _update["attack_vector"] = details["attack_vector"]
-                if not existing_vuln.links and details.get("links"):
-                    _update["links"] = details["links"]
-                if not existing_vuln.weaknesses and details.get("weaknesses"):
-                    _update["weaknesses"] = details["weaknesses"]
-                if _update:
-                    existing_vuln.update_record(**_update, commit=False)
-
-            # Persist CVSS metrics
-            if details.get("base_score") is not None:
-                _cvss_v = details.get("cvss_version")
-                _cvss_s = details["base_score"]
-                _cvss_vec = details.get("cvss_vector")
-                _dedup = (cve_id.upper(), _cvss_v, float(_cvss_s))
-                if _dedup not in MetricsModel._seen:
-                    try:
-                        MetricsModel.from_cvss(
-                            CVSS(
-                                version=_cvss_v or "",
-                                vector_string=_cvss_vec or "",
-                                author="nvd",
-                                base_score=float(_cvss_s),
-                                exploitability_score=(
-                                    float(details["cvss_exploitability"])
-                                    if details.get("cvss_exploitability") is not None
-                                    else 0
-                                ),
-                                impact_score=(
-                                    float(details["cvss_impact"])
-                                    if details.get("cvss_impact") is not None
-                                    else 0
-                                ),
-                            ),
-                            existing_vuln.id,
-                        )
-                    except Exception:
-                        pass
+            persist_nvd_cve(cve_id, details)
 
             for pkg in pkgs:
                 _persist_finding(pkg.id, cve_id, scan.id, variant_uuid, "nvd",
                                  observation_pairs, assessed_findings)
 
     _db.session.commit()
+    cve_count = len(cves_found)
     click.echo(
-        f"✓ Scan complete — found {len(cves_found)} unique CVEs "
-        f"across {total_cpes} CPEs"
+        f"✓ Scan complete — found {cve_count} unique CVEs across {total_cpes} CPEs"
+    )
+
+
+def _nvd_scan_local(variant_uuid, packages) -> None:
+    """NVD scan using the local NVD-FKIE advisory database."""
+    click.echo("Loading local NVD advisory database…")
+    engine = get_engine()
+
+    scan = _create_tool_scan(variant_uuid, "nvd")
+    total = len(packages)
+    writer = _SccBulkWriter(scan.id, variant_uuid, packages)
+    seen_keys: set = set()
+
+    for idx, pkg in enumerate(packages, 1):
+        click.echo(f"[{idx}/{total}] Scanning {pkg.name} {pkg.version}…")
+        try:
+            for computed, status in engine.applicable_vulns(pkg):
+                writer.add(pkg, computed, status, seen_keys)
+        except Exception as exc:
+            click.echo(
+                f"[{idx}/{total}] ERROR {pkg.name}: {str(exc)[:200]}",
+                err=True,
+            )
+        writer.maybe_flush()
+
+    writer.flush()
+    click.echo(
+        f"✓ Scan complete — found {len(seen_keys)} unique CVEs "
+        f"across {total} packages"
     )
 
 

--- a/src/controllers/nvd_apply.py
+++ b/src/controllers/nvd_apply.py
@@ -22,7 +22,7 @@ def apply_cvss_update(rec, details: dict, db) -> None:
             Metrics.version == cvss_version,
             Metrics.variant_id.is_(None),
         )
-    ).scalar_one_or_none()
+    ).scalars().first()
     if existing is not None:
         if float(existing.score or 0) != float(base_score) or existing.vector != cvss_vector:
             existing.score = base_score

--- a/src/controllers/nvd_db.py
+++ b/src/controllers/nvd_db.py
@@ -1,25 +1,44 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
+"""NVD CVE data client — supports both local (NVD-FKIE) and REST API modes.
+
+The preferred mode is **local**: CVE data is sourced from the local NVD-FKIE
+git feed managed by sbom-cve-check (see
+:func:`~src.controllers.scc_engine.get_cve_json`).  No network calls, no rate
+limits, no API key needed.
+
+The **api** mode queries the NVD REST API v2 directly.  An optional API key
+(``NVD_API_KEY`` env var or constructor param) increases the rate limit from
+5 to 50 requests per 30 seconds.
+"""
 
 import json
 import os
 import urllib.request
 import urllib.parse
 import urllib.error
+import time
+from typing import Optional, Tuple
+
 from ..helpers.fixs_scrapper import FixsScrapper
 from ..helpers.base_api_client import BaseAPIClient
-from typing import Optional, Tuple
-import time
+from .nvd_extract import extract_cve_details, api_weaknesses_to_list_str, api_references_filter_patches
 
 
 class NVD_DB(BaseAPIClient):
-    """
-    API client for NVD (National Vulnerability Database).
-    Fetches CVE data directly from the NVD API without local caching.
+    """NVD CVE data client.
+
+    Re-exports the pure extraction helpers as static methods so existing call
+    sites that use ``NVD_DB.extract_cve_details(cve)`` continue to work.
+    Also provides the full NVD REST API v2 client for *api* mode.
     """
 
     # HTTP status codes that should not be retried (permanent client errors)
     _NON_RETRYABLE_STATUSES = {400, 403, 404}
+
+    # Pure extraction helpers — available as both static class methods and
+    # module-level functions (imported from nvd_extract).
+    extract_cve_details = staticmethod(extract_cve_details)
 
     def __init__(self, nvd_api_key: Optional[str] = None):
         super().__init__()
@@ -27,15 +46,15 @@ class NVD_DB(BaseAPIClient):
         self.nvd_api_key = api_key or None
 
     def _call_nvd_api(self, params: dict | None = None) -> Tuple[int, dict, dict[str, str]]:
-        """
-        Call the NVD API and return status, JSON body, and response headers.
-        Header names are normalized to lower-case for case-insensitive lookup.
+        """Call the NVD REST API and return (status, body, headers).
+
+        Header names are normalised to lower-case for case-insensitive lookup.
         """
         if params is None:
             params = {}
         url = "https://services.nvd.nist.gov/rest/json/cves/2.0?" + urllib.parse.urlencode(params)
 
-        headers = {
+        headers: dict[str, str] = {
             'User-Agent': 'vulnscout/1.0 (https://github.com/savoirfairelinux/vulnscout)',
             'Accept': 'application/json',
         }
@@ -62,42 +81,40 @@ class NVD_DB(BaseAPIClient):
                     flush=True,
                 )
                 resp_json = {}
-
             return resp_status, resp_json, resp_headers
 
         except urllib.error.HTTPError as e:
             body_preview = b""
-            resp_headers = {}
+            resp_headers_err: dict[str, str] = {}
             try:
                 body_preview = e.read(200)
             except Exception:
                 pass
             try:
                 if e.headers:
-                    resp_headers = {k.lower(): v for k, v in e.headers.items()}
+                    resp_headers_err = {k.lower(): v for k, v in e.headers.items()}
             except Exception:
                 pass
-            if e.code not in {429}:  # 429 = rate-limited, expected under load
+            if e.code not in {429}:
                 print(
                     f"NVD API HTTP {e.code} for URL: {url} — {e.reason}. "
                     f"Body preview: {body_preview!r}",
                     flush=True,
                 )
-            return e.code, {}, resp_headers
-        except Exception as e:
-            print(f"Error calling NVD API: {e}", flush=True)
-            raise e
+            return e.code, {}, resp_headers_err
+        except Exception as exc:
+            print(f"Error calling NVD API: {exc}", flush=True)
+            raise exc
 
     def api_get_cve(self, cve_id: str, max_retries: int = 3) -> Tuple[int, dict]:
-        """
-        Call the NVD API to get a specific CVE.
+        """Call the NVD API to get a specific CVE.
 
-        *max_retries* caps the number of retry attempts (default 3).
-        Pass ``max_retries=0`` for a single non-blocking attempt suitable
-        for user-triggered, synchronous request contexts.
+        *max_retries* caps retry attempts (default 3).  Pass ``max_retries=0``
+        for a single non-blocking attempt suitable for synchronous contexts.
         """
         retry = 0
         status = 0
+        data: dict = {}
         while retry <= max_retries:
             time.sleep(10 * retry)
             status, data, _ = self._call_nvd_api({"cveId": cve_id.strip()})
@@ -117,15 +134,8 @@ class NVD_DB(BaseAPIClient):
     ) -> list[dict]:
         """Query the NVD API for CVEs matching a CPE name.
 
-        When *use_virtual_match* is ``True`` the ``virtualMatchString``
-        parameter is sent instead of ``cpeName``.  This is required when
-        the CPE contains wildcard fields (e.g. vendor ``*``) because the
-        NVD ``cpeName`` parameter expects an entry from its CPE
-        dictionary, whereas ``virtualMatchString`` performs pattern
-        matching against CVE match criteria.
-
-        Returns a (possibly empty) list of CVE items from the NVD response.
-        Handles pagination transparently.
+        When *use_virtual_match* is ``True`` the ``virtualMatchString`` param is
+        sent instead of ``cpeName``.  Handles pagination transparently.
         """
         all_vulns: list[dict] = []
         start_index = 0
@@ -135,15 +145,10 @@ class NVD_DB(BaseAPIClient):
             status = 0
             data: dict = {}
             while retry <= 3:
-                # Rate-limit: skip sleep for the very first request of this CPE,
-                # sleep between retries / pagination pages.
                 if not first_request or retry > 0:
                     time.sleep(max(6, 10 * retry))
                 first_request = False
-                param_key = (
-                    "virtualMatchString" if use_virtual_match
-                    else "cpeName"
-                )
+                param_key = "virtualMatchString" if use_virtual_match else "cpeName"
                 status, data, _ = self._call_nvd_api({
                     param_key: cpe_name,
                     "startIndex": start_index,
@@ -170,132 +175,18 @@ class NVD_DB(BaseAPIClient):
         return self._call_nvd_api({"cveId": cve_id.strip()})
 
     def api_weaknesses_to_list_str(self, weaknesses: list) -> list[str]:
-        """
-        Convert a list of weaknesses obtained from API to a list of strings.
-        """
-        weaks = set([x["value"] for publisher in weaknesses for x in publisher["description"]])
-        return list(weaks)
+        """Convert a list of weakness objects to a list of CWE strings."""
+        return api_weaknesses_to_list_str(weaknesses)
 
     def api_references_filter_patches(self, references: list) -> list[str]:
-        """
-        Filter a list of references to get only the ones related to git patches.
-        """
-        return [x["url"] for x in references if "tags" in x and "Patch" in x["tags"]]
-
-    @staticmethod
-    def extract_cve_details(cve: dict) -> dict:
-        """Extract description, severity, links, weaknesses from an NVD CVE dict.
-
-        *cve* is the ``vulnerabilities[n]["cve"]`` object returned by the
-        NVD API v2.0.  Returns a dict with keys usable by
-        ``Vulnerability.update_record`` / ``create_record``.
-        """
-        # Description — prefer English
-        description = None
-        for desc in cve.get("descriptions", []):
-            if desc.get("lang", "").startswith("en"):
-                description = desc.get("value")
-                break
-        if description is None:
-            descs = cve.get("descriptions", [])
-            if descs:
-                description = descs[0].get("value")
-
-        # Severity label + base score — try CVSS v3.1, v3.0, v4.0, v2.0
-        severity = None
-        base_score = None
-        attack_vector = None
-        cvss_version = None
-        cvss_vector = None
-        cvss_exploitability = None
-        cvss_impact = None
-        metrics = cve.get("metrics", {})
-        _metric_version_map = {
-            "cvssMetricV31": "3.1",
-            "cvssMetricV30": "3.0",
-            "cvssMetricV40": "4.0",
-            "cvssMetricV2": "2.0",
-        }
-        for metric_key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV40", "cvssMetricV2"):
-            metric_list = metrics.get(metric_key, [])
-            if metric_list:
-                primary = next(
-                    (m for m in metric_list if m.get("type") == "Primary"),
-                    metric_list[0],
-                )
-                cvss_data = primary.get("cvssData", {})
-                severity = (
-                    primary.get("baseSeverity")
-                    or cvss_data.get("baseSeverity")
-                    or ""
-                ).lower() or None
-                base_score = cvss_data.get("baseScore")
-                attack_vector = cvss_data.get("attackVector")
-                cvss_version = _metric_version_map.get(metric_key)
-                cvss_vector = cvss_data.get("vectorString")
-                cvss_exploitability = primary.get("exploitabilityScore")
-                cvss_impact = primary.get("impactScore")
-                break
-
-        # References / links
-        links = [
-            ref.get("url")
-            for ref in cve.get("references", [])
-            if ref.get("url")
-        ]
-        # Always include the NVD detail page
-        cve_id = cve.get("id", "")
-        nvd_url = f"https://nvd.nist.gov/vuln/detail/{cve_id}"
-        if nvd_url not in links:
-            links.insert(0, nvd_url)
-
-        # Published date
-        published = cve.get("published")
-        publish_date = None
-        if published:
-            try:
-                import datetime
-                publish_date = datetime.date.fromisoformat(str(published)[:10])
-            except ValueError:
-                pass
-
-        # Weaknesses
-        weaknesses = []
-        for w in cve.get("weaknesses", []):
-            for d in w.get("description", []):
-                val = d.get("value", "")
-                if val and val not in weaknesses:
-                    weaknesses.append(val)
-
-        return {
-            "description": description,
-            "status": severity,
-            "base_score": base_score,
-            "attack_vector": attack_vector,
-            "cvss_version": cvss_version,
-            "cvss_vector": cvss_vector,
-            "cvss_exploitability": cvss_exploitability,
-            "cvss_impact": cvss_impact,
-            "links": links,
-            "publish_date": publish_date,
-            "weaknesses": weaknesses or None,
-            "nvd_last_modified": cve.get("lastModified"),
-        }
+        """Filter a list of references to only those tagged as patches."""
+        return api_references_filter_patches(references)
 
     def fetch_cve_data(self, cve_id: str) -> Optional[dict]:
-        """
-        Fetch and parse NVD data for a single CVE directly from the API.
+        """Fetch and parse NVD REST API data for a single CVE.
 
-        Returns a dict with keys:
-            published, lastModified, weaknesses, versions_data, patch_url
-
-        Returns None on transient/connection failures (caller should retry later).
-        Returns {"not_found": True} when NVD definitively has no record for this
-        CVE (200 with empty result set) — caller should persist a sentinel so
-        the CVE is not re-queried on every restart.
-
-        Note: NVD API v2 always returns HTTP 200 for CVE queries — a 404 is
-        never a "CVE not found" signal but always a network/proxy problem.
+        Returns ``None`` on transient failures; ``{"not_found": True}`` when the
+        CVE is definitively absent from NVD.
         """
         try:
             status, data = self.api_get_cve(cve_id)
@@ -326,15 +217,15 @@ class NVD_DB(BaseAPIClient):
                 "published": cve.get("published"),
                 "lastModified": cve.get("lastModified"),
                 "weaknesses": (
-                    self.api_weaknesses_to_list_str(cve["weaknesses"])
+                    api_weaknesses_to_list_str(cve["weaknesses"])
                     if "weaknesses" in cve else []
                 ),
                 "versions_data": fix_scrapper.list_per_packages(),
                 "patch_url": (
-                    self.api_references_filter_patches(cve["references"])
+                    api_references_filter_patches(cve["references"])
                     if "references" in cve else []
                 ),
             }
-        except Exception as e:
-            print(f"Error fetching NVD data for {cve_id}: {e}", flush=True)
+        except Exception as exc:
+            print(f"Error fetching NVD data for {cve_id}: {exc}", flush=True)
             return None

--- a/src/controllers/nvd_extract.py
+++ b/src/controllers/nvd_extract.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+"""Pure extraction helpers for NVD CVE JSON.
+
+These functions operate on the raw NVD CVE dict as returned by the
+NVD API v2 *and* as stored in the local NVD-FKIE git feed — both use
+the same JSON schema.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+
+def extract_cve_details(cve: dict) -> dict:
+    """Extract description, severity, links, weaknesses from an NVD CVE dict.
+
+    *cve* is the ``cve`` object from a single entry — either from
+    ``vulnerabilities[n]["cve"]`` (NVD API) or directly from a FKIE
+    advisory JSON file. Returns a dict with keys matching the
+    ``Vulnerability.update_record`` / ``create_record`` signature.
+    """
+    # Description — prefer English
+    description = None
+    for desc in cve.get("descriptions", []):
+        if desc.get("lang", "").startswith("en"):
+            description = desc.get("value")
+            break
+    if description is None:
+        descs = cve.get("descriptions", [])
+        if descs:
+            description = descs[0].get("value")
+
+    # Severity label + base score — try CVSS v3.1, v3.0, v4.0, v2.0
+    severity = None
+    base_score = None
+    attack_vector = None
+    cvss_version = None
+    cvss_vector = None
+    cvss_exploitability = None
+    cvss_impact = None
+    metrics = cve.get("metrics", {})
+    _metric_version_map = {
+        "cvssMetricV31": "3.1",
+        "cvssMetricV30": "3.0",
+        "cvssMetricV40": "4.0",
+        "cvssMetricV2": "2.0",
+    }
+    for metric_key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV40", "cvssMetricV2"):
+        metric_list = metrics.get(metric_key, [])
+        if metric_list:
+            primary = next(
+                (m for m in metric_list if m.get("type") == "Primary"),
+                metric_list[0],
+            )
+            cvss_data = primary.get("cvssData", {})
+            severity = (
+                primary.get("baseSeverity")
+                or cvss_data.get("baseSeverity")
+                or ""
+            ).lower() or None
+            base_score = cvss_data.get("baseScore")
+            attack_vector = cvss_data.get("attackVector")
+            cvss_version = _metric_version_map.get(metric_key)
+            cvss_vector = cvss_data.get("vectorString")
+            cvss_exploitability = primary.get("exploitabilityScore")
+            cvss_impact = primary.get("impactScore")
+            break
+
+    # References / links
+    links = [
+        ref.get("url")
+        for ref in cve.get("references", [])
+        if ref.get("url")
+    ]
+    # Always include the NVD detail page
+    cve_id = cve.get("id", "")
+    nvd_url = f"https://nvd.nist.gov/vuln/detail/{cve_id}"
+    if nvd_url not in links:
+        links.insert(0, nvd_url)
+
+    # Published date
+    published = cve.get("published")
+    publish_date = None
+    if published:
+        try:
+            publish_date = datetime.date.fromisoformat(str(published)[:10])
+        except ValueError:
+            pass
+
+    # Weaknesses
+    weaknesses = []
+    for w in cve.get("weaknesses", []):
+        for d in w.get("description", []):
+            val = d.get("value", "")
+            if val and val not in weaknesses:
+                weaknesses.append(val)
+
+    return {
+        "description": description,
+        "status": severity,
+        "base_score": base_score,
+        "attack_vector": attack_vector,
+        "cvss_version": cvss_version,
+        "cvss_vector": cvss_vector,
+        "cvss_exploitability": cvss_exploitability,
+        "cvss_impact": cvss_impact,
+        "links": links,
+        "publish_date": publish_date,
+        "weaknesses": weaknesses or None,
+        "nvd_last_modified": cve.get("lastModified"),
+    }
+
+
+def api_weaknesses_to_list_str(weaknesses: list) -> list[str]:
+    """Flatten a NVD ``weaknesses`` list to a deduplicated list of strings."""
+    return list({x["value"] for publisher in weaknesses for x in publisher["description"]})
+
+
+def api_references_filter_patches(references: list) -> list[str]:
+    """Filter a NVD ``references`` list to URLs tagged as patches."""
+    return [x["url"] for x in references if "tags" in x and "Patch" in x["tags"]]

--- a/src/controllers/nvd_persist.py
+++ b/src/controllers/nvd_persist.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+"""Shared persistence for NVD-API CVE results.
+
+The NVD-scan API path is driven from two places — the web route
+(:mod:`src.routes.scan_triggers`) and the CLI command
+(:mod:`src.bin.cmd_vuln_scan`).  Both turn a raw NVD CVE dict into a
+:class:`Vulnerability` record (create-or-update) plus its CVSS metrics.  That
+per-CVE logic lives here so the two callers cannot drift apart; each caller
+still owns its own progress reporting and finding/observation creation.
+"""
+
+from __future__ import annotations
+
+from ..extensions import db
+from ..models.vulnerability import Vulnerability as VulnModel
+from ..models.metrics import Metrics as MetricsModel
+from ..models.cvss import CVSS
+
+
+def persist_nvd_cve(cve_id: str, details: dict) -> VulnModel:
+    """Create or update the :class:`Vulnerability` for *cve_id* and its CVSS metric.
+
+    *details* is the dict returned by
+    :func:`~src.controllers.nvd_extract.extract_cve_details`.  Only empty fields
+    are filled in on an existing record, so scanner data never overwrites
+    richer values already present.  The row is flushed (``commit=False``); the
+    caller is responsible for committing and for creating findings/observations.
+
+    :return: the persisted :class:`Vulnerability` model.
+    """
+    existing_vuln = db.session.get(VulnModel, cve_id.upper())
+    if existing_vuln is None:
+        existing_vuln = VulnModel.create_record(
+            id=cve_id,
+            description=details.get("description"),
+            status=details.get("status"),
+            publish_date=details.get("publish_date"),
+            attack_vector=details.get("attack_vector"),
+            links=details.get("links"),
+            weaknesses=details.get("weaknesses"),
+            nvd_last_modified=details.get("nvd_last_modified"),
+        )
+        existing_vuln.add_found_by("nvd")
+    else:
+        existing_vuln.add_found_by("nvd")
+        update: dict = {}
+        if not existing_vuln.description and details.get("description"):
+            update["description"] = details["description"]
+        if not existing_vuln.status and details.get("status"):
+            update["status"] = details["status"]
+        if not existing_vuln.publish_date and details.get("publish_date"):
+            update["publish_date"] = details["publish_date"]
+        if not existing_vuln.attack_vector and details.get("attack_vector"):
+            update["attack_vector"] = details["attack_vector"]
+        if not existing_vuln.links and details.get("links"):
+            update["links"] = details["links"]
+        if not existing_vuln.weaknesses and details.get("weaknesses"):
+            update["weaknesses"] = details["weaknesses"]
+        if update:
+            existing_vuln.update_record(**update, commit=False)
+
+    _persist_cvss_metric(details, existing_vuln)
+    return existing_vuln
+
+
+def _persist_cvss_metric(details: dict, vuln: VulnModel) -> None:
+    """Persist the NVD CVSS base metric for *vuln* when one is present.
+
+    ``Metrics.from_cvss`` dedups within the session on its own, so no external
+    pre-check is needed.  Failures are swallowed so one malformed metric never
+    aborts the enrichment run.
+    """
+    if details.get("base_score") is None:
+        return
+    try:
+        MetricsModel.from_cvss(
+            CVSS(
+                version=details.get("cvss_version") or "",
+                vector_string=details.get("cvss_vector") or "",
+                author="nvd",
+                base_score=float(details["base_score"]),
+                exploitability_score=float(details.get("cvss_exploitability") or 0),
+                impact_score=float(details.get("cvss_impact") or 0),
+            ),
+            vuln.id,
+        )
+    except Exception:
+        pass

--- a/src/controllers/scc_engine.py
+++ b/src/controllers/scc_engine.py
@@ -11,9 +11,9 @@ the lifetime of the process.
 Configuration (environment variables):
 
 * ``SBOM_CVE_CHECK_DATABASES_DIR`` — directory holding the ``nvd-fkie`` and ``cvelist`` git
-  clones.  Defaults to a ``sbom_cve_check_databases`` sub-directory of the VulnScout
-  cache directory (``$VULNSCOUT_CACHE_DIR/sbom_cve_check_databases``, i.e.
-  ``/cache/vulnscout/sbom_cve_check_databases`` inside the container), so the advisory
+  clones.  Defaults to a ``local_databases`` sub-directory of the VulnScout
+  cache directory (``$VULNSCOUT_CACHE_DIR/local_databases``, i.e.
+  ``/cache/vulnscout/local_databases`` inside the container), so the advisory
   clones live next to ``vulnscout.db`` instead of in a separate XDG cache tree.
 * ``SBOM_CVE_CHECK_GIT_FETCH_DEPTH`` — git fetch/clone depth (default ``1``: shallow clone).
 * ``SBOM_CVE_CHECK_AUTO_UPDATE`` — ``"1"``/``"true"`` to let the engine clone/fetch fresh
@@ -30,14 +30,17 @@ import os
 import pathlib
 import threading
 from collections.abc import Generator
+from typing import cast
 
-from sbom_cve_check.analysis.computed_vuln import ComputedVulnInfo
 from sbom_cve_check.database.db_git import GitDatabase
 from sbom_cve_check.database.locking import init_global_databases_lock
 from sbom_cve_check.database.manager import DatabasesConfigData, VulnDbManager
 from sbom_cve_check.products.products import init_products_database
 from sbom_cve_check.vuln.cna import init_cna_database
-
+from sbom_cve_check.analysis.computed_vuln import ComputedVulnInfo
+from sbom_cve_check.database.db_nvd import NvdFkieVulnDatabase
+from sbom_cve_check.vuln.vuln import CveId
+from sbom_cve_check.vuln.vex import VexStatus as _VexStatus
 from .scc_adapter import build_comp_build
 
 _logger = logging.getLogger(__name__)
@@ -45,6 +48,10 @@ _logger = logging.getLogger(__name__)
 _ENGINE_LOCK = threading.Lock()
 _ENGINE: "SccEngine | None" = None
 _PURE_CACHES_INSTALLED = False
+
+# Sentinel distinguishing "attribute genuinely absent" (upstream rename) from a
+# legitimate ``None`` value when reaching into sbom-cve-check internals.
+_MISSING = object()
 
 
 def _install_cpe_parse_caches() -> None:
@@ -88,7 +95,7 @@ def _install_cpe_parse_caches() -> None:
 def _databases_dir() -> pathlib.Path:
     """Resolve the directory holding the local advisory git clones.
 
-    Defaults to a ``sbom_cve_check_databases`` sub-directory of the VulnScout cache
+    Defaults to a ``local_databases`` sub-directory of the VulnScout cache
     directory so the NVD-FKIE and CVEList clones sit next to ``vulnscout.db`` instead
     of in a separate ``~/.cache/sbom_cve_check`` tree.
     """
@@ -96,7 +103,7 @@ def _databases_dir() -> pathlib.Path:
     if env and env.strip():
         return pathlib.Path(env).expanduser().resolve()
     cache = os.getenv("VULNSCOUT_CACHE_DIR") or "/cache/vulnscout"
-    return pathlib.Path(cache).expanduser().joinpath("sbom_cve_check_databases").resolve()
+    return pathlib.Path(cache).expanduser().joinpath("local_databases").resolve()
 
 
 def _truthy(value: str | None) -> bool:
@@ -141,6 +148,9 @@ class SccEngine:
         # Serialises per-scan database refreshes so two concurrent scans never
         # fetch / rebuild the index at the same time.
         self._refresh_lock = threading.Lock()
+        # Tracks which "upstream internal changed" warnings have already been
+        # emitted so a rename in sbom-cve-check is logged once, not per lookup.
+        self._degraded_warnings: set = set()
         self._manager = VulnDbManager()
 
         nvd_dir = databases_dir.joinpath("nvd-fkie")
@@ -222,9 +232,42 @@ class SccEngine:
             tuple[frozenset, str | None], dict[str, str]
         ] = {}
 
+    def _warn_degraded(self, key: str, message: str) -> None:
+        """Log ``message`` once per ``key`` when an upstream internal looks renamed.
+
+        The engine reaches into a handful of private sbom-cve-check attributes
+        (``VulnDbManager._databases``, ``NvdFkieVulnDatabase``, the advisory
+        record's ``_json``).  If any of those is renamed by an upstream version
+        bump the old ``getattr(..., None)`` fall-back silently returned no data
+        for every lookup — indistinguishable from "not in DB".  Failing loudly
+        (once) makes such a break diagnosable instead of globally invisible.
+        """
+        if key not in self._degraded_warnings:
+            self._degraded_warnings.add(key)
+            _logger.error(message)
+
+    def _managed_databases(self) -> dict:
+        """Return the manager's ``_databases`` mapping, warning once if it is gone.
+
+        ``_databases`` is a private attribute of the upstream manager.  A
+        missing attribute (rename / API change) is distinguished from a legit
+        empty mapping via a sentinel so the former is logged as an error and the
+        latter is not.
+        """
+        databases = getattr(self._manager, "_databases", _MISSING)
+        if databases is _MISSING:
+            self._warn_degraded(
+                "manager_databases",
+                "sbom-cve-check VulnDbManager has no '_databases' attribute — "
+                "the upstream library layout may have changed; every advisory "
+                "lookup will return no data. Check sbom-cve-check compatibility.",
+            )
+            return {}
+        return cast("dict", databases) or {}
+
     def _install_get_vuln_caches(self) -> None:
         """Wrap every database's ``get_vuln`` with a bounded per-record cache."""
-        databases = getattr(self._manager, "_databases", None)
+        databases = self._managed_databases()
         if not databases:
             return
         for dbs in databases.values():
@@ -236,7 +279,7 @@ class SccEngine:
     def _git_databases(self) -> list:
         """Return the underlying ``GitDatabase`` objects of every managed DB."""
         result: list = []
-        databases = getattr(self._manager, "_databases", None)
+        databases = self._managed_databases()
         if not databases:
             return result
         for dbs in databases.values():
@@ -250,7 +293,7 @@ class SccEngine:
         """Drop every per-scan cache so a refreshed index is never served stale data."""
         self._applicable_cache.clear()
         self._verdict_cache.clear()
-        databases = getattr(self._manager, "_databases", None)
+        databases = self._managed_databases()
         if databases:
             for dbs in databases.values():
                 for db in dbs:
@@ -298,26 +341,24 @@ class SccEngine:
             return changed
 
     @staticmethod
-    def _vex_status_str(computed: ComputedVulnInfo) -> str:
+    def _vex_status_str(computed: "ComputedVulnInfo") -> str:
         """Map an engine VEX assessment to a VulnScout OpenVEX status string.
 
         Triggers the engine's (expensive) version-range evaluation via
         ``computed.vex_assessment``.
         """
-        from sbom_cve_check.vuln.vex import VexStatus
-
         status = computed.vex_assessment.status
-        if status == VexStatus.AFFECTED:
+        if status == _VexStatus.AFFECTED:
             return "affected"
-        if status == VexStatus.NOT_AFFECTED:
+        if status == _VexStatus.NOT_AFFECTED:
             return "not_affected"
-        if status == VexStatus.FIXED:
+        if status == _VexStatus.FIXED:
             return "fixed"
         return "under_investigation"
 
     def applicable_vulns(
         self, pkg
-    ) -> Generator[tuple[ComputedVulnInfo, str], None, None]:
+    ) -> Generator[tuple["ComputedVulnInfo", str], None, None]:
         """Yield ``(ComputedVulnInfo, status)`` for every applicable vuln of a package.
 
         ``status`` is the OpenVEX verdict string (``affected`` /
@@ -375,15 +416,62 @@ class SccEngine:
                 verdicts[cve_id] = status
             yield computed, status
 
+    def get_nvd_cve_json(self, cve_id: str) -> "dict | None":
+        """Return the raw NVD JSON for a CVE from the local NVD-FKIE database.
+
+        The NVD-FKIE git feed stores the same JSON schema as the NVD API v2
+        response, so the result can be passed directly to
+        :func:`~src.controllers.nvd_extract.extract_cve_details`.
+        Returns ``None`` if the CVE is not present in the local database.
+        """
+        databases = self._managed_databases()
+        if not databases:
+            return None
+        try:
+            cve_id_obj = CveId(cve_id.upper().strip())
+        except Exception:
+            return None
+        nvd_db_seen = False
+        for dbs in databases.values():
+            for db in dbs:
+                if not isinstance(db, NvdFkieVulnDatabase):
+                    continue
+                nvd_db_seen = True
+                # get_vuln may be lru_cache-wrapped by _install_get_vuln_caches;
+                # calling it directly is fine — the cache avoids repeated disk reads.
+                entry = db.get_vuln(cve_id_obj)
+                if entry is not None:
+                    raw = getattr(entry, "_json", _MISSING)
+                    if raw is _MISSING:
+                        self._warn_degraded(
+                            "entry_json",
+                            "sbom-cve-check advisory record has no '_json' "
+                            "attribute — the upstream library layout may have "
+                            "changed; NVD CVE JSON lookups will return no data. "
+                            "Check sbom-cve-check compatibility.",
+                        )
+                        return None
+                    return cast("dict | None", raw)
+        if not nvd_db_seen:
+            self._warn_degraded(
+                "no_nvd_fkie_db",
+                "sbom-cve-check databases are present but none is an "
+                "NvdFkieVulnDatabase — the upstream database class may have "
+                "changed; NVD CVE JSON lookups will return no data. "
+                "Check sbom-cve-check compatibility.",
+            )
+        return None
+
 
 def get_engine() -> SccEngine:
     """Return the process-wide indexed engine, building it on first use.
 
     The engine is expensive to build and is cached for the lifetime of the
-    process.  Because that one build would otherwise be the only time the advisory
-    clones are fetched, every call refreshes the databases before returning (a
-    no-op unless ``SBOM_CVE_CHECK_AUTO_UPDATE`` is enabled) so each scan — the
-    first included — runs against up-to-date advisories.
+    process.  Every call refreshes the advisory git clones before returning so
+    scans always run against up-to-date data.  Call this from full-scan paths.
+    For single-CVE look-ups that do not need an immediate git fetch, use
+    :func:`get_cve_json` instead (it reuses the cached engine without
+    triggering a refresh).
     """
     global _ENGINE
     with _ENGINE_LOCK:
@@ -407,3 +495,26 @@ def reset_engine() -> None:
     global _ENGINE
     with _ENGINE_LOCK:
         _ENGINE = None
+
+
+def get_cve_json(cve_id: str) -> "dict | None":
+    """Look up a CVE by ID in the local NVD-FKIE database.
+
+    Reuses the already-built engine without triggering a git fetch so
+    single-CVE look-ups (e.g. from the UI refresh button) are fast.  If no
+    engine has been built yet it falls back to :func:`get_engine` which
+    performs the initial build (including a first fetch).
+
+    Returns the raw NVD CVE JSON dict (same schema as NVD API v2) or ``None``
+    if the CVE is not found or the database is not yet initialised.
+    """
+    with _ENGINE_LOCK:
+        engine = _ENGINE
+    if engine is None:
+        # Engine not yet built — the first build includes a fetch.
+        engine = get_engine()
+    try:
+        return engine.get_nvd_cve_json(cve_id)
+    except Exception as exc:
+        _logger.warning("Failed to look up %s in local NVD database: %s", cve_id, exc)
+        return None

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -4,7 +4,6 @@
 import datetime
 import decimal
 import time
-import os
 import json
 import logging
 import typing
@@ -16,7 +15,8 @@ from typing import Optional
 from ..models import Vulnerability, Package, SBOMObservation
 from ..controllers.packages import PackagesController
 from ..controllers.epss_db import EPSS_DB
-from ..controllers.nvd_db import NVD_DB
+from ..controllers.scc_engine import get_cve_json
+from ..controllers.nvd_extract import api_weaknesses_to_list_str, api_references_filter_patches
 from ..helpers.verbose import verbose
 from ._base import to_dict_with_fallback
 from ..models.cvss import CVSS
@@ -126,7 +126,6 @@ class VulnerabilitiesController:
         are scoped to this variant so scores from one project/variant don't leak
         into another. Set by the process run from the latest scan's variant."""
         self.epss_api = EPSS_DB()
-        self.nvd_api = NVD_DB()
         self._preload_cache()
 
     def _preload_cache(self) -> None:
@@ -440,32 +439,22 @@ class VulnerabilitiesController:
         return None
 
     def fetch_published_dates(self):
-        """Fetch published dates for all vulnerabilities from local cache / GHSA API.
+        """Fetch published dates for all vulnerabilities from local NVD cache / GHSA API.
 
-        CVE-prefixed IDs are looked up from the local NVD SQLite cache (if
-        available).  GHSA-prefixed IDs are fetched from the GitHub Advisories
-        API via a thread pool.  All errors are silently caught so that a
-        single failure never aborts the whole run.
+        CVE-prefixed IDs are looked up from the local NVD-FKIE advisory database
+        via :func:`~src.controllers.scc_engine.get_cve_json`. GHSA-prefixed IDs
+        are fetched from the GitHub Advisories API via a thread pool. All errors
+        are silently caught so that a single failure never aborts the whole run.
         """
-        import sqlite3
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
-        nvd_db_path = os.path.join(
-            os.getenv("VULNSCOUT_CACHE_DIR", "/cache/vulnscout"), "nvd.db"
-        )
-
-        # CVE vulns: try local NVD SQLite cache
+        # CVE vulns: look up from local NVD-FKIE database
         for vuln in self.vulnerabilities.values():
             if vuln.id.startswith("CVE-"):
                 try:
-                    conn = sqlite3.connect(nvd_db_path)
-                    cursor = conn.execute(
-                        "SELECT published FROM cves WHERE id = ?", (vuln.id,)
-                    )
-                    row = cursor.fetchone()
-                    if row and row[0]:
-                        vuln.published = row[0]
-                    conn.close()
+                    cve_json = get_cve_json(vuln.id)
+                    if cve_json and cve_json.get("published"):
+                        vuln.published = cve_json["published"]
                 except Exception:
                     pass
 
@@ -518,29 +507,38 @@ class VulnerabilitiesController:
         tracker = NVDProgressTracker
         tracker.start("nvd_enrichment")
 
-        # NVD lookups via API
-        nvd_api = NVD_DB()
+        # NVD lookups via local FKIE database
         DB_COMMIT_EVERY = 100
         done = 0
         for vuln in nvd_vulns:
             try:
-                result = nvd_api.fetch_cve_data(vuln.id)
-                if result and result.get("not_found"):
-                    # NVD has no record for this CVE (404 or empty result set).
-                    print(f"=== NVD: {vuln.id} not found in NVD database.", flush=True)
+                cve_json = get_cve_json(vuln.id)
+                if cve_json is None:
+                    print(f"=== NVD: {vuln.id} not found in local database.", flush=True)
                     try:
                         rec = self._db_record_cache.get(vuln.id) or Vulnerability.get_by_id(vuln.id)
                         if rec is not None:
                             rec.update_record(nvd_fetched_at=datetime.datetime.utcnow(), commit=False)
                     except Exception as e:
                         verbose(f"[fetch_nvd_data not_found sentinel {vuln.id!r}] {e}")
-                elif result:
-                    if result.get("published"):
-                        vuln.published = result["published"]
-                    vuln.weaknesses = result.get("weaknesses")
-                    vuln.versions_data = result.get("versions_data")
-                    vuln.patch_url = result.get("patch_url")
-                    vuln.nvd_last_modified = result.get("lastModified")
+                else:
+                    if cve_json.get("published"):
+                        vuln.published = cve_json["published"]
+                    vuln.weaknesses = (
+                        api_weaknesses_to_list_str(cve_json["weaknesses"])
+                        if "weaknesses" in cve_json else None
+                    )
+                    # Fix scrapper for versions_data
+                    from typing import cast
+                    from ..helpers.fixs_scrapper import FixsScrapper, NvdCve
+                    fix_scrapper = FixsScrapper()
+                    fix_scrapper.search_in_nvd({"cve": cast(NvdCve, cve_json)})
+                    vuln.versions_data = fix_scrapper.list_per_packages()
+                    vuln.patch_url = (
+                        api_references_filter_patches(cve_json["references"])
+                        if "references" in cve_json else None
+                    )
+                    vuln.nvd_last_modified = cve_json.get("lastModified")
                     # Persist the enriched fields
                     try:
                         rec = self._db_record_cache.get(vuln.id) or Vulnerability.get_by_id(vuln.id)

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -21,11 +21,11 @@ if [ -f "$CONFIG_FILE" ]; then
 fi
 
 # The sbom-cve-check advisory databases live inside the VulnScout cache directory
-# (mounted at /cache/vulnscout), in a sbom_cve_check_databases sub-folder next to
+# (mounted at /cache/vulnscout), in a local_databases sub-folder next to
 # vulnscout.db.  Default SBOM_CVE_CHECK_DATABASES_DIR to that location so the engine
 # finds (and, with SBOM_CVE_CHECK_AUTO_UPDATE=1, clones) them without an explicit env
 # var; config.env (sourced above) or an explicit override may still change this.
-export SBOM_CVE_CHECK_DATABASES_DIR="${SBOM_CVE_CHECK_DATABASES_DIR:-/cache/vulnscout/sbom_cve_check_databases}"
+export SBOM_CVE_CHECK_DATABASES_DIR="${SBOM_CVE_CHECK_DATABASES_DIR:-/cache/vulnscout/local_databases}"
 
 # resolve_grype_memlimit  —  translate GRYPE_MEMLIMIT into a GOMEMLIMIT value.
 #
@@ -478,6 +478,7 @@ cmd_scan() {
         echo "------------------------------------------------------------------------------"
         echo "Initialization Done - Loading is over and WebUI is ready !!!"
         echo "Open  $_url in your browser to access VulnScout"
+        print_nvd_status
         echo "------------------------------------------------------------------------------"
         fg %?flask 2>/dev/null || true # Bring back process named 'flask' (flask run) to foreground.
     fi
@@ -609,9 +610,35 @@ cmd_delete_scan() {
     flask --app src.bin.webapp delete-scan "$scan_id"
 }
 
+#######################################
+# Print a one-line NVD configuration summary
+#######################################
+print_nvd_status() {
+    local nvd_db_dir="${SBOM_CVE_CHECK_DATABASES_DIR:-/cache/vulnscout/local_databases}"
+    local auto_update="${SBOM_CVE_CHECK_AUTO_UPDATE:-1}"
+
+    local db_status
+    if [[ -d "$nvd_db_dir/nvd-fkie" ]] && [[ -d "$nvd_db_dir/cvelist" ]]; then
+        db_status="databases present"
+    else
+        db_status="databases not yet cloned"
+    fi
+    local update_label
+    [[ "$auto_update" == "1" ]] && update_label="auto-update on" || update_label="auto-update off"
+
+    echo "  NVD local    : $nvd_db_dir  [$db_status, $update_label]"
+
+    if [[ -n "${NVD_API_KEY:-}" ]]; then
+        echo "  NVD API key  : configured (API mode available)"
+    else
+        echo "  NVD API key  : not set  (local mode is the default)"
+    fi
+}
+
 cmd_daemon() {
     setup_user
     echo "VulnScout ready. Use '/scan/src/entrypoint.sh --help' for available commands."
+    print_nvd_status
     tail -f /dev/null
 }
 

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -23,6 +23,8 @@ from flask.typing import ResponseReturnValue
 from ..models import Vulnerability
 from ..extensions import db
 from ..controllers.nvd_db import NVD_DB
+from ..controllers.scc_engine import get_cve_json, get_engine as _get_scc_engine
+from ..controllers.nvd_extract import extract_cve_details
 from ..controllers.nvd_apply import apply_nvd_update, apply_cvss_update
 from ..controllers.epss_db import EPSS_DB
 from ..controllers.nvd_progress import NVDProgressTracker
@@ -48,7 +50,7 @@ _EUVD_COMMIT_EVERY = 200
 
 
 def _nvd_sleep_interval() -> float:
-    """Return seconds to sleep between NVD API calls based on key presence.
+    """Seconds to sleep between NVD REST API calls based on key presence.
 
     Without an API key: 5 req / 30 s → 6 s per call.
     With an API key:   50 req / 30 s → 0.6 s per call.
@@ -80,7 +82,11 @@ def init_app(app: Flask) -> None:
     def bulk_nvd_refresh() -> ResponseReturnValue:
         """Trigger a bulk NVD refresh for a list of CVE IDs.
 
-        Body: ``{"cve_ids": ["CVE-A", "CVE-B", ...]}``
+        Body: ``{"cve_ids": ["CVE-A", ...], "mode": "local"|"api"}``
+
+        ``mode`` defaults to ``"local"`` (uses the local NVD-FKIE database;
+        no rate limits, no API key needed).  Pass ``"api"`` to use the NVD
+        REST API instead (respects rate limits and NVD_API_KEY if set).
 
         Returns 202 immediately and runs the refresh in a background thread.
         Returns 409 if a refresh is already in progress.
@@ -95,8 +101,14 @@ def init_app(app: Flask) -> None:
         cve_ids = [c for c in cve_ids if _CVE_RE.match(c)]
         if not cve_ids:
             return jsonify({"error": "cve_ids must contain valid CVE identifiers (e.g. CVE-2024-1234)"}), 400
-        if len(cve_ids) > _MAX_CVE_IDS:
-            return jsonify({"error": f"cve_ids must contain at most {_MAX_CVE_IDS} entries"}), 400
+
+        mode = body.get("mode", "local")  # "local" (default) or "api"
+        # The cap exists to avoid burning NVD API rate-limit quota. Local mode
+        # hits no external service, so the limit does not apply there.
+        if mode == "api" and len(cve_ids) > _MAX_CVE_IDS:
+            return jsonify(
+                {"error": f"cve_ids must contain at most {_MAX_CVE_IDS} entries when using NVD API mode"}
+            ), 400
 
         total = len(cve_ids)
         if not NVDProgressTracker.start_if_idle("bulk_nvd_refresh"):
@@ -105,11 +117,23 @@ def init_app(app: Flask) -> None:
 
         def _run() -> None:
             with app.app_context():
-                sleep_between = _nvd_sleep_interval()
-                nvd_api_key = os.getenv("NVD_API_KEY")
-                nvd = NVD_DB(nvd_api_key=nvd_api_key)
                 done = 0
                 try:
+                    if mode == "api":
+                        sleep_between = _nvd_sleep_interval()
+                        nvd_api_key = os.getenv("NVD_API_KEY")
+                        nvd = NVD_DB(nvd_api_key=nvd_api_key)
+                    else:
+                        # Pre-warm the engine once (fetches latest advisories if
+                        # auto-update is on) so individual CVE lookups in the loop
+                        # below reuse the cached engine without re-fetching.
+                        try:
+                            _get_scc_engine()
+                        except Exception as exc:
+                            NVDProgressTracker.error(
+                                f"Failed to load local NVD database: {exc}"
+                            )
+                            return
                     for cve_id in cve_ids:
                         if NVDProgressTracker.is_cancelled():
                             _safe_commit("bulk NVD refresh cancel")
@@ -118,20 +142,35 @@ def init_app(app: Flask) -> None:
 
                         try:
                             now = datetime.datetime.now(datetime.timezone.utc)
-                            status_code, data = nvd.api_get_cve(cve_id, max_retries=2)
-                            if status_code == 200 and data.get("vulnerabilities"):
-                                cve = data["vulnerabilities"][0]["cve"]
-                                details = NVD_DB.extract_cve_details(cve)
-                                rec = db.session.get(Vulnerability, cve_id)
-                                if rec is not None:
-                                    apply_nvd_update(rec, details, now)
-                                    apply_cvss_update(rec, details, db)
+                            if mode == "api":
+                                status_code, data_api = nvd.api_get_cve(cve_id, max_retries=2)
+                                if status_code == 200 and data_api.get("vulnerabilities"):
+                                    cve_obj = data_api["vulnerabilities"][0]["cve"]
+                                    details = NVD_DB.extract_cve_details(cve_obj)
+                                    rec = db.session.get(Vulnerability, cve_id)
+                                    if rec is not None:
+                                        apply_nvd_update(rec, details, now)
+                                        apply_cvss_update(rec, details, db)
+                                else:
+                                    print(
+                                        f"[bulk NVD refresh] {cve_id}: status={status_code}, "
+                                        "skipping",
+                                        flush=True,
+                                    )
                             else:
-                                print(
-                                    f"[bulk NVD refresh] {cve_id}: status={status_code}, "
-                                    "skipping",
-                                    flush=True,
-                                )
+                                cve_obj = get_cve_json(cve_id)
+                                if cve_obj is not None:
+                                    details = extract_cve_details(cve_obj)
+                                    rec = db.session.get(Vulnerability, cve_id)
+                                    if rec is not None:
+                                        apply_nvd_update(rec, details, now)
+                                        apply_cvss_update(rec, details, db)
+                                else:
+                                    print(
+                                        f"[bulk NVD refresh] {cve_id}: not found in local "
+                                        "NVD database, skipping",
+                                        flush=True,
+                                    )
                         except Exception as exc:
                             print(f"[bulk NVD refresh] error for {cve_id}: {exc}", flush=True)
 
@@ -142,7 +181,7 @@ def init_app(app: Flask) -> None:
                         )
                         if done % _NVD_COMMIT_EVERY == 0:
                             _safe_commit("bulk NVD refresh")
-                        if done < total:
+                        if mode == "api" and done < total:
                             time.sleep(sleep_between)
 
                     _safe_commit("bulk NVD refresh final")

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -106,6 +106,16 @@ def _resolve_grype_memlimit() -> str | None:
     return None
 
 
+def _read_nvd_mode() -> str:
+    """Read the ``mode`` request option for NVD operations (defaults to ``"local"``).
+
+    ``"local"`` uses the local NVD-FKIE advisory database (no network, no rate
+    limits).  ``"api"`` queries the NVD REST API v2 (requires network; optional
+    NVD_API_KEY env var increases rate limit).
+    """
+    return request.args.get("mode", "local").strip().lower()
+
+
 def init_app(app: Flask) -> None:
 
     # ------------------------------------------------------------------
@@ -385,12 +395,18 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/variants/<variant_id>/nvd-scan', methods=['POST'])
     def trigger_nvd_scan(variant_id: str) -> ResponseReturnValue:
-        """Trigger an NVD CPE-based vulnerability scan for the given variant.
+        """Trigger an NVD vulnerability scan for the given variant.
 
-        For every active package that has CPE identifiers, query the NVD CVE
-        API (``cpeName=…``) and create findings/observations for any CVEs
-        returned.  The result is stored as a tool scan.
+        Supports two modes (``?mode=local`` is the default):
+
+        * **local** — uses the local NVD-FKIE advisory database via the
+          sbom-cve-check engine; no network, no rate limits.
+        * **api** — queries the NVD REST API v2 using CPE identifiers from
+          packages; honours NVD_API_KEY and rate limits.
         """
+        from ..controllers.scc_engine import get_engine
+        from ..bin.cmd_vuln_scan import _SccBulkWriter
+
         variant_uuid, variant, err = validate_trigger(
             variant_id, _nvd_scans_in_progress, "NVD scan")
         if err is not None:
@@ -400,6 +416,7 @@ def init_app(app: Flask) -> None:
 
         vid_str = str(variant_uuid)
         exclude_kernel = _read_exclude_kernel()
+        nvd_mode = _read_nvd_mode()
         init_progress(_nvd_scans_in_progress, vid_str)
 
         def _run_nvd_scan() -> None:
@@ -408,15 +425,6 @@ def init_app(app: Flask) -> None:
 
         def _do_nvd_scan(vid_str: str, variant_uuid: uuid.UUID) -> None:
             try:
-                from ..controllers.nvd_db import NVD_DB
-                from ..models.vulnerability import Vulnerability as VulnModel
-                from ..models.metrics import Metrics as MetricsModel
-                from ..models.cvss import CVSS
-
-                nvd_api_key = os.getenv("NVD_API_KEY")
-                nvd = NVD_DB(nvd_api_key=nvd_api_key)
-
-                # 1. Get active packages
                 _nvd_scans_in_progress[vid_str]["logs"].append(
                     "Resolving active packages…"
                 )
@@ -426,187 +434,196 @@ def init_app(app: Flask) -> None:
                 if pkg_err:
                     return
 
-                # 2. Collect CPE names from packages
-                cpe_to_pkgs: dict[str, list[Package]] = {}
-                for pkg in packages:
-                    for cpe in (pkg.cpe or []):
-                        parts = cpe.split(":")
-                        if len(parts) >= 6 and parts[4] != "*":
-                            cpe_to_pkgs.setdefault(cpe, []).append(pkg)
-
-                if not cpe_to_pkgs:
-                    set_error(_nvd_scans_in_progress, vid_str,
-                              "No packages with valid CPE identifiers")
-                    return
-
-                _nvd_scans_in_progress[vid_str]["logs"].append(
-                    f"Found {len(packages)} packages with "
-                    f"{len(cpe_to_pkgs)} unique CPEs to query"
-                )
-
-                # 3. Create a tool scan
-                scan = Scan.create(
-                    description="empty description",
-                    variant_id=variant_uuid,
-                    scan_type="tool",
-                    scan_source="nvd",
-                )
-                total_cpes = len(cpe_to_pkgs)
-                _nvd_scans_in_progress[vid_str]["total"] = total_cpes
-                cves_found: set[str] = set()
-                observation_pairs: set[tuple[uuid.UUID, uuid.UUID]] = set()
-                assessed_findings: set[tuple[uuid.UUID, uuid.UUID]] = set()
-
-                for idx, (cpe_name, pkgs) in enumerate(
-                    cpe_to_pkgs.items(), 1
-                ):
-                    _nvd_scans_in_progress[vid_str]["progress"] = (
-                        f"{idx}/{total_cpes} CPEs"
-                    )
-                    _nvd_scans_in_progress[vid_str]["logs"].append(
-                        f"[{idx}/{total_cpes}] Querying {cpe_name}…"
-                    )
-                    try:
-                        cpe_parts = cpe_name.split(":")
-                        has_wildcards = (
-                            len(cpe_parts) >= 6
-                            and (cpe_parts[2] == "*"
-                                 or cpe_parts[3] == "*"
-                                 or cpe_parts[5] == "*")
-                        )
-                        nvd_vulns = nvd.api_get_cves_by_cpe(
-                            cpe_name,
-                            results_per_page=100,
-                            use_virtual_match=has_wildcards,
-                        )
-                    except Exception as e:
-                        log_entry = (
-                            f"[{idx}/{total_cpes}] ERROR "
-                            f"{cpe_name}: {str(e)[:200]}"
-                        )
-                        _nvd_scans_in_progress[vid_str]["logs"].append(log_entry)
-                        _nvd_scans_in_progress[vid_str]["done_count"] = idx
-                        print(f"[NVD Scan] Error querying CPE {cpe_name}: {e}", flush=True)
-                        continue
-
-                    cpe_cves = [
-                        v.get("cve", {}).get("id", "")
-                        for v in nvd_vulns
-                        if v.get("cve", {}).get("id")
-                    ]
-                    if cpe_cves:
-                        ids_str = ', '.join(cpe_cves[:10])
-                        ellip = '…' if len(cpe_cves) > 10 else ''
-                        log_entry = (
-                            f"[{idx}/{total_cpes}] {cpe_name} → "
-                            f"{len(cpe_cves)} CVE(s): {ids_str}{ellip}"
-                        )
-                    else:
-                        log_entry = (
-                            f"[{idx}/{total_cpes}] {cpe_name} → no CVEs"
-                        )
-                    _nvd_scans_in_progress[vid_str]["logs"].append(log_entry)
-                    _nvd_scans_in_progress[vid_str]["done_count"] = idx
-
-                    for nvd_vuln in nvd_vulns:
-                        cve = nvd_vuln.get("cve", {})
-                        cve_id = cve.get("id", "")
-                        if not cve_id:
-                            continue
-
-                        cves_found.add(cve_id)
-                        details = NVD_DB.extract_cve_details(cve)
-
-                        existing_vuln = db.session.get(VulnModel, cve_id.upper())
-                        if existing_vuln is None:
-                            existing_vuln = VulnModel.create_record(
-                                id=cve_id,
-                                description=details.get("description"),
-                                status=details.get("status"),
-                                publish_date=details.get("publish_date"),
-                                attack_vector=details.get("attack_vector"),
-                                links=details.get("links"),
-                                weaknesses=details.get("weaknesses"),
-                                nvd_last_modified=details.get("nvd_last_modified"),
-                            )
-                            existing_vuln.add_found_by("nvd")
-                        else:
-                            existing_vuln.add_found_by("nvd")
-                            _update = {}
-                            if not existing_vuln.description and details.get("description"):
-                                _update["description"] = details["description"]
-                            if not existing_vuln.status and details.get("status"):
-                                _update["status"] = details["status"]
-                            if not existing_vuln.publish_date and details.get("publish_date"):
-                                _update["publish_date"] = details["publish_date"]
-                            if not existing_vuln.attack_vector and details.get("attack_vector"):
-                                _update["attack_vector"] = details["attack_vector"]
-                            if not existing_vuln.links and details.get("links"):
-                                _update["links"] = details["links"]
-                            if not existing_vuln.weaknesses and details.get("weaknesses"):
-                                _update["weaknesses"] = details["weaknesses"]
-                            if _update:
-                                existing_vuln.update_record(**_update, commit=False)
-
-                        # Persist CVSS metrics
-                        if details.get("base_score") is not None:
-                            _cvss_v = details.get("cvss_version")
-                            _cvss_s = details["base_score"]
-                            _cvss_vec = details.get("cvss_vector")
-                            _dedup = (cve_id.upper(), _cvss_v, float(_cvss_s))
-                            if _dedup not in MetricsModel._seen:
-                                try:
-                                    MetricsModel.from_cvss(
-                                        CVSS(
-                                            version=_cvss_v or "",
-                                            vector_string=_cvss_vec or "",
-                                            author="nvd",
-                                            base_score=float(_cvss_s),
-                                            exploitability_score=(
-                                                float(details["cvss_exploitability"])
-                                                if details.get("cvss_exploitability") is not None
-                                                else 0
-                                            ),
-                                            impact_score=(
-                                                float(details["cvss_impact"])
-                                                if details.get("cvss_impact") is not None
-                                                else 0
-                                            ),
-                                        ),
-                                        existing_vuln.id,
-                                    )
-                                except Exception:
-                                    pass
-
-                        for pkg in pkgs:
-                            finding = Finding.get_or_create(pkg.id, cve_id)
-                            create_observation_and_assessment(
-                                finding, scan, variant_uuid, "nvd",
-                                observation_pairs, assessed_findings,
-                            )
-
-                db.session.commit()
-
-                done_logs = _nvd_scans_in_progress[vid_str].get("logs", [])
-                done_logs.append(
-                    f"✓ Scan complete — found {len(cves_found)} "
-                    f"unique CVEs across {total_cpes} CPEs"
-                )
-                _nvd_scans_in_progress[vid_str] = {
-                    "status": "done",
-                    "error": None,
-                    "progress": (
-                        f"Found {len(cves_found)} CVEs "
-                        f"across {total_cpes} CPEs"
-                    ),
-                    "logs": done_logs,
-                    "total": total_cpes,
-                    "done_count": total_cpes,
-                }
+                if nvd_mode == "api":
+                    _do_nvd_scan_api(vid_str, variant_uuid, list(packages))
+                else:
+                    _do_nvd_scan_local(vid_str, variant_uuid, list(packages))
 
             except Exception as e:
                 db.session.rollback()
                 set_error(_nvd_scans_in_progress, vid_str, str(e)[:500])
+
+        def _do_nvd_scan_local(
+            vid_str: str, variant_uuid: uuid.UUID, packages: list
+        ) -> None:
+            """NVD scan using the local NVD-FKIE advisory database."""
+            _nvd_scans_in_progress[vid_str]["logs"].append(
+                "Loading local NVD advisory database…"
+            )
+            try:
+                engine = get_engine()
+            except Exception as exc:
+                set_error(_nvd_scans_in_progress, vid_str,
+                          f"Failed to load local NVD database: {exc}")
+                return
+
+            scan = Scan.create(
+                description="empty description",
+                variant_id=variant_uuid,
+                scan_type="tool",
+                scan_source="nvd",
+            )
+
+            total = len(packages)
+            _nvd_scans_in_progress[vid_str]["total"] = total
+            writer = _SccBulkWriter(scan.id, variant_uuid, packages)
+            seen_keys: set = set()
+
+            for idx, pkg in enumerate(packages, 1):
+                _nvd_scans_in_progress[vid_str]["progress"] = (
+                    f"{idx}/{total} packages"
+                )
+                try:
+                    for computed, status in engine.applicable_vulns(pkg):
+                        writer.add(pkg, computed, status, seen_keys)
+                except Exception as exc:
+                    _nvd_scans_in_progress[vid_str]["logs"].append(
+                        f"[{idx}/{total}] ERROR {pkg.name}: {str(exc)[:200]}"
+                    )
+                _nvd_scans_in_progress[vid_str]["done_count"] = idx
+
+            writer.flush()
+
+            cves_found = len(seen_keys)
+            done_logs = _nvd_scans_in_progress[vid_str].get("logs", [])
+            done_logs.append(
+                f"✓ Scan complete — found {cves_found} "
+                f"unique CVEs across {total} packages"
+            )
+            _nvd_scans_in_progress[vid_str] = {
+                "status": "done",
+                "error": None,
+                "progress": f"Found {cves_found} CVEs across {total} packages",
+                "logs": done_logs,
+                "total": total,
+                "done_count": total,
+            }
+
+        def _do_nvd_scan_api(
+            vid_str: str, variant_uuid: uuid.UUID, packages: list
+        ) -> None:
+            """NVD scan using the NVD REST API v2 (CPE-based)."""
+            from ..controllers.nvd_db import NVD_DB
+            from ..controllers.nvd_persist import persist_nvd_cve
+
+            nvd_api_key = os.getenv("NVD_API_KEY")
+            nvd = NVD_DB(nvd_api_key=nvd_api_key)
+
+            # Collect CPE names from packages
+            cpe_to_pkgs: dict[str, list[Package]] = {}
+            for pkg in packages:
+                for cpe in (pkg.cpe or []):
+                    parts = cpe.split(":")
+                    if len(parts) >= 6 and parts[4] != "*":
+                        cpe_to_pkgs.setdefault(cpe, []).append(pkg)
+
+            if not cpe_to_pkgs:
+                set_error(_nvd_scans_in_progress, vid_str,
+                          "No packages with valid CPE identifiers")
+                return
+
+            _nvd_scans_in_progress[vid_str]["logs"].append(
+                f"Found {len(packages)} packages with "
+                f"{len(cpe_to_pkgs)} unique CPEs to query"
+            )
+
+            scan = Scan.create(
+                description="empty description",
+                variant_id=variant_uuid,
+                scan_type="tool",
+                scan_source="nvd",
+            )
+            total_cpes = len(cpe_to_pkgs)
+            _nvd_scans_in_progress[vid_str]["total"] = total_cpes
+            cves_found: set[str] = set()
+            observation_pairs: set[tuple[uuid.UUID, uuid.UUID]] = set()
+            assessed_findings: set[tuple[uuid.UUID, uuid.UUID]] = set()
+
+            for idx, (cpe_name, pkgs) in enumerate(cpe_to_pkgs.items(), 1):
+                _nvd_scans_in_progress[vid_str]["progress"] = (
+                    f"{idx}/{total_cpes} CPEs"
+                )
+                _nvd_scans_in_progress[vid_str]["logs"].append(
+                    f"[{idx}/{total_cpes}] Querying {cpe_name}…"
+                )
+                try:
+                    cpe_parts = cpe_name.split(":")
+                    has_wildcards = (
+                        len(cpe_parts) >= 6
+                        and (cpe_parts[2] == "*"
+                             or cpe_parts[3] == "*"
+                             or cpe_parts[5] == "*")
+                    )
+                    nvd_vulns = nvd.api_get_cves_by_cpe(
+                        cpe_name,
+                        results_per_page=100,
+                        use_virtual_match=has_wildcards,
+                    )
+                except Exception as e:
+                    log_entry = (
+                        f"[{idx}/{total_cpes}] ERROR "
+                        f"{cpe_name}: {str(e)[:200]}"
+                    )
+                    _nvd_scans_in_progress[vid_str]["logs"].append(log_entry)
+                    _nvd_scans_in_progress[vid_str]["done_count"] = idx
+                    print(f"[NVD Scan] Error querying CPE {cpe_name}: {e}", flush=True)
+                    continue
+
+                cpe_cves = [
+                    v.get("cve", {}).get("id", "")
+                    for v in nvd_vulns
+                    if v.get("cve", {}).get("id")
+                ]
+                if cpe_cves:
+                    ids_str = ', '.join(cpe_cves[:10])
+                    ellip = '…' if len(cpe_cves) > 10 else ''
+                    log_entry = (
+                        f"[{idx}/{total_cpes}] {cpe_name} → "
+                        f"{len(cpe_cves)} CVE(s): {ids_str}{ellip}"
+                    )
+                else:
+                    log_entry = (
+                        f"[{idx}/{total_cpes}] {cpe_name} → no CVEs"
+                    )
+                _nvd_scans_in_progress[vid_str]["logs"].append(log_entry)
+                _nvd_scans_in_progress[vid_str]["done_count"] = idx
+
+                for nvd_vuln in nvd_vulns:
+                    cve = nvd_vuln.get("cve", {})
+                    cve_id = cve.get("id", "")
+                    if not cve_id:
+                        continue
+
+                    cves_found.add(cve_id)
+                    details = NVD_DB.extract_cve_details(cve)
+
+                    persist_nvd_cve(cve_id, details)
+
+                    for pkg in pkgs:
+                        finding = Finding.get_or_create(pkg.id, cve_id)
+                        create_observation_and_assessment(
+                            finding, scan, variant_uuid, "nvd",
+                            observation_pairs, assessed_findings,
+                        )
+
+            db.session.commit()
+
+            done_logs = _nvd_scans_in_progress[vid_str].get("logs", [])
+            done_logs.append(
+                f"✓ Scan complete — found {len(cves_found)} "
+                f"unique CVEs across {total_cpes} CPEs"
+            )
+            _nvd_scans_in_progress[vid_str] = {
+                "status": "done",
+                "error": None,
+                "progress": (
+                    f"Found {len(cves_found)} CVEs "
+                    f"across {total_cpes} CPEs"
+                ),
+                "logs": done_logs,
+                "total": total_cpes,
+                "done_count": total_cpes,
+            }
 
         thread = threading.Thread(
             target=_run_nvd_scan,

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -3,7 +3,6 @@
 
 import datetime
 import decimal
-import os
 import dataclasses
 import typing
 import re
@@ -29,7 +28,9 @@ from ..models import (
 )
 from ..helpers.datetime_utils import ensure_utc_iso
 from ..extensions import db
+from ..controllers.scc_engine import get_cve_json
 from ..controllers.nvd_db import NVD_DB
+from ..controllers.nvd_extract import extract_cve_details
 from ..controllers.nvd_apply import apply_nvd_update
 from ..controllers.epss_db import EPSS_DB
 from ..controllers.vulnerabilities import VulnerabilitiesController
@@ -1011,38 +1012,50 @@ def init_app(app: Flask) -> None:
         if rec is None:
             return jsonify({"error": "CVE not found"}), 404
 
-        api_key = os.getenv("NVD_API_KEY")
-        try:
-            nvd = NVD_DB(nvd_api_key=api_key)
-            status_code, data = nvd.api_get_cve(cve_id_upper, max_retries=0)
-        except Exception as e:
-            return jsonify({
-                "error": f"NVD API unavailable: {e}",
-                "error_code": "unavailable",
-                "api_key_configured": bool(api_key),
-            }), 503
+        body = request.get_json(force=True, silent=True) or {}
+        mode = body.get("mode", "local")  # "local" (default) or "api"
 
-        if status_code == 429:
-            return jsonify({
-                "error": "NVD API rate limit exceeded",
-                "error_code": "rate_limited",
-                "api_key_configured": bool(api_key),
-            }), 429
-        if status_code in (401, 403):
-            return jsonify({
-                "error": f"NVD API rejected credentials (HTTP {status_code})",
-                "error_code": "unauthorized",
-                "api_key_configured": bool(api_key),
-            }), status_code
-        if status_code != 200 or not data.get("vulnerabilities"):
-            return jsonify({
-                "error": "NVD API returned no data for this CVE",
-                "error_code": "unavailable",
-                "api_key_configured": bool(api_key),
-            }), 503
-
-        cve = data["vulnerabilities"][0]["cve"]
-        details = NVD_DB.extract_cve_details(cve)
+        if mode == "api":
+            import os as _os
+            api_key = _os.getenv("NVD_API_KEY")
+            api_key_configured = bool(api_key)
+            try:
+                nvd = NVD_DB(nvd_api_key=api_key)
+                status_code, data_api = nvd.api_get_cve(cve_id_upper, max_retries=0)
+            except Exception as e:
+                return jsonify({
+                    "error": f"NVD API unavailable: {e}",
+                    "error_code": "unavailable",
+                    "api_key_configured": api_key_configured,
+                }), 503
+            if status_code == 429:
+                return jsonify({
+                    "error": "NVD API rate limit exceeded",
+                    "error_code": "rate_limited",
+                    "api_key_configured": api_key_configured,
+                }), 429
+            if status_code in (401, 403):
+                return jsonify({
+                    "error": f"NVD API rejected credentials (HTTP {status_code})",
+                    "error_code": "unauthorized",
+                    "api_key_configured": api_key_configured,
+                }), status_code
+            if status_code != 200 or not data_api.get("vulnerabilities"):
+                return jsonify({
+                    "error": "NVD API returned no data for this CVE",
+                    "error_code": "unavailable",
+                    "api_key_configured": api_key_configured,
+                }), 503
+            cve_obj = data_api["vulnerabilities"][0]["cve"]
+            details = NVD_DB.extract_cve_details(cve_obj)
+        else:
+            cve_obj = get_cve_json(cve_id_upper)
+            if cve_obj is None:
+                return jsonify({
+                    "error": "CVE not found in local NVD database",
+                    "error_code": "unavailable",
+                }), 503
+            details = extract_cve_details(cve_obj)
         now = datetime.datetime.now(datetime.timezone.utc)
         apply_nvd_update(rec, details, now)
 

--- a/tests/unit_tests/test_bulk_refresh.py
+++ b/tests/unit_tests/test_bulk_refresh.py
@@ -57,7 +57,7 @@ class TestApplyCvssUpdate:
         existing.score = 5.0
         existing.vector = "old-vector"
         mock_db = self._make_db()
-        mock_db.session.execute.return_value.scalar_one_or_none.return_value = existing
+        mock_db.session.execute.return_value.scalars.return_value.first.return_value = existing
 
         with patch("src.controllers.nvd_apply.Metrics"):
             apply_cvss_update(rec, {
@@ -73,7 +73,7 @@ class TestApplyCvssUpdate:
         """When no Metrics row exists, a new one is added to the session."""
         rec = self._make_rec()
         mock_db = self._make_db()
-        mock_db.session.execute.return_value.scalar_one_or_none.return_value = None
+        mock_db.session.execute.return_value.scalars.return_value.first.return_value = None
 
         with patch("src.controllers.nvd_apply.Metrics") as MockMetrics:
             apply_cvss_update(rec, {
@@ -97,7 +97,7 @@ class TestApplyCvssUpdate:
         existing.score = 8.1
         existing.vector = vector
         mock_db = self._make_db()
-        mock_db.session.execute.return_value.scalar_one_or_none.return_value = existing
+        mock_db.session.execute.return_value.scalars.return_value.first.return_value = existing
 
         with patch("src.controllers.nvd_apply.Metrics"):
             apply_cvss_update(rec, {

--- a/tests/unit_tests/test_initial_enrichment_data_updated_at.py
+++ b/tests/unit_tests/test_initial_enrichment_data_updated_at.py
@@ -64,17 +64,22 @@ def test_nvd_initial_populate_sets_nvd_data_updated_at(app):
 
     ctrl = _make_controller(app, cve_id)
 
-    fake_result = {
-        "published": "2020-05-01",
-        "weaknesses": ["CWE-787"],
-        "versions_data": {},
-        "patch_url": [],
-        "lastModified": "2020-06-01",
+    fake_cve_json = {
+        "id": cve_id,
+        "published": "2020-05-01T00:00:00.000",
+        "lastModified": "2020-06-01T00:00:00.000",
+        "vulnStatus": "Analyzed",
+        "weaknesses": [
+            {"source": "nvd", "type": "Primary",
+             "description": [{"lang": "en", "value": "CWE-787"}]}
+        ],
+        "references": [],
+        "descriptions": [{"lang": "en", "value": "test description"}],
     }
 
     with app.app_context():
-        with patch("src.controllers.vulnerabilities.NVD_DB") as MockNVD:
-            MockNVD.return_value.fetch_cve_data.return_value = fake_result
+        with patch("src.controllers.vulnerabilities.get_cve_json",
+                   return_value=fake_cve_json):
             ctrl.fetch_nvd_data()
             db.session.commit()
 
@@ -84,7 +89,7 @@ def test_nvd_initial_populate_sets_nvd_data_updated_at(app):
 
 
 def test_nvd_not_found_does_not_set_nvd_data_updated_at(app):
-    """fetch_nvd_data() does NOT stamp nvd_data_updated_at for a not_found sentinel."""
+    """fetch_nvd_data() does NOT stamp nvd_data_updated_at for a CVE not found in local DB."""
     cve_id = "CVE-2020-35492"
 
     with app.app_context():
@@ -96,8 +101,7 @@ def test_nvd_not_found_does_not_set_nvd_data_updated_at(app):
     ctrl = _make_controller(app, cve_id)
 
     with app.app_context():
-        with patch("src.controllers.vulnerabilities.NVD_DB") as MockNVD:
-            MockNVD.return_value.fetch_cve_data.return_value = {"not_found": True}
+        with patch("src.controllers.vulnerabilities.get_cve_json", return_value=None):
             ctrl.fetch_nvd_data()
             db.session.commit()
 
@@ -133,10 +137,8 @@ def test_ghsa_initial_populate_sets_ghsa_data_updated_at(app):
         ctrl._db_record_cache = {}
 
         with patch.object(VulnerabilitiesController, "_fetch_ghsa_published",
-                          return_value="2023-06-15T00:00:00Z"), \
-             patch("src.controllers.vulnerabilities.NVD_DB") as MockNVD:
-            # No CVE-prefixed IDs → NVD fetch skipped
-            MockNVD.return_value.fetch_cve_data.return_value = None
+                          return_value="2023-06-15T00:00:00Z"):
+            # No CVE-prefixed IDs → NVD (get_cve_json) path skipped entirely
             ctrl.fetch_nvd_data()
             db.session.commit()
 

--- a/tests/unit_tests/test_scc_engine_utils.py
+++ b/tests/unit_tests/test_scc_engine_utils.py
@@ -51,21 +51,21 @@ class TestDatabasesDir:
         monkeypatch.setenv("VULNSCOUT_CACHE_DIR", str(tmp_path))
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
-        assert result == tmp_path.joinpath("sbom_cve_check_databases").resolve()
+        assert result == tmp_path.joinpath("local_databases").resolve()
 
     def test_falls_back_to_cache_vulnscout(self, monkeypatch):
         monkeypatch.delenv("SBOM_CVE_CHECK_DATABASES_DIR", raising=False)
         monkeypatch.delenv("VULNSCOUT_CACHE_DIR", raising=False)
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
-        assert str(result).endswith("/cache/vulnscout/sbom_cve_check_databases")
+        assert str(result).endswith("/cache/vulnscout/local_databases")
 
     def test_blank_env_var_falls_back(self, monkeypatch):
         monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", "   ")
         monkeypatch.delenv("VULNSCOUT_CACHE_DIR", raising=False)
         from src.controllers import scc_engine as mod
         result = mod._databases_dir()
-        assert "sbom_cve_check_databases" in str(result)
+        assert "local_databases" in str(result)
 
 
 class TestTrustGitDirectories:

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -177,12 +177,12 @@ class TestBulkNvdRefreshEndpoint:
         assert "valid CVE" in resp.get_json()["error"]
 
     def test_returns_400_when_count_exceeds_max(self, client):
-        """400 when more than _MAX_CVE_IDS valid IDs are submitted."""
+        """400 when more than _MAX_CVE_IDS valid IDs are submitted in API mode."""
         from src.routes.bulk_refresh import _MAX_CVE_IDS
         ids = [f"CVE-2024-{i:05d}" for i in range(_MAX_CVE_IDS + 1)]
         resp = client.post(
             "/api/vulnerabilities/bulk-nvd-refresh",
-            json={"cve_ids": ids},
+            json={"cve_ids": ids, "mode": "api"},
         )
         assert resp.status_code == 400
         assert "at most" in resp.get_json()["error"]
@@ -302,7 +302,7 @@ class TestBulkNvdRefreshBackground:
     """Tests for the _run() closure spawned by bulk_nvd_refresh."""
 
     def _capture_target(self, client, cve_ids):
-        """POST to the endpoint and return the captured _run target without starting it."""
+        """POST to the endpoint with mode=api and return the captured _run target without starting it."""
         captured = {}
 
         def fake_thread(target=None, **kwargs):
@@ -312,7 +312,7 @@ class TestBulkNvdRefreshBackground:
         with patch("src.routes.bulk_refresh.threading.Thread", side_effect=fake_thread):
             resp = client.post(
                 "/api/vulnerabilities/bulk-nvd-refresh",
-                json={"cve_ids": cve_ids},
+                json={"cve_ids": cve_ids, "mode": "api"},
             )
         assert resp.status_code == 202
         return captured["target"]
@@ -758,7 +758,7 @@ def _capture_refresh_target(client, endpoint, cve_ids):
         return MagicMock()
 
     with patch("src.routes.bulk_refresh.threading.Thread", side_effect=fake_thread):
-        resp = client.post(endpoint, json={"cve_ids": cve_ids})
+        resp = client.post(endpoint, json={"cve_ids": cve_ids, "mode": "api"})
     assert resp.status_code == 202
     return captured["target"]
 
@@ -1497,6 +1497,148 @@ class TestBulkGhsaRefreshFailedCounter:
 
         MockTracker.error.assert_called_once()
         MockTracker.complete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Bulk NVD refresh — mode parameter (local vs api)
+# ---------------------------------------------------------------------------
+
+class TestBulkNvdRefreshMode:
+    """Tests for the ``mode`` body parameter added by the local-nvd-fkie feature."""
+
+    def test_default_mode_is_local(self, client, existing_cve_id):
+        """When no mode is supplied the endpoint accepts the request (local default)."""
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": [existing_cve_id]},
+            )
+        assert resp.status_code == 202
+
+    def test_explicit_local_mode_accepted(self, client, existing_cve_id):
+        """mode='local' is accepted with 202."""
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": [existing_cve_id], "mode": "local"},
+            )
+        assert resp.status_code == 202
+
+    def test_explicit_api_mode_accepted(self, client, existing_cve_id):
+        """mode='api' is accepted with 202."""
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": [existing_cve_id], "mode": "api"},
+            )
+        assert resp.status_code == 202
+
+    def test_local_mode_background_uses_get_cve_json(self, client, existing_cve_id):
+        """_run() uses get_cve_json (local DB) when mode is 'local'."""
+        captured = {}
+
+        def fake_thread(target=None, **kwargs):
+            captured["target"] = target
+            return MagicMock()
+
+        with patch("src.routes.bulk_refresh.threading.Thread", side_effect=fake_thread):
+            client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": [existing_cve_id], "mode": "local"},
+            )
+
+        with patch("src.routes.bulk_refresh.get_cve_json") as mock_local, \
+             patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh._get_scc_engine"), \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
+            mock_local.return_value = None
+            captured["target"]()
+
+        mock_local.assert_called_once_with(existing_cve_id)
+        MockNVD.return_value.api_get_cve.assert_not_called()
+
+    def test_api_mode_background_uses_nvd_db(self, client, existing_cve_id):
+        """_run() uses NVD_DB (REST API) when mode is 'api'."""
+        captured = {}
+
+        def fake_thread(target=None, **kwargs):
+            captured["target"] = target
+            return MagicMock()
+
+        with patch("src.routes.bulk_refresh.threading.Thread", side_effect=fake_thread):
+            client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": [existing_cve_id], "mode": "api"},
+            )
+
+        with patch("src.routes.bulk_refresh.get_cve_json") as mock_local, \
+             patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep"), \
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            captured["target"]()
+
+        MockNVD.return_value.api_get_cve.assert_called_once_with(existing_cve_id, max_retries=2)
+        mock_local.assert_not_called()
+
+    def test_local_mode_background_no_sleep(self, client):
+        """_run() does NOT sleep between CVEs when mode is 'local'."""
+        cve_ids = ["CVE-2024-00001", "CVE-2024-00002"]
+        captured = {}
+
+        def fake_thread(target=None, **kwargs):
+            captured["target"] = target
+            return MagicMock()
+
+        with patch("src.routes.bulk_refresh.threading.Thread", side_effect=fake_thread):
+            client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": cve_ids, "mode": "local"},
+            )
+
+        with patch("src.routes.bulk_refresh.get_cve_json", return_value=None), \
+             patch("src.routes.bulk_refresh._get_scc_engine"), \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep") as mock_sleep, \
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
+            captured["target"]()
+
+        mock_sleep.assert_not_called()
+
+    def test_api_mode_background_sleeps_between_cves(self, client, monkeypatch):
+        """_run() sleeps between CVEs when mode is 'api'."""
+        monkeypatch.delenv("NVD_API_KEY", raising=False)
+        cve_ids = ["CVE-2024-00001", "CVE-2024-00002"]
+        captured = {}
+
+        def fake_thread(target=None, **kwargs):
+            captured["target"] = target
+            return MagicMock()
+
+        with patch("src.routes.bulk_refresh.threading.Thread", side_effect=fake_thread):
+            client.post(
+                "/api/vulnerabilities/bulk-nvd-refresh",
+                json={"cve_ids": cve_ids, "mode": "api"},
+            )
+
+        with patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
+             patch("src.routes.bulk_refresh.db"), \
+             patch("src.routes.bulk_refresh.time.sleep") as mock_sleep, \
+             patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
+            MockNVD.return_value.api_get_cve.return_value = (404, {})
+            captured["target"]()
+
+        # One sleep between two CVEs, none after the last
+        mock_sleep.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webapp_tests/test_config_routes.py
+++ b/tests/webapp_tests/test_config_routes.py
@@ -234,3 +234,134 @@ class TestApiVersion:
         assert resp.status_code == 200
         data = resp.get_json()
         assert "version" in data
+
+
+# ---------------------------------------------------------------------------
+# GET /api/config/nvd-api-key — happy paths and edge cases
+# ---------------------------------------------------------------------------
+
+class TestGetNvdApiKey:
+
+    def test_returns_has_key_false_when_env_unset(self, client, monkeypatch):
+        """GET returns has_key:false and empty masked_key when NVD_API_KEY is unset."""
+        monkeypatch.delenv("NVD_API_KEY", raising=False)
+        resp = client.get("/api/config/nvd-api-key")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["has_key"] is False
+        assert data["masked_key"] == ""
+
+    def test_returns_has_key_true_and_masked_key_when_set(self, client, monkeypatch):
+        """GET returns has_key:true and a partially-masked key when NVD_API_KEY is set."""
+        monkeypatch.setenv("NVD_API_KEY", "abcdefghijklmnop")  # 16 chars
+        resp = client.get("/api/config/nvd-api-key")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["has_key"] is True
+        masked = data["masked_key"]
+        assert len(masked) == 16
+        # First 4 and last 4 chars should be plaintext, middle masked
+        assert masked[:4] == "abcd"
+        assert masked[-4:] == "mnop"
+        assert "*" in masked[4:-4]
+
+    def test_masked_key_is_all_stars_for_short_key(self, client, monkeypatch):
+        """Short keys (≤8 chars) are fully masked."""
+        monkeypatch.setenv("NVD_API_KEY", "shortkey")  # exactly 8 chars
+        resp = client.get("/api/config/nvd-api-key")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["masked_key"] == "********"
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/config/nvd-api-key — store and validate
+# ---------------------------------------------------------------------------
+
+class TestPutNvdApiKey:
+
+    def test_returns_400_when_body_missing_api_key_field(self, client):
+        """400 when the request body does not contain api_key."""
+        resp = client.put("/api/config/nvd-api-key", json={"wrong_field": "value"})
+        assert resp.status_code == 400
+        assert "api_key" in resp.get_json()["error"].lower()
+
+    def test_returns_400_when_api_key_not_string(self, client):
+        """400 when api_key is not a string."""
+        resp = client.put("/api/config/nvd-api-key", json={"api_key": 12345})
+        assert resp.status_code == 400
+
+    def test_valid_key_is_saved_and_returns_200(self, client, tmp_path):
+        """A valid key is probed, persisted, and the response includes masked_key."""
+        from src.controllers.nvd_db import NVD_DB
+        with patch.object(NVD_DB, "api_probe_cve",
+                          return_value=(200, {}, {"x-ratelimit-limit": "50"})):
+            with patch("src.routes.config._write_config_key", return_value=True):
+                resp = client.put("/api/config/nvd-api-key",
+                                  json={"api_key": "valid-key-1234567890"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "ok"
+        assert data["has_key"] is True
+        assert "*" in data["masked_key"]
+
+    def test_401_from_nvd_rejects_key_with_400(self, client):
+        """When the NVD probe returns 401, the key is rejected with 400."""
+        from src.controllers.nvd_db import NVD_DB
+        with patch.object(NVD_DB, "api_probe_cve",
+                          return_value=(401, {}, {})):
+            resp = client.put("/api/config/nvd-api-key",
+                              json={"api_key": "bad-key-9999"})
+        assert resp.status_code == 400
+        assert "Invalid NVD API key" in resp.get_json()["error"]
+
+    def test_403_from_nvd_rejects_key_with_400(self, client):
+        """When the NVD probe returns 403, the key is rejected with 400."""
+        from src.controllers.nvd_db import NVD_DB
+        with patch.object(NVD_DB, "api_probe_cve",
+                          return_value=(403, {}, {})):
+            resp = client.put("/api/config/nvd-api-key",
+                              json={"api_key": "bad-key-forbidden"})
+        assert resp.status_code == 400
+
+    def test_anonymous_rate_limit_header_rejects_key(self, client):
+        """A key that leaves the rate limit at ≤5 req/30s is treated as invalid."""
+        from src.controllers.nvd_db import NVD_DB
+        with patch.object(NVD_DB, "api_probe_cve",
+                          return_value=(200, {}, {"x-ratelimit-limit": "5"})):
+            resp = client.put("/api/config/nvd-api-key",
+                              json={"api_key": "anon-key-0001"})
+        assert resp.status_code == 400
+        assert "anonymous" in resp.get_json()["error"].lower()
+
+    def test_non_200_probe_saves_key_with_warning(self, client):
+        """Non-200, non-401/403 probe still saves the key but adds a warning."""
+        from src.controllers.nvd_db import NVD_DB
+        with patch.object(NVD_DB, "api_probe_cve",
+                          return_value=(503, {}, {})):
+            with patch("src.routes.config._write_config_key", return_value=True):
+                resp = client.put("/api/config/nvd-api-key",
+                                  json={"api_key": "uncertain-key-2222"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "warning" in data
+
+    def test_empty_api_key_removes_key(self, client, monkeypatch):
+        """Sending api_key='' removes the key from env and config.env."""
+        monkeypatch.setenv("NVD_API_KEY", "old-key")
+        with patch("src.routes.config._write_config_key", return_value=True):
+            resp = client.put("/api/config/nvd-api-key", json={"api_key": ""})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["has_key"] is False
+
+    def test_write_failure_returns_500(self, client):
+        """500 when _write_config_key fails after successful probe."""
+        from src.controllers.nvd_db import NVD_DB
+        with patch.object(NVD_DB, "api_probe_cve",
+                          return_value=(200, {}, {"x-ratelimit-limit": "50"})):
+            with patch("src.routes.config._write_config_key", return_value=False):
+                resp = client.put("/api/config/nvd-api-key",
+                                  json={"api_key": "valid-key-write-fails"})
+        assert resp.status_code == 500
+        assert "error" in resp.get_json()

--- a/tests/webapp_tests/test_nvd_refresh_routes.py
+++ b/tests/webapp_tests/test_nvd_refresh_routes.py
@@ -74,7 +74,8 @@ class TestSingleCveRefreshEndpoint:
                 "vulnerabilities": [{"cve": {"id": existing_cve_id}}]
             })
             MockNVD.extract_cve_details.return_value = mock_details
-            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                               json={"mode": "api"})
         assert resp.status_code == 200
         data = resp.get_json()
         assert "vulnerabilities" in data
@@ -112,7 +113,8 @@ class TestSingleCveRefreshEndpoint:
                 "vulnerabilities": [{"cve": {"id": existing_cve_id}}]
             })
             MockNVD.extract_cve_details.return_value = mock_details
-            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                               json={"mode": "api"})
         assert resp.status_code == 200
         vuln = resp.get_json()["vulnerabilities"][0]
         cvss_scores = vuln["severity"]["cvss"]
@@ -126,14 +128,16 @@ class TestSingleCveRefreshEndpoint:
         """503 when NVD returns 200 but no vulnerability data."""
         with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
             MockNVD.return_value.api_get_cve.return_value = (200, {"vulnerabilities": []})
-            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                               json={"mode": "api"})
         assert resp.status_code == 503
 
     def test_single_refresh_503_on_nvd_failure(self, client, existing_cve_id):
         """503 when api_get_cve exhausts retries and returns a non-200/429/401/403 status."""
         with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
             MockNVD.return_value.api_get_cve.return_value = (0, {})
-            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                               json={"mode": "api"})
         assert resp.status_code == 503
         data = resp.get_json()
         assert data["error_code"] == "unavailable"
@@ -143,7 +147,8 @@ class TestSingleCveRefreshEndpoint:
         """503 when an unexpected exception (e.g. network error) escapes api_get_cve."""
         with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
             MockNVD.return_value.api_get_cve.side_effect = OSError("network unreachable")
-            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                               json={"mode": "api"})
         assert resp.status_code == 503
         data = resp.get_json()
         assert data["error_code"] == "unavailable"
@@ -153,7 +158,8 @@ class TestSingleCveRefreshEndpoint:
         """429 + rate_limited error_code when NVD throttles the request."""
         with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
             MockNVD.return_value.api_get_cve.return_value = (429, {})
-            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                               json={"mode": "api"})
         assert resp.status_code == 429
         data = resp.get_json()
         assert data["error_code"] == "rate_limited"
@@ -166,9 +172,11 @@ class TestSingleCveRefreshEndpoint:
             MockNVD.return_value.api_get_cve.return_value = (429, {})
             os.environ.pop("NVD_API_KEY", None)
             try:
-                resp_no_key = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+                resp_no_key = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                                          json={"mode": "api"})
                 os.environ["NVD_API_KEY"] = "test-key-value"
-                resp_with_key = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh")
+                resp_with_key = client.post(f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                                            json={"mode": "api"})
             finally:
                 os.environ.pop("NVD_API_KEY", None)
         assert resp_no_key.get_json()["api_key_configured"] is False
@@ -181,5 +189,133 @@ class TestSingleCveRefreshEndpoint:
                 "vulnerabilities": [{"cve": {"id": existing_cve_id}}]
             })
             MockNVD.extract_cve_details.return_value = {}
-            resp = client.post(f"/api/vulnerabilities/{existing_cve_id.lower()}/nvd-refresh")
+            resp = client.post(f"/api/vulnerabilities/{existing_cve_id.lower()}/nvd-refresh",
+                               json={"mode": "api"})
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Single CVE refresh — mode parameter (local vs api)
+# ---------------------------------------------------------------------------
+
+class TestSingleCveRefreshMode:
+    """Tests for the ``mode`` parameter added by the local-nvd-fkie feature."""
+
+    def test_default_mode_is_local(self, client, existing_cve_id):
+        """When no mode is supplied, the local NVD-FKIE database is used."""
+        with patch("src.routes.vulnerabilities.get_cve_json") as mock_local:
+            mock_local.return_value = None  # not found in local DB → 503
+            resp = client.post(
+                f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                json={},
+            )
+        mock_local.assert_called_once_with(existing_cve_id)
+        assert resp.status_code == 503
+        data = resp.get_json()
+        assert data["error_code"] == "unavailable"
+
+    def test_explicit_local_mode_uses_local_db(self, client, existing_cve_id):
+        """mode='local' explicitly routes to the local NVD-FKIE database."""
+        with patch("src.routes.vulnerabilities.get_cve_json") as mock_local:
+            mock_local.return_value = None
+            resp = client.post(
+                f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                json={"mode": "local"},
+            )
+        mock_local.assert_called_once_with(existing_cve_id)
+        assert resp.status_code == 503
+
+    def test_local_mode_returns_200_when_cve_found(self, client, existing_cve_id):
+        """mode='local' returns 200 when the CVE is found in the local database."""
+        cve_obj = {"id": existing_cve_id}
+        with patch("src.routes.vulnerabilities.get_cve_json", return_value=cve_obj):
+            with patch("src.routes.vulnerabilities.extract_cve_details", return_value={}):
+                resp = client.post(
+                    f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                    json={"mode": "local"},
+                )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "vulnerabilities" in data
+
+    def test_api_mode_uses_nvd_rest_api(self, client, existing_cve_id):
+        """mode='api' calls NVD_DB.api_get_cve and does NOT call get_cve_json."""
+        with patch("src.routes.vulnerabilities.get_cve_json") as mock_local, \
+             patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.api_get_cve.return_value = (200, {
+                "vulnerabilities": [{"cve": {"id": existing_cve_id}}]
+            })
+            MockNVD.extract_cve_details.return_value = {}
+            resp = client.post(
+                f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                json={"mode": "api"},
+            )
+        mock_local.assert_not_called()
+        assert resp.status_code == 200
+
+    def test_api_mode_returns_429_on_rate_limit(self, client, existing_cve_id):
+        """mode='api' propagates a 429 rate-limit response with error_code."""
+        with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.api_get_cve.return_value = (429, {})
+            resp = client.post(
+                f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                json={"mode": "api"},
+            )
+        assert resp.status_code == 429
+        data = resp.get_json()
+        assert data["error_code"] == "rate_limited"
+        assert "api_key_configured" in data
+
+    def test_api_mode_returns_503_on_network_exception(self, client, existing_cve_id):
+        """mode='api' catches network errors and returns 503 unavailable."""
+        with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.api_get_cve.side_effect = OSError("network down")
+            resp = client.post(
+                f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                json={"mode": "api"},
+            )
+        assert resp.status_code == 503
+        data = resp.get_json()
+        assert data["error_code"] == "unavailable"
+
+    def test_api_mode_unauthorized_returns_4xx(self, client, existing_cve_id):
+        """mode='api' returns 401 with error_code unauthorized when NVD rejects key."""
+        with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.api_get_cve.return_value = (401, {})
+            resp = client.post(
+                f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                json={"mode": "api"},
+            )
+        assert resp.status_code == 401
+        data = resp.get_json()
+        assert data["error_code"] == "unauthorized"
+
+    def test_api_mode_returns_503_on_empty_nvd_response(self, client, existing_cve_id):
+        """mode='api' returns 503 when NVD returns 200 but no vulnerability data."""
+        with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.api_get_cve.return_value = (200, {"vulnerabilities": []})
+            resp = client.post(
+                f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                json={"mode": "api"},
+            )
+        assert resp.status_code == 503
+
+    def test_api_mode_api_key_configured_reflects_env(self, client, existing_cve_id, monkeypatch):
+        """api_key_configured in error payload reflects NVD_API_KEY presence."""
+        monkeypatch.delenv("NVD_API_KEY", raising=False)
+        with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.api_get_cve.return_value = (429, {})
+            resp_no_key = client.post(
+                f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                json={"mode": "api"},
+            )
+        assert resp_no_key.get_json()["api_key_configured"] is False
+
+        monkeypatch.setenv("NVD_API_KEY", "mykey")
+        with patch("src.routes.vulnerabilities.NVD_DB") as MockNVD:
+            MockNVD.return_value.api_get_cve.return_value = (429, {})
+            resp_with_key = client.post(
+                f"/api/vulnerabilities/{existing_cve_id}/nvd-refresh",
+                json={"mode": "api"},
+            )
+        assert resp_with_key.get_json()["api_key_configured"] is True

--- a/tests/webapp_tests/test_scan_advanced.py
+++ b/tests/webapp_tests/test_scan_advanced.py
@@ -527,7 +527,7 @@ class TestNvdScanWithToolAndSbom:
 
         with _make_sync_thread_patch():
             resp = client.post(
-                f"/api/variants/{ids['variant_id']}/nvd-scan"
+                f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api"
             )
         assert resp.status_code == 202
 
@@ -803,7 +803,7 @@ class TestNvdScanOuterException:
 
         with _make_sync_thread_patch():
             resp = client.post(
-                f"/api/variants/{ids['variant_id']}/nvd-scan"
+                f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api"
             )
         assert resp.status_code == 202
 

--- a/tests/webapp_tests/test_scan_cli.py
+++ b/tests/webapp_tests/test_scan_cli.py
@@ -137,6 +137,7 @@ class TestNvdScanCLI:
             "nvd-scan",
             "--project", ids["project_name"],
             "--variant", ids["variant_name"],
+            "--mode", "api",
         ])
         assert result.exit_code == 0, result.output
         assert "Scan complete" in result.output
@@ -174,6 +175,7 @@ class TestNvdScanCLI:
             "nvd-scan",
             "--project", ids["project_name"],
             "--variant", ids["variant_name"],
+            "--mode", "api",
         ])
         assert result.exit_code == 0, result.output
         assert "CVE-EXISTING-1" in result.output
@@ -190,6 +192,7 @@ class TestNvdScanCLI:
             "nvd-scan",
             "--project", ids["project_name"],
             "--variant", ids["variant_name"],
+            "--mode", "api",
         ])
         assert result.exit_code == 0, result.output
         assert "Scan complete" in result.output
@@ -218,6 +221,7 @@ class TestNvdScanCLI:
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "nvd-scan", "--project", "NoCPE", "--variant", "NoCPEVar",
+            "--mode", "api",
         ])
         assert result.exit_code != 0
         assert "CPE" in result.output
@@ -232,6 +236,7 @@ class TestNvdScanCLI:
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "nvd-scan", "--project", ids["project_name"],
+            "--mode", "api",
         ])
         assert result.exit_code != 0
         assert "No scans found" in result.output
@@ -248,6 +253,7 @@ class TestNvdScanCLI:
             "nvd-scan",
             "--project", ids["project_name"],
             "--variant", ids["variant_name"],
+            "--mode", "api",
         ])
         assert result.exit_code == 0, result.output
         assert "no CVEs" in result.output
@@ -420,6 +426,7 @@ class TestNvdScanCoverage:
             "nvd-scan",
             "--project", ids["project_name"],
             "--variant", ids["variant_name"],
+            "--mode", "api",
         ])
         assert result.exit_code == 0, result.output
         assert "Scan complete" in result.output
@@ -473,6 +480,7 @@ class TestNvdScanCoverage:
             "nvd-scan",
             "--project", ids["project_name"],
             "--variant", ids["variant_name"],
+            "--mode", "api",
         ])
         assert result.exit_code == 0, result.output
         assert "Scan complete" in result.output
@@ -507,6 +515,7 @@ class TestNvdScanCoverage:
             "nvd-scan",
             "--project", ids["project_name"],
             "--variant", ids["variant_name"],
+            "--mode", "api",
         ])
         assert result.exit_code == 0, result.output
 
@@ -544,6 +553,7 @@ class TestNvdScanCoverage:
                 "nvd-scan",
                 "--project", ids["project_name"],
                 "--variant", ids["variant_name"],
+                "--mode", "api",
             ])
         assert result.exit_code == 0, result.output
         assert "Scan complete" in result.output

--- a/tests/webapp_tests/test_scan_logic.py
+++ b/tests/webapp_tests/test_scan_logic.py
@@ -128,7 +128,7 @@ class TestDoNvdScan:
         ]
 
         with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
         assert resp.status_code == 202
 
         # Check the scan status was set to done
@@ -157,7 +157,7 @@ class TestDoNvdScan:
         mock_nvd.api_get_cves_by_cpe.return_value = []
 
         with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
         assert resp.status_code == 202
 
         resp_status = client.get(
@@ -175,7 +175,7 @@ class TestDoNvdScan:
         mock_nvd.api_get_cves_by_cpe.side_effect = Exception("NVD timeout")
 
         with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
         assert resp.status_code == 202
 
         resp_status = client.get(
@@ -339,7 +339,7 @@ class TestNvdScanNoCpes:
         client = app_no_cpe.test_client()
         vid = app_no_cpe._test_ids["variant_id"]
         with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/nvd-scan")
+            resp = client.post(f"/api/variants/{vid}/nvd-scan?mode=api")
         assert resp.status_code == 202
 
         resp_s = client.get(f"/api/variants/{vid}/nvd-scan/status")
@@ -446,7 +446,7 @@ class TestNvdScanNoPackages:
         client = app_no_pkgs.test_client()
         vid = app_no_pkgs._test_ids["variant_id"]
         with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/nvd-scan")
+            resp = client.post(f"/api/variants/{vid}/nvd-scan?mode=api")
         assert resp.status_code == 202
 
         resp_s = client.get(f"/api/variants/{vid}/nvd-scan/status")
@@ -530,7 +530,7 @@ class TestNvdScanExistingVuln:
         ]
 
         with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
         assert resp.status_code == 202
 
         resp_s = client.get(
@@ -599,7 +599,7 @@ class TestNvdScanManyCves:
         ]
 
         with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
         assert resp.status_code == 202
 
         resp_s = client.get(

--- a/tests/webapp_tests/test_scan_triggers.py
+++ b/tests/webapp_tests/test_scan_triggers.py
@@ -368,7 +368,7 @@ class TestTriggerNvdScan:
         with patch.object(_db.session, "get", side_effect=_fake_get):
             with patch("src.models.metrics.Metrics.from_cvss", side_effect=Exception("boom")):
                 with _sync_thread_patch():
-                    resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+                    resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
 
         assert resp.status_code == 202
 
@@ -521,4 +521,90 @@ class TestRunningScans:
         assert resp.status_code == 200
         data = json.loads(resp.data)
         assert data["grype"] == []
+
+
+# ---------------------------------------------------------------------------
+# NVD scan — mode parameter (local vs api)
+# ---------------------------------------------------------------------------
+
+class TestNvdScanMode:
+    """Tests for the ``?mode=`` query parameter on the NVD scan trigger."""
+
+    def test_default_mode_is_local(self, client, ids):
+        """When ?mode is absent the scan starts (defaults to local)."""
+        with patch("threading.Thread") as mock_thread:
+            mock_thread.return_value = MagicMock()
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan")
+        assert resp.status_code == 202
+
+    def test_explicit_local_mode_accepted(self, client, ids):
+        """?mode=local is accepted with 202."""
+        with patch("threading.Thread") as mock_thread:
+            mock_thread.return_value = MagicMock()
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=local")
+        assert resp.status_code == 202
+
+    def test_explicit_api_mode_accepted(self, client, ids):
+        """?mode=api is accepted with 202."""
+        with patch("threading.Thread") as mock_thread:
+            mock_thread.return_value = MagicMock()
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
+        assert resp.status_code == 202
+
+    def test_local_mode_uses_scc_engine(self, client, ids):
+        """In local mode the worker calls get_engine() (SCC engine)."""
+        captured = {}
+
+        def fake_thread(target=None, **kwargs):
+            captured["target"] = target
+            return MagicMock()
+
+        # get_engine is imported inside trigger_nvd_scan (lazy closure), so
+        # all patches must be active across both client.post and target().
+        with patch("threading.Thread", side_effect=fake_thread), \
+             patch("src.controllers.scc_engine.get_engine") as mock_engine, \
+             patch("src.controllers.nvd_db.NVD_DB") as MockNVD, \
+             patch("src.routes.scan_triggers.db"), \
+             patch("src.routes.scan_triggers.resolve_active_packages") as mock_pkgs:
+            mock_pkgs.return_value = ([], None)
+            mock_engine.side_effect = RuntimeError("no db")  # bail early
+            client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=local")
+            try:
+                captured["target"]()
+            except Exception:
+                pass
+
+        mock_engine.assert_called()
+        MockNVD.assert_not_called()
+
+    def test_api_mode_uses_nvd_db(self, client, ids):
+        """In api mode the worker instantiates NVD_DB and does NOT call get_engine()."""
+        captured = {}
+
+        def fake_thread(target=None, **kwargs):
+            captured["target"] = target
+            return MagicMock()
+
+        # NVD_DB is imported lazily inside _do_nvd_scan_api; all patches must
+        # span both client.post (which imports get_engine via closure) and
+        # target() (which imports NVD_DB on demand).
+        with patch("threading.Thread", side_effect=fake_thread), \
+             patch("src.controllers.scc_engine.get_engine") as mock_engine, \
+             patch("src.controllers.nvd_db.NVD_DB") as MockNVD, \
+             patch("src.routes.scan_triggers.db"), \
+             patch("src.routes.scan_triggers.resolve_active_packages") as mock_pkgs:
+            # Empty package list → cpe_to_pkgs empty → early return after NVD_DB()
+            mock_pkgs.return_value = ([], None)
+            client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
+            captured["target"]()
+
+        mock_engine.assert_not_called()
+        MockNVD.assert_called_once()
+
+    def test_mode_query_param_is_case_insensitive(self, client, ids):
+        """mode=LOCAL (uppercase) is treated the same as mode=local."""
+        with patch("threading.Thread") as mock_thread:
+            mock_thread.return_value = MagicMock()
+            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=LOCAL")
+        assert resp.status_code == 202
 

--- a/tests/webapp_tests/test_vulnerabilities_coverage.py
+++ b/tests/webapp_tests/test_vulnerabilities_coverage.py
@@ -1289,7 +1289,8 @@ def test_nvd_refresh_api_exception_returns_503(client):
     from unittest.mock import patch, MagicMock
     with patch("src.routes.vulnerabilities.NVD_DB") as mock_nvd_cls:
         mock_nvd_cls.return_value.api_get_cve.side_effect = Exception("Network error")
-        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh")
+        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh",
+                               json={"mode": "api"})
     assert response.status_code == 503
     data = json.loads(response.data)
     assert data["error_code"] == "unavailable"
@@ -1300,7 +1301,8 @@ def test_nvd_refresh_rate_limited_returns_429(client):
     from unittest.mock import patch
     with patch("src.routes.vulnerabilities.NVD_DB") as mock_nvd_cls:
         mock_nvd_cls.return_value.api_get_cve.return_value = (429, {})
-        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh")
+        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh",
+                               json={"mode": "api"})
     assert response.status_code == 429
     data = json.loads(response.data)
     assert data["error_code"] == "rate_limited"
@@ -1311,7 +1313,8 @@ def test_nvd_refresh_unauthorized_returns_401(client):
     from unittest.mock import patch
     with patch("src.routes.vulnerabilities.NVD_DB") as mock_nvd_cls:
         mock_nvd_cls.return_value.api_get_cve.return_value = (401, {})
-        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh")
+        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh",
+                               json={"mode": "api"})
     assert response.status_code == 401
     data = json.loads(response.data)
     assert data["error_code"] == "unauthorized"
@@ -1322,7 +1325,8 @@ def test_nvd_refresh_forbidden_returns_403(client):
     from unittest.mock import patch
     with patch("src.routes.vulnerabilities.NVD_DB") as mock_nvd_cls:
         mock_nvd_cls.return_value.api_get_cve.return_value = (403, {})
-        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh")
+        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh",
+                               json={"mode": "api"})
     assert response.status_code == 403
     data = json.loads(response.data)
     assert data["error_code"] == "unauthorized"
@@ -1333,7 +1337,8 @@ def test_nvd_refresh_no_data_returns_503(client):
     from unittest.mock import patch
     with patch("src.routes.vulnerabilities.NVD_DB") as mock_nvd_cls:
         mock_nvd_cls.return_value.api_get_cve.return_value = (200, {"vulnerabilities": []})
-        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh")
+        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh",
+                               json={"mode": "api"})
     assert response.status_code == 503
     data = json.loads(response.data)
     assert data["error_code"] == "unavailable"
@@ -1356,7 +1361,8 @@ def test_nvd_refresh_success_no_cvss(client):
             {"vulnerabilities": [{"cve": cve_payload}]},
         )
         mock_nvd_cls.extract_cve_details.return_value = fake_details
-        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh")
+        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh",
+                               json={"mode": "api"})
     assert response.status_code == 200
     data = json.loads(response.data)
     assert "vulnerabilities" in data
@@ -1401,7 +1407,8 @@ def test_nvd_refresh_success_updates_existing_metric(app, client):
             {"vulnerabilities": [{"cve": cve_payload}]},
         )
         mock_nvd_cls.extract_cve_details.return_value = fake_details
-        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh")
+        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh",
+                               json={"mode": "api"})
 
     assert response.status_code == 200
 
@@ -1424,7 +1431,8 @@ def test_nvd_refresh_success_adds_new_metric(app, client):
             {"vulnerabilities": [{"cve": cve_payload}]},
         )
         mock_nvd_cls.extract_cve_details.return_value = fake_details
-        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh")
+        response = client.post("/api/vulnerabilities/CVE-2020-35492/nvd-refresh",
+                               json={"mode": "api"})
 
     assert response.status_code == 200
 

--- a/vulnscout
+++ b/vulnscout
@@ -203,10 +203,11 @@ EOF
         echo "Created default config at $VULNSCOUT_CONFIG_FILE"
     fi
     # The sbom-cve-check advisory databases (NVD-FKIE + CVEList) live inside the
-    # VulnScout cache directory by default (sub-folder next to vulnscout.db), so the
-    # existing cache mount already covers them and no extra mount is needed.  An
-    # explicit VULNSCOUT_SBOM_CVE_CHECK_DB_DIR override (e.g. a shared host clone) is
-    # mounted separately and pointed at by SBOM_CVE_CHECK_DATABASES_DIR.
+    # VulnScout cache directory by default (local_databases sub-folder next to
+    # vulnscout.db), so the existing cache mount already covers them and no extra
+    # mount is needed.  An explicit VULNSCOUT_SBOM_CVE_CHECK_DB_DIR override (e.g. a
+    # shared host clone) is mounted separately and pointed at by
+    # SBOM_CVE_CHECK_DATABASES_DIR.
     local _sbom_cve_check_host_db="${VULNSCOUT_SBOM_CVE_CHECK_DB_DIR:-}"
 
     local -a env_args=()
@@ -228,8 +229,8 @@ EOF
     )
     if [[ -n "$_sbom_cve_check_host_db" ]]; then
         mkdir -p "$_sbom_cve_check_host_db"
-        vol_args+=(-v "$_sbom_cve_check_host_db:/sbom_cve_check_databases:Z")
-        env_args+=(-e "SBOM_CVE_CHECK_DATABASES_DIR=/sbom_cve_check_databases")
+        vol_args+=(-v "$_sbom_cve_check_host_db:/local_databases:Z")
+        env_args+=(-e "SBOM_CVE_CHECK_DATABASES_DIR=/local_databases")
     fi
     if [ "$DEV_MODE" = true ] && [ -d "$SCRIPT_DIR/src" ]; then
         vol_args+=(-v "$SCRIPT_DIR/src":/scan/src:Z)


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

NVD refresh and NVD scan will both allow users to select if they want to use a Local Database (NVD FKIE repurposed from the sbom-cve-check feature) or live NVD API calls. 

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Go to vulns table, pick vulns, then click Refresh in the multiedit bar, you will be presented by radio button to pick between local and live API fetching.
The same applies when you go Scan tab then pick NVD CPE as a scanner.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


