### PR TITLE
review: Sort exported vulnerabilities by timestamp

### DIFF
--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -19,6 +19,8 @@ from collections import defaultdict
 from datetime import datetime as _dt, timezone as _tz
 from typing import TYPE_CHECKING, Any
 
+from .datetime_utils import normalize_timestamp_for_sort
+
 if TYPE_CHECKING:
     from ..models.variant import Variant as _Variant
     from ..models.assessment import Assessment as _Assessment
@@ -124,11 +126,23 @@ def build_openvex_doc(
             })
         stmt["products"] = products
         stmt.setdefault("action_statement_timestamp", "")
-        stmt["scanners"] = list({
+        stmt["scanners"] = sorted({
             assess.source or "local_user_data",
             assess.origin or "local_user_data",
         })
         statements.append(stmt)
+
+    # Deterministic ordering so the exported file is stable in git and
+    # identical between developers regardless of import history: sort by the
+    # assessment date first, then by vulnerability name and product ids as
+    # stable tie-breakers.
+    statements.sort(
+        key=lambda s: (
+            normalize_timestamp_for_sort(s.get("timestamp")),
+            s.get("vulnerability", {}).get("name") or "",
+            tuple(p.get("@id", "") for p in s.get("products", [])),
+        )
+    )
 
     return {
         "@context": "https://openvex.dev/ns/v0.2.0",
@@ -281,6 +295,17 @@ def import_statements(
         status_notes = stmt.get("status_notes", "")
         workaround = stmt.get("action_statement", "")
 
+        # Preserve the original assessment date so exports remain ordered by
+        # the date of the custom assessment and stay reproducible when two
+        # developers import each other's assessments.
+        imported_ts: "_dt | None" = None
+        raw_ts = stmt.get("timestamp")
+        if isinstance(raw_ts, str) and raw_ts:
+            try:
+                imported_ts = _dt.fromisoformat(raw_ts)
+            except (ValueError, TypeError):
+                imported_ts = None
+
         for pkg_string_id in pkg_ids:
             try:
                 if "@" in pkg_string_id:
@@ -316,6 +341,7 @@ def import_statements(
                     impact_statement=impact_statement,
                     workaround=workaround,
                     responses=[],
+                    timestamp=imported_ts,
                     commit=True,
                 )
                 created.append(db_a.to_dict())

--- a/tests/unit_tests/test_assessment_io.py
+++ b/tests/unit_tests/test_assessment_io.py
@@ -585,6 +585,61 @@ class TestBuildOpenvexDoc:
             doc = build_openvex_doc([assess], "author")
         assert "action_statement_timestamp" in doc["statements"][0]
 
+    def _make_assessment(self, vuln_id, pkg, ts):
+        assess = mock.MagicMock()
+        assess.to_openvex_dict.return_value = {"status": "affected", "timestamp": ts}
+        assess.vuln_id = vuln_id
+        assess.packages = [pkg]
+        assess.source = "s"
+        assess.origin = "o"
+        return assess
+
+    def test_statements_ordered_by_assessment_date(self):
+        """GIVEN assessments in arbitrary order WHEN building doc THEN statements sorted by date."""
+        a_new = self._make_assessment("CVE-2021-0003", "pkg@1.0", "2025-03-01T00:00:00+00:00")
+        a_old = self._make_assessment("CVE-2021-0001", "pkg@1.0", "2025-01-01T00:00:00+00:00")
+        a_mid = self._make_assessment("CVE-2021-0002", "pkg@1.0", "2025-02-01T00:00:00+00:00")
+        with mock.patch("src.helpers.assessment_io._get_vuln_info", return_value=_EMPTY_VULN_INFO):
+            doc = build_openvex_doc([a_new, a_old, a_mid], "author")
+        names = [s["vulnerability"]["name"] for s in doc["statements"]]
+        assert names == ["CVE-2021-0001", "CVE-2021-0002", "CVE-2021-0003"]
+
+    def test_equal_dates_ordered_by_vuln_then_package(self):
+        """GIVEN assessments with equal dates WHEN building doc THEN tie-broken deterministically."""
+        ts = "2025-01-01T00:00:00+00:00"
+        a_b = self._make_assessment("CVE-2021-0002", "zlib@1.0", ts)
+        a_a2 = self._make_assessment("CVE-2021-0001", "zlib@2.0", ts)
+        a_a1 = self._make_assessment("CVE-2021-0001", "zlib@1.0", ts)
+        with mock.patch("src.helpers.assessment_io._get_vuln_info", return_value=_EMPTY_VULN_INFO):
+            doc = build_openvex_doc([a_b, a_a2, a_a1], "author")
+        keys = [
+            (s["vulnerability"]["name"], s["products"][0]["@id"])
+            for s in doc["statements"]
+        ]
+        assert keys == [
+            ("CVE-2021-0001", "zlib@1.0"),
+            ("CVE-2021-0001", "zlib@2.0"),
+            ("CVE-2021-0002", "zlib@1.0"),
+        ]
+
+    def test_ordering_independent_of_input_order(self):
+        """GIVEN the same assessments in two different orders THEN identical output ordering."""
+        specs = [
+            ("CVE-2021-0003", "pkg@1.0", "2025-03-01T00:00:00+00:00"),
+            ("CVE-2021-0001", "pkg@1.0", "2025-01-01T00:00:00+00:00"),
+            ("CVE-2021-0002", "pkg@1.0", "2025-02-01T00:00:00+00:00"),
+        ]
+        with mock.patch("src.helpers.assessment_io._get_vuln_info", return_value=_EMPTY_VULN_INFO):
+            doc1 = build_openvex_doc(
+                [self._make_assessment(*s) for s in specs], "author"
+            )
+            doc2 = build_openvex_doc(
+                [self._make_assessment(*s) for s in reversed(specs)], "author"
+            )
+        names1 = [s["vulnerability"]["name"] for s in doc1["statements"]]
+        names2 = [s["vulnerability"]["name"] for s in doc2["statements"]]
+        assert names1 == names2
+
 
 # ---------------------------------------------------------------------------
 # build_openvex_archive() tests

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -1260,6 +1260,68 @@ def test_import_statements_not_skipped_when_only_scanner_assessment_exists(app):
     assert len(created) == 1
 
 
+def test_import_statements_preserves_original_timestamp(app):
+    """The OpenVEX statement timestamp must be persisted on the assessment.
+
+    This keeps exports ordered by the date of the custom assessment and makes
+    the exported file reproducible when two developers import each other's
+    assessments (the date travels with the assessment instead of being reset
+    to the import time).
+    """
+    from src.helpers.assessment_io import import_statements
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.assessment import Assessment
+    from src.helpers.datetime_utils import ensure_utc_iso
+
+    original_ts = "2024-05-01T12:00:00+00:00"
+    with app.app_context():
+        Package.find_or_create("tspreserve", "1.0.0", supplier="")
+        Vulnerability.get_or_create("CVE-2024-90001")
+
+        statements = [{
+            "vulnerability": {"name": "CVE-2024-90001"},
+            "status": "fixed",
+            "products": ["tspreserve@1.0.0"],
+            "timestamp": original_ts,
+        }]
+        created, errors, skipped = import_statements(statements, VARIANT_UUID)
+
+        assert errors == []
+        assert len(created) == 1
+
+        finding = Finding.get_or_create(
+            Package.find_or_create("tspreserve", "1.0.0", supplier="").id,
+            "CVE-2024-90001",
+        )
+        stored = Assessment.get_by_finding_and_variant(finding.id, VARIANT_UUID)
+        assert stored
+        assert ensure_utc_iso(stored[0].timestamp) == original_ts
+
+
+def test_import_statements_invalid_timestamp_falls_back(app):
+    """An unparseable statement timestamp must not break the import."""
+    from src.helpers.assessment_io import import_statements
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+
+    with app.app_context():
+        Package.find_or_create("tsbad", "1.0.0", supplier="")
+        Vulnerability.get_or_create("CVE-2024-90002")
+
+        statements = [{
+            "vulnerability": {"name": "CVE-2024-90002"},
+            "status": "fixed",
+            "products": ["tsbad@1.0.0"],
+            "timestamp": "not-a-date",
+        }]
+        created, errors, skipped = import_statements(statements, VARIANT_UUID)
+
+    assert errors == []
+    assert len(created) == 1
+
+
 def test_import_custom_data_not_skipped_when_only_scanner_assessment_exists(app, client):
     """A scanner-origin assessment must not block importing a custom one.
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Updated the sort is ascending by date, so oldest is at the top and the most recent assessment ends up at the bottom of the statements list.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Exported assessments are sorted by date

```
./vulnscout --project project_name --export-custom-assessments
```