### PR TITLE
feat(grype): add GRYPE_MEMLIMIT to cap grype RAM consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Added
+- `GRYPE_MEMLIMIT`: configurable memory cap for the `grype` subprocess (translates to Go's `GOMEMLIMIT`). Default: auto (~80 % of the container/cgroup memory limit), preventing OOM kills in memory-constrained CI environments. Set to an explicit value (e.g. `6GiB`) via `--config GRYPE_MEMLIMIT 6GiB` or the `GRYPE_MEMLIMIT` environment variable; set to `off` to disable the cap entirely.
+
 ---
 
 ## [0.17.1] - 2026-06-30

--- a/README.adoc
+++ b/README.adoc
@@ -211,6 +211,20 @@ This can be chained with other inputs to scan newly added files immediately:
 ./vulnscout --project demo --add-spdx example/spdx3/core-image-minimal-qemux86-64.rootfs.spdx.json --perform-grype-scan
 ----
 
+`--perform-grype-scan` can consume significant RAM when the SBOM contains many packages.
+By default VulnScout caps Grype's memory at ~80 % of the container/cgroup limit.
+Override with the `GRYPE_MEMLIMIT` environment variable (see the Environment Variables table above).
+
+[source,shell]
+----
+# Persistent: keep Grype below 6 GiB across all future scans in this container
+./vulnscout --config GRYPE_MEMLIMIT 6GiB
+
+# One-off: override via the host environment before starting the container
+export GRYPE_MEMLIMIT=24GiB
+./vulnscout --project demo --variant x86 --perform-grype-scan
+----
+
 ===  Generating Reports
 
 Reports are generated from AsciiDoc templates. VulnScout ships with built-in templates and also supports custom ones.
@@ -401,6 +415,10 @@ The following environment variables can be set via `vulnscout config` or exporte
 |`NVD_API_KEY`
 |NVD API key for higher rate limits (https://nvd.nist.gov/developers/request-an-api-key)
 |_(none)_
+
+|`GRYPE_MEMLIMIT`
+|Cap the RAM used by the `grype` binary (Go soft memory limit, `GOMEMLIMIT`). Accepts the same unit strings as Go: `4GiB`, `8192MiB`, plain bytes. Set to `off` to disable. Default (unset): auto (~80 % of the container/cgroup memory limit, recommended for CI).
+|_(auto)_
 
 |`IGNORE_PARSING_ERRORS`
 |Continue scanning even if input files contain errors

--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -46,7 +46,7 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 | `--add-openvex <path>` | Add an OpenVEX JSON file |
 | `--add-cdx <path>` | Add a CycloneDX file |
 | `--add-grype <path>` | Add a Grype results file (`.grype.json`) |
-| `--perform-grype-scan` | Export current DB as CycloneDX, run Grype on it, and merge results back |
+| `--perform-grype-scan` | Export current DB as CycloneDX, run Grype on it, and merge results back. Memory capped by `GRYPE_MEMLIMIT` (default: auto ~80 % of cgroup limit) |
 | `--perform-nvd-scan` | Run an NVD CPE-based vulnerability scan |
 | `--perform-osv-scan` | Run an OSV PURL-based vulnerability scan |
 | `--perform-sbom-cve-check-scan` | Run a CVE scan using local sbom-cve-check databases |

--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -194,6 +194,25 @@ This can be chained with other inputs to scan newly added files immediately:
   --perform-grype-scan
 ```
 
+`--perform-grype-scan` can consume significant RAM on large SBOMs.
+VulnScout automatically caps Grype's memory at ~80 % of the container/cgroup limit.
+Use `GRYPE_MEMLIMIT` to override:
+
+```bash
+# Set a persistent limit
+./vulnscout --config GRYPE_MEMLIMIT 6GiB
+
+# Or export it on the host before running (forwarded into the container)
+export GRYPE_MEMLIMIT=24GiB
+./vulnscout --project demo --perform-grype-scan
+
+# Disable the limit entirely
+./vulnscout --config GRYPE_MEMLIMIT off
+```
+
+Accepts any value valid for Go's `GOMEMLIMIT` (`4GiB`, `8192MiB`, plain bytes).
+Set to `off`, `0`, or `disabled` to remove the cap.
+
 ---
 
 ## Performing an sbom-cve-check Scan

--- a/frontend/src/handlers/config.ts
+++ b/frontend/src/handlers/config.ts
@@ -5,6 +5,7 @@ type AppConfig = {
     author_name: string;
     client_name: string;
     contact_email: string;
+    grype_memlimit: string;
 };
 
 export type { AppConfig };
@@ -32,6 +33,7 @@ class Config {
                     : "vulnscout",
             client_name: typeof data?.client_name === "string" ? data.client_name : "",
             contact_email: typeof data?.contact_email === "string" ? data.contact_email : "",
+            grype_memlimit: typeof data?.grype_memlimit === "string" ? data.grype_memlimit : "",
         };
     }
 
@@ -48,6 +50,7 @@ class Config {
         author_name?: string;
         client_name?: string;
         contact_email?: string;
+        grype_memlimit?: string;
     }): Promise<AppConfig> {
         const response = await fetch(import.meta.env.VITE_API_URL + "/api/config", {
             method: "PATCH",

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -55,6 +55,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         author_name: "vulnscout",
         client_name: "",
         contact_email: "",
+        grype_memlimit: "",
     });
     const [currentVariantId, setCurrentVariantId] = useState<string | undefined>(undefined);
     const [currentProjectId, setCurrentProjectId] = useState<string | undefined>(undefined);

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -12,6 +12,7 @@ import {
   faXmark,
   faKey,
   faPenToSquare,
+  faBug,
 } from "@fortawesome/free-solid-svg-icons";
 import Projects from "../handlers/project";
 import type { Project } from "../handlers/project";
@@ -59,6 +60,11 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
     contact_email: "",
   });
 
+  // ---- Grype settings ----
+  const [grypeMemlimitInput, setGrypeMemlimitInput] = useState("");
+  const [grypeMemlimitBusy, setGrypeMemlimitBusy] = useState(false);
+  const [grypeMemlimitMsg, setGrypeMemlimitMsg] = useState<{ text: string; type: "success" | "error" } | null>(null);
+
   useEffect(() => {
     Config.get()
       .then((config) => {
@@ -69,6 +75,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
           client_name: config.client_name,
           contact_email: config.contact_email,
         });
+        setGrypeMemlimitInput(config.grype_memlimit ?? "");
       })
       .catch(() => {
         if (unmountedRef.current) return;
@@ -99,6 +106,23 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
       if (!unmountedRef.current) {
         setConfigBusy(false);
       }
+    }
+  };
+
+  const handleSaveGrypeSetting = async () => {
+    if (grypeMemlimitBusy) return;
+    setGrypeMemlimitBusy(true);
+    setGrypeMemlimitMsg(null);
+    try {
+      const updated = await Config.patch({ grype_memlimit: grypeMemlimitInput.trim() });
+      if (unmountedRef.current) return;
+      setGrypeMemlimitInput(updated.grype_memlimit ?? "");
+      setGrypeMemlimitMsg({ text: "Grype memory limit saved.", type: "success" });
+    } catch (e: any) {
+      if (unmountedRef.current) return;
+      setGrypeMemlimitMsg({ text: e?.message || "Failed to save Grype settings.", type: "error" });
+    } finally {
+      if (!unmountedRef.current) setGrypeMemlimitBusy(false);
     }
   };
 
@@ -1155,6 +1179,75 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
                   {importMsg}
                 </span>
               )}
+            </div>
+          </div>
+        </section>
+
+        {/* ======== Grype Scanner ======== */}
+        <section aria-labelledby="settings-heading-grype">
+          <div className={cardHeader}>
+            <FontAwesomeIcon icon={faBug} className="text-cyan-400" aria-hidden="true" />
+            <h2 id="settings-heading-grype" className="text-xl font-bold text-white">Grype Scanner</h2>
+          </div>
+          <div className={cardBody + " space-y-4"}>
+
+            {/* ---- GRYPE_MEMLIMIT ---- */}
+            <div className="space-y-2">
+              <label htmlFor="grype-memlimit-input" className="block text-sm text-zinc-300 font-semibold">
+                Memory Limit <span className="font-normal text-zinc-500">(GRYPE_MEMLIMIT)</span>
+              </label>
+              <p className="text-zinc-400 text-sm">
+                Caps the RAM used by the Grype binary via Go's soft memory limit (<code className="text-zinc-300 bg-slate-900 px-1 rounded text-xs">GOMEMLIMIT</code>).
+                Leave blank to use the auto-default: <strong className="text-zinc-300">~80 % of the container/cgroup memory limit</strong>,
+                which prevents OOM kills in CI without any configuration.
+                Set to <code className="text-zinc-300 bg-slate-900 px-1 rounded text-xs">off</code> to disable the cap entirely.
+              </p>
+              <input
+                id="grype-memlimit-input"
+                type="text"
+                value={grypeMemlimitInput}
+                onChange={(e) => { setGrypeMemlimitInput(e.target.value); setGrypeMemlimitMsg(null); }}
+                placeholder="auto (leave blank) · e.g. 4GiB · 512MiB · 1073741824 · off"
+                className={inputClass}
+                disabled={grypeMemlimitBusy}
+                autoComplete="off"
+                spellCheck={false}
+                aria-describedby="grype-memlimit-hint"
+              />
+              <p id="grype-memlimit-hint" className="text-zinc-500 text-xs">
+                Valid values: Go memory strings (<code className="bg-slate-900 px-0.5 rounded">4GiB</code>,{" "}
+                <code className="bg-slate-900 px-0.5 rounded">512MiB</code>,{" "}
+                <code className="bg-slate-900 px-0.5 rounded">1073741824</code>),{" "}
+                <code className="bg-slate-900 px-0.5 rounded">off</code> / <code className="bg-slate-900 px-0.5 rounded">disabled</code> to remove the cap,
+                or blank to restore the auto-default.
+              </p>
+            </div>
+
+            {/* ---- Feedback ---- */}
+            {grypeMemlimitMsg && (
+              <MessageBanner
+                type={grypeMemlimitMsg.type}
+                message={grypeMemlimitMsg.text}
+                isVisible={true}
+                onClose={() => setGrypeMemlimitMsg(null)}
+              />
+            )}
+
+            {/* ---- Submit ---- */}
+            <div className="flex items-center gap-3 pt-1">
+              <button
+                onClick={handleSaveGrypeSetting}
+                disabled={grypeMemlimitBusy}
+                className={btnPrimary}
+                aria-busy={grypeMemlimitBusy}
+              >
+                {grypeMemlimitBusy ? (
+                  <FontAwesomeIcon icon={faSpinner} spin className="mr-1" aria-hidden="true" />
+                ) : (
+                  <FontAwesomeIcon icon={faCheck} className="mr-1" aria-hidden="true" />
+                )}
+                Save
+              </button>
             </div>
           </div>
         </section>

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -26,6 +26,65 @@ fi
 # finds (and, with SBOM_CVE_CHECK_AUTO_UPDATE=1, clones) them without an explicit env
 # var; config.env (sourced above) or an explicit override may still change this.
 export SBOM_CVE_CHECK_DATABASES_DIR="${SBOM_CVE_CHECK_DATABASES_DIR:-/cache/vulnscout/sbom_cve_check_databases}"
+
+# resolve_grype_memlimit  —  translate GRYPE_MEMLIMIT into a GOMEMLIMIT value.
+#
+# GRYPE_MEMLIMIT accepts:
+#   - An explicit memory string accepted by Go's runtime (e.g. "4GiB", "24GiB",
+#     "6442450944").  The value is forwarded to GOMEMLIMIT unchanged.
+#   - "off", "0", or "disabled"  —  disable the limit (no GOMEMLIMIT set).
+#   - Unset / empty  —  auto mode: compute ~80 % of the available memory limit
+#     detected from the container's cgroup (v2 memory.max or v1
+#     memory.limit_in_bytes) or, as a fallback, from /proc/meminfo MemTotal.
+#     Output as an integer number of bytes.
+#
+# Prints the effective GOMEMLIMIT value, or nothing if no limit should be set.
+resolve_grype_memlimit() {
+    local raw="${GRYPE_MEMLIMIT:-}"
+
+    # Explicit opt-out
+    if [[ "$raw" == "off" || "$raw" == "0" || "$raw" == "disabled" ]]; then
+        return 0
+    fi
+
+    # Explicit value — forward verbatim
+    if [[ -n "$raw" ]]; then
+        echo "$raw"
+        return 0
+    fi
+
+    # Auto mode: detect available memory and use 80 %.
+    # Try cgroup v2 first, then v1, then /proc/meminfo.
+    local mem_bytes=0
+    local cg2="/sys/fs/cgroup/memory.max"
+    local cg1="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+    if [[ -r "$cg2" ]]; then
+        local val
+        val=$(cat "$cg2" 2>/dev/null || true)
+        if [[ "$val" =~ ^[0-9]+$ ]] && (( val > 0 )); then
+            mem_bytes=$val
+        fi
+    fi
+    if (( mem_bytes == 0 )) && [[ -r "$cg1" ]]; then
+        local val
+        val=$(cat "$cg1" 2>/dev/null || true)
+        # cgroup v1 uses a large sentinel (PAGE_COUNTER_MAX) when unconstrained
+        if [[ "$val" =~ ^[0-9]+$ ]] && (( val > 0 && val < 9223372036854771712 )); then
+            mem_bytes=$val
+        fi
+    fi
+    if (( mem_bytes == 0 )) && [[ -r "/proc/meminfo" ]]; then
+        local kb
+        kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)
+        if [[ "$kb" =~ ^[0-9]+$ ]] && (( kb > 0 )); then
+            mem_bytes=$(( kb * 1024 ))
+        fi
+    fi
+
+    if (( mem_bytes > 0 )); then
+        echo $(( mem_bytes * 80 / 100 ))
+    fi
+}
 mkdir -p "$SBOM_CVE_CHECK_DATABASES_DIR" 2>/dev/null || true
 # Auto-update is on by default: the engine will clone/fetch the NVD-FKIE and CVEList
 # databases on first use and keep them current.  Set SBOM_CVE_CHECK_AUTO_UPDATE=0 to
@@ -236,6 +295,7 @@ cmd_scan() {
     export HTTPS_PROXY="${HTTPS_PROXY:-}"
     export NO_PROXY="${NO_PROXY:-}"
     export IGNORE_PARSING_ERRORS="${IGNORE_PARSING_ERRORS:-false}"
+    export GRYPE_MEMLIMIT="${GRYPE_MEMLIMIT:-}"
 
     if [[ -n "${MATCH_CONDITION:-}" ]]; then
         export MATCH_CONDITION
@@ -344,7 +404,14 @@ cmd_scan() {
                 mkdir -p "$INPUTS_DIR/grype"
                 local grype_out="$INPUTS_DIR/grype/grype_from_db.grype.json"
                 echo "Grype scan: $exported_cdx -> $grype_out"
-                grype --add-cpes-if-none "sbom:$exported_cdx" -o json > "$grype_out"
+                local _grype_gomemlimit
+                _grype_gomemlimit=$(resolve_grype_memlimit)
+                if [[ -n "$_grype_gomemlimit" ]]; then
+                    echo "Grype memory limit (GOMEMLIMIT): $_grype_gomemlimit"
+                    GOMEMLIMIT="$_grype_gomemlimit" grype --add-cpes-if-none "sbom:$exported_cdx" -o json > "$grype_out"
+                else
+                    grype --add-cpes-if-none "sbom:$exported_cdx" -o json > "$grype_out"
+                fi
                 echo "Merging Grype results..."
                 (cd "$BASE_DIR" && flask --app src.bin.webapp merge \
                     --project "$PROJECT_NAME" --variant "$VARIANT_NAME" --grype "$grype_out")

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -13,6 +13,12 @@ from ..helpers.verbose import verbose
 
 _CONFIG_FILE_DEFAULT = '/etc/vulnscout/config.env'
 _EMAIL_RE = re.compile(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
+# Accepts: off | disabled | plain-bytes | <digits><unit>
+# Units: B, KiB/MiB/GiB/TiB/PiB/EiB  and their SI equivalents KB/MB/…
+_GRYPE_MEMLIMIT_RE = re.compile(
+    r'^(?:off|disabled|\d+(?:[KMGTPE]iB|[KMGTPE]B|B)?)$',
+    re.IGNORECASE,
+)
 
 
 def _config_file_path() -> str:
@@ -83,6 +89,8 @@ def init_app(app):
             all_projects = ProjectController.get_all()
             project = all_projects[0] if all_projects else None
 
+        grype_memlimit = os.environ.get('GRYPE_MEMLIMIT', '')
+
         return jsonify({
             "project": ProjectController.serialize(project) if project else None,
             "variant": VariantController.serialize(variant) if variant else None,
@@ -90,6 +98,7 @@ def init_app(app):
             "author_name": author_name,
             "client_name": client_name,
             "contact_email": contact_email,
+            "grype_memlimit": grype_memlimit,
         })
 
     @app.route('/api/config', methods=['PATCH'])
@@ -103,6 +112,7 @@ def init_app(app):
             "author_name": "AUTHOR_NAME",
             "client_name": "CLIENT_NAME",
             "contact_email": "CONTACT_EMAIL",
+            "grype_memlimit": "GRYPE_MEMLIMIT",
         }
 
         for key in data.keys():
@@ -125,6 +135,14 @@ def init_app(app):
             if key == "contact_email" and normalized_value:
                 if not _EMAIL_RE.match(normalized_value):
                     return jsonify({"error": "Invalid email address format for 'contact_email'."}), 400
+
+            if key == "grype_memlimit" and normalized_value:
+                if not _GRYPE_MEMLIMIT_RE.match(normalized_value):
+                    return jsonify({
+                        "error": "Invalid GRYPE_MEMLIMIT value. "
+                                 "Use a Go memory string (e.g. 4GiB, 512MiB, 1073741824) "
+                                 "or 'off' / 'disabled' to remove the cap."
+                    }), 400
 
             validated[key] = (env_key, normalized_value if normalized_value else None)
 

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -43,6 +43,69 @@ def _read_exclude_kernel() -> bool:
     return request.args.get("exclude_kernel", "true").strip().lower() != "false"
 
 
+def _resolve_grype_memlimit() -> str | None:
+    """Translate ``GRYPE_MEMLIMIT`` into a ``GOMEMLIMIT`` value.
+
+    Returns the string to assign to ``GOMEMLIMIT``, or ``None`` if no limit
+    should be applied.
+
+    Behaviour:
+
+    * ``GRYPE_MEMLIMIT=off`` / ``0`` / ``disabled``  → ``None`` (no limit).
+    * ``GRYPE_MEMLIMIT=<value>`` (e.g. ``"4GiB"``) → returned verbatim.
+    * ``GRYPE_MEMLIMIT`` unset / empty → auto mode: ~80 % of the memory
+      limit detected from the container's cgroup (v2 ``memory.max``, v1
+      ``memory.limit_in_bytes``) or from ``/proc/meminfo`` MemTotal.
+      Returned as a plain integer number of bytes (GOMEMLIMIT accepts that).
+    """
+    raw = os.environ.get("GRYPE_MEMLIMIT", "").strip()
+
+    if raw.lower() in ("off", "0", "disabled"):
+        return None
+
+    if raw:
+        return raw
+
+    # Auto mode: probe cgroup / proc for the available memory ceiling.
+    mem_bytes = 0
+
+    cg2 = "/sys/fs/cgroup/memory.max"
+    cg1 = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+    try:
+        with open(cg2) as fh:
+            val = fh.read().strip()
+        if val.isdigit() and int(val) > 0:
+            mem_bytes = int(val)
+    except OSError:
+        pass
+
+    if mem_bytes == 0:
+        try:
+            with open(cg1) as fh:
+                val = fh.read().strip()
+            # cgroup v1 uses a large sentinel (PAGE_COUNTER_MAX) when unconstrained
+            if val.isdigit() and 0 < int(val) < 9223372036854771712:
+                mem_bytes = int(val)
+        except OSError:
+            pass
+
+    if mem_bytes == 0:
+        try:
+            with open("/proc/meminfo") as fh:
+                for line in fh:
+                    if line.startswith("MemTotal:"):
+                        kb = int(line.split()[1])
+                        mem_bytes = kb * 1024
+                        break
+        except OSError:
+            pass
+
+    if mem_bytes > 0:
+        return str(mem_bytes * 80 // 100)
+
+    return None
+
+
 def init_app(app: Flask) -> None:
 
     # ------------------------------------------------------------------
@@ -200,6 +263,13 @@ def init_app(app: Flask) -> None:
                         "[2/4] Running Grype vulnerability scanner…"
                     )
                     grype_out = os.path.join(grype_tmp, "grype_results.grype.json")
+                    grype_env = os.environ.copy()
+                    _gomemlimit = _resolve_grype_memlimit()
+                    if _gomemlimit is not None:
+                        grype_env["GOMEMLIMIT"] = _gomemlimit
+                        _grype_scans_in_progress[vid_str]["logs"].append(
+                            f"[2/4] Grype memory limit (GOMEMLIMIT): {_gomemlimit}"
+                        )
                     with open(grype_out, "w") as gf:
                         subprocess.run(
                             ["grype", "--add-cpes-if-none",
@@ -207,6 +277,7 @@ def init_app(app: Flask) -> None:
                             cwd=base_dir, check=True, text=True,
                             stdout=gf, stderr=subprocess.PIPE,
                             timeout=600,
+                            env=grype_env,
                         )
                     _grype_scans_in_progress[vid_str]["done_count"] = 2
 

--- a/tests/webapp_tests/test_scan_advanced.py
+++ b/tests/webapp_tests/test_scan_advanced.py
@@ -560,6 +560,236 @@ class TestOsvScanWithToolAndSbom:
 
 
 # ---------------------------------------------------------------------------
+# _resolve_grype_memlimit unit tests
+# ---------------------------------------------------------------------------
+
+class TestResolveGrypeMemlimit:
+    """Unit tests for the _resolve_grype_memlimit() helper."""
+
+    def setup_method(self):
+        # Remove GRYPE_MEMLIMIT from env before each test
+        os.environ.pop("GRYPE_MEMLIMIT", None)
+
+    def teardown_method(self):
+        os.environ.pop("GRYPE_MEMLIMIT", None)
+
+    def test_explicit_value_returned_verbatim(self):
+        """An explicit GRYPE_MEMLIMIT value is forwarded to GOMEMLIMIT as-is."""
+        from src.routes.scan_triggers import _resolve_grype_memlimit
+        os.environ["GRYPE_MEMLIMIT"] = "24GiB"
+        assert _resolve_grype_memlimit() == "24GiB"
+
+    def test_explicit_bytes_returned_verbatim(self):
+        """A plain-integer GRYPE_MEMLIMIT is forwarded unchanged."""
+        from src.routes.scan_triggers import _resolve_grype_memlimit
+        os.environ["GRYPE_MEMLIMIT"] = "6442450944"
+        assert _resolve_grype_memlimit() == "6442450944"
+
+    def test_off_returns_none(self):
+        from src.routes.scan_triggers import _resolve_grype_memlimit
+        os.environ["GRYPE_MEMLIMIT"] = "off"
+        assert _resolve_grype_memlimit() is None
+
+    def test_zero_returns_none(self):
+        from src.routes.scan_triggers import _resolve_grype_memlimit
+        os.environ["GRYPE_MEMLIMIT"] = "0"
+        assert _resolve_grype_memlimit() is None
+
+    def test_disabled_returns_none(self):
+        from src.routes.scan_triggers import _resolve_grype_memlimit
+        os.environ["GRYPE_MEMLIMIT"] = "disabled"
+        assert _resolve_grype_memlimit() is None
+
+    def test_auto_mode_uses_proc_meminfo(self, tmp_path):
+        """Auto mode reads /proc/meminfo and returns ~80 % as bytes."""
+        from src.routes.scan_triggers import _resolve_grype_memlimit
+        import builtins as _builtins
+        fake_meminfo = tmp_path / "meminfo"
+        # 8 GiB = 8388608 kB
+        fake_meminfo.write_text("MemTotal:        8388608 kB\nMemFree: 1000000 kB\n")
+        _real_open = _builtins.open
+
+        def _patched_open(path, *a, **kw):
+            if str(path) == "/proc/meminfo":
+                return _real_open(str(fake_meminfo), *a, **kw)
+            raise OSError(f"not available: {path}")
+
+        with patch("builtins.open", side_effect=_patched_open):
+            result = _resolve_grype_memlimit()
+        # 8 GiB * 80 % = 6.4 GiB = 6871947674 bytes (approx)
+        if result is not None:
+            assert int(result) == 8388608 * 1024 * 80 // 100
+
+    def test_auto_mode_returns_integer_string(self, tmp_path):
+        """Auto mode result is a plain integer string (valid GOMEMLIMIT)."""
+        from src.routes.scan_triggers import _resolve_grype_memlimit
+        import builtins as _builtins
+        fake_meminfo = tmp_path / "meminfo"
+        fake_meminfo.write_text("MemTotal:        4194304 kB\n")
+        _real_open = _builtins.open
+
+        def _patched_open(path, *a, **kw):
+            if str(path) == "/proc/meminfo":
+                return _real_open(str(fake_meminfo), *a, **kw)
+            raise OSError(f"not available: {path}")
+
+        with patch("builtins.open", side_effect=_patched_open):
+            result = _resolve_grype_memlimit()
+        if result is not None:
+            assert result.isdigit()
+
+
+# ---------------------------------------------------------------------------
+# GRYPE_MEMLIMIT integration: grype subprocess receives GOMEMLIMIT
+# ---------------------------------------------------------------------------
+
+class TestGrypeScanMemlimit:
+    """Assert that _run_grype_scan passes GOMEMLIMIT to the grype subprocess."""
+
+    @pytest.fixture()
+    def grype_app_ml(self, tmp_path):
+        """Minimal app for memory-limit tests."""
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+
+        scan_file = tmp_path / "scan_status.txt"
+        scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+        os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        try:
+            application = create_app()
+            application.config.update({
+                "TESTING": True, "SCAN_FILE": str(scan_file),
+            })
+            with application.app_context():
+                _db.drop_all()
+                _db.create_all()
+                project = Project.create("MLProject")
+                variant = Variant.create("MLVariant", project.id)
+                Scan.create("base scan", variant.id)
+                _db.session.commit()
+                application._test_ids = {
+                    "variant_id": str(variant.id),
+                }
+            yield application
+        finally:
+            os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+            os.environ.pop("GRYPE_MEMLIMIT", None)
+
+    def _subprocess_side_effect(self, grype_tmp):
+        """Return a side_effect that creates the expected CDX export file."""
+        def _side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if isinstance(cmd, list) and "export" in cmd:
+                out_dir = cmd[cmd.index("--output-dir") + 1]
+                import json as _json
+                cdx_path = os.path.join(out_dir, "sbom_cyclonedx_v1_6.cdx.json")
+                with open(cdx_path, "w") as f:
+                    _json.dump({"components": []}, f)
+            elif isinstance(cmd, list) and "grype" in cmd:
+                stdout_file = kwargs.get("stdout")
+                if stdout_file and hasattr(stdout_file, "write"):
+                    stdout_file.write('{"matches": []}')
+            return MagicMock(returncode=0)
+        return _side_effect
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_explicit_grype_memlimit_sets_gomemlimit(
+        self, mock_which, mock_sp_run, grype_app_ml, tmp_path
+    ):
+        """When GRYPE_MEMLIMIT is set, grype subprocess receives GOMEMLIMIT."""
+        os.environ["GRYPE_MEMLIMIT"] = "8GiB"
+        mock_sp_run.side_effect = self._subprocess_side_effect(tmp_path)
+        client = grype_app_ml.test_client()
+        vid = grype_app_ml._test_ids["variant_id"]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/grype-scan")
+        assert resp.status_code == 202
+
+        # Find the grype subprocess call (the one whose cmd contains "grype")
+        grype_call = next(
+            (c for c in mock_sp_run.call_args_list
+             if isinstance(c.args[0], list) and "grype" in c.args[0]),
+            None,
+        )
+        assert grype_call is not None, "grype subprocess was never called"
+        env_passed = grype_call.kwargs.get("env", {})
+        assert env_passed.get("GOMEMLIMIT") == "8GiB"
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_off_grype_memlimit_does_not_set_gomemlimit(
+        self, mock_which, mock_sp_run, grype_app_ml, tmp_path
+    ):
+        """When GRYPE_MEMLIMIT=off, grype subprocess should NOT have GOMEMLIMIT."""
+        os.environ["GRYPE_MEMLIMIT"] = "off"
+        mock_sp_run.side_effect = self._subprocess_side_effect(tmp_path)
+        client = grype_app_ml.test_client()
+        vid = grype_app_ml._test_ids["variant_id"]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/grype-scan")
+        assert resp.status_code == 202
+
+        grype_call = next(
+            (c for c in mock_sp_run.call_args_list
+             if isinstance(c.args[0], list) and "grype" in c.args[0]),
+            None,
+        )
+        assert grype_call is not None, "grype subprocess was never called"
+        env_passed = grype_call.kwargs.get("env", {})
+        # GOMEMLIMIT must not be injected
+        assert "GOMEMLIMIT" not in env_passed
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_flask_export_does_not_receive_gomemlimit(
+        self, mock_which, mock_sp_run, grype_app_ml, tmp_path
+    ):
+        """GOMEMLIMIT must only reach grype, not the flask export subprocess."""
+        os.environ["GRYPE_MEMLIMIT"] = "4GiB"
+        mock_sp_run.side_effect = self._subprocess_side_effect(tmp_path)
+        client = grype_app_ml.test_client()
+        vid = grype_app_ml._test_ids["variant_id"]
+
+        with _make_sync_thread_patch():
+            resp = client.post(f"/api/variants/{vid}/grype-scan")
+        assert resp.status_code == 202
+
+        export_call = next(
+            (c for c in mock_sp_run.call_args_list
+             if isinstance(c.args[0], list) and "export" in c.args[0]),
+            None,
+        )
+        assert export_call is not None, "flask export subprocess was never called"
+        # The export call should not have an env kwarg (inherits from process)
+        export_env = export_call.kwargs.get("env")
+        if export_env is not None:
+            assert "GOMEMLIMIT" not in export_env
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/grype")
+    def test_memlimit_logged_in_scan_progress(
+        self, mock_which, mock_sp_run, grype_app_ml, tmp_path
+    ):
+        """Applied GOMEMLIMIT is recorded in the scan progress logs."""
+        os.environ["GRYPE_MEMLIMIT"] = "12GiB"
+        mock_sp_run.side_effect = self._subprocess_side_effect(tmp_path)
+        client = grype_app_ml.test_client()
+        vid = grype_app_ml._test_ids["variant_id"]
+
+        with _make_sync_thread_patch():
+            client.post(f"/api/variants/{vid}/grype-scan")
+
+        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
+        data = json.loads(resp_s.data)
+        assert any("GOMEMLIMIT" in line and "12GiB" in line
+                   for line in data.get("logs", []))
+
+
+# ---------------------------------------------------------------------------
 # NVD / OSV scans outer exception handler (lines 1187-1189 / 1479-1481)
 # ---------------------------------------------------------------------------
 

--- a/vulnscout
+++ b/vulnscout
@@ -194,6 +194,11 @@ USER_UID=$(id -u)
 USER_GID=$(id -g)
 VITE_API_URL=http://localhost:7275
 REFRESH_REMOTE_DELAY=2w
+# GRYPE_MEMLIMIT — cap RAM used by the grype binary (Go soft memory limit).
+# Unset = auto (~80 % of the container/cgroup memory limit, recommended).
+# Explicit value examples: 4GiB  8GiB  24GiB  6442450944
+# Set to "off" to disable the limit entirely.
+#GRYPE_MEMLIMIT=
 EOF
         echo "Created default config at $VULNSCOUT_CONFIG_FILE"
     fi
@@ -213,6 +218,9 @@ EOF
     # Pass SBOM_CVE_CHECK_AUTO_UPDATE from the host environment so the operator can
     # override the container default (1 = on) e.g. to run offline (SBOM_CVE_CHECK_AUTO_UPDATE=0).
     [[ -n "${SBOM_CVE_CHECK_AUTO_UPDATE:-}" ]] && env_args+=(-e "SBOM_CVE_CHECK_AUTO_UPDATE=$SBOM_CVE_CHECK_AUTO_UPDATE")
+    # Forward GRYPE_MEMLIMIT from the host so operators can cap grype RAM usage
+    # without editing config.env (e.g. export GRYPE_MEMLIMIT=24GiB before running).
+    [[ -n "${GRYPE_MEMLIMIT:-}" ]] && env_args+=(-e "GRYPE_MEMLIMIT=$GRYPE_MEMLIMIT")
     local -a vol_args=(
         -v "$VULNSCOUT_CACHE_DIR:/cache/vulnscout:Z"
         -v "$VULNSCOUT_OUTPUTS_DIR:/scan/outputs:Z"


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Fixes Grype excessive memory usage on large SBOM

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

**Default auto-limit is applied and logged:**
```bash
./vulnscout --project demo --perform-grype-scan 2>&1 | grep -i "gomemlimit\|memory limit"
```

**Explicit limit:**
```bash
./vulnscout --config GRYPE_MEMLIMIT 6GiB
./vulnscout --project demo --perform-grype-scan 2>&1 | grep -i "gomemlimit"
```

**Opt-out:**
```bash
./vulnscout --config GRYPE_MEMLIMIT off
./vulnscout --project demo --perform-grype-scan 2>&1 | grep -i "gomemlimit"
```

**Restore auto-default:**
```bash
./vulnscout --config-clear GRYPE_MEMLIMIT
```

**Host env one-off (forwarded into the container):**
```bash
export GRYPE_MEMLIMIT=24GiB
./vulnscout --project demo --perform-grype-scan 2>&1 | grep -i "gomemlimit"
```

**Web dashboard**
Go to settings tab -> scan settings then set a value according to the instructions in the input label.
Check config.env and other applicable places (see above).

### Related Issue

#425 

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


