### PR TITLE
fix(cli): accept both bare and -- prefix for all commands

### DIFF
--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -50,7 +50,6 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 | `--perform-nvd-scan` | Run an NVD CPE-based vulnerability scan |
 | `--perform-osv-scan` | Run an OSV PURL-based vulnerability scan |
 | `--perform-sbom-cve-check-scan` | Run a CVE scan using local sbom-cve-check databases |
-| `--clear-inputs` | Remove all staged input files |
 
 ### Scan & Output Commands
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -615,11 +615,6 @@ cmd_daemon() {
     tail -f /dev/null
 }
 
-cmd_clear_inputs() {
-    rm -f "$INPUTS_DIR"/*/*
-    echo "Cleared all inputs"
-}
-
 #######################################
 # Print status update to file + console
 # Globals:
@@ -692,8 +687,6 @@ while [[ $# -gt 0 ]]; do
             OSV_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --perform-sbom-cve-check-scan)
             SBOM_CVE_CHECK_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
-        --clear-inputs)
-            cmd_clear_inputs; shift ;;
         --delete-scan)
             cmd_delete_scan "$2"; shift 2 ;;
         --serve)

--- a/vulnscout
+++ b/vulnscout
@@ -43,15 +43,15 @@ VulnScout - Vulnerability Scanner
 Usage: vulnscout [--project <name>] [--variant <name>] <command> [options]
 
 Container lifecycle:
-  start                           Start VulnScout container (auto-started by other commands)
-  stop                            Stop and remove VulnScout container
-  restart                         Restart VulnScout container
+  start|--start                   Start VulnScout container (auto-started by other commands)
+  stop|--stop                     Stop and remove VulnScout container
+  restart|--restart               Restart VulnScout container
   --update                        Pull latest image and restart if a new version is available
   --version                       Show current version
   --dev                           Dev mode: mount local src/ into container and start frontend npm dev server
 
 Note: The container runs as a daemon. All commands auto-start it if needed and
-leave it running afterward (including --serve). Use 'stop' to remove it.
+leave it running afterward (including --serve). Use 'stop' or '--stop' to remove it.
 
 Global flags:
   --project <name>                Set project name (default: 'default')
@@ -83,14 +83,14 @@ Scan & output commands:
   --delete-scan <id>                Delete a past scan by its ID
 
 Data retrieval commands:
-  list-projects                   List all projects and their variants
-  list-scans                      List all past scans
+  --list-projects                 List all projects and their variants
+  --list-scans                    List all past scans
   --json                          Output objects in JSON format
 
 Configuration:
-  config <key> <value>            Set a config value
-  config-list                     Show current configuration
-  config-clear <key>              Remove a config key
+  --config <key> <value>          Set a config value
+  --config-list                   Show current configuration
+  --config-clear <key>            Remove a config key
 
 Environment variables:
   VULNSCOUT_CONTAINER   Container name (default: vulnscout)
@@ -104,7 +104,7 @@ Examples:
   vulnscout --project test --match-condition "cvss >= 9.0"
   vulnscout --serve
   vulnscout --report summary.adoc
-  vulnscout config NVD_API_KEY abc123
+  vulnscout --config NVD_API_KEY abc123
 
 Exit codes:
   0   Success
@@ -345,7 +345,7 @@ parse_and_run() {
                 call_container_engine cp "$import_file" "$CONTAINER_NAME:$import_staged"
                 EXPORT_ARGS+=(--import-custom-assessments "$import_staged")
                 shift 2 ;;
-            --delete-scan)
+            delete-scan|--delete-scan)
                 ensure_running
                 exec_container --delete-scan "$2"
                 shift 2 ;;
@@ -365,9 +365,9 @@ parse_and_run() {
                 fi
                 REPORT_ARGS+=(--report "$tpl")
                 shift 2 ;;
-            list-projects|list-scans)
+            list-projects|--list-projects|list-scans|--list-scans)
                 ensure_running
-                command="$1"
+                command="${1#--}"
                 if [[ "$DATA_REQUESTED" != "" ]]; then
                     # Only 1 data request command is allowed at the same time
                     echo "Cannot use $command and $DATA_REQUESTED together"
@@ -377,27 +377,27 @@ parse_and_run() {
                 shift ;;
             --json)
                 DATA_ARGS+=(--json); shift ;;
-            start)
+            start|--start)
                 do_start
                 if [ "$DEV_MODE" = true ]; then
                     start_frontend_dev
                 fi
                 shift ;;
-            stop)
+            stop|--stop)
                 call_container_engine rm -f "$CONTAINER_NAME"; shift ;;
-            restart)
+            restart|--restart)
                 call_container_engine rm -f "$CONTAINER_NAME" 2>/dev/null || true
                 do_start
                 if [ "$DEV_MODE" = true ]; then
                     start_frontend_dev
                 fi
                 shift ;;
-            config)
+            config|--config)
                 config_set "$2" "$3"; shift 3 ;;
-            config-list)
+            config-list|--config-list)
                 cat "$VULNSCOUT_CONFIG_FILE" 2>/dev/null || echo "No config file found."
                 shift ;;
-            config-clear)
+            config-clear|--config-clear)
                 config_clear "$2"; shift 2 ;;
             help|--help|-h)
                 show_help; shift ;;
@@ -406,7 +406,7 @@ parse_and_run() {
                 _v="$(call_container_engine inspect "$DOCKER_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.version"}}' 2>/dev/null || echo unknown)"
                 echo "VulnScout $_v"
                 shift ;;
-            update)
+            update|--update)
                 local _cur_ver _new_ver _running_img
                 _cur_ver="$(call_container_engine inspect "$DOCKER_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.version"}}' 2>/dev/null || echo unknown)"
                 if call_container_engine pull "$DOCKER_IMAGE" > /dev/null 2>&1; then


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

In the vulnscout host wrapper, lifecycle and configuration commands (start, stop, restart, update, list-projects, list-scans, config, config-list, config-clear, delete-scan) previously only accepted one form or the other, inconsistently with --serve, --add-spdx and other flags that already used --.

- Accept both 'cmd' and '--cmd' forms for: start, stop, restart, update, list-projects, list-scans, config, config-list, config-clear, delete-scan
- Update help text and example to use the -- prefix for list-* and config commands, and show 'cmd|--cmd' for lifecycle commands
- Update the 'stop' note to mention both forms
- Fix help example: 'vulnscout config' -> 'vulnscout --config'

In the container entrypoint, add the missing --clear-inputs entry to the help text (the flag was already parsed but undocumented).

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


