### PR TITLE
Transfer tab: move assessments between variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ venv.bak/
 
 # testing .adoc files
 tests/*.adoc
+
+# local-only dev seeding script
+demo/seed_copy_test.py

--- a/frontend/src/components/CopyAssessmentsReviewModal.tsx
+++ b/frontend/src/components/CopyAssessmentsReviewModal.tsx
@@ -1,0 +1,426 @@
+import { useEffect, useReducer, useCallback } from "react";
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCopy, faXmark, faChevronDown, faChevronRight } from "@fortawesome/free-solid-svg-icons";
+import type {
+    CopyAssessmentsPreviewGroup,
+    CopyAssessmentsPreviewCandidate,
+    CopyAssessmentsSelection,
+    CopyAssessmentsAssessmentDetails,
+} from "../handlers/variant";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type RowState = {
+    /** Whether the row checkbox is checked (will be included in copy). */
+    selected: boolean;
+    /** Index into `candidates` for the chosen target finding. */
+    candidateIndex: number;
+    /** Whether the assessment-details sub-row is visible. */
+    expanded: boolean;
+};
+
+type ModalState = {
+    /** Per-group row state, keyed by source_assessment_id. */
+    rows: Record<string, RowState>;
+};
+
+type Action =
+    | { type: "TOGGLE"; assessmentId: string }
+    | { type: "TOGGLE_EXPAND"; assessmentId: string }
+    | { type: "SET_CANDIDATE"; assessmentId: string; index: number }
+    | { type: "SELECT_ALL" }
+    | { type: "DESELECT_ALL" };
+
+function buildInitialState(groups: CopyAssessmentsPreviewGroup[]): ModalState {
+    const rows: Record<string, RowState> = {};
+    for (const g of groups) {
+        const defaultIndex = g.candidates.findIndex((c) => c.selected && !c.already_has_custom);
+        rows[g.source_assessment_id] = {
+            selected: defaultIndex >= 0,
+            candidateIndex: Math.max(0, defaultIndex),
+            expanded: false,
+        };
+    }
+    return { rows };
+}
+
+function reducer(state: ModalState, action: Action): ModalState {
+    switch (action.type) {
+        case "TOGGLE": {
+            const prev = state.rows[action.assessmentId];
+            if (!prev) return state;
+            return {
+                ...state,
+                rows: { ...state.rows, [action.assessmentId]: { ...prev, selected: !prev.selected } },
+            };
+        }
+        case "TOGGLE_EXPAND": {
+            const prev = state.rows[action.assessmentId];
+            if (!prev) return state;
+            return {
+                ...state,
+                rows: { ...state.rows, [action.assessmentId]: { ...prev, expanded: !prev.expanded } },
+            };
+        }
+        case "SET_CANDIDATE": {
+            const prev = state.rows[action.assessmentId];
+            if (!prev) return state;
+            return {
+                ...state,
+                rows: {
+                    ...state.rows,
+                    [action.assessmentId]: {
+                        ...prev,
+                        candidateIndex: action.index,
+                        selected: true,
+                    },
+                },
+            };
+        }
+        case "SELECT_ALL": {
+            const next = { ...state.rows };
+            for (const id of Object.keys(next)) {
+                if (next[id]) next[id] = { ...next[id], selected: true };
+            }
+            return { ...state, rows: next };
+        }
+        case "DESELECT_ALL": {
+            const next = { ...state.rows };
+            for (const id of Object.keys(next)) {
+                if (next[id]) next[id] = { ...next[id], selected: false };
+            }
+            return { ...state, rows: next };
+        }
+        default:
+            return state;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Assessment-detail badge helpers
+// ---------------------------------------------------------------------------
+
+function statusBadgeClass(simplified: string): string {
+    switch (simplified) {
+        case "Not affected":       return "bg-emerald-700 text-emerald-100";
+        case "Exploitable":        return "bg-red-800 text-red-100";
+        case "Fixed":              return "bg-teal-700 text-teal-100";
+        case "Pending Assessment": return "bg-amber-700 text-amber-100";
+        case "False Positive":     return "bg-purple-700 text-purple-100";
+        default:                   return "bg-slate-600 text-zinc-200";
+    }
+}
+
+function AssessmentDetailRow({ details }: Readonly<{ details: CopyAssessmentsAssessmentDetails }>) {
+    const fields: { label: string; value: string | null | undefined }[] = [
+        { label: "Justification",    value: details.justification },
+        { label: "Notes",            value: details.status_notes },
+        { label: "Impact",           value: details.impact_statement },
+        { label: "Workaround",       value: details.workaround },
+        { label: "Responses",        value: details.responses?.length ? details.responses.join(", ") : null },
+    ];
+    const populated = fields.filter((f) => f.value);
+    return (
+        <div className="flex flex-wrap items-start gap-x-6 gap-y-1.5 text-xs">
+            <span>
+                <span className="text-zinc-400">Status: </span>
+                <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold ${
+                    statusBadgeClass(details.simplified_status)
+                }`}>
+                    {details.simplified_status || details.status || "—"}
+                </span>
+            </span>
+            {populated.map(({ label, value }) => (
+                <span key={label}>
+                    <span className="text-zinc-400">{label}: </span>
+                    <span className="text-zinc-200">{value}</span>
+                </span>
+            ))}
+            {populated.length === 0 && !details.simplified_status && (
+                <span className="text-zinc-500 italic">No additional details.</span>
+            )}
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+type Props = {
+    isOpen: boolean;
+    groups: CopyAssessmentsPreviewGroup[];
+    /** Summary message from the preview response (e.g. "3 assessments to copy"). */
+    previewMessage?: string;
+    /** Called with the final selections when the user confirms. */
+    onConfirm: (selections: CopyAssessmentsSelection[]) => void;
+    onCancel: () => void;
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+function CopyAssessmentsReviewModal({ isOpen, groups, previewMessage, onConfirm, onCancel }: Readonly<Props>) {
+    const [state, dispatch] = useReducer(reducer, groups, buildInitialState);
+
+    // Escape key to close
+    useEffect(() => {
+        if (!isOpen) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") onCancel();
+        };
+        document.addEventListener("keydown", onKey);
+        return () => document.removeEventListener("keydown", onKey);
+    }, [isOpen, onCancel]);
+
+    const handleConfirm = useCallback(() => {
+        const selections: CopyAssessmentsSelection[] = [];
+        for (const g of groups) {
+            const rowState = state.rows[g.source_assessment_id];
+            if (!rowState?.selected) continue;
+            const candidate: CopyAssessmentsPreviewCandidate | undefined =
+                g.candidates[rowState.candidateIndex];
+            if (!candidate || candidate.already_has_custom) continue;
+            selections.push({
+                source_assessment_id: g.source_assessment_id,
+                target_finding_id: candidate.target_finding_id,
+            });
+        }
+        onConfirm(selections);
+    }, [groups, state, onConfirm]);
+
+    if (!isOpen) return null;
+
+    const selectableCount = groups.filter((g) => {
+        const rowState = state.rows[g.source_assessment_id];
+        return rowState?.selected && !g.candidates[rowState.candidateIndex ?? 0]?.already_has_custom;
+    }).length;
+
+    const totalSelectable = groups.filter((g) => {
+        const rowState = state.rows[g.source_assessment_id];
+        // Has at least one non-already_has_custom candidate
+        return g.candidates.some((c) => !c.already_has_custom) && rowState !== undefined;
+    }).length;
+
+    return (
+        <div
+            data-testid="copy-review-modal-backdrop"
+            tabIndex={-1}
+            onMouseDown={(e) => {
+                if (e.target === e.currentTarget) onCancel();
+            }}
+            className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
+        >
+            <div className="relative w-full max-w-4xl max-h-[90vh] mx-4 flex flex-col rounded-lg shadow-2xl bg-slate-800 border border-slate-600">
+
+                {/* Header */}
+                <div className="flex items-center justify-between px-5 py-4 border-b border-slate-600">
+                    <div className="flex items-center gap-2">
+                        <FontAwesomeIcon icon={faCopy} className="text-cyan-400" aria-hidden="true" />
+                        <div>
+                            <h2 className="text-lg font-semibold text-white">Review Copy Alignments</h2>
+                            {previewMessage && (
+                                <p className="text-xs text-cyan-300 mt-0.5">{previewMessage}</p>
+                            )}
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        className="text-zinc-400 hover:text-white hover:bg-slate-700 rounded-lg p-1.5 transition-colors"
+                        aria-label="Close"
+                    >
+                        <FontAwesomeIcon icon={faXmark} className="w-4 h-4" aria-hidden="true" />
+                    </button>
+                </div>
+
+                {/* Toolbar */}
+                <div className="flex items-center gap-3 px-5 py-2 border-b border-slate-700/70 bg-slate-900/30">
+                    <span className="text-xs text-zinc-400">
+                        {selectableCount} of {totalSelectable} selected
+                    </span>
+                    <button
+                        type="button"
+                        onClick={() => dispatch({ type: "SELECT_ALL" })}
+                        className="text-xs text-cyan-400 hover:text-cyan-300 underline"
+                    >
+                        Select all
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => dispatch({ type: "DESELECT_ALL" })}
+                        className="text-xs text-zinc-400 hover:text-zinc-200 underline"
+                    >
+                        Deselect all
+                    </button>
+                </div>
+
+                {/* Table */}
+                <div className="flex-1 overflow-auto">
+                    {groups.length === 0 ? (
+                        <p className="px-5 py-6 text-sm text-zinc-400 text-center">
+                            No alignments found for the selected options.
+                        </p>
+                    ) : (
+                        <table className="min-w-full text-sm text-zinc-200">
+                            <thead className="sticky top-0 bg-slate-800 text-zinc-300 text-xs uppercase tracking-wide z-10">
+                                <tr>
+                                    <th className="px-4 py-2 text-left w-10">Copy</th>
+                                    <th className="px-4 py-2 text-left">Vulnerability</th>
+                                    <th className="px-4 py-2 text-left">Source package</th>
+                                    <th className="px-4 py-2 text-left">Target package</th>
+                                    <th className="px-4 py-2 w-8" />
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {groups.map((g) => {
+                                    const rowState = state.rows[g.source_assessment_id];
+                                    const candidateIndex = rowState?.candidateIndex ?? 0;
+                                    const currentCandidate = g.candidates[candidateIndex];
+                                    const isChecked = rowState?.selected ?? false;
+                                    const isDisabled = g.candidates.every((c) => c.already_has_custom);
+                                    const isExpanded = rowState?.expanded ?? false;
+
+                                    return (
+                                        <React.Fragment key={g.source_assessment_id}>
+                                        <tr
+                                            className={[
+                                                "border-t border-slate-700/60 transition-colors",
+                                                isDisabled ? "opacity-50" : "hover:bg-slate-700/30",
+                                            ].join(" ")}
+                                        >
+                                            {/* Checkbox */}
+                                            <td className="px-4 py-2">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={isChecked && !isDisabled}
+                                                    disabled={isDisabled}
+                                                    onChange={() => dispatch({ type: "TOGGLE", assessmentId: g.source_assessment_id })}
+                                                    className="rounded border-slate-500 bg-slate-900 text-cyan-500 focus:ring-cyan-500 disabled:cursor-not-allowed"
+                                                    aria-label={`Include ${g.vulnerability_id}`}
+                                                />
+                                            </td>
+
+                                            {/* Vulnerability ID */}
+                                            <td className="px-4 py-2 font-mono text-xs text-cyan-300 whitespace-nowrap">
+                                                {g.vulnerability_id}
+                                            </td>
+
+                                            {/* Source package */}
+                                            <td className="px-4 py-2 font-mono text-xs text-zinc-300 whitespace-nowrap">
+                                                {g.source_package || "—"}
+                                            </td>
+
+                                            {/* Target package — dropdown if multiple candidates */}
+                                            <td className="px-4 py-2">
+                                                {g.candidates.length === 1 ? (
+                                                    <span className={[
+                                                        "font-mono text-xs",
+                                                        currentCandidate?.already_has_custom
+                                                            ? "text-amber-400"
+                                                            : "text-zinc-300",
+                                                    ].join(" ")}>
+                                                        {currentCandidate?.target_package || "—"}
+                                                        {currentCandidate?.already_has_custom && (
+                                                            <span className="ml-1 text-amber-500 text-[10px]">(already assessed)</span>
+                                                        )}
+                                                    </span>
+                                                ) : (
+                                                    <select
+                                                        value={candidateIndex}
+                                                        onChange={(e) =>
+                                                            dispatch({
+                                                                type: "SET_CANDIDATE",
+                                                                assessmentId: g.source_assessment_id,
+                                                                index: Number(e.target.value),
+                                                            })
+                                                        }
+                                                        disabled={isDisabled}
+                                                        className="w-full rounded border border-slate-600 bg-slate-900 text-xs text-zinc-200 px-2 py-1 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-1 focus:ring-cyan-500"
+                                                        aria-label={`Target for ${g.vulnerability_id}`}
+                                                    >
+                                                        {g.candidates.map((c, i) => (
+                                                            <option key={c.target_finding_id} value={i}>
+                                                                {c.target_package || "—"}
+                                                                {c.already_has_custom ? " (already assessed)" : ""}
+                                                            </option>
+                                                        ))}
+                                                    </select>
+                                                )}
+                                            </td>
+
+                                            {/* Expand / collapse details */}
+                                            <td className="px-2 py-2 text-center">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => dispatch({ type: "TOGGLE_EXPAND", assessmentId: g.source_assessment_id })}
+                                                    className="text-zinc-500 hover:text-zinc-200 transition-colors"
+                                                    aria-label={`${isExpanded ? "Collapse" : "Expand"} details for ${g.vulnerability_id}`}
+                                                    aria-expanded={isExpanded}
+                                                >
+                                                    <FontAwesomeIcon
+                                                        icon={isExpanded ? faChevronDown : faChevronRight}
+                                                        className="w-3 h-3"
+                                                        aria-hidden="true"
+                                                    />
+                                                </button>
+                                            </td>
+                                        </tr>
+
+                                        {/* Assessment details sub-row */}
+                                        {isExpanded && (
+                                            <tr
+                                                key={`${g.source_assessment_id}-details`}
+                                                className="bg-slate-900/60 border-b border-slate-700/30"
+                                            >
+                                                <td colSpan={5} className="px-8 pb-3 pt-2">
+                                                    {g.assessment_details
+                                                        ? <AssessmentDetailRow details={g.assessment_details} />
+                                                        : <span className="text-xs text-zinc-500 italic">No details available.</span>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        )}
+                                        </React.Fragment>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    )}
+                </div>
+
+                {/* Footer */}
+                <div className="flex items-center justify-between gap-3 px-5 py-4 border-t border-slate-600 bg-slate-900/40">
+                    <p className="text-xs text-zinc-400">
+                        {selectableCount === 0
+                            ? "Nothing selected — confirm to copy nothing."
+                            : `${selectableCount} assessment${selectableCount !== 1 ? "s" : ""} will be copied.`}
+                    </p>
+                    <div className="flex gap-3">
+                        <button
+                            type="button"
+                            onClick={onCancel}
+                            className="px-4 py-2 text-sm font-medium text-zinc-300 bg-slate-700 hover:bg-slate-600 rounded-lg transition-colors"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleConfirm}
+                            className="px-4 py-2 text-sm font-medium text-white bg-cyan-600 hover:bg-cyan-500 rounded-lg transition-colors"
+                        >
+                            <FontAwesomeIcon icon={faCopy} className="mr-2" aria-hidden="true" />
+                            Confirm Copy
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default CopyAssessmentsReviewModal;

--- a/frontend/src/components/CopyAssessmentsReviewModal.tsx
+++ b/frontend/src/components/CopyAssessmentsReviewModal.tsx
@@ -41,7 +41,7 @@ function buildInitialState(groups: CopyAssessmentsPreviewGroup[]): ModalState {
         rows[g.source_assessment_id] = {
             selected: defaultIndex >= 0,
             candidateIndex: Math.max(0, defaultIndex),
-            expanded: false,
+            expanded: true,
         };
     }
     return { rows };

--- a/frontend/src/components/CopyAssessmentsReviewModal.tsx
+++ b/frontend/src/components/CopyAssessmentsReviewModal.tsx
@@ -37,7 +37,7 @@ type Action =
 function buildInitialState(groups: CopyAssessmentsPreviewGroup[]): ModalState {
     const rows: Record<string, RowState> = {};
     for (const g of groups) {
-        const defaultIndex = g.candidates.findIndex((c) => c.selected && !c.already_has_custom);
+        const defaultIndex = g.candidates.findIndex((c) => c.selected);
         rows[g.source_assessment_id] = {
             selected: defaultIndex >= 0,
             candidateIndex: Math.max(0, defaultIndex),

--- a/frontend/src/components/CopyAssessmentsReviewModal.tsx
+++ b/frontend/src/components/CopyAssessmentsReviewModal.tsx
@@ -182,9 +182,11 @@ function CopyAssessmentsReviewModal({ isOpen, groups, previewMessage, onConfirm,
         for (const g of groups) {
             const rowState = state.rows[g.source_assessment_id];
             if (!rowState?.selected) continue;
+            // Skip groups the copy condition disallows entirely.
+            if (!g.candidates.some((c) => c.selected)) continue;
             const candidate: CopyAssessmentsPreviewCandidate | undefined =
                 g.candidates[rowState.candidateIndex];
-            if (!candidate || candidate.already_has_custom) continue;
+            if (!candidate) continue;
             selections.push({
                 source_assessment_id: g.source_assessment_id,
                 target_finding_id: candidate.target_finding_id,
@@ -197,13 +199,13 @@ function CopyAssessmentsReviewModal({ isOpen, groups, previewMessage, onConfirm,
 
     const selectableCount = groups.filter((g) => {
         const rowState = state.rows[g.source_assessment_id];
-        return rowState?.selected && !g.candidates[rowState.candidateIndex ?? 0]?.already_has_custom;
+        return rowState?.selected && g.candidates.some((c) => c.selected);
     }).length;
 
     const totalSelectable = groups.filter((g) => {
         const rowState = state.rows[g.source_assessment_id];
-        // Has at least one non-already_has_custom candidate
-        return g.candidates.some((c) => !c.already_has_custom) && rowState !== undefined;
+        // Has at least one candidate the copy condition allows
+        return g.candidates.some((c) => c.selected) && rowState !== undefined;
     }).length;
 
     return (
@@ -282,7 +284,7 @@ function CopyAssessmentsReviewModal({ isOpen, groups, previewMessage, onConfirm,
                                     const candidateIndex = rowState?.candidateIndex ?? 0;
                                     const currentCandidate = g.candidates[candidateIndex];
                                     const isChecked = rowState?.selected ?? false;
-                                    const isDisabled = g.candidates.every((c) => c.already_has_custom);
+                                    const isDisabled = g.candidates.every((c) => !c.selected);
                                     const isExpanded = rowState?.expanded ?? false;
 
                                     return (

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBox, faShieldHalved, faFileExport, faMoon, faSun, faClockRotateLeft, faClipboardCheck, faGear } from '@fortawesome/free-solid-svg-icons';
+import { faBox, faShieldHalved, faFileExport, faMoon, faSun, faClockRotateLeft, faClipboardCheck, faGear, faRightLeft } from '@fortawesome/free-solid-svg-icons';
 import ProjectVariantSelector from './ProjectVariantSelector';
 
 const greenTheme = true;
@@ -82,6 +82,18 @@ function NavigationBar({ tab, changeTab, darkMode, setDarkMode, defaultProject, 
         >
           <FontAwesomeIcon icon={faClipboardCheck} className="mr-1" />
           Review
+        </button>
+      </li>
+
+      {/* === Transfer === */}
+      <li className={[bgHoverColor, tab == 'transfer' && bgActiveColor].join(' ')}>
+        <button
+          onClick={() => changeTab('transfer')}
+          className="flex items-center h-full px-4 py-2"
+          aria-current={tab === 'transfer' ? 'page' : undefined}
+        >
+          <FontAwesomeIcon icon={faRightLeft} className="mr-1" />
+          Transfer
         </button>
       </li>
 

--- a/frontend/src/handlers/variant.ts
+++ b/frontend/src/handlers/variant.ts
@@ -4,6 +4,21 @@ type Variant = {
     project_id: string;
 };
 
+/** One of the three copy-assessment matching modes. */
+type CopyMatchMode = "exact" | "ignore_minor_version" | "ignore_version";
+
+/** The user-visible fields of the source assessment, for display in the review popup. */
+type CopyAssessmentsAssessmentDetails = {
+    simplified_status: string;
+    status: string;
+    justification?: string | null;
+    status_notes?: string | null;
+    impact_statement?: string | null;
+    workaround?: string | null;
+    responses?: string[];
+};
+
+/** A single row in an exact-mode flat preview. */
 type CopyAssessmentsPreviewEntry = {
     source_assessment_id: string;
     source_finding_id: string;
@@ -11,13 +26,38 @@ type CopyAssessmentsPreviewEntry = {
     vulnerability_id: string;
     source_package: string;
     target_package: string;
+    assessment_details?: CopyAssessmentsAssessmentDetails;
 };
 
+/** One candidate target finding within a review-popup group. */
+type CopyAssessmentsPreviewCandidate = {
+    target_finding_id: string;
+    target_package: string;
+    already_has_custom: boolean;
+    selected: boolean;
+};
+
+/** One source-assessment group in alternative-mode preview (for the review popup). */
+type CopyAssessmentsPreviewGroup = {
+    source_assessment_id: string;
+    source_finding_id: string;
+    vulnerability_id: string;
+    source_package: string;
+    assessment_details?: CopyAssessmentsAssessmentDetails;
+    candidates: CopyAssessmentsPreviewCandidate[];
+};
+
+/** Preview response from the backend. */
 type CopyAssessmentsPreview = {
     count: number;
     skipped: number;
+    skipped_count?: number;
     message: string;
-    entries: CopyAssessmentsPreviewEntry[];
+    mode: CopyMatchMode;
+    /** Present for exact mode. */
+    entries?: CopyAssessmentsPreviewEntry[];
+    /** Present for alternative modes. */
+    groups?: CopyAssessmentsPreviewGroup[];
 };
 
 type CopyAssessmentsPreviewUnsupported = {
@@ -26,11 +66,22 @@ type CopyAssessmentsPreviewUnsupported = {
     message: string;
 };
 
+/** One element in the selections array sent to the copy endpoint. */
+type CopyAssessmentsSelection = {
+    source_assessment_id: string;
+    target_finding_id: string;
+};
+
 export type {
     Variant,
+    CopyMatchMode,
+    CopyAssessmentsAssessmentDetails,
     CopyAssessmentsPreview,
     CopyAssessmentsPreviewEntry,
+    CopyAssessmentsPreviewCandidate,
+    CopyAssessmentsPreviewGroup,
     CopyAssessmentsPreviewUnsupported,
+    CopyAssessmentsSelection,
 };
 
 class Variants {
@@ -164,7 +215,9 @@ class Variants {
     static async copyAssessments(
         sourceVariantId: string,
         targetVariantId: string,
-        ignorePackageVersion = false,
+        matchMode: CopyMatchMode = "exact",
+        versionPrecision = 1,
+        selections?: CopyAssessmentsSelection[],
     ): Promise<{ copied: number; skipped: number; message: string }> {
         const response = await fetch(
             import.meta.env.VITE_API_URL + "/api/variants/copy-assessments",
@@ -175,7 +228,9 @@ class Variants {
                 body: JSON.stringify({
                     source_variant_id: sourceVariantId,
                     target_variant_id: targetVariantId,
-                    ignore_package_version: ignorePackageVersion,
+                    match_mode: matchMode,
+                    version_precision: versionPrecision,
+                    ...(selections !== undefined ? { selections } : {}),
                 }),
             }
         );
@@ -189,7 +244,8 @@ class Variants {
     static async previewCopyAssessments(
         sourceVariantId: string,
         targetVariantId: string,
-        ignorePackageVersion = false,
+        matchMode: CopyMatchMode = "exact",
+        versionPrecision = 1,
     ): Promise<CopyAssessmentsPreview | CopyAssessmentsPreviewUnsupported> {
         const response = await fetch(
             import.meta.env.VITE_API_URL + "/api/variants/copy-assessments/preview",
@@ -200,7 +256,8 @@ class Variants {
                 body: JSON.stringify({
                     source_variant_id: sourceVariantId,
                     target_variant_id: targetVariantId,
-                    ignore_package_version: ignorePackageVersion,
+                    match_mode: matchMode,
+                    version_precision: versionPrecision,
                 }),
             }
         );

--- a/frontend/src/handlers/variant.ts
+++ b/frontend/src/handlers/variant.ts
@@ -7,6 +7,9 @@ type Variant = {
 /** One of the three copy-assessment matching modes. */
 type CopyMatchMode = "exact" | "ignore_minor_version" | "ignore_version";
 
+/** Condition that decides which target findings a copy is proposed onto. */
+type CopyCondition = "no_custom" | "different_status" | "different_value";
+
 /** The user-visible fields of the source assessment, for display in the review popup. */
 type CopyAssessmentsAssessmentDetails = {
     simplified_status: string;
@@ -27,6 +30,7 @@ type CopyAssessmentsPreviewEntry = {
     source_package: string;
     target_package: string;
     already_has_custom?: boolean;
+    selected?: boolean;
     assessment_details?: CopyAssessmentsAssessmentDetails;
 };
 
@@ -76,6 +80,7 @@ type CopyAssessmentsSelection = {
 export type {
     Variant,
     CopyMatchMode,
+    CopyCondition,
     CopyAssessmentsAssessmentDetails,
     CopyAssessmentsPreview,
     CopyAssessmentsPreviewEntry,
@@ -219,6 +224,7 @@ class Variants {
         matchMode: CopyMatchMode = "exact",
         versionPrecision = 1,
         selections?: CopyAssessmentsSelection[],
+        copyCondition: CopyCondition = "no_custom",
     ): Promise<{ copied: number; skipped: number; message: string }> {
         const response = await fetch(
             import.meta.env.VITE_API_URL + "/api/variants/copy-assessments",
@@ -231,6 +237,7 @@ class Variants {
                     target_variant_id: targetVariantId,
                     match_mode: matchMode,
                     version_precision: versionPrecision,
+                    copy_condition: copyCondition,
                     ...(selections !== undefined ? { selections } : {}),
                 }),
             }
@@ -247,6 +254,7 @@ class Variants {
         targetVariantId: string,
         matchMode: CopyMatchMode = "exact",
         versionPrecision = 1,
+        copyCondition: CopyCondition = "no_custom",
     ): Promise<CopyAssessmentsPreview | CopyAssessmentsPreviewUnsupported> {
         const response = await fetch(
             import.meta.env.VITE_API_URL + "/api/variants/copy-assessments/preview",
@@ -259,6 +267,7 @@ class Variants {
                     target_variant_id: targetVariantId,
                     match_mode: matchMode,
                     version_precision: versionPrecision,
+                    copy_condition: copyCondition,
                 }),
             }
         );

--- a/frontend/src/handlers/variant.ts
+++ b/frontend/src/handlers/variant.ts
@@ -26,6 +26,7 @@ type CopyAssessmentsPreviewEntry = {
     vulnerability_id: string;
     source_package: string;
     target_package: string;
+    already_has_custom?: boolean;
     assessment_details?: CopyAssessmentsAssessmentDetails;
 };
 

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -15,6 +15,7 @@ import ScanHistory from "./ScanHistory";
 import Review from './Review';
 import type { AssessmentMutation } from './Review';
 import Settings from './Settings';
+import Transfer from './Transfer';
 import Assessments, { removeDuplicateAssessments, STATUS_VEX_TO_GRAPH } from '../handlers/assessments';
 import Config from "../handlers/config";
 import type { AppConfig } from "../handlers/config";
@@ -25,6 +26,7 @@ const tabLabels: Record<string, string> = {
         vulnerabilities: 'Vulnerabilities',
         scans: 'Scans',
         review: 'Review',
+        transfer: 'Transfer',
         exports: 'Export',
         settings: 'Settings',
 };
@@ -308,6 +310,10 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                 {tab === 'scans' && <ScanHistory variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onScanComplete={handleScanComplete} />}
                 {tab === 'review' && <Review variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onAssessmentChanged={handleAssessmentChanged} />}
                 {tab === 'exports' && <Exports variantId={currentVariantId} projectId={currentProjectId} />}
+                {tab === 'transfer' && <Transfer projectId={currentProjectId} onDataChanged={(message) => {
+                    if (message) setLoadingMessage(message);
+                    loadData(currentVariantId, currentVariantId ? undefined : currentProjectId, undefined, undefined, currentVariantIds, currentMultiOperation);
+                }} />}
                 {tab === 'settings' && <Settings onDataChanged={(message) => {
                     if (message) setLoadingMessage(message);
                     Config.get().then(config => setDefaultConfig(config)).catch(() => {});

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -12,17 +12,11 @@ import {
   faXmark,
   faKey,
   faPenToSquare,
-  faCopy,
-  faRightLeft,
 } from "@fortawesome/free-solid-svg-icons";
 import Projects from "../handlers/project";
 import type { Project } from "../handlers/project";
 import Variants from "../handlers/variant";
-import type {
-  Variant,
-  CopyAssessmentsPreview,
-  CopyAssessmentsPreviewUnsupported,
-} from "../handlers/variant";
+import type { Variant } from "../handlers/variant";
 import Config from "../handlers/config";
 import ConfirmationModal from "../components/ConfirmationModal";
 import MessageBanner from "../components/MessageBanner";
@@ -33,7 +27,7 @@ type Props = {
   onLoadingMessage?: (message: string | null) => void;
 };
 
-type SettingsTab = "general" | "projects" | "variants" | "customData" | "scan";
+type SettingsTab = "general" | "projects" | "variants" | "scan";
 
 function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
   // ---- Active category tab ----
@@ -178,12 +172,6 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         setRenameProjectId("");
         setRenameProjectName("");
       }
-      if (customProjectId === deleteProjectId) {
-        setCustomProjectId("");
-        setCustomProjectVariants([]);
-        setCopySourceId("");
-        setCopyTargetId("");
-      }
       setDeleteProjectId("");
       setConfirmDeleteProject(false);
       loadProjects();
@@ -209,19 +197,6 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
   const [confirmDeleteVariant, setConfirmDeleteVariant] = useState(false);
   const [deleteVariantBusy, setDeleteVariantBusy] = useState(false);
 
-  // ---- Copy Custom Assessments ----
-  const [customProjectId, setCustomProjectId] = useState<string>("");
-  const [customProjectVariants, setCustomProjectVariants] = useState<Variant[]>([]);
-  const [copySourceId, setCopySourceId] = useState<string>("");
-  const [copyTargetId, setCopyTargetId] = useState<string>("");
-  const [copyIgnorePackageVersion, setCopyIgnorePackageVersion] = useState(false);
-  const [copyBusy, setCopyBusy] = useState(false);
-  const [copyMsg, setCopyMsg] = useState<string | null>(null);
-  const [copyPreviewBusy, setCopyPreviewBusy] = useState(false);
-  const [copyPreviewError, setCopyPreviewError] = useState<string | null>(null);
-  const [copyPreview, setCopyPreview] = useState<CopyAssessmentsPreview | null>(null);
-  const [copyPreviewUnavailableMsg, setCopyPreviewUnavailableMsg] = useState<string | null>(null);
-
   const reloadVariants = useCallback((projectId: string) => {
     if (!projectId) { setVariantProjectVariants([]); return; }
     Variants.list(projectId)
@@ -240,11 +215,6 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
     try {
       await Variants.rename(renameVariantId, renameVariantName.trim());
       reloadVariants(variantProjectId);
-      if (customProjectId === variantProjectId) {
-        Variants.list(customProjectId)
-          .then(setCustomProjectVariants)
-          .catch(() => setCustomProjectVariants([]));
-      }
       onDataChanged?.("Renaming variant...");
     } catch (e: any) {
       setVariantMsg(e.message);
@@ -261,11 +231,6 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
       await Variants.create(variantProjectId, newVariantName.trim());
       setNewVariantName("");
       reloadVariants(variantProjectId);
-      if (customProjectId === variantProjectId) {
-        Variants.list(customProjectId)
-          .then(setCustomProjectVariants)
-          .catch(() => setCustomProjectVariants([]));
-      }
       onDataChanged?.("Creating variant...");
     } catch (e: any) {
       setVariantMsg(e.message);
@@ -283,18 +248,10 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
       if (renameVariantId === deleteVariantId) {
         setRenameVariantId("");
         setRenameVariantName("");
-        setCopyPreview(null);
-        setCopyPreviewError(null);
-        setCopyPreviewBusy(false);
       }
       setDeleteVariantId("");
       setConfirmDeleteVariant(false);
       reloadVariants(variantProjectId);
-      if (customProjectId === variantProjectId) {
-        Variants.list(customProjectId)
-          .then(setCustomProjectVariants)
-          .catch(() => setCustomProjectVariants([]));
-      }
       onDataChanged?.("Deleting variant...");
     } catch (e: any) {
       setVariantMsg(e.message);
@@ -303,85 +260,6 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
       setDeleteVariantBusy(false);
     }
   };
-
-  const handleCopyAssessments = async () => {
-    if (!copySourceId || !copyTargetId || copyBusy) return;
-    if (copySourceId === copyTargetId) {
-      setCopyMsg("Source and target variants must be different.");
-      return;
-    }
-    setCopyBusy(true);
-    setCopyMsg(null);
-    try {
-      const result = await Variants.copyAssessments(
-        copySourceId,
-        copyTargetId,
-        copyIgnorePackageVersion,
-      );
-      setCopyMsg(result.message);
-      onDataChanged?.("Copying assessments...");
-    } catch (e: any) {
-      setCopyMsg(e.message);
-    } finally {
-      setCopyBusy(false);
-    }
-  };
-
-  useEffect(() => {
-    if (!customProjectId) {
-      setCustomProjectVariants([]);
-      setCopySourceId("");
-      setCopyTargetId("");
-      setCopyPreview(null);
-      setCopyPreviewError(null);
-      setCopyPreviewUnavailableMsg(null);
-      setCopyPreviewBusy(false);
-      return;
-    }
-    Variants.list(customProjectId)
-      .then(setCustomProjectVariants)
-      .catch(() => setCustomProjectVariants([]));
-  }, [customProjectId]);
-
-  useEffect(() => {
-    if (!customProjectId || !copySourceId || !copyTargetId || copySourceId === copyTargetId) {
-      setCopyPreview(null);
-      setCopyPreviewError(null);
-      setCopyPreviewUnavailableMsg(null);
-      setCopyPreviewBusy(false);
-      return;
-    }
-
-    let cancelled = false;
-    setCopyPreviewBusy(true);
-    setCopyPreviewError(null);
-    setCopyPreviewUnavailableMsg(null);
-
-    Variants.previewCopyAssessments(copySourceId, copyTargetId, copyIgnorePackageVersion)
-      .then((data) => {
-        if (cancelled || unmountedRef.current) return;
-        if ((data as CopyAssessmentsPreviewUnsupported).unsupported) {
-          setCopyPreview(null);
-          setCopyPreviewUnavailableMsg(data.message);
-          return;
-        }
-        setCopyPreview(data as CopyAssessmentsPreview);
-      })
-      .catch((e: any) => {
-        if (cancelled || unmountedRef.current) return;
-        setCopyPreview(null);
-        setCopyPreviewUnavailableMsg(null);
-        setCopyPreviewError(e?.message || "Failed to generate preview.");
-      })
-      .finally(() => {
-        if (cancelled || unmountedRef.current) return;
-        setCopyPreviewBusy(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [customProjectId, copySourceId, copyTargetId, copyIgnorePackageVersion]);
 
   // ---- Import SBOM ----
   const [importProjectId, setImportProjectId] = useState<string>("");
@@ -588,16 +466,6 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
             onClick={() => setActiveTab("scan")}
           >
             Scan Settings
-          </button>
-          <button
-            className={`px-4 py-2 text-sm font-medium rounded-t transition-colors ${
-              activeTab === "customData"
-                ? "bg-sky-800 text-white border-b-2 border-sky-400"
-                : "text-gray-400 hover:text-gray-200 hover:bg-gray-800"
-            }`}
-            onClick={() => setActiveTab("customData")}
-          >
-            Custom Data Settings
           </button>
         </div>
 
@@ -1179,220 +1047,6 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         </>
         )}
 
-        {/* ======== Custom Data Settings tab ======== */}
-        {activeTab === "customData" && (
-        <>
-        {/* ======== Select Project ======== */}
-        <section aria-labelledby="settings-heading-custom-project">
-          <div className={cardHeader}>
-            <FontAwesomeIcon icon={faFolderOpen} className="text-cyan-400" aria-hidden="true" />
-            <h2 id="settings-heading-custom-project" className="text-xl font-bold text-white">Select Project</h2>
-          </div>
-          <div className={cardBody + " space-y-4"}>
-            <div>
-              <label htmlFor="custom-project-select" className="block text-sm text-zinc-300 mb-1">Project</label>
-              <select
-                id="custom-project-select"
-                value={customProjectId}
-                onChange={(e) => {
-                  setCustomProjectId(e.target.value);
-                  setCopyMsg(null);
-                  setCopyPreview(null);
-                  setCopyPreviewError(null);
-                  setCopyPreviewUnavailableMsg(null);
-                }}
-                className={selectClass}
-              >
-                <option value="">— select a project —</option>
-                {projects.map((p) => (
-                  <option key={p.id} value={p.id}>{p.name}</option>
-                ))}
-              </select>
-              {!customProjectId && (
-                <p className="text-zinc-400 text-sm mt-2">
-                  Select a project to manage custom data operations.
-                </p>
-              )}
-            </div>
-          </div>
-        </section>
-
-        {/* ======== Copy Custom Assessments ======== */}
-        <section
-          aria-labelledby="settings-heading-copy-assessments"
-          aria-disabled={!customProjectId}
-          className={!customProjectId ? "opacity-50" : ""}
-        >
-          <div className={cardHeader}>
-            <FontAwesomeIcon icon={faCopy} className="text-cyan-400" aria-hidden="true" />
-            <h2 id="settings-heading-copy-assessments" className="text-xl font-bold text-white">Copy Custom Assessments</h2>
-          </div>
-          <div className={cardBody + " space-y-4"}>
-            <p className="text-sm text-zinc-400">
-              Copy custom assessments from a source variant to a target variant in the selected project.
-            </p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <label htmlFor="copy-source-select" className="block text-sm text-zinc-300 font-semibold">Source</label>
-                <select
-                  id="copy-source-select"
-                  value={copySourceId}
-                  onChange={(e) => {
-                    setCopySourceId(e.target.value);
-                    setCopyMsg(null);
-                    setCopyPreviewError(null);
-                    setCopyPreviewUnavailableMsg(null);
-                  }}
-                  className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
-                  disabled={!customProjectId}
-                >
-                  <option value="">— select a variant —</option>
-                  {customProjectVariants.map((v) => (
-                    <option key={v.id} value={v.id}>{v.name}</option>
-                  ))}
-                </select>
-              </div>
-              <div className="flex items-end justify-center sm:justify-start">
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (!customProjectId || copyBusy) return;
-                    setCopySourceId(copyTargetId);
-                    setCopyTargetId(copySourceId);
-                    setCopyMsg(null);
-                    setCopyPreviewError(null);
-                    setCopyPreviewUnavailableMsg(null);
-                  }}
-                  disabled={!customProjectId || copyBusy || !copySourceId || !copyTargetId}
-                  className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
-                  title="Swap source and target variants"
-                  aria-label="Swap source and target variants"
-                >
-                  <FontAwesomeIcon icon={faRightLeft} className="mr-2" aria-hidden="true" />
-                  Swap
-                </button>
-              </div>
-              <div className="space-y-2">
-                <label htmlFor="copy-target-select" className="block text-sm text-zinc-300 font-semibold">Copy to</label>
-                <select
-                  id="copy-target-select"
-                  value={copyTargetId}
-                  onChange={(e) => {
-                    setCopyTargetId(e.target.value);
-                    setCopyMsg(null);
-                    setCopyPreviewError(null);
-                    setCopyPreviewUnavailableMsg(null);
-                  }}
-                  className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
-                  disabled={!customProjectId}
-                >
-                  <option value="">— select a variant —</option>
-                  {customProjectVariants.map((v) => (
-                    <option key={v.id} value={v.id}>{v.name}</option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            <label className="inline-flex items-center gap-2 text-sm text-zinc-300">
-              <input
-                type="checkbox"
-                checked={copyIgnorePackageVersion}
-                onChange={(e) => {
-                  setCopyIgnorePackageVersion(e.target.checked);
-                  setCopyMsg(null);
-                  setCopyPreviewError(null);
-                  setCopyPreviewUnavailableMsg(null);
-                }}
-                disabled={!customProjectId || copyBusy}
-                className="rounded border-slate-500 bg-slate-900"
-              />
-              Ignore packages version
-            </label>
-
-            <p className="text-xs text-zinc-400">
-              When enabled, copy by vulnerabilities in common, regardless of package name/version differences.
-            </p>
-
-            <div className="rounded-md border border-slate-600/70 bg-slate-900/40 p-3 space-y-2">
-              <h3 className="text-sm font-semibold text-zinc-200">Preview</h3>
-              {(!customProjectId || !copySourceId || !copyTargetId) && (
-                <p className="text-xs text-zinc-400">Select a source and a target variant to generate a preview.</p>
-              )}
-              {copySourceId && copyTargetId && copySourceId === copyTargetId && (
-                <p className="text-xs text-amber-300">Source and target variants must be different.</p>
-              )}
-              {copyPreviewBusy && (
-                <p className="text-xs text-zinc-300">
-                  <FontAwesomeIcon icon={faSpinner} spin className="mr-1" aria-hidden="true" />
-                  Computing preview...
-                </p>
-              )}
-              {copyPreviewError && (
-                <p className="text-xs text-red-300">
-                  <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
-                  {copyPreviewError}
-                </p>
-              )}
-              {copyPreviewUnavailableMsg && (
-                <p className="text-xs text-amber-300">
-                  <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
-                  {copyPreviewUnavailableMsg}
-                </p>
-              )}
-              {!copyPreviewBusy && !copyPreviewError && copyPreview && (
-                <>
-                  <p className="text-xs text-cyan-300">{copyPreview.message}</p>
-                  {copyPreview.entries.length > 0 && (
-                    <div className="max-h-56 overflow-auto rounded border border-slate-700/80">
-                      <table className="min-w-full text-xs text-zinc-200">
-                        <thead className="bg-slate-800/80 text-zinc-300">
-                          <tr>
-                            <th className="px-2 py-1 text-left">Vulnerability</th>
-                            <th className="px-2 py-1 text-left">Source package</th>
-                            <th className="px-2 py-1 text-left">Target package</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {copyPreview.entries.map((entry) => (
-                            <tr key={`${entry.source_assessment_id}-${entry.target_finding_id}`} className="border-t border-slate-700/70">
-                              <td className="px-2 py-1 font-mono">{entry.vulnerability_id}</td>
-                              <td className="px-2 py-1">{entry.source_package || "-"}</td>
-                              <td className="px-2 py-1">{entry.target_package || "-"}</td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-
-            <button
-              onClick={handleCopyAssessments}
-              disabled={!customProjectId || !copySourceId || !copyTargetId || copySourceId === copyTargetId || copyBusy}
-              className={btnPrimary}
-            >
-              {copyBusy ? (
-                <FontAwesomeIcon icon={faSpinner} spin className="mr-2" aria-hidden="true" />
-              ) : (
-                <FontAwesomeIcon icon={faCopy} className="mr-2" aria-hidden="true" />
-              )}
-              Copy Assessments
-            </button>
-
-            {copyMsg && (
-              <span role="alert" className="block text-sm text-cyan-300">
-                <FontAwesomeIcon icon={faCheck} className="mr-1" aria-hidden="true" />
-                {copyMsg}
-              </span>
-            )}
-          </div>
-        </section>
-        </>
-        )}
-
         {/* ======== Scan Settings tab ======== */}
         {activeTab === "scan" && (
         <>
@@ -1507,6 +1161,7 @@ function Settings({ onDataChanged, onLoadingMessage }: Readonly<Props>) {
         </>
         )}
       </div>
+
 
       {/* ======== Confirmation Modals ======== */}
       <ConfirmationModal

--- a/frontend/src/pages/Transfer.tsx
+++ b/frontend/src/pages/Transfer.tsx
@@ -201,7 +201,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                         )}
 
                         {/* ---- Source / Target selectors ---- */}
-                        <div className="space-y-3">
+                        <div className="relative space-y-3">
                             <div className="space-y-2">
                                 <label htmlFor="copy-source-select" className="block text-sm text-zinc-300 font-semibold">Source</label>
                                 <select
@@ -222,26 +222,8 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                                     ))}
                                 </select>
                             </div>
-                            <div className="flex justify-center">
-                                <button
-                                    type="button"
-                                    onClick={() => {
-                                        if (!customProjectId || copyBusy) return;
-                                        setCopySourceId(copyTargetId);
-                                        setCopyTargetId(copySourceId);
-                                        setCopyMsg(null);
-                                        setCopyPreviewError(null);
-                                        setCopyPreviewUnavailableMsg(null);
-                                    }}
-                                    disabled={!customProjectId || copyBusy || !copySourceId || !copyTargetId}
-                                    className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
-                                    title="Swap source and target variants"
-                                    aria-label="Swap source and target variants"
-                                >
-                                    <FontAwesomeIcon icon={faArrowsUpDown} className="mr-2" aria-hidden="true" />
-                                    Swap
-                                </button>
-                            </div>
+                            {/* Spacer that reserves room for the absolutely-centered Swap button */}
+                            <div className="h-9" aria-hidden="true" />
                             <div className="space-y-2">
                                 <label htmlFor="copy-target-select" className="block text-sm text-zinc-300 font-semibold">Target</label>
                                 <select
@@ -262,6 +244,24 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                                     ))}
                                 </select>
                             </div>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    if (!customProjectId || copyBusy) return;
+                                    setCopySourceId(copyTargetId);
+                                    setCopyTargetId(copySourceId);
+                                    setCopyMsg(null);
+                                    setCopyPreviewError(null);
+                                    setCopyPreviewUnavailableMsg(null);
+                                }}
+                                disabled={!customProjectId || copyBusy || !copySourceId || !copyTargetId}
+                                className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+                                title="Swap source and target variants"
+                                aria-label="Swap source and target variants"
+                            >
+                                <FontAwesomeIcon icon={faArrowsUpDown} className="mr-2" aria-hidden="true" />
+                                Swap
+                            </button>
                         </div>
 
                         {/* ---- Copy condition ---- */}

--- a/frontend/src/pages/Transfer.tsx
+++ b/frontend/src/pages/Transfer.tsx
@@ -263,18 +263,21 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
 
                         {/* ---- Matching mode ---- */}
                         <div className="space-y-2">
-                            <p className="text-sm font-semibold text-zinc-300">Matching mode</p>
-                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                            <p className="text-sm font-semibold text-zinc-300">How should packages be matched?</p>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2">
                                 {([
-                                    { value: "exact",                label: "Exact",                desc: "Same package name and version" },
-                                    { value: "ignore_minor_version", label: "Ignore minor version",  desc: "Same name, major version must match" },
-                                    { value: "ignore_version",       label: "Ignore version",        desc: "Same name, any version" },
-                                ] as { value: CopyMatchMode; label: string; desc: string }[]).map(({ value, label, desc }) => (
+                                    { value: "exact",                precision: 1, label: "Same Versions",                 desc: "Package name and full version must match (e.g. 6.5.1 \u2192 6.5.1)" },
+                                    { value: "ignore_minor_version", precision: 2, label: "Same Major and Minor Versions", desc: "Major and minor must match; patch may differ (e.g. 6.5.1 \u2192 6.5.9)" },
+                                    { value: "ignore_minor_version", precision: 1, label: "Same Major Versions",           desc: "Major must match; minor and patch may differ (e.g. 6.5.1 \u2192 6.9.0)" },
+                                    { value: "ignore_version",       precision: 1, label: "Any Versions",                  desc: "Same name; version is ignored (e.g. 6.5.1 \u2192 7.0.0)" },
+                                ] as { value: CopyMatchMode; precision: number; label: string; desc: string }[]).map(({ value, precision, label, desc }) => {
+                                    const selected = copyMatchMode === value && (value === "ignore_minor_version" ? copyVersionPrecision === precision : true);
+                                    return (
                                     <label
-                                        key={value}
+                                        key={label}
                                         className={[
                                             "flex items-start gap-2 rounded-lg border px-3 py-2 cursor-pointer transition-colors",
-                                            copyMatchMode === value
+                                            selected
                                                 ? "border-cyan-500 bg-cyan-950/40 text-white"
                                                 : "border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500",
                                             (!customProjectId || copyBusy) ? "opacity-50 cursor-not-allowed" : "",
@@ -283,11 +286,12 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                                         <input
                                             type="radio"
                                             name="copy-match-mode"
-                                            value={value}
-                                            checked={copyMatchMode === value}
+                                            value={label}
+                                            checked={selected}
                                             disabled={!customProjectId || copyBusy}
                                             onChange={() => {
                                                 setCopyMatchMode(value);
+                                                setCopyVersionPrecision(precision);
                                                 setCopyMsg(null);
                                                 setCopyPreviewError(null);
                                                 setCopyPreviewUnavailableMsg(null);
@@ -299,39 +303,10 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                                             <span className="text-xs text-zinc-400">{desc}</span>
                                         </span>
                                     </label>
-                                ))}
+                                    );
+                                })}
                             </div>
                         </div>
-
-                        {/* ---- Version precision (only for ignore_minor_version) ---- */}
-                        {copyMatchMode === "ignore_minor_version" && (
-                            <div className="flex items-center gap-4 pl-1">
-                                <p className="text-xs text-zinc-400 font-semibold">Version precision:</p>
-                                {([
-                                    { precision: 1, label: "Major only",  example: "6.x → 6.y" },
-                                    { precision: 2, label: "Major.Minor", example: "6.5.x → 6.5.y" },
-                                ] as { precision: number; label: string; example: string }[]).map(({ precision, label, example }) => (
-                                    <label key={precision} className="flex items-center gap-1.5 text-xs text-zinc-300 cursor-pointer">
-                                        <input
-                                            type="radio"
-                                            name="copy-version-precision"
-                                            value={precision}
-                                            checked={copyVersionPrecision === precision}
-                                            disabled={!customProjectId || copyBusy}
-                                            onChange={() => {
-                                                setCopyVersionPrecision(precision);
-                                                setCopyMsg(null);
-                                                setCopyPreviewError(null);
-                                                setCopyPreviewUnavailableMsg(null);
-                                            }}
-                                            className="accent-cyan-500"
-                                        />
-                                        <span>{label}</span>
-                                        <span className="text-zinc-500">{example}</span>
-                                    </label>
-                                ))}
-                            </div>
-                        )}
 
                         {/* ---- Preview summary ---- */}
                         {copyPreviewBusy && (

--- a/frontend/src/pages/Transfer.tsx
+++ b/frontend/src/pages/Transfer.tsx
@@ -11,6 +11,7 @@ import Variants from "../handlers/variant";
 import type {
     Variant,
     CopyMatchMode,
+    CopyCondition,
     CopyAssessmentsPreview,
     CopyAssessmentsPreviewGroup,
     CopyAssessmentsPreviewCandidate,
@@ -42,6 +43,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
     const [copyTargetId, setCopyTargetId] = useState<string>("");
     const [copyMatchMode, setCopyMatchMode] = useState<CopyMatchMode>("exact");
     const [copyVersionPrecision, setCopyVersionPrecision] = useState<number>(1);
+    const [copyCondition, setCopyCondition] = useState<CopyCondition>("no_custom");
     const [copyBusy, setCopyBusy] = useState(false);
     const [copyMsg, setCopyMsg] = useState<string | null>(null);
     const [copyPreviewBusy, setCopyPreviewBusy] = useState(false);
@@ -65,6 +67,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                 copyMatchMode,
                 copyVersionPrecision,
                 selections,
+                copyCondition,
             );
             setCopyMsg(result.message);
             onDataChanged?.("Copying assessments...");
@@ -91,7 +94,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                         target_finding_id:  entry.target_finding_id,
                         target_package:     entry.target_package,
                         already_has_custom: entry.already_has_custom ?? false,
-                        selected:           !(entry.already_has_custom ?? false),
+                        selected:           entry.selected ?? !(entry.already_has_custom ?? false),
                     } satisfies CopyAssessmentsPreviewCandidate],
                 })
             );
@@ -136,7 +139,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
         setCopyPreviewError(null);
         setCopyPreviewUnavailableMsg(null);
 
-        Variants.previewCopyAssessments(copySourceId, copyTargetId, copyMatchMode, copyVersionPrecision)
+        Variants.previewCopyAssessments(copySourceId, copyTargetId, copyMatchMode, copyVersionPrecision, copyCondition)
             .then((data) => {
                 if (cancelled || unmountedRef.current) return;
                 if ((data as CopyAssessmentsPreviewUnsupported).unsupported) {
@@ -158,7 +161,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
             });
 
         return () => { cancelled = true; };
-    }, [customProjectId, copySourceId, copyTargetId, copyMatchMode, copyVersionPrecision]);
+    }, [customProjectId, copySourceId, copyTargetId, copyMatchMode, copyVersionPrecision, copyCondition]);
 
     // ---- Styles ----
     const inputClass =
@@ -258,6 +261,48 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                                         <option key={v.id} value={v.id}>{v.name}</option>
                                     ))}
                                 </select>
+                            </div>
+                        </div>
+
+                        {/* ---- Copy condition ---- */}
+                        <div className="space-y-2">
+                            <p className="text-sm font-semibold text-zinc-300">Conditions to copy assessments</p>
+                            <div className="grid grid-cols-1 gap-2">
+                                {([
+                                    { value: "no_custom",        label: "Target has no custom assessment",                    desc: "Only copy onto \u201cCopy to\u201d findings that have no custom assessment yet." },
+                                    { value: "different_status", label: "Target has a different status",                      desc: "Also copy when the target already has a custom assessment with a different status." },
+                                    { value: "different_value",  label: "Target differs in any value",                       desc: "Also copy when the target's custom assessment differs in status, justification, workaround or any other value." },
+                                ] as { value: CopyCondition; label: string; desc: string }[]).map(({ value, label, desc }) => (
+                                    <label
+                                        key={value}
+                                        className={[
+                                            "flex items-start gap-2 rounded-lg border px-3 py-2 cursor-pointer transition-colors",
+                                            copyCondition === value
+                                                ? "border-cyan-500 bg-cyan-950/40 text-white"
+                                                : "border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500",
+                                            (!customProjectId || copyBusy) ? "opacity-50 cursor-not-allowed" : "",
+                                        ].join(" ")}
+                                    >
+                                        <input
+                                            type="radio"
+                                            name="copy-condition"
+                                            value={value}
+                                            checked={copyCondition === value}
+                                            disabled={!customProjectId || copyBusy}
+                                            onChange={() => {
+                                                setCopyCondition(value);
+                                                setCopyMsg(null);
+                                                setCopyPreviewError(null);
+                                                setCopyPreviewUnavailableMsg(null);
+                                            }}
+                                            className="mt-0.5 accent-cyan-500"
+                                        />
+                                        <span className="flex flex-col">
+                                            <span className="text-sm font-medium">{label}</span>
+                                            <span className="text-xs text-zinc-400">{desc}</span>
+                                        </span>
+                                    </label>
+                                ))}
                             </div>
                         </div>
 

--- a/frontend/src/pages/Transfer.tsx
+++ b/frontend/src/pages/Transfer.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
     faCopy,
-    faRightLeft,
+    faArrowsUpDown,
     faSpinner,
     faTriangleExclamation,
     faCheck,
@@ -201,7 +201,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                         )}
 
                         {/* ---- Source / Target selectors ---- */}
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div className="space-y-3">
                             <div className="space-y-2">
                                 <label htmlFor="copy-source-select" className="block text-sm text-zinc-300 font-semibold">Source</label>
                                 <select
@@ -222,7 +222,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                                     ))}
                                 </select>
                             </div>
-                            <div className="flex items-end justify-center sm:justify-start">
+                            <div className="flex justify-center">
                                 <button
                                     type="button"
                                     onClick={() => {
@@ -238,12 +238,12 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                                     title="Swap source and target variants"
                                     aria-label="Swap source and target variants"
                                 >
-                                    <FontAwesomeIcon icon={faRightLeft} className="mr-2" aria-hidden="true" />
+                                    <FontAwesomeIcon icon={faArrowsUpDown} className="mr-2" aria-hidden="true" />
                                     Swap
                                 </button>
                             </div>
                             <div className="space-y-2">
-                                <label htmlFor="copy-target-select" className="block text-sm text-zinc-300 font-semibold">Copy to</label>
+                                <label htmlFor="copy-target-select" className="block text-sm text-zinc-300 font-semibold">Target</label>
                                 <select
                                     id="copy-target-select"
                                     value={copyTargetId}
@@ -269,7 +269,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                             <p className="text-sm font-semibold text-zinc-300">Conditions to copy assessments</p>
                             <div className="grid grid-cols-1 gap-2">
                                 {([
-                                    { value: "no_custom",        label: "Target has no custom assessment",                    desc: "Only copy onto \u201cCopy to\u201d findings that have no custom assessment yet." },
+                                    { value: "no_custom",        label: "Target has no custom assessment",                    desc: "Only copy onto target findings that have no custom assessment yet." },
                                     { value: "different_status", label: "Target has a different status",                      desc: "Also copy when the target already has a custom assessment with a different status." },
                                     { value: "different_value",  label: "Target differs in any value",                       desc: "Also copy when the target's custom assessment differs in status, justification, workaround or any other value." },
                                 ] as { value: CopyCondition; label: string; desc: string }[]).map(({ value, label, desc }) => (

--- a/frontend/src/pages/Transfer.tsx
+++ b/frontend/src/pages/Transfer.tsx
@@ -90,8 +90,8 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                     candidates: [{
                         target_finding_id:  entry.target_finding_id,
                         target_package:     entry.target_package,
-                        already_has_custom: false,
-                        selected:           true,
+                        already_has_custom: entry.already_has_custom ?? false,
+                        selected:           !(entry.already_has_custom ?? false),
                     } satisfies CopyAssessmentsPreviewCandidate],
                 })
             );

--- a/frontend/src/pages/Transfer.tsx
+++ b/frontend/src/pages/Transfer.tsx
@@ -1,0 +1,400 @@
+import { useState, useEffect, useRef } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+    faCopy,
+    faRightLeft,
+    faSpinner,
+    faTriangleExclamation,
+    faCheck,
+} from "@fortawesome/free-solid-svg-icons";
+import Variants from "../handlers/variant";
+import type {
+    Variant,
+    CopyMatchMode,
+    CopyAssessmentsPreview,
+    CopyAssessmentsPreviewGroup,
+    CopyAssessmentsPreviewCandidate,
+    CopyAssessmentsPreviewUnsupported,
+    CopyAssessmentsSelection,
+} from "../handlers/variant";
+import CopyAssessmentsReviewModal from "../components/CopyAssessmentsReviewModal";
+
+type Props = {
+    /** Project currently selected in the global selector; drives the variant lists. */
+    projectId?: string;
+    onDataChanged?: (message?: string) => void;
+};
+
+function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
+    // ---- Unmount guard for async operations ----
+    const unmountedRef = useRef(false);
+    useEffect(() => {
+        unmountedRef.current = false;
+        return () => { unmountedRef.current = true; };
+    }, []);
+
+    // The active project comes from the global project/variant selector.
+    const customProjectId = projectId ?? "";
+
+    // ---- Copy Custom Assessments state ----
+    const [customProjectVariants, setCustomProjectVariants] = useState<Variant[]>([]);
+    const [copySourceId, setCopySourceId] = useState<string>("");
+    const [copyTargetId, setCopyTargetId] = useState<string>("");
+    const [copyMatchMode, setCopyMatchMode] = useState<CopyMatchMode>("exact");
+    const [copyVersionPrecision, setCopyVersionPrecision] = useState<number>(1);
+    const [copyBusy, setCopyBusy] = useState(false);
+    const [copyMsg, setCopyMsg] = useState<string | null>(null);
+    const [copyPreviewBusy, setCopyPreviewBusy] = useState(false);
+    const [copyPreviewError, setCopyPreviewError] = useState<string | null>(null);
+    const [copyPreview, setCopyPreview] = useState<CopyAssessmentsPreview | null>(null);
+    const [copyPreviewUnavailableMsg, setCopyPreviewUnavailableMsg] = useState<string | null>(null);
+    const [copyReviewOpen, setCopyReviewOpen] = useState(false);
+    const [copyReviewGroups, setCopyReviewGroups] = useState<CopyAssessmentsPreviewGroup[]>([]);
+    const [reviewKey, setReviewKey] = useState(0);
+
+    // ---- Handlers ----
+    const handleCopyFromReview = async (selections: CopyAssessmentsSelection[]) => {
+        setCopyReviewOpen(false);
+        if (!copySourceId || !copyTargetId || copyBusy) return;
+        setCopyBusy(true);
+        setCopyMsg(null);
+        try {
+            const result = await Variants.copyAssessments(
+                copySourceId,
+                copyTargetId,
+                copyMatchMode,
+                copyVersionPrecision,
+                selections,
+            );
+            setCopyMsg(result.message);
+            onDataChanged?.("Copying assessments...");
+        } catch (e: any) {
+            setCopyMsg(e.message);
+        } finally {
+            setCopyBusy(false);
+        }
+    };
+
+    const handleOpenReview = () => {
+        if (!copyPreview) return;
+        let groups: CopyAssessmentsPreviewGroup[];
+        if (copyPreview.mode === "exact") {
+            // Convert flat entries to groups — one candidate per group, all pre-selected
+            groups = (copyPreview.entries ?? []).map(
+                (entry): CopyAssessmentsPreviewGroup => ({
+                    source_assessment_id: entry.source_assessment_id,
+                    source_finding_id:    entry.source_finding_id,
+                    vulnerability_id:     entry.vulnerability_id,
+                    source_package:       entry.source_package,
+                    assessment_details:   entry.assessment_details,
+                    candidates: [{
+                        target_finding_id:  entry.target_finding_id,
+                        target_package:     entry.target_package,
+                        already_has_custom: false,
+                        selected:           true,
+                    } satisfies CopyAssessmentsPreviewCandidate],
+                })
+            );
+        } else {
+            groups = copyPreview.groups ?? [];
+        }
+        setCopyReviewGroups(groups);
+        setReviewKey((k) => k + 1);
+        setCopyReviewOpen(true);
+    };
+
+    // ---- Effects ----
+    useEffect(() => {
+        // Reset any in-progress selection whenever the active project changes.
+        setCopySourceId("");
+        setCopyTargetId("");
+        setCopyMsg(null);
+        setCopyPreview(null);
+        setCopyPreviewError(null);
+        setCopyPreviewUnavailableMsg(null);
+        setCopyPreviewBusy(false);
+        if (!customProjectId) {
+            setCustomProjectVariants([]);
+            return;
+        }
+        Variants.list(customProjectId)
+            .then(setCustomProjectVariants)
+            .catch(() => setCustomProjectVariants([]));
+    }, [customProjectId]);
+
+    useEffect(() => {
+        if (!customProjectId || !copySourceId || !copyTargetId || copySourceId === copyTargetId) {
+            setCopyPreview(null);
+            setCopyPreviewError(null);
+            setCopyPreviewUnavailableMsg(null);
+            setCopyPreviewBusy(false);
+            return;
+        }
+
+        let cancelled = false;
+        setCopyPreviewBusy(true);
+        setCopyPreviewError(null);
+        setCopyPreviewUnavailableMsg(null);
+
+        Variants.previewCopyAssessments(copySourceId, copyTargetId, copyMatchMode, copyVersionPrecision)
+            .then((data) => {
+                if (cancelled || unmountedRef.current) return;
+                if ((data as CopyAssessmentsPreviewUnsupported).unsupported) {
+                    setCopyPreview(null);
+                    setCopyPreviewUnavailableMsg(data.message);
+                    return;
+                }
+                setCopyPreview(data as CopyAssessmentsPreview);
+            })
+            .catch((e: any) => {
+                if (cancelled || unmountedRef.current) return;
+                setCopyPreview(null);
+                setCopyPreviewUnavailableMsg(null);
+                setCopyPreviewError(e?.message || "Failed to generate preview.");
+            })
+            .finally(() => {
+                if (cancelled || unmountedRef.current) return;
+                setCopyPreviewBusy(false);
+            });
+
+        return () => { cancelled = true; };
+    }, [customProjectId, copySourceId, copyTargetId, copyMatchMode, copyVersionPrecision]);
+
+    // ---- Styles ----
+    const inputClass =
+        "w-full rounded px-2 py-1.5 text-sm bg-slate-900/60 border border-slate-600 text-white focus:outline-none focus:border-cyan-400";
+    const selectClass = inputClass;
+    const btnPrimary =
+        "px-4 py-2 rounded-lg bg-cyan-800 hover:bg-cyan-700 focus:ring-4 focus:outline-none focus:ring-blue-800 text-white text-sm font-semibold disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150";
+    const cardHeader =
+        "bg-gradient-to-r from-slate-700 to-slate-800 px-4 py-2.5 flex items-center gap-2 rounded-t-lg border-b border-slate-600/60";
+    const cardBody =
+        "bg-slate-800/60 p-4 rounded-b-lg ring-1 ring-slate-700/70 shadow-lg shadow-black/20";
+
+    return (
+        <div className="w-full">
+            <div className="w-full space-y-6">
+                <h1 className="text-3xl font-bold text-white mb-2">Transfer</h1>
+
+                {/* ======== Copy Custom Assessments ======== */}
+                <section
+                    aria-labelledby="transfer-heading-copy"
+                    aria-disabled={!customProjectId}
+                    className={!customProjectId ? "opacity-50" : ""}
+                >
+                    <div className={cardHeader}>
+                        <FontAwesomeIcon icon={faCopy} className="text-cyan-400" aria-hidden="true" />
+                        <h2 id="transfer-heading-copy" className="text-xl font-bold text-white">Copy Custom Assessments</h2>
+                    </div>
+                    <div className={cardBody + " space-y-4"}>
+                        <p className="text-sm text-zinc-400">
+                            Copy custom assessments from a source variant to a target variant in the selected project.
+                        </p>
+
+                        {!customProjectId && (
+                            <p className="text-amber-300 text-sm">
+                                Select a project or variant from the selector above to copy assessments.
+                            </p>
+                        )}
+
+                        {/* ---- Source / Target selectors ---- */}
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <div className="space-y-2">
+                                <label htmlFor="copy-source-select" className="block text-sm text-zinc-300 font-semibold">Source</label>
+                                <select
+                                    id="copy-source-select"
+                                    value={copySourceId}
+                                    onChange={(e) => {
+                                        setCopySourceId(e.target.value);
+                                        setCopyMsg(null);
+                                        setCopyPreviewError(null);
+                                        setCopyPreviewUnavailableMsg(null);
+                                    }}
+                                    className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
+                                    disabled={!customProjectId}
+                                >
+                                    <option value="">— select a variant —</option>
+                                    {customProjectVariants.map((v) => (
+                                        <option key={v.id} value={v.id}>{v.name}</option>
+                                    ))}
+                                </select>
+                            </div>
+                            <div className="flex items-end justify-center sm:justify-start">
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        if (!customProjectId || copyBusy) return;
+                                        setCopySourceId(copyTargetId);
+                                        setCopyTargetId(copySourceId);
+                                        setCopyMsg(null);
+                                        setCopyPreviewError(null);
+                                        setCopyPreviewUnavailableMsg(null);
+                                    }}
+                                    disabled={!customProjectId || copyBusy || !copySourceId || !copyTargetId}
+                                    className="px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+                                    title="Swap source and target variants"
+                                    aria-label="Swap source and target variants"
+                                >
+                                    <FontAwesomeIcon icon={faRightLeft} className="mr-2" aria-hidden="true" />
+                                    Swap
+                                </button>
+                            </div>
+                            <div className="space-y-2">
+                                <label htmlFor="copy-target-select" className="block text-sm text-zinc-300 font-semibold">Copy to</label>
+                                <select
+                                    id="copy-target-select"
+                                    value={copyTargetId}
+                                    onChange={(e) => {
+                                        setCopyTargetId(e.target.value);
+                                        setCopyMsg(null);
+                                        setCopyPreviewError(null);
+                                        setCopyPreviewUnavailableMsg(null);
+                                    }}
+                                    className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
+                                    disabled={!customProjectId}
+                                >
+                                    <option value="">— select a variant —</option>
+                                    {customProjectVariants.map((v) => (
+                                        <option key={v.id} value={v.id}>{v.name}</option>
+                                    ))}
+                                </select>
+                            </div>
+                        </div>
+
+                        {/* ---- Matching mode ---- */}
+                        <div className="space-y-2">
+                            <p className="text-sm font-semibold text-zinc-300">Matching mode</p>
+                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                                {([
+                                    { value: "exact",                label: "Exact",                desc: "Same package name and version" },
+                                    { value: "ignore_minor_version", label: "Ignore minor version",  desc: "Same name, major version must match" },
+                                    { value: "ignore_version",       label: "Ignore version",        desc: "Same name, any version" },
+                                ] as { value: CopyMatchMode; label: string; desc: string }[]).map(({ value, label, desc }) => (
+                                    <label
+                                        key={value}
+                                        className={[
+                                            "flex items-start gap-2 rounded-lg border px-3 py-2 cursor-pointer transition-colors",
+                                            copyMatchMode === value
+                                                ? "border-cyan-500 bg-cyan-950/40 text-white"
+                                                : "border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500",
+                                            (!customProjectId || copyBusy) ? "opacity-50 cursor-not-allowed" : "",
+                                        ].join(" ")}
+                                    >
+                                        <input
+                                            type="radio"
+                                            name="copy-match-mode"
+                                            value={value}
+                                            checked={copyMatchMode === value}
+                                            disabled={!customProjectId || copyBusy}
+                                            onChange={() => {
+                                                setCopyMatchMode(value);
+                                                setCopyMsg(null);
+                                                setCopyPreviewError(null);
+                                                setCopyPreviewUnavailableMsg(null);
+                                            }}
+                                            className="mt-0.5 accent-cyan-500"
+                                        />
+                                        <span className="flex flex-col">
+                                            <span className="text-sm font-medium">{label}</span>
+                                            <span className="text-xs text-zinc-400">{desc}</span>
+                                        </span>
+                                    </label>
+                                ))}
+                            </div>
+                        </div>
+
+                        {/* ---- Version precision (only for ignore_minor_version) ---- */}
+                        {copyMatchMode === "ignore_minor_version" && (
+                            <div className="flex items-center gap-4 pl-1">
+                                <p className="text-xs text-zinc-400 font-semibold">Version precision:</p>
+                                {([
+                                    { precision: 1, label: "Major only",  example: "6.x → 6.y" },
+                                    { precision: 2, label: "Major.Minor", example: "6.5.x → 6.5.y" },
+                                ] as { precision: number; label: string; example: string }[]).map(({ precision, label, example }) => (
+                                    <label key={precision} className="flex items-center gap-1.5 text-xs text-zinc-300 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="copy-version-precision"
+                                            value={precision}
+                                            checked={copyVersionPrecision === precision}
+                                            disabled={!customProjectId || copyBusy}
+                                            onChange={() => {
+                                                setCopyVersionPrecision(precision);
+                                                setCopyMsg(null);
+                                                setCopyPreviewError(null);
+                                                setCopyPreviewUnavailableMsg(null);
+                                            }}
+                                            className="accent-cyan-500"
+                                        />
+                                        <span>{label}</span>
+                                        <span className="text-zinc-500">{example}</span>
+                                    </label>
+                                ))}
+                            </div>
+                        )}
+
+                        {/* ---- Preview summary ---- */}
+                        {copyPreviewBusy && (
+                            <p className="text-xs text-zinc-400">
+                                <FontAwesomeIcon icon={faSpinner} spin className="mr-1" aria-hidden="true" />
+                                Computing preview…
+                            </p>
+                        )}
+                        {!copyPreviewBusy && copyPreview && (
+                            <p className="text-xs text-cyan-300">{copyPreview.message}</p>
+                        )}
+
+                        {/* ---- Action button ---- */}
+                        {copyPreviewError && (
+                            <p className="text-xs text-red-300">
+                                <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
+                                {copyPreviewError}
+                            </p>
+                        )}
+                        {copyPreviewUnavailableMsg && (
+                            <p className="text-xs text-amber-300">
+                                <FontAwesomeIcon icon={faTriangleExclamation} className="mr-1" aria-hidden="true" />
+                                {copyPreviewUnavailableMsg}
+                            </p>
+                        )}
+                        <button
+                                onClick={handleOpenReview}
+                                disabled={
+                                    !customProjectId || !copySourceId || !copyTargetId ||
+                                    copySourceId === copyTargetId || copyBusy ||
+                                    copyPreviewBusy || !!copyPreviewError || !!copyPreviewUnavailableMsg || !copyPreview
+                                }
+                                className={btnPrimary}
+                            >
+                                {(copyBusy || copyPreviewBusy) ? (
+                                    <FontAwesomeIcon icon={faSpinner} spin className="mr-2" aria-hidden="true" />
+                                ) : (
+                                    <FontAwesomeIcon icon={faCopy} className="mr-2" aria-hidden="true" />
+                                )}
+                                {copyPreviewBusy ? "Loading preview…" : "Preview & Copy"}
+                            </button>
+
+                        {copyMsg && (
+                            <span role="alert" className="block text-sm text-cyan-300">
+                                <FontAwesomeIcon icon={faCheck} className="mr-1" aria-hidden="true" />
+                                {copyMsg}
+                            </span>
+                        )}
+                    </div>
+                </section>
+            </div>
+
+            {/* ======== Review popup ======== */}
+            <CopyAssessmentsReviewModal
+                key={reviewKey}
+                isOpen={copyReviewOpen}
+                groups={copyReviewGroups}
+                previewMessage={copyPreview?.message}
+                onConfirm={handleCopyFromReview}
+                onCancel={() => setCopyReviewOpen(false)}
+            />
+        </div>
+    );
+}
+
+export default Transfer;

--- a/frontend/tests/unit_tests/test_copy_assessments_review_modal.tsx
+++ b/frontend/tests/unit_tests/test_copy_assessments_review_modal.tsx
@@ -198,28 +198,27 @@ describe('CopyAssessmentsReviewModal', () => {
         expect(onConfirm).toHaveBeenCalledWith([]);
     });
 
-    test('expand arrow reveals assessment details and collapse hides them', () => {
+    test('rows are expanded by default; collapse hides details and expand reveals them', () => {
         render(<CopyAssessmentsReviewModal {...baseProps} />);
-        // Details are initially hidden
-        expect(screen.queryByText('component_not_present')).not.toBeInTheDocument();
-        // Click the expand button for CVE-2024-0001
-        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0001'));
+        // Details are visible by default
         expect(screen.getByText('component_not_present')).toBeInTheDocument();
         expect(screen.getByText('Reviewed by security team.')).toBeInTheDocument();
         // Status badge is shown
         expect(screen.getByText('Not affected')).toBeInTheDocument();
-        // Collapse again
+        // Collapse the row
         fireEvent.click(screen.getByLabelText('Collapse details for CVE-2024-0001'));
         expect(screen.queryByText('component_not_present')).not.toBeInTheDocument();
+        // Expand it again
+        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0001'));
+        expect(screen.getByText('component_not_present')).toBeInTheDocument();
     });
 
-    test('expand shows status badge with correct text when no other details', () => {
+    test('status badge shows correct text when no other details', () => {
         render(<CopyAssessmentsReviewModal {...baseProps} />);
-        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0002'));
         expect(screen.getByText('Exploitable')).toBeInTheDocument();
     });
 
-    test('expand on group without assessment_details shows fallback message', () => {
+    test('group without assessment_details shows fallback message', () => {
         const groups: CopyAssessmentsPreviewGroup[] = [{
             source_assessment_id: 'a1',
             source_finding_id: 'sf1',
@@ -228,19 +227,20 @@ describe('CopyAssessmentsReviewModal', () => {
             candidates: [{ target_finding_id: 'tf1', target_package: 'pkg@2.0', already_has_custom: false, selected: true }],
         }];
         render(<CopyAssessmentsReviewModal {...baseProps} groups={groups} />);
-        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0003'));
         expect(screen.getByText('No details available.')).toBeInTheDocument();
     });
 
-    test('expanding one row does not expand others', () => {
+    test('collapsing one row does not collapse others', () => {
         render(<CopyAssessmentsReviewModal {...baseProps} />);
-        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0001'));
+        // Both rows are expanded by default
         expect(screen.getByText('component_not_present')).toBeInTheDocument();
-        // CVE-2024-0002 detail (Exploitable badge) is not yet shown
-        // The word 'Exploitable' appears only once (in the sub-row for CVE-2024-0001's row is not expanded, so we check CVE-2024-0002's detail text)
-        expect(screen.queryByText('Reviewed by security team.')).toBeInTheDocument();
-        // CVE-2024-0002 row should NOT be expanded
-        expect(screen.queryByLabelText('Collapse details for CVE-2024-0002')).not.toBeInTheDocument();
+        expect(screen.getByText('Exploitable')).toBeInTheDocument();
+        // Collapse CVE-2024-0001
+        fireEvent.click(screen.getByLabelText('Collapse details for CVE-2024-0001'));
+        expect(screen.queryByText('component_not_present')).not.toBeInTheDocument();
+        // CVE-2024-0002 row should still be expanded
+        expect(screen.getByText('Exploitable')).toBeInTheDocument();
+        expect(screen.getByLabelText('Collapse details for CVE-2024-0002')).toBeInTheDocument();
     });
 
     test.each([
@@ -257,7 +257,6 @@ describe('CopyAssessmentsReviewModal', () => {
             candidates: [{ target_finding_id: 'tf1', target_package: 'pkg@2.0', already_has_custom: false, selected: true }],
         }];
         render(<CopyAssessmentsReviewModal {...baseProps} groups={groups} />);
-        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0099'));
         expect(screen.getByText(simplified)).toBeInTheDocument();
     });
 });

--- a/frontend/tests/unit_tests/test_copy_assessments_review_modal.tsx
+++ b/frontend/tests/unit_tests/test_copy_assessments_review_modal.tsx
@@ -198,6 +198,41 @@ describe('CopyAssessmentsReviewModal', () => {
         expect(onConfirm).toHaveBeenCalledWith([]);
     });
 
+    test('already-assessed candidate allowed by the copy condition is included in confirm', () => {
+        // The copy condition (e.g. "different status") marks the candidate
+        // selected even though it already has a custom assessment. It must not
+        // be skipped by the modal.
+        const groups: CopyAssessmentsPreviewGroup[] = [
+            {
+                source_assessment_id: 'a1',
+                source_finding_id: 'sf1',
+                vulnerability_id: 'CVE-2024-7777',
+                source_package: 'openssl@1.1.1',
+                assessment_details: { simplified_status: 'Fixed', status: 'fixed' },
+                candidates: [
+                    {
+                        target_finding_id: 'tf1',
+                        target_package: 'openssl@1.4.2',
+                        already_has_custom: true,
+                        selected: true,
+                    },
+                ],
+            },
+        ];
+        const onConfirm = jest.fn();
+        render(
+            <CopyAssessmentsReviewModal {...baseProps} groups={groups} onConfirm={onConfirm} />,
+        );
+        const checkbox = screen.getByLabelText('Include CVE-2024-7777') as HTMLInputElement;
+        expect(checkbox).not.toBeDisabled();
+        expect(checkbox).toBeChecked();
+        expect(screen.getByText('(already assessed)')).toBeInTheDocument();
+        fireEvent.click(screen.getByText('Confirm Copy'));
+        expect(onConfirm).toHaveBeenCalledWith([
+            { source_assessment_id: 'a1', target_finding_id: 'tf1' },
+        ]);
+    });
+
     test('rows are expanded by default; collapse hides details and expand reveals them', () => {
         render(<CopyAssessmentsReviewModal {...baseProps} />);
         // Details are visible by default

--- a/frontend/tests/unit_tests/test_copy_assessments_review_modal.tsx
+++ b/frontend/tests/unit_tests/test_copy_assessments_review_modal.tsx
@@ -1,0 +1,263 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import "@testing-library/jest-dom";
+// @ts-expect-error TS6133
+import React from 'react';
+
+import CopyAssessmentsReviewModal from '../../src/components/CopyAssessmentsReviewModal';
+import type { CopyAssessmentsPreviewGroup } from '../../src/handlers/variant';
+
+function makeGroups(): CopyAssessmentsPreviewGroup[] {
+    return [
+        {
+            source_assessment_id: 'a1',
+            source_finding_id: 'sf1',
+            vulnerability_id: 'CVE-2024-0001',
+            source_package: 'openssl@1.1.1',
+            assessment_details: {
+                simplified_status: 'Not affected',
+                status: 'not_affected',
+                justification: 'component_not_present',
+                status_notes: 'Reviewed by security team.',
+            },
+            candidates: [
+                {
+                    target_finding_id: 'tf1',
+                    target_package: 'openssl@1.4.2',
+                    already_has_custom: false,
+                    selected: true,
+                },
+                {
+                    target_finding_id: 'tf2',
+                    target_package: 'openssl@1.1.5',
+                    already_has_custom: false,
+                    selected: false,
+                },
+            ],
+        },
+        {
+            source_assessment_id: 'a2',
+            source_finding_id: 'sf2',
+            vulnerability_id: 'CVE-2024-0002',
+            source_package: 'curl@7.64.1',
+            assessment_details: {
+                simplified_status: 'Exploitable',
+                status: 'affected',
+            },
+            candidates: [
+                {
+                    target_finding_id: 'tf3',
+                    target_package: 'curl@8.0.0',
+                    already_has_custom: false,
+                    selected: true,
+                },
+            ],
+        },
+    ];
+}
+
+describe('CopyAssessmentsReviewModal', () => {
+    const baseProps = {
+        isOpen: true,
+        groups: makeGroups(),
+        previewMessage: '2 assessments would be copied.',
+        onConfirm: jest.fn(),
+        onCancel: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('does not render when isOpen is false', () => {
+        render(<CopyAssessmentsReviewModal {...baseProps} isOpen={false} />);
+        expect(screen.queryByText('Review Copy Alignments')).not.toBeInTheDocument();
+    });
+
+    test('renders header, preview message and both vulnerability rows', () => {
+        render(<CopyAssessmentsReviewModal {...baseProps} />);
+        expect(screen.getByText('Review Copy Alignments')).toBeInTheDocument();
+        expect(screen.getByText('2 assessments would be copied.')).toBeInTheDocument();
+        expect(screen.getByText('CVE-2024-0001')).toBeInTheDocument();
+        expect(screen.getByText('CVE-2024-0002')).toBeInTheDocument();
+    });
+
+    test('renders a dropdown for multi-candidate groups and plain text for single', () => {
+        render(<CopyAssessmentsReviewModal {...baseProps} />);
+        // CVE-2024-0001 has two candidates → a select
+        const select = screen.getByLabelText('Target for CVE-2024-0001') as HTMLSelectElement;
+        expect(select).toBeInTheDocument();
+        expect(select.options).toHaveLength(2);
+        // CVE-2024-0002 has one candidate → plain text
+        expect(screen.getByText('curl@8.0.0')).toBeInTheDocument();
+    });
+
+    test('confirm sends default selections (first non-assessed candidate per group)', () => {
+        const onConfirm = jest.fn();
+        render(<CopyAssessmentsReviewModal {...baseProps} onConfirm={onConfirm} />);
+        fireEvent.click(screen.getByText('Confirm Copy'));
+        expect(onConfirm).toHaveBeenCalledWith([
+            { source_assessment_id: 'a1', target_finding_id: 'tf1' },
+            { source_assessment_id: 'a2', target_finding_id: 'tf3' },
+        ]);
+    });
+
+    test('changing the dropdown updates the chosen target finding', () => {
+        const onConfirm = jest.fn();
+        render(<CopyAssessmentsReviewModal {...baseProps} onConfirm={onConfirm} />);
+        const select = screen.getByLabelText('Target for CVE-2024-0001') as HTMLSelectElement;
+        fireEvent.change(select, { target: { value: '1' } });
+        fireEvent.click(screen.getByText('Confirm Copy'));
+        expect(onConfirm).toHaveBeenCalledWith([
+            { source_assessment_id: 'a1', target_finding_id: 'tf2' },
+            { source_assessment_id: 'a2', target_finding_id: 'tf3' },
+        ]);
+    });
+
+    test('deselect all then confirm sends no selections', () => {
+        const onConfirm = jest.fn();
+        render(<CopyAssessmentsReviewModal {...baseProps} onConfirm={onConfirm} />);
+        fireEvent.click(screen.getByText('Deselect all'));
+        fireEvent.click(screen.getByText('Confirm Copy'));
+        expect(onConfirm).toHaveBeenCalledWith([]);
+    });
+
+    test('toggling a row checkbox off excludes it from the selections', () => {
+        const onConfirm = jest.fn();
+        render(<CopyAssessmentsReviewModal {...baseProps} onConfirm={onConfirm} />);
+        fireEvent.click(screen.getByLabelText('Include CVE-2024-0001'));
+        fireEvent.click(screen.getByText('Confirm Copy'));
+        expect(onConfirm).toHaveBeenCalledWith([
+            { source_assessment_id: 'a2', target_finding_id: 'tf3' },
+        ]);
+    });
+
+    test('select all re-checks every row', () => {
+        const onConfirm = jest.fn();
+        render(<CopyAssessmentsReviewModal {...baseProps} onConfirm={onConfirm} />);
+        fireEvent.click(screen.getByText('Deselect all'));
+        fireEvent.click(screen.getByText('Select all'));
+        fireEvent.click(screen.getByText('Confirm Copy'));
+        expect(onConfirm).toHaveBeenCalledWith([
+            { source_assessment_id: 'a1', target_finding_id: 'tf1' },
+            { source_assessment_id: 'a2', target_finding_id: 'tf3' },
+        ]);
+    });
+
+    test('cancel button calls onCancel', () => {
+        const onCancel = jest.fn();
+        render(<CopyAssessmentsReviewModal {...baseProps} onCancel={onCancel} />);
+        fireEvent.click(screen.getByText('Cancel'));
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('Escape key calls onCancel', () => {
+        const onCancel = jest.fn();
+        render(<CopyAssessmentsReviewModal {...baseProps} onCancel={onCancel} />);
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('clicking the backdrop calls onCancel', () => {
+        const onCancel = jest.fn();
+        render(<CopyAssessmentsReviewModal {...baseProps} onCancel={onCancel} />);
+        fireEvent.mouseDown(screen.getByTestId('copy-review-modal-backdrop'));
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('empty groups shows the no-alignments message', () => {
+        render(<CopyAssessmentsReviewModal {...baseProps} groups={[]} />);
+        expect(screen.getByText('No alignments found for the selected options.')).toBeInTheDocument();
+    });
+
+    test('already-assessed candidate is disabled and excluded from confirm', () => {
+        const groups: CopyAssessmentsPreviewGroup[] = [
+            {
+                source_assessment_id: 'a1',
+                source_finding_id: 'sf1',
+                vulnerability_id: 'CVE-2024-9999',
+                source_package: 'openssl@1.1.1',
+                assessment_details: { simplified_status: 'Fixed', status: 'fixed' },
+                candidates: [
+                    {
+                        target_finding_id: 'tf1',
+                        target_package: 'openssl@1.4.2',
+                        already_has_custom: true,
+                        selected: false,
+                    },
+                ],
+            },
+        ];
+        const onConfirm = jest.fn();
+        render(
+            <CopyAssessmentsReviewModal {...baseProps} groups={groups} onConfirm={onConfirm} />,
+        );
+        const checkbox = screen.getByLabelText('Include CVE-2024-9999') as HTMLInputElement;
+        expect(checkbox).toBeDisabled();
+        expect(screen.getByText('(already assessed)')).toBeInTheDocument();
+        fireEvent.click(screen.getByText('Confirm Copy'));
+        expect(onConfirm).toHaveBeenCalledWith([]);
+    });
+
+    test('expand arrow reveals assessment details and collapse hides them', () => {
+        render(<CopyAssessmentsReviewModal {...baseProps} />);
+        // Details are initially hidden
+        expect(screen.queryByText('component_not_present')).not.toBeInTheDocument();
+        // Click the expand button for CVE-2024-0001
+        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0001'));
+        expect(screen.getByText('component_not_present')).toBeInTheDocument();
+        expect(screen.getByText('Reviewed by security team.')).toBeInTheDocument();
+        // Status badge is shown
+        expect(screen.getByText('Not affected')).toBeInTheDocument();
+        // Collapse again
+        fireEvent.click(screen.getByLabelText('Collapse details for CVE-2024-0001'));
+        expect(screen.queryByText('component_not_present')).not.toBeInTheDocument();
+    });
+
+    test('expand shows status badge with correct text when no other details', () => {
+        render(<CopyAssessmentsReviewModal {...baseProps} />);
+        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0002'));
+        expect(screen.getByText('Exploitable')).toBeInTheDocument();
+    });
+
+    test('expand on group without assessment_details shows fallback message', () => {
+        const groups: CopyAssessmentsPreviewGroup[] = [{
+            source_assessment_id: 'a1',
+            source_finding_id: 'sf1',
+            vulnerability_id: 'CVE-2024-0003',
+            source_package: 'pkg@1.0',
+            candidates: [{ target_finding_id: 'tf1', target_package: 'pkg@2.0', already_has_custom: false, selected: true }],
+        }];
+        render(<CopyAssessmentsReviewModal {...baseProps} groups={groups} />);
+        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0003'));
+        expect(screen.getByText('No details available.')).toBeInTheDocument();
+    });
+
+    test('expanding one row does not expand others', () => {
+        render(<CopyAssessmentsReviewModal {...baseProps} />);
+        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0001'));
+        expect(screen.getByText('component_not_present')).toBeInTheDocument();
+        // CVE-2024-0002 detail (Exploitable badge) is not yet shown
+        // The word 'Exploitable' appears only once (in the sub-row for CVE-2024-0001's row is not expanded, so we check CVE-2024-0002's detail text)
+        expect(screen.queryByText('Reviewed by security team.')).toBeInTheDocument();
+        // CVE-2024-0002 row should NOT be expanded
+        expect(screen.queryByLabelText('Collapse details for CVE-2024-0002')).not.toBeInTheDocument();
+    });
+
+    test.each([
+        ['Pending Assessment', 'bg-amber-700'],
+        ['False Positive',     'bg-purple-700'],
+        ['Unknown',            'bg-slate-600'],
+    ])('status badge renders correct colour for "%s"', (simplified) => {
+        const groups: CopyAssessmentsPreviewGroup[] = [{
+            source_assessment_id: 'a1',
+            source_finding_id: 'sf1',
+            vulnerability_id: 'CVE-2024-0099',
+            source_package: 'pkg@1.0',
+            assessment_details: { simplified_status: simplified, status: 'under_investigation' },
+            candidates: [{ target_finding_id: 'tf1', target_package: 'pkg@2.0', already_has_custom: false, selected: true }],
+        }];
+        render(<CopyAssessmentsReviewModal {...baseProps} groups={groups} />);
+        fireEvent.click(screen.getByLabelText('Expand details for CVE-2024-0099'));
+        expect(screen.getByText(simplified)).toBeInTheDocument();
+    });
+});

--- a/frontend/tests/unit_tests/test_settings_handlers.ts
+++ b/frontend/tests/unit_tests/test_settings_handlers.ts
@@ -440,6 +440,7 @@ describe('Variants.copyAssessments', () => {
                     target_variant_id: 'target-v2',
                     match_mode: 'exact',
                     version_precision: 1,
+                    copy_condition: 'no_custom',
                 }),
             })
         );

--- a/frontend/tests/unit_tests/test_settings_handlers.ts
+++ b/frontend/tests/unit_tests/test_settings_handlers.ts
@@ -438,19 +438,53 @@ describe('Variants.copyAssessments', () => {
                 body: JSON.stringify({
                     source_variant_id: 'source-v1',
                     target_variant_id: 'target-v2',
-                    ignore_package_version: false,
+                    match_mode: 'exact',
+                    version_precision: 1,
                 }),
             })
         );
     });
 
-    test('passes ignore_package_version flag when true', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify({ copied: 3, skipped: 0, message: 'ok' }));
+    test('sends version_precision for ignore_minor_version mode', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ copied: 1, skipped: 0, message: 'ok' }));
 
-        await Variants.copyAssessments('src', 'tgt', true);
+        await Variants.copyAssessments('src', 'tgt', 'ignore_minor_version', 2);
 
         const body = JSON.parse((fetchMock.mock.calls[0] as any[])[1].body as string);
-        expect(body.ignore_package_version).toBe(true);
+        expect(body.match_mode).toBe('ignore_minor_version');
+        expect(body.version_precision).toBe(2);
+    });
+
+    test('omits selections when not provided', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ copied: 0, skipped: 0, message: 'ok' }));
+
+        await Variants.copyAssessments('src', 'tgt', 'ignore_version', 1);
+
+        const body = JSON.parse((fetchMock.mock.calls[0] as any[])[1].body as string);
+        expect('selections' in body).toBe(false);
+    });
+
+    test('includes selections array when provided', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ copied: 2, skipped: 0, message: 'ok' }));
+
+        const selections = [
+            { source_assessment_id: 'a1', target_finding_id: 'tf1' },
+            { source_assessment_id: 'a2', target_finding_id: 'tf2' },
+        ];
+        await Variants.copyAssessments('src', 'tgt', 'ignore_version', 1, selections);
+
+        const body = JSON.parse((fetchMock.mock.calls[0] as any[])[1].body as string);
+        expect(body.selections).toEqual(selections);
+        expect(body.match_mode).toBe('ignore_version');
+    });
+
+    test('includes an empty selections array when explicitly passed', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ copied: 0, skipped: 0, message: 'ok' }));
+
+        await Variants.copyAssessments('src', 'tgt', 'ignore_version', 1, []);
+
+        const body = JSON.parse((fetchMock.mock.calls[0] as any[])[1].body as string);
+        expect(body.selections).toEqual([]);
     });
 
     test('throws on error response', async () => {
@@ -504,7 +538,7 @@ describe('Variants.previewCopyAssessments', () => {
         if (!('unsupported' in result)) {
             expect(result.count).toBe(3);
             expect(result.entries).toHaveLength(1);
-            expect(result.entries[0].vulnerability_id).toBe('CVE-2023-1234');
+            expect(result.entries![0].vulnerability_id).toBe('CVE-2023-1234');
         }
         expect(fetchMock).toHaveBeenCalledWith(
             expect.stringContaining('/api/variants/copy-assessments/preview'),
@@ -560,12 +594,61 @@ describe('Variants.previewCopyAssessments', () => {
         await expect(Variants.previewCopyAssessments('src', 'tgt')).rejects.toThrow('Preview failed (503)');
     });
 
-    test('passes ignore_package_version flag', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify({ count: 0, skipped: 0, message: '', entries: [] }));
+    test('passes match_mode for ignore_version mode', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ count: 0, skipped: 0, message: '', mode: 'ignore_version', groups: [] }));
 
-        await Variants.previewCopyAssessments('src', 'tgt', true);
+        await Variants.previewCopyAssessments('src', 'tgt', 'ignore_version');
 
         const body = JSON.parse((fetchMock.mock.calls[0] as any[])[1].body as string);
-        expect(body.ignore_package_version).toBe(true);
+        expect(body.match_mode).toBe('ignore_version');
+        expect('ignore_package_version' in body).toBe(false);
+    });
+
+    test('sends match_mode and version_precision for ignore_minor_version', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ count: 0, skipped: 0, message: '', mode: 'ignore_minor_version', groups: [] }));
+
+        await Variants.previewCopyAssessments('src', 'tgt', 'ignore_minor_version', 2);
+
+        const body = JSON.parse((fetchMock.mock.calls[0] as any[])[1].body as string);
+        expect(body.match_mode).toBe('ignore_minor_version');
+        expect(body.version_precision).toBe(2);
+        expect('ignore_package_version' in body).toBe(false);
+    });
+
+    test('returns grouped candidates for alternative modes', async () => {
+        const grouped = {
+            count: 2,
+            skipped: 1,
+            skipped_count: 1,
+            message: '2 assessments would be copied. 1 already present would be skipped.',
+            mode: 'ignore_version',
+            groups: [
+                {
+                    source_assessment_id: 'a1',
+                    source_finding_id: 'sf1',
+                    vulnerability_id: 'CVE-2024-0001',
+                    source_package: 'openssl@1.1.1',
+                    candidates: [
+                        {
+                            target_finding_id: 'tf1',
+                            target_package: 'openssl@1.4.2',
+                            already_has_custom: false,
+                            selected: true,
+                        },
+                    ],
+                },
+            ],
+        };
+        fetchMock.mockResponseOnce(JSON.stringify(grouped));
+
+        const result = await Variants.previewCopyAssessments('src', 'tgt', 'ignore_version');
+
+        expect('unsupported' in result).toBe(false);
+        if (!('unsupported' in result)) {
+            expect(result.mode).toBe('ignore_version');
+            expect(result.groups).toHaveLength(1);
+            expect(result.groups![0].candidates[0].target_finding_id).toBe('tf1');
+            expect(result.entries).toBeUndefined();
+        }
     });
 });

--- a/src/helpers/version_match.py
+++ b/src/helpers/version_match.py
@@ -1,0 +1,84 @@
+"""
+Helpers for fuzzy version comparison used by the copy-assessments feature.
+
+``versions_match(v1, v2, precision)`` returns True when the first
+``precision`` numeric components of both version strings are equal.
+
+precision=1  →  only the major component must match  (e.g. 6.5 vs 6.9 ✓, 6.5 vs 7.0 ✗)
+precision=2  →  major + minor must match             (e.g. 6.5.1 vs 6.5.9 ✓, 6.5 vs 6.7 ✗)
+
+Parsing strategy (most-specific first):
+1. Try ``semver`` (already a project dependency) with optional minor/patch.
+2. Fall back to splitting on "." and comparing integer prefixes.
+"""
+
+from __future__ import annotations
+
+import re
+
+import semver
+
+
+def _semver_components(version_str: str) -> tuple[int, ...]:
+    """Return (major, minor, patch) from a semver-parseable string."""
+    v = semver.Version.parse(version_str, optional_minor_and_patch=True)
+    return (v.major, v.minor, v.patch)
+
+
+def _split_components(version_str: str) -> tuple[int, ...]:
+    """
+    Fallback: split on "." and "+" / "-" delimiters and collect leading
+    integer parts.  Non-numeric trailing parts are ignored.
+    """
+    # Strip build metadata and pre-release suffixes first
+    clean = re.split(r"[+\-]", version_str, maxsplit=1)[0]
+    parts: list[int] = []
+    for segment in clean.split("."):
+        m = re.match(r"^(\d+)", segment)
+        if m:
+            parts.append(int(m.group(1)))
+        else:
+            break
+    return tuple(parts)
+
+
+def _parse_components(version_str: str) -> tuple[int, ...]:
+    """Return a tuple of numeric version components, at least length 1."""
+    if not version_str:
+        return (0,)
+    try:
+        return _semver_components(version_str)
+    except ValueError:
+        components = _split_components(version_str)
+        if not components:
+            return (0,)
+        return components
+
+
+def versions_match(v1: str | None, v2: str | None, precision: int) -> bool:
+    """
+    Return True when the two version strings agree on the first ``precision``
+    numeric components.
+
+    None or empty strings are treated as "0".
+
+    Examples (precision=1):
+        "6.5"  vs "6.7"  → True
+        "6.5"  vs "7.0"  → False
+
+    Examples (precision=2):
+        "6.5.1" vs "6.5.9" → True
+        "6.5"   vs "6.7"   → False
+    """
+    if precision <= 0:
+        return True
+
+    c1 = _parse_components(v1 or "")
+    c2 = _parse_components(v2 or "")
+
+    for i in range(precision):
+        n1 = c1[i] if i < len(c1) else 0
+        n2 = c2[i] if i < len(c2) else 0
+        if n1 != n2:
+            return False
+    return True

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -10,7 +10,7 @@ import threading
 import tarfile
 import subprocess
 import shutil
-from typing import Callable, Protocol, TypeVar, cast
+from typing import Callable, Protocol, TypeVar, cast, TYPE_CHECKING
 import io as _io
 
 from flask import jsonify, request, Flask
@@ -30,6 +30,9 @@ from ..models.project import Project
 from ..models.variant import Variant
 from ..helpers.verbose import verbose
 from ._scan_helpers import parse_uuid_or_400, ErrorResponse
+
+if TYPE_CHECKING:
+    from ..models.assessment import Assessment as DBAssessment
 
 T = TypeVar("T")
 _C = TypeVar("_C")
@@ -394,7 +397,9 @@ def init_app(app: Flask) -> None:
     #     skipped_count, empty_message, mode }
     # ------------------------------------------------------------------
 
-    def _clone_assessment(src, finding_id, variant_id) -> None:  # type: ignore[no-untyped-def]
+    def _clone_assessment(
+        src: "DBAssessment", finding_id: uuid.UUID, variant_id: uuid.UUID,
+    ) -> None:
         """Create a copy of *src* Assessment bound to a new finding and variant."""
         from ..models.assessment import Assessment as DBAssessment
         DBAssessment.create(
@@ -412,7 +417,7 @@ def init_app(app: Flask) -> None:
             commit=False,
         )
 
-    def _serialize_assessment_details(assessment) -> dict:  # type: ignore[no-untyped-def]
+    def _serialize_assessment_details(assessment: "DBAssessment") -> dict:
         """Return the user-visible fields of an assessment for the preview popup."""
         return {
             "simplified_status": assessment.simplified_status or "",
@@ -424,11 +429,48 @@ def init_app(app: Flask) -> None:
             "responses": list(assessment.responses) if assessment.responses else [],
         }
 
+    def _assessment_value_tuple(a: "DBAssessment") -> tuple:
+        """Comparable snapshot of the fields a copy carries over."""
+        return (
+            (a.status or ""),
+            (a.simplified_status or ""),
+            (a.justification or ""),
+            (a.impact_statement or ""),
+            (a.workaround or ""),
+            (a.status_notes or ""),
+            tuple(a.responses or []),
+        )
+
+    def _copy_condition_allows(
+        existing_customs: list["DBAssessment"],
+        src_assessment: "DBAssessment",
+        copy_condition: str,
+    ) -> bool:
+        """Decide whether a copy should be proposed onto a target finding.
+
+        *existing_customs* is the list of custom-origin assessments already on the
+        target finding for the target variant. The three conditions:
+          - "no_custom":        only when the target has no custom assessment.
+          - "different_status": also when the current custom status differs.
+          - "different_value":  also when the current custom differs in any field.
+        """
+        if not existing_customs:
+            return True
+        if copy_condition == "no_custom":
+            return False
+        current = max(existing_customs, key=lambda a: a.timestamp)
+        if copy_condition == "different_status":
+            return (current.simplified_status or "") != (src_assessment.simplified_status or "")
+        if copy_condition == "different_value":
+            return _assessment_value_tuple(current) != _assessment_value_tuple(src_assessment)
+        return False
+
     def _compute_copy_assessment_operations(
         source_id: str,
         target_id: str,
         match_mode: str = "exact",
         version_precision: int = 1,
+        copy_condition: str = "no_custom",
     ) -> tuple[dict, None] | tuple[None, ErrorResponse]:
         from ..models.assessment import Assessment as DBAssessment
         from ..models.finding import Finding
@@ -513,11 +555,13 @@ def init_app(app: Flask) -> None:
                 processed_target_finding_ids.add(target_finding.id)
 
                 existing = DBAssessment.get_by_finding_and_variant(target_finding.id, target_uuid)
-                already_has_custom = any(e.origin == "custom" for e in existing)
-                if already_has_custom:
+                existing_customs = [e for e in existing if e.origin == "custom"]
+                already_has_custom = bool(existing_customs)
+                selected = _copy_condition_allows(existing_customs, assessment, copy_condition)
+                if not selected:
                     skipped += 1
 
-                operations.append((assessment, source_finding, target_finding, already_has_custom))
+                operations.append((assessment, source_finding, target_finding, already_has_custom, selected))
 
             return {
                 "source": source, "target": target,
@@ -563,9 +607,10 @@ def init_app(app: Flask) -> None:
 
         # Batch-load existing custom assessments for the target variant once
         target_custom_assessments = DBAssessment.get_handmade([target_uuid])
-        target_custom_finding_ids: set = {
-            a.finding_id for a in target_custom_assessments if a.finding_id is not None
-        }
+        target_customs_by_finding: dict = {}
+        for a in target_custom_assessments:
+            if a.finding_id is not None:
+                target_customs_by_finding.setdefault(a.finding_id, []).append(a)
 
         groups = []
         skipped_count = 0
@@ -596,14 +641,16 @@ def init_app(app: Flask) -> None:
                     ):
                         continue
 
-                already_has_custom = tf.id in target_custom_finding_ids
-                if already_has_custom:
+                existing_customs = target_customs_by_finding.get(tf.id, [])
+                already_has_custom = bool(existing_customs)
+                selected = _copy_condition_allows(existing_customs, assessment, copy_condition)
+                if not selected:
                     skipped_count += 1
 
                 candidates.append({
                     "target_finding": tf,
                     "already_has_custom": already_has_custom,
-                    "selected": not already_has_custom,
+                    "selected": selected,
                 })
 
             if not candidates:
@@ -637,6 +684,13 @@ def init_app(app: Flask) -> None:
             version_precision = 1
         return match_mode, version_precision
 
+    def _resolve_copy_condition(payload: dict) -> tuple[str, None] | tuple[None, ErrorResponse]:
+        """Extract and validate the copy_condition from a request payload."""
+        copy_condition = payload.get("copy_condition", "no_custom")
+        if copy_condition not in ("no_custom", "different_status", "different_value"):
+            return None, (jsonify({"error": "Invalid copy_condition."}), 400)
+        return copy_condition, None
+
     @app.route('/api/variants/copy-assessments/preview', methods=['POST'])
     def preview_copy_variant_assessments() -> ResponseReturnValue:
         payload = request.get_json(silent=True) or {}
@@ -652,8 +706,13 @@ def init_app(app: Flask) -> None:
         if match_mode not in ("exact", "ignore_minor_version", "ignore_version"):
             return jsonify({"error": "Invalid match_mode."}), 400
 
+        copy_condition, cond_err = _resolve_copy_condition(payload)
+        if cond_err:
+            return cond_err
+        copy_condition = cast(str, copy_condition)
+
         result, err = _compute_copy_assessment_operations(
-            source_id, target_id, match_mode, version_precision,
+            source_id, target_id, match_mode, version_precision, copy_condition,
         )
         if err:
             return err
@@ -664,7 +723,7 @@ def init_app(app: Flask) -> None:
         if mode == "exact":
             operations = result["operations"]
             preview_rows = []
-            for assessment, source_finding, target_finding, already_has_custom in operations:
+            for assessment, source_finding, target_finding, already_has_custom, selected in operations:
                 preview_rows.append({
                     "source_assessment_id": str(assessment.id),
                     "source_finding_id": str(source_finding.id),
@@ -673,10 +732,11 @@ def init_app(app: Flask) -> None:
                     "source_package": source_finding.package.string_id if source_finding.package else "",
                     "target_package": target_finding.package.string_id if target_finding.package else "",
                     "already_has_custom": already_has_custom,
+                    "selected": selected,
                     "assessment_details": _serialize_assessment_details(assessment),
                 })
 
-            selectable = sum(1 for r in preview_rows if not r["already_has_custom"])
+            selectable = sum(1 for r in preview_rows if r["selected"])
             message = result["empty_message"]
             if message is None:
                 message = (
@@ -760,6 +820,11 @@ def init_app(app: Flask) -> None:
         if match_mode not in ("exact", "ignore_minor_version", "ignore_version"):
             return jsonify({"error": "Invalid match_mode."}), 400
 
+        copy_condition, cond_err = _resolve_copy_condition(payload)
+        if cond_err:
+            return cond_err
+        copy_condition = cast(str, copy_condition)
+
         selections = payload.get("selections")  # list[{source_assessment_id, target_finding_id}]
 
         # ---- Selections-based copy (from review popup, alternative modes) ----
@@ -836,7 +901,8 @@ def init_app(app: Flask) -> None:
                         continue  # already queued in this batch
 
                     existing = DBAssessment.get_by_finding_and_variant(tgt_finding.id, target_uuid)
-                    if any(e.origin == "custom" for e in existing):
+                    existing_customs = [e for e in existing if e.origin == "custom"]
+                    if not _copy_condition_allows(existing_customs, assessment, copy_condition):
                         skipped += 1
                         continue
 
@@ -856,7 +922,7 @@ def init_app(app: Flask) -> None:
 
         # ---- Recompute-based copy (exact mode, no popup) ----
         result, err = _compute_copy_assessment_operations(
-            source_id, target_id, match_mode, version_precision,
+            source_id, target_id, match_mode, version_precision, copy_condition,
         )
         if err:
             return err
@@ -882,7 +948,7 @@ def init_app(app: Flask) -> None:
                 for g in groups:
                     src_assessment: DBAssessment = g["assessment"]
                     for c in g["candidates"]:
-                        if c["already_has_custom"]:
+                        if not c["selected"]:
                             continue
                         tf = c["target_finding"]
                         if tf.id in processed_target_finding_ids:
@@ -915,8 +981,8 @@ def init_app(app: Flask) -> None:
 
         copied = 0
         with batch_session():
-            for a, _source_finding, target_finding, already_has_custom in operations:
-                if already_has_custom:
+            for a, _source_finding, target_finding, already_has_custom, selected in operations:
+                if not selected:
                     continue
                 _clone_assessment(a, target_finding.id, target.id)
                 copied += 1

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -513,11 +513,11 @@ def init_app(app: Flask) -> None:
                 processed_target_finding_ids.add(target_finding.id)
 
                 existing = DBAssessment.get_by_finding_and_variant(target_finding.id, target_uuid)
-                if any(e.origin == "custom" for e in existing):
+                already_has_custom = any(e.origin == "custom" for e in existing)
+                if already_has_custom:
                     skipped += 1
-                    continue
 
-                operations.append((assessment, source_finding, target_finding))
+                operations.append((assessment, source_finding, target_finding, already_has_custom))
 
             return {
                 "source": source, "target": target,
@@ -664,7 +664,7 @@ def init_app(app: Flask) -> None:
         if mode == "exact":
             operations = result["operations"]
             preview_rows = []
-            for assessment, source_finding, target_finding in operations:
+            for assessment, source_finding, target_finding, already_has_custom in operations:
                 preview_rows.append({
                     "source_assessment_id": str(assessment.id),
                     "source_finding_id": str(source_finding.id),
@@ -672,19 +672,21 @@ def init_app(app: Flask) -> None:
                     "vulnerability_id": source_finding.vulnerability_id,
                     "source_package": source_finding.package.string_id if source_finding.package else "",
                     "target_package": target_finding.package.string_id if target_finding.package else "",
+                    "already_has_custom": already_has_custom,
                     "assessment_details": _serialize_assessment_details(assessment),
                 })
 
+            selectable = sum(1 for r in preview_rows if not r["already_has_custom"])
             message = result["empty_message"]
             if message is None:
                 message = (
-                    f"{len(preview_rows)} assessment{'s' if len(preview_rows) != 1 else ''} "
+                    f"{selectable} assessment{'s' if selectable != 1 else ''} "
                     "would be copied."
                     + (f" {result['skipped']} already present would be skipped." if result["skipped"] else "")
                 )
 
             return jsonify({
-                "count": len(preview_rows),
+                "count": selectable,
                 "skipped": result["skipped"],
                 "message": message,
                 "entries": preview_rows,
@@ -913,7 +915,9 @@ def init_app(app: Flask) -> None:
 
         copied = 0
         with batch_session():
-            for a, _source_finding, target_finding in operations:
+            for a, _source_finding, target_finding, already_has_custom in operations:
+                if already_has_custom:
+                    continue
                 _clone_assessment(a, target_finding.id, target.id)
                 copied += 1
 

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -376,8 +376,59 @@ def init_app(app: Flask) -> None:
     # ------------------------------------------------------------------
     # Copy custom assessments between two variants
     # ------------------------------------------------------------------
+    #
+    # match_mode values:
+    #   "exact"               – same package name AND version (default)
+    #   "ignore_minor_version"– same name, leading version components match
+    #                           (precision controls how many: 1=major, 2=major+minor)
+    #   "ignore_version"      – same name, any version
+    #
+    # Return shape for "exact":
+    #   { source, target, operations: [(assessment, source_finding, target_finding)],
+    #     skipped, empty_message, mode }
+    #
+    # Return shape for alternative modes:
+    #   { source, target,
+    #     groups: [{ assessment, source_finding,
+    #                candidates: [{ target_finding, already_has_custom, selected }] }],
+    #     skipped_count, empty_message, mode }
+    # ------------------------------------------------------------------
+
+    def _clone_assessment(src, finding_id, variant_id) -> None:  # type: ignore[no-untyped-def]
+        """Create a copy of *src* Assessment bound to a new finding and variant."""
+        from ..models.assessment import Assessment as DBAssessment
+        DBAssessment.create(
+            status=src.status or "under_investigation",
+            finding_id=finding_id,
+            variant_id=variant_id,
+            source=src.source,
+            origin="custom",
+            simplified_status=src.simplified_status,
+            status_notes=src.status_notes,
+            justification=src.justification,
+            impact_statement=src.impact_statement,
+            workaround=src.workaround,
+            responses=list(src.responses) if src.responses else [],
+            commit=False,
+        )
+
+    def _serialize_assessment_details(assessment) -> dict:  # type: ignore[no-untyped-def]
+        """Return the user-visible fields of an assessment for the preview popup."""
+        return {
+            "simplified_status": assessment.simplified_status or "",
+            "status": assessment.status or "",
+            "justification": assessment.justification or None,
+            "status_notes": assessment.status_notes or None,
+            "impact_statement": assessment.impact_statement or None,
+            "workaround": assessment.workaround or None,
+            "responses": list(assessment.responses) if assessment.responses else [],
+        }
+
     def _compute_copy_assessment_operations(
-        source_id: str, target_id: str, ignore_package_version: bool,
+        source_id: str,
+        target_id: str,
+        match_mode: str = "exact",
+        version_precision: int = 1,
     ) -> tuple[dict, None] | tuple[None, ErrorResponse]:
         from ..models.assessment import Assessment as DBAssessment
         from ..models.finding import Finding
@@ -385,6 +436,7 @@ def init_app(app: Flask) -> None:
             active_sbom_scan_ids_for_variant,
             active_package_ids_for_scans,
         )
+        from ..helpers.version_match import versions_match
 
         source_uuid, err = parse_uuid_or_400(source_id, "source_variant_id")
         if err:
@@ -409,68 +461,32 @@ def init_app(app: Flask) -> None:
             active_sbom_scan_ids_for_variant(source_uuid))
         target_pkg_ids = active_package_ids_for_scans(
             active_sbom_scan_ids_for_variant(target_uuid))
-        common_pkg_ids = source_pkg_ids & target_pkg_ids
 
         source_assessments = DBAssessment.get_handmade([source_uuid])
 
-        source_vuln_ids: set[str] = set()
-        target_findings_by_vuln: dict[str, list[Finding]] = {}
-
-        if ignore_package_version:
-            source_vuln_ids = {
-                a.finding.vulnerability_id
-                for a in source_assessments
-                if a.finding is not None and a.finding.package_id in source_pkg_ids
-            }
-
-            if source_vuln_ids:
-                target_findings = list(db.session.execute(
-                    db.select(Finding).where(
-                        Finding.package_id.in_(target_pkg_ids),
-                        Finding.vulnerability_id.in_(source_vuln_ids),
-                    )
-                ).scalars().all())
-            else:
-                target_findings = []
-
-            for f in target_findings:
-                target_findings_by_vuln.setdefault(f.vulnerability_id, []).append(f)
-
-            if not target_findings_by_vuln:
-                return {
-                    "source": source,
-                    "target": target,
-                    "operations": [],
-                    "skipped": 0,
-                    "empty_message": "No vulnerabilities in common between the two variants.",
-                }, None
-        else:
+        # ---- exact mode: original flat-operations behavior ----
+        if match_mode == "exact":
+            common_pkg_ids = source_pkg_ids & target_pkg_ids
             if not common_pkg_ids:
                 return {
-                    "source": source,
-                    "target": target,
-                    "operations": [],
-                    "skipped": 0,
+                    "source": source, "target": target,
+                    "operations": [], "skipped": 0,
                     "empty_message": "No packages in common between the two variants.",
+                    "mode": "exact",
                 }, None
 
-        operations = []
-        skipped = 0
-        processed_target_finding_ids: set = set()
+            operations = []
+            skipped = 0
+            processed_target_finding_ids: set = set()
 
-        for assessment in source_assessments:
-            source_finding = assessment.finding
-            if source_finding is None:
-                continue
-
-            if ignore_package_version:
-                target_findings = target_findings_by_vuln.get(source_finding.vulnerability_id, [])
-            else:
+            for assessment in source_assessments:
+                source_finding = assessment.finding
+                if source_finding is None:
+                    continue
                 if source_finding.package_id not in common_pkg_ids:
                     continue
-                target_findings = [source_finding]
-
-            for target_finding in target_findings:
+                # Exact mode: same package_id → same Finding row shared across variants
+                target_finding = source_finding
                 if target_finding.id in processed_target_finding_ids:
                     continue
                 processed_target_finding_ids.add(target_finding.id)
@@ -482,13 +498,116 @@ def init_app(app: Flask) -> None:
 
                 operations.append((assessment, source_finding, target_finding))
 
+            return {
+                "source": source, "target": target,
+                "operations": operations, "skipped": skipped,
+                "empty_message": None, "mode": "exact",
+            }, None
+
+        # ---- alternative modes: build grouped candidates ----
+        source_vuln_ids: set[str] = {
+            a.finding.vulnerability_id
+            for a in source_assessments
+            if a.finding is not None and a.finding.package_id in source_pkg_ids
+        }
+
+        if source_vuln_ids:
+            target_findings_all: list[Finding] = list(db.session.execute(
+                db.select(Finding).where(
+                    Finding.package_id.in_(target_pkg_ids),
+                    Finding.vulnerability_id.in_(source_vuln_ids),
+                )
+            ).scalars().all())
+        else:
+            target_findings_all = []
+
+        target_findings_by_vuln: dict[str, list[Finding]] = {}
+        for f in target_findings_all:
+            target_findings_by_vuln.setdefault(f.vulnerability_id, []).append(f)
+
+        if not target_findings_by_vuln:
+            return {
+                "source": source, "target": target,
+                "groups": [], "skipped_count": 0,
+                "empty_message": "No vulnerabilities in common between the two variants.",
+                "mode": match_mode,
+            }, None
+
+        # Batch-load existing custom assessments for the target variant once
+        target_custom_assessments = DBAssessment.get_handmade([target_uuid])
+        target_custom_finding_ids: set = {
+            a.finding_id for a in target_custom_assessments if a.finding_id is not None
+        }
+
+        groups = []
+        skipped_count = 0
+
+        for assessment in source_assessments:
+            source_finding = assessment.finding
+            if source_finding is None:
+                continue
+            if source_finding.package_id not in source_pkg_ids:
+                continue
+
+            vuln_id = source_finding.vulnerability_id
+            potential_targets = target_findings_by_vuln.get(vuln_id, [])
+            if not potential_targets:
+                continue
+
+            source_pkg = source_finding.package
+            candidates = []
+
+            for tf in potential_targets:
+                if source_pkg is None or tf.package is None:
+                    continue
+                if source_pkg.name != tf.package.name:
+                    continue
+                if match_mode == "ignore_minor_version":
+                    if not versions_match(
+                        source_pkg.version, tf.package.version, version_precision,
+                    ):
+                        continue
+
+                already_has_custom = tf.id in target_custom_finding_ids
+                if already_has_custom:
+                    skipped_count += 1
+
+                candidates.append({
+                    "target_finding": tf,
+                    "already_has_custom": already_has_custom,
+                    "selected": not already_has_custom,
+                })
+
+            if not candidates:
+                continue
+
+            groups.append({
+                "assessment": assessment,
+                "source_finding": source_finding,
+                "candidates": candidates,
+            })
+
         return {
-            "source": source,
-            "target": target,
-            "operations": operations,
-            "skipped": skipped,
-            "empty_message": None,
+            "source": source, "target": target,
+            "groups": groups, "skipped_count": skipped_count,
+            "empty_message": None, "mode": match_mode,
         }, None
+
+    def _resolve_match_mode(payload: dict) -> tuple[str, int] | tuple[None, ErrorResponse]:
+        """Extract and validate match_mode and version_precision from a request payload.
+
+        Returns (match_mode, version_precision) on success, or (None, error_response)
+        when version_precision cannot be parsed as an integer.
+        """
+        match_mode = payload.get("match_mode", "exact")
+        raw_precision = payload.get("version_precision", 1)
+        try:
+            version_precision = int(raw_precision)
+        except (TypeError, ValueError):
+            return None, (jsonify({"error": "version_precision must be an integer."}), 400)
+        if version_precision < 1:
+            version_precision = 1
+        return match_mode, version_precision
 
     @app.route('/api/variants/copy-assessments/preview', methods=['POST'])
     def preview_copy_variant_assessments() -> ResponseReturnValue:
@@ -497,67 +616,266 @@ def init_app(app: Flask) -> None:
         target_id = payload.get("target_variant_id")
         if not isinstance(source_id, str) or not isinstance(target_id, str):
             return jsonify({"error": "source_variant_id and target_variant_id are required strings."}), 400
-        ignore_package_version = bool(payload.get("ignore_package_version", False))
+
+        resolved = _resolve_match_mode(payload)
+        if resolved[0] is None:
+            return resolved[1]  # type: ignore[return-value]
+        match_mode, version_precision = resolved  # type: ignore[misc]
+        if match_mode not in ("exact", "ignore_minor_version", "ignore_version"):
+            return jsonify({"error": "Invalid match_mode."}), 400
 
         result, err = _compute_copy_assessment_operations(
-            source_id,
-            target_id,
-            ignore_package_version,
+            source_id, target_id, match_mode, version_precision,
         )
         if err:
             return err
         assert result is not None
 
-        operations = result["operations"]
-        preview_rows = []
-        for assessment, source_finding, target_finding in operations:
-            preview_rows.append({
+        mode = result["mode"]
+
+        if mode == "exact":
+            operations = result["operations"]
+            preview_rows = []
+            for assessment, source_finding, target_finding in operations:
+                preview_rows.append({
+                    "source_assessment_id": str(assessment.id),
+                    "source_finding_id": str(source_finding.id),
+                    "target_finding_id": str(target_finding.id),
+                    "vulnerability_id": source_finding.vulnerability_id,
+                    "source_package": source_finding.package.string_id if source_finding.package else "",
+                    "target_package": target_finding.package.string_id if target_finding.package else "",
+                    "assessment_details": _serialize_assessment_details(assessment),
+                })
+
+            message = result["empty_message"]
+            if message is None:
+                message = (
+                    f"{len(preview_rows)} assessment{'s' if len(preview_rows) != 1 else ''} "
+                    "would be copied."
+                    + (f" {result['skipped']} already present would be skipped." if result["skipped"] else "")
+                )
+
+            return jsonify({
+                "count": len(preview_rows),
+                "skipped": result["skipped"],
+                "message": message,
+                "entries": preview_rows,
+                "mode": mode,
+            }), 200
+
+        # Alternative modes: return grouped candidates for review popup
+        groups = result["groups"]
+        skipped_count = result["skipped_count"]
+
+        serialized_groups = []
+        for g in groups:
+            assessment = g["assessment"]
+            sf = g["source_finding"]
+            candidates_ser = []
+            for c in g["candidates"]:
+                tf = c["target_finding"]
+                candidates_ser.append({
+                    "target_finding_id": str(tf.id),
+                    "target_package": tf.package.string_id if tf.package else "",
+                    "already_has_custom": c["already_has_custom"],
+                    "selected": c["selected"],
+                })
+            serialized_groups.append({
                 "source_assessment_id": str(assessment.id),
-                "source_finding_id": str(source_finding.id),
-                "target_finding_id": str(target_finding.id),
-                "vulnerability_id": source_finding.vulnerability_id,
-                "source_package": source_finding.package.string_id if source_finding.package else "",
-                "target_package": target_finding.package.string_id if target_finding.package else "",
+                "source_finding_id": str(sf.id),
+                "vulnerability_id": sf.vulnerability_id,
+                "source_package": sf.package.string_id if sf.package else "",
+                "assessment_details": _serialize_assessment_details(assessment),
+                "candidates": candidates_ser,
             })
 
-        message = result["empty_message"]
-        if message is None:
+        total_selectable = sum(
+            sum(1 for c in g["candidates"] if c["selected"])
+            for g in groups
+        )
+
+        empty_message = result["empty_message"]
+        if empty_message is None:
             message = (
-                f"{len(preview_rows)} assessment{'s' if len(preview_rows) != 1 else ''} "
+                f"{total_selectable} assessment{'s' if total_selectable != 1 else ''} "
                 "would be copied."
-                + (f" {result['skipped']} already present would be skipped." if result["skipped"] else "")
+                + (f" {skipped_count} already present would be skipped." if skipped_count else "")
             )
+        else:
+            message = empty_message
 
         return jsonify({
-            "count": len(preview_rows),
-            "skipped": result["skipped"],
+            "count": total_selectable,
+            "skipped": skipped_count,
             "message": message,
-            "entries": preview_rows,
+            "groups": serialized_groups,
+            "mode": mode,
         }), 200
 
     @app.route('/api/variants/copy-assessments', methods=['POST'])
     def copy_variant_assessments() -> ResponseReturnValue:
         from ..models.assessment import Assessment as DBAssessment
+        from ..models.finding import Finding
 
         payload = request.get_json(silent=True) or {}
         source_id = payload.get("source_variant_id")
         target_id = payload.get("target_variant_id")
         if not isinstance(source_id, str) or not isinstance(target_id, str):
             return jsonify({"error": "source_variant_id and target_variant_id are required strings."}), 400
-        ignore_package_version = bool(payload.get("ignore_package_version", False))
 
+        resolved = _resolve_match_mode(payload)
+        if resolved[0] is None:
+            return resolved[1]  # type: ignore[return-value]
+        match_mode, version_precision = resolved  # type: ignore[misc]
+        if match_mode not in ("exact", "ignore_minor_version", "ignore_version"):
+            return jsonify({"error": "Invalid match_mode."}), 400
+
+        selections = payload.get("selections")  # list[{source_assessment_id, target_finding_id}]
+
+        # ---- Selections-based copy (from review popup, alternative modes) ----
+        if selections is not None:
+            if not isinstance(selections, list):
+                return jsonify({"error": "selections must be a list."}), 400
+
+            source_uuid, err = parse_uuid_or_400(source_id, "source_variant_id")
+            if err:
+                return err
+            source_uuid = cast(uuid.UUID, source_uuid)
+            target_uuid, err = parse_uuid_or_400(target_id, "target_variant_id")
+            if err:
+                return err
+            target_uuid = cast(uuid.UUID, target_uuid)
+
+            source = VariantController.get(source_id)
+            target = VariantController.get(target_id)
+            if source is None or target is None:
+                return jsonify({"error": "Variant not found."}), 404
+            if source.project_id != target.project_id:
+                return jsonify({"error": "Both variants must belong to the same project."}), 400
+
+            if not selections:
+                return jsonify({
+                    "copied": 0,
+                    "skipped": 0,
+                    "message": f"Copied 0 assessments to '{target.name}'.",
+                }), 200
+
+            from ..helpers.active_scans import (
+                active_sbom_scan_ids_for_variant,
+                active_package_ids_for_scans,
+            )
+            target_pkg_ids = active_package_ids_for_scans(
+                active_sbom_scan_ids_for_variant(target_uuid))
+
+            source_assessments = DBAssessment.get_handmade([source_uuid])
+            source_assessment_by_id = {str(a.id): a for a in source_assessments}
+
+            copied = 0
+            skipped = 0
+            processed_in_batch: set = set()  # prevent duplicate copies within the same call
+            with batch_session():
+                for sel in selections:
+                    if not isinstance(sel, dict):
+                        continue
+                    src_assessment_id = sel.get("source_assessment_id")
+                    tgt_finding_id = sel.get("target_finding_id")
+                    if not isinstance(src_assessment_id, str) or not isinstance(tgt_finding_id, str):
+                        continue
+
+                    assessment = source_assessment_by_id.get(src_assessment_id)
+                    if assessment is None:
+                        continue
+
+                    tgt_finding_uuid, ferr = parse_uuid_or_400(tgt_finding_id, "target_finding_id")
+                    if ferr:
+                        continue
+                    tgt_finding = db.session.get(Finding, tgt_finding_uuid)
+                    if tgt_finding is None or tgt_finding.package_id not in target_pkg_ids:
+                        continue
+
+                    # Reject mismatched vulnerability ids — a fabricated selection
+                    # must not copy a verdict for CVE-A onto a finding for CVE-B.
+                    src_finding = assessment.finding
+                    if (
+                        src_finding is None
+                        or tgt_finding.vulnerability_id != src_finding.vulnerability_id
+                    ):
+                        continue
+
+                    if tgt_finding.id in processed_in_batch:
+                        continue  # already queued in this batch
+
+                    existing = DBAssessment.get_by_finding_and_variant(tgt_finding.id, target_uuid)
+                    if any(e.origin == "custom" for e in existing):
+                        skipped += 1
+                        continue
+
+                    processed_in_batch.add(tgt_finding.id)
+                    _clone_assessment(assessment, tgt_finding.id, target.id)
+                    copied += 1
+
+            return jsonify({
+                "copied": copied,
+                "skipped": skipped,
+                "message": (
+                    f"Copied {copied} assessment{'s' if copied != 1 else ''} to "
+                    f"'{target.name}'."
+                    + (f" Skipped {skipped} already present." if skipped else "")
+                ),
+            }), 200
+
+        # ---- Recompute-based copy (exact mode, no popup) ----
         result, err = _compute_copy_assessment_operations(
-            source_id,
-            target_id,
-            ignore_package_version,
+            source_id, target_id, match_mode, version_precision,
         )
         if err:
             return err
         assert result is not None
 
+        if result["mode"] != "exact":
+            # Auto-copy: pick all non-skipped candidates from each group
+            target = result["target"]
+            assert target is not None
+            groups = result["groups"]
+            skipped = result["skipped_count"]
+
+            if not groups and result["empty_message"]:
+                return jsonify({
+                    "copied": 0,
+                    "skipped": skipped,
+                    "message": result["empty_message"],
+                }), 200
+
+            copied = 0
+            processed_target_finding_ids: set = set()
+            with batch_session():
+                for g in groups:
+                    src_assessment: DBAssessment = g["assessment"]
+                    for c in g["candidates"]:
+                        if c["already_has_custom"]:
+                            continue
+                        tf = c["target_finding"]
+                        if tf.id in processed_target_finding_ids:
+                            continue
+                        processed_target_finding_ids.add(tf.id)
+                        _clone_assessment(src_assessment, tf.id, target.id)
+                        copied += 1
+
+            return jsonify({
+                "copied": copied,
+                "skipped": skipped,
+                "message": (
+                    f"Copied {copied} assessment{'s' if copied != 1 else ''} to "
+                    f"'{target.name}'."
+                    + (f" Skipped {skipped} already present." if skipped else "")
+                ),
+            }), 200
+
         target = result["target"]
+        assert target is not None
         operations = result["operations"]
         skipped = result["skipped"]
+
         if not operations and result["empty_message"]:
             return jsonify({
                 "copied": 0,
@@ -568,20 +886,7 @@ def init_app(app: Flask) -> None:
         copied = 0
         with batch_session():
             for a, _source_finding, target_finding in operations:
-                DBAssessment.create(
-                    status=a.status or "under_investigation",
-                    finding_id=target_finding.id,
-                    variant_id=target.id,
-                    source=a.source,
-                    origin="custom",
-                    simplified_status=a.simplified_status,
-                    status_notes=a.status_notes,
-                    justification=a.justification,
-                    impact_statement=a.impact_statement,
-                    workaround=a.workaround,
-                    responses=list(a.responses) if a.responses else [],
-                    commit=False,
-                )
+                _clone_assessment(a, target_finding.id, target.id)
                 copied += 1
 
         return jsonify({

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -432,8 +432,10 @@ def init_app(app: Flask) -> None:
     ) -> tuple[dict, None] | tuple[None, ErrorResponse]:
         from ..models.assessment import Assessment as DBAssessment
         from ..models.finding import Finding
+        from ..models.observation import Observation
         from ..helpers.active_scans import (
             active_sbom_scan_ids_for_variant,
+            active_scan_ids_for_variant,
             active_package_ids_for_scans,
         )
         from ..helpers.version_match import versions_match
@@ -462,6 +464,21 @@ def init_app(app: Flask) -> None:
         target_pkg_ids = active_package_ids_for_scans(
             active_sbom_scan_ids_for_variant(target_uuid))
 
+        # Findings actually detected (observed) in the target variant's active
+        # scans — i.e. the target's pool of vulnerabilities. A copy must only be
+        # proposed onto a finding that is present in this pool; otherwise we
+        # would attach an assessment to a vulnerability the target variant is
+        # not affected by.
+        target_active_scan_ids = active_scan_ids_for_variant(target_uuid)
+        if target_active_scan_ids:
+            target_observed_finding_ids: set = set(db.session.execute(
+                db.select(Observation.finding_id)
+                .where(Observation.scan_id.in_(target_active_scan_ids))
+                .distinct()
+            ).scalars().all())
+        else:
+            target_observed_finding_ids = set()
+
         source_assessments = DBAssessment.get_handmade([source_uuid])
 
         # ---- exact mode: original flat-operations behavior ----
@@ -487,6 +504,10 @@ def init_app(app: Flask) -> None:
                     continue
                 # Exact mode: same package_id → same Finding row shared across variants
                 target_finding = source_finding
+                # Only propose the copy if this vulnerability is actually part of
+                # the target variant's pool (observed in its active scans).
+                if target_finding.id not in target_observed_finding_ids:
+                    continue
                 if target_finding.id in processed_target_finding_ids:
                     continue
                 processed_target_finding_ids.add(target_finding.id)
@@ -518,6 +539,13 @@ def init_app(app: Flask) -> None:
                     Finding.vulnerability_id.in_(source_vuln_ids),
                 )
             ).scalars().all())
+            # Restrict to findings present in the target variant's pool (observed
+            # in its active scans) so we never propose copying an assessment onto
+            # a vulnerability the target is not affected by.
+            target_findings_all = [
+                f for f in target_findings_all
+                if f.id in target_observed_finding_ids
+            ]
         else:
             target_findings_all = []
 

--- a/tests/unit_tests/test_version_match.py
+++ b/tests/unit_tests/test_version_match.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+"""Unit tests for the fuzzy version comparison helper used by copy-assessments."""
+
+import pytest
+
+from src.helpers.version_match import (
+    versions_match,
+    _parse_components,
+    _semver_components,
+    _split_components,
+)
+
+
+class TestVersionsMatchPrecisionOne:
+    """precision=1 → only the major component must match."""
+
+    def test_same_major_different_minor_matches(self):
+        assert versions_match("6.5", "6.7", 1) is True
+
+    def test_different_major_does_not_match(self):
+        assert versions_match("6.5", "7.0", 1) is False
+
+    def test_major_only_versions(self):
+        assert versions_match("2", "2.0.0", 1) is True
+
+    def test_different_major_full_versions(self):
+        assert versions_match("1.1.1", "3.0.0", 1) is False
+
+
+class TestVersionsMatchPrecisionTwo:
+    """precision=2 → major AND minor must match."""
+
+    def test_same_major_minor_different_patch_matches(self):
+        assert versions_match("6.5.1", "6.5.9", 2) is True
+
+    def test_same_major_different_minor_does_not_match(self):
+        assert versions_match("6.5", "6.7", 2) is False
+
+    def test_same_major_minor_matches(self):
+        assert versions_match("10.2.3", "10.2.99", 2) is True
+
+
+class TestVersionsMatchEdgeCases:
+    def test_both_none_treated_as_zero(self):
+        assert versions_match(None, None, 1) is True
+
+    def test_empty_versus_nonzero(self):
+        assert versions_match("", "1.0", 1) is False
+
+    def test_none_versus_zero_major(self):
+        assert versions_match(None, "0.5", 1) is True
+
+    def test_precision_zero_always_matches(self):
+        assert versions_match("6.5", "9.9", 0) is True
+
+    def test_negative_precision_always_matches(self):
+        assert versions_match("6.5", "9.9", -1) is True
+
+    def test_precision_beyond_available_components_pads_with_zero(self):
+        # "6" → (6, 0, 0); "6.0.0" → (6, 0, 0); equal up to precision 3
+        assert versions_match("6", "6.0.0", 3) is True
+
+    def test_precision_beyond_components_detects_difference(self):
+        # "6" → (6, 0, 0); "6.1" → (6, 1, 0) differ at index 1
+        assert versions_match("6", "6.1", 2) is False
+
+
+class TestVersionsMatchNonSemver:
+    """Versions that are not valid semver fall back to integer-prefix splitting."""
+
+    def test_openssl_style_suffix_matches(self):
+        assert versions_match("1.1.1w", "1.1.1k", 3) is True
+
+    def test_openssl_style_suffix_differs_on_patch(self):
+        assert versions_match("1.1.1w", "1.1.2k", 3) is False
+
+    def test_build_metadata_is_stripped(self):
+        assert versions_match("2.4.1+deb10", "2.4.1-1ubuntu", 3) is True
+
+    def test_non_semver_full_mismatch(self):
+        assert versions_match("1.2.3", "1.2.4", 3) is False
+
+
+class TestParseComponents:
+    def test_semver_path(self):
+        assert _parse_components("6.5.1") == (6, 5, 1)
+
+    def test_semver_optional_minor_patch(self):
+        assert _parse_components("6.5") == (6, 5, 0)
+
+    def test_empty_returns_zero(self):
+        assert _parse_components("") == (0,)
+
+    def test_non_numeric_returns_zero(self):
+        assert _parse_components("abc") == (0,)
+
+    def test_fallback_split_for_suffix(self):
+        assert _parse_components("1.1.1w") == (1, 1, 1)
+
+
+class TestSemverComponents:
+    def test_full_semver(self):
+        assert _semver_components("1.2.3") == (1, 2, 3)
+
+    def test_optional_minor_patch(self):
+        assert _semver_components("4") == (4, 0, 0)
+
+    def test_invalid_raises_value_error(self):
+        with pytest.raises(ValueError):
+            _semver_components("1.1.1w")
+
+
+class TestSplitComponents:
+    def test_plain_dotted(self):
+        assert _split_components("1.2.3") == (1, 2, 3)
+
+    def test_stops_at_non_numeric_segment(self):
+        assert _split_components("1.2.beta") == (1, 2)
+
+    def test_strips_prerelease_and_build(self):
+        assert _split_components("1.2.3-rc1+build") == (1, 2, 3)
+
+    def test_leading_non_numeric_returns_empty(self):
+        assert _split_components("abc.def") == ()

--- a/tests/webapp_tests/test_settings_endpoints.py
+++ b/tests/webapp_tests/test_settings_endpoints.py
@@ -324,7 +324,7 @@ class TestCopyCustomAssessments:
             json={
                 "source_variant_id": ids["source_variant_id"],
                 "target_variant_id": ids["target_variant_id"],
-                "ignore_package_version": True,
+                "match_mode": "ignore_version",
             },
         )
         assert resp.status_code == 200
@@ -363,17 +363,19 @@ class TestCopyCustomAssessments:
             json={
                 "source_variant_id": ids["source_variant_id"],
                 "target_variant_id": ids["target_variant_id"],
-                "ignore_package_version": True,
+                "match_mode": "ignore_version",
             },
         )
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["count"] == 1
         assert data["skipped"] == 0
-        assert len(data["entries"]) == 1
-        assert data["entries"][0]["vulnerability_id"] == "CVE-COPY-0001"
-        assert data["entries"][0]["source_package"] == "openssl@1.1.1"
-        assert data["entries"][0]["target_package"] == "openssl@3.0.0"
+        assert len(data["groups"]) == 1
+        group = data["groups"][0]
+        assert group["vulnerability_id"] == "CVE-COPY-0001"
+        assert group["source_package"] == "openssl@1.1.1"
+        assert len(group["candidates"]) == 1
+        assert group["candidates"][0]["target_package"] == "openssl@3.0.0"
 
 
 # ---------------------------------------------------------------------------
@@ -1502,14 +1504,14 @@ class TestCopyAssessmentsEdgeCases:
             return {"source_id": str(source.id), "target_id": str(target.id)}
 
     def test_ignore_version_empty_source_active_packages_returns_no_vulns(self, app, client):
-        """ignore_package_version=True with no active source packages → no vulns in common."""
+        """ignore_version mode with no active source packages → no vulns in common."""
         ids = self._seed_no_source_active_packages(app)
         resp = client.post(
             "/api/variants/copy-assessments",
             json={
                 "source_variant_id": ids["source_id"],
                 "target_variant_id": ids["target_id"],
-                "ignore_package_version": True,
+                "match_mode": "ignore_version",
             },
         )
         assert resp.status_code == 200
@@ -1518,14 +1520,14 @@ class TestCopyAssessmentsEdgeCases:
         assert "No vulnerabilities in common" in data["message"]
 
     def test_ignore_version_no_matching_target_findings_returns_no_vulns(self, app, client):
-        """ignore_package_version=True with non-empty source_vuln_ids but no target findings."""
+        """ignore_version mode with non-empty source_vuln_ids but no target findings."""
         ids = self._seed_no_matching_target_findings(app)
         resp = client.post(
             "/api/variants/copy-assessments",
             json={
                 "source_variant_id": ids["source_id"],
                 "target_variant_id": ids["target_id"],
-                "ignore_package_version": True,
+                "match_mode": "ignore_version",
             },
         )
         assert resp.status_code == 200
@@ -1560,7 +1562,7 @@ class TestCopyAssessmentsEdgeCases:
             json={
                 "source_variant_id": ids["source_variant_id"],
                 "target_variant_id": ids["target_variant_id"],
-                "ignore_package_version": True,
+                "match_mode": "ignore_version",
             },
         )
         assert r1.get_json()["copied"] == 1
@@ -1571,7 +1573,7 @@ class TestCopyAssessmentsEdgeCases:
             json={
                 "source_variant_id": ids["source_variant_id"],
                 "target_variant_id": ids["target_variant_id"],
-                "ignore_package_version": True,
+                "match_mode": "ignore_version",
             },
         )
         assert r2.status_code == 200
@@ -1579,6 +1581,529 @@ class TestCopyAssessmentsEdgeCases:
         assert data["copied"] == 0
         assert data["skipped"] == 1
         assert "already present" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: copy-assessments match modes (match_mode / selections)
+# ---------------------------------------------------------------------------
+
+class TestCopyAssessmentsMatchModes:
+    """Exercise the match_mode / version_precision / selections API surface."""
+
+    def _seed_modes_data(self, app):
+        """Source openssl@1.1.1 + custom assessment; several target findings for CVE-NEW-0001.
+
+        Target findings (all on CVE-NEW-0001):
+          - openssl@1.4.2  (same name; major matches, minor differs)
+          - openssl@3.0.0  (same name; major differs)
+          - curl@2.0.0     (different name)
+          - openssl@1.1.5  (same name; major AND minor match)
+        """
+        from src.extensions import db
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.package import Package
+        from src.models.vulnerability import Vulnerability
+        from src.models.finding import Finding
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.assessment import Assessment
+
+        with app.app_context():
+            project = Project.create("ModesProject")
+            source = Variant.create("ModesSource", project.id)
+            target = Variant.create("ModesTarget", project.id)
+
+            source_scan = Scan.create("source sbom", source.id, scan_type="sbom")
+            target_scan = Scan.create("target sbom", target.id, scan_type="sbom")
+
+            src_pkg = Package.find_or_create("openssl", "1.1.1")
+            tgt_major_ok = Package.find_or_create("openssl", "1.4.2")
+            tgt_major_diff = Package.find_or_create("openssl", "3.0.0")
+            tgt_other_name = Package.find_or_create("curl", "2.0.0")
+            tgt_minor_ok = Package.find_or_create("openssl", "1.1.5")
+
+            vuln = Vulnerability.create_record(id="CVE-NEW-0001", description="new mode")
+            db.session.commit()
+
+            src_finding = Finding.get_or_create(src_pkg.id, vuln.id)
+            f_major_ok = Finding.get_or_create(tgt_major_ok.id, vuln.id)
+            f_major_diff = Finding.get_or_create(tgt_major_diff.id, vuln.id)
+            f_other_name = Finding.get_or_create(tgt_other_name.id, vuln.id)
+            f_minor_ok = Finding.get_or_create(tgt_minor_ok.id, vuln.id)
+
+            source_doc = SBOMDocument.create("/tmp/modes_src.spdx.json", "spdx", source_scan.id)
+            target_doc = SBOMDocument.create("/tmp/modes_tgt.spdx.json", "spdx", target_scan.id)
+            SBOMPackage.create(source_doc.id, src_pkg.id)
+            for pkg in (tgt_major_ok, tgt_major_diff, tgt_other_name, tgt_minor_ok):
+                SBOMPackage.create(target_doc.id, pkg.id)
+
+            Assessment.create(
+                status="not_affected",
+                simplified_status="Not affected",
+                origin="custom",
+                finding_id=src_finding.id,
+                variant_id=source.id,
+                source="manual",
+                justification="component_not_present",
+            )
+            db.session.commit()
+
+            return {
+                "source_variant_id": str(source.id),
+                "target_variant_id": str(target.id),
+                "vuln_id": "CVE-NEW-0001",
+                "finding_major_ok": str(f_major_ok.id),
+                "finding_major_diff": str(f_major_diff.id),
+                "finding_other_name": str(f_other_name.id),
+                "finding_minor_ok": str(f_minor_ok.id),
+            }
+
+    # -- validation --------------------------------------------------------
+
+    def test_preview_invalid_match_mode_returns_400(self, client):
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": str(uuid.uuid4()),
+                "target_variant_id": str(uuid.uuid4()),
+                "match_mode": "bogus",
+            },
+        )
+        assert resp.status_code == 400
+        assert "match_mode" in resp.get_json()["error"].lower()
+
+    def test_copy_invalid_match_mode_returns_400(self, client):
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": str(uuid.uuid4()),
+                "target_variant_id": str(uuid.uuid4()),
+                "match_mode": "bogus",
+            },
+        )
+        assert resp.status_code == 400
+        assert "match_mode" in resp.get_json()["error"].lower()
+
+    def test_selections_must_be_a_list(self, client):
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": str(uuid.uuid4()),
+                "target_variant_id": str(uuid.uuid4()),
+                "match_mode": "ignore_version",
+                "selections": {"not": "a list"},
+            },
+        )
+        assert resp.status_code == 400
+        assert "selections" in resp.get_json()["error"].lower()
+
+    def test_invalid_version_precision_returns_400(self, client):
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": str(uuid.uuid4()),
+                "target_variant_id": str(uuid.uuid4()),
+                "match_mode": "ignore_minor_version",
+                "version_precision": "not-a-number",
+            },
+        )
+        assert resp.status_code == 400
+        assert "version_precision" in resp.get_json()["error"].lower()
+
+    def test_null_version_precision_returns_400(self, client):
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": str(uuid.uuid4()),
+                "target_variant_id": str(uuid.uuid4()),
+                "match_mode": "ignore_minor_version",
+                "version_precision": None,
+            },
+        )
+        assert resp.status_code == 400
+        assert "version_precision" in resp.get_json()["error"].lower()
+
+    # -- ignore_version (grouped candidates) ------------------------------
+
+    def test_preview_ignore_version_returns_grouped_candidates(self, app, client):
+        ids = self._seed_modes_data(app)
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["mode"] == "ignore_version"
+        assert "groups" in data
+        assert len(data["groups"]) == 1
+        group = data["groups"][0]
+        # same name openssl → 1.4.2, 3.0.0, 1.1.5 (curl excluded)
+        target_findings = {c["target_finding_id"] for c in group["candidates"]}
+        assert target_findings == {
+            ids["finding_major_ok"],
+            ids["finding_major_diff"],
+            ids["finding_minor_ok"],
+        }
+        assert ids["finding_other_name"] not in target_findings
+        assert all(c["selected"] and not c["already_has_custom"] for c in group["candidates"])
+        assert data["count"] == len(group["candidates"])
+        # The source assessment content is surfaced for the review popup.
+        details = group["assessment_details"]
+        assert details["simplified_status"] == "Not affected"
+        assert details["status"] == "not_affected"
+        assert details["justification"] == "component_not_present"
+
+    # -- ignore_minor_version + version_precision -------------------------
+
+    def test_preview_ignore_minor_version_precision_one_matches_major(self, app, client):
+        ids = self._seed_modes_data(app)
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_minor_version",
+                "version_precision": 1,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["mode"] == "ignore_minor_version"
+        assert len(data["groups"]) == 1
+        target_findings = {c["target_finding_id"] for c in data["groups"][0]["candidates"]}
+        # major-1 openssl → 1.4.2 and 1.1.5 (3.0.0 major differs, curl excluded)
+        assert target_findings == {ids["finding_major_ok"], ids["finding_minor_ok"]}
+
+    def test_preview_ignore_minor_version_precision_two_matches_major_minor(self, app, client):
+        ids = self._seed_modes_data(app)
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_minor_version",
+                "version_precision": 2,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data["groups"]) == 1
+        target_findings = {c["target_finding_id"] for c in data["groups"][0]["candidates"]}
+        # 1.1.x only → openssl@1.1.5 matches source openssl@1.1.1
+        assert target_findings == {ids["finding_minor_ok"]}
+
+    def test_preview_version_precision_below_one_is_clamped(self, app, client):
+        """version_precision < 1 clamps to 1 (major-only match)."""
+        ids = self._seed_modes_data(app)
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_minor_version",
+                "version_precision": 0,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        target_findings = {c["target_finding_id"] for c in data["groups"][0]["candidates"]}
+        assert target_findings == {ids["finding_major_ok"], ids["finding_minor_ok"]}
+
+    # -- selections-based copy --------------------------------------------
+
+    def test_copy_with_selections_copies_only_chosen(self, app, client):
+        from src.models.assessment import Assessment
+
+        ids = self._seed_modes_data(app)
+        # First preview to get the source_assessment_id
+        preview = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+            },
+        ).get_json()
+        source_assessment_id = preview["groups"][0]["source_assessment_id"]
+
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+                "selections": [
+                    {
+                        "source_assessment_id": source_assessment_id,
+                        "target_finding_id": ids["finding_minor_ok"],
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["copied"] == 1
+
+        with app.app_context():
+            copied = Assessment.get_by_finding_and_variant(
+                ids["finding_minor_ok"], ids["target_variant_id"],
+            )
+            assert any(a.origin == "custom" for a in copied)
+            # A non-selected target finding must NOT have received a copy
+            not_copied = Assessment.get_by_finding_and_variant(
+                ids["finding_major_diff"], ids["target_variant_id"],
+            )
+            assert not any(a.origin == "custom" for a in not_copied)
+
+    def test_copy_with_empty_selections_copies_nothing(self, app, client):
+        ids = self._seed_modes_data(app)
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+                "selections": [],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["copied"] == 0
+
+    def test_copy_with_selections_skips_already_assessed(self, app, client):
+        ids = self._seed_modes_data(app)
+        preview = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+            },
+        ).get_json()
+        source_assessment_id = preview["groups"][0]["source_assessment_id"]
+        selection = [{
+            "source_assessment_id": source_assessment_id,
+            "target_finding_id": ids["finding_minor_ok"],
+        }]
+
+        first = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+                "selections": selection,
+            },
+        )
+        assert first.get_json()["copied"] == 1
+
+        second = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+                "selections": selection,
+            },
+        )
+        data = second.get_json()
+        assert data["copied"] == 0
+        assert data["skipped"] == 1
+
+    # -- auto-copy (alternative mode, no selections) ----------------------
+
+    def test_copy_ignore_version_without_selections_copies_all_candidates(self, app, client):
+        from src.models.assessment import Assessment
+
+        ids = self._seed_modes_data(app)
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # openssl name → 1.4.2, 3.0.0, 1.1.5
+        assert data["copied"] == 3
+
+        with app.app_context():
+            for fid in (ids["finding_major_ok"], ids["finding_major_diff"], ids["finding_minor_ok"]):
+                assessments = Assessment.get_by_finding_and_variant(fid, ids["target_variant_id"])
+                assert any(a.origin == "custom" for a in assessments)
+
+    def test_preview_already_assessed_candidate_marked(self, app, client):
+        """A target finding that already has a custom assessment is flagged and skipped."""
+        from src.extensions import db
+        from src.models.assessment import Assessment
+
+        ids = self._seed_modes_data(app)
+        with app.app_context():
+            Assessment.create(
+                status="affected",
+                simplified_status="Exploitable",
+                origin="custom",
+                finding_id=ids["finding_minor_ok"],
+                variant_id=ids["target_variant_id"],
+                source="manual",
+            )
+            db.session.commit()
+
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        candidates = data["groups"][0]["candidates"]
+        flagged = next(c for c in candidates if c["target_finding_id"] == ids["finding_minor_ok"])
+        assert flagged["already_has_custom"] is True
+        assert flagged["selected"] is False
+        assert data["skipped"] == 1
+
+    def test_copy_selections_rejects_mismatched_vulnerability_id(self, app, client):
+        """A selection that points a source assessment at a finding for a different CVE
+        must be silently rejected (copied=0) to prevent VEX-data corruption."""
+        from src.extensions import db
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.package import Package
+        from src.models.vulnerability import Vulnerability
+        from src.models.finding import Finding
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.assessment import Assessment
+
+        with app.app_context():
+            project = Project.create("VulnMismatchProject")
+            source = Variant.create("VulnMismatchSrc", project.id)
+            target = Variant.create("VulnMismatchTgt", project.id)
+
+            src_scan = Scan.create("", source.id, scan_type="sbom")
+            tgt_scan = Scan.create("", target.id, scan_type="sbom")
+
+            pkg_a = Package.find_or_create("lib-a-vmm", "1.0")
+            pkg_b = Package.find_or_create("lib-b-vmm", "1.0")
+            cve_a = Vulnerability.create_record(id="CVE-VULN-MM-001", description="a")
+            cve_b = Vulnerability.create_record(id="CVE-VULN-MM-002", description="b")
+            db.session.commit()
+
+            finding_a = Finding.get_or_create(pkg_a.id, cve_a.id)
+            finding_b = Finding.get_or_create(pkg_b.id, cve_b.id)
+
+            src_doc = SBOMDocument.create("/tmp/vmm_src.spdx.json", "spdx", src_scan.id)
+            tgt_doc = SBOMDocument.create("/tmp/vmm_tgt.spdx.json", "spdx", tgt_scan.id)
+            SBOMPackage.create(src_doc.id, pkg_a.id)
+            SBOMPackage.create(tgt_doc.id, pkg_b.id)
+
+            assessment = Assessment.create(
+                status="not_affected",
+                origin="custom",
+                finding_id=finding_a.id,
+                variant_id=source.id,
+                source="manual",
+            )
+            db.session.commit()
+
+            source_id = str(source.id)
+            target_id = str(target.id)
+            src_assessment_id = str(assessment.id)
+            # Craft a selection that pairs the source assessment (CVE-VULN-MM-001)
+            # with a target finding for a different CVE (CVE-VULN-MM-002).
+            mismatched_finding_id = str(finding_b.id)
+
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": source_id,
+                "target_variant_id": target_id,
+                "match_mode": "exact",
+                "selections": [
+                    {
+                        "source_assessment_id": src_assessment_id,
+                        "target_finding_id": mismatched_finding_id,
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["copied"] == 0
+
+    def test_preview_exact_mode_includes_assessment_details(self, app, client):
+        """Exact-mode flat entries carry the source assessment's details for the popup."""
+        from src.extensions import db
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+        from src.models.package import Package
+        from src.models.vulnerability import Vulnerability
+        from src.models.finding import Finding
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.assessment import Assessment
+
+        with app.app_context():
+            project = Project.create("ExactDetailsProject")
+            source = Variant.create("ExactDetailsSrc", project.id)
+            target = Variant.create("ExactDetailsTgt", project.id)
+
+            src_scan = Scan.create("", source.id, scan_type="sbom")
+            tgt_scan = Scan.create("", target.id, scan_type="sbom")
+
+            # Same package row shared by both variants → exact match.
+            pkg = Package.find_or_create("shared-exact-lib", "1.0.0")
+            vuln = Vulnerability.create_record(id="CVE-EXACT-DET-001", description="x")
+            db.session.commit()
+            finding = Finding.get_or_create(pkg.id, vuln.id)
+
+            src_doc = SBOMDocument.create("/tmp/exd_src.spdx.json", "spdx", src_scan.id)
+            tgt_doc = SBOMDocument.create("/tmp/exd_tgt.spdx.json", "spdx", tgt_scan.id)
+            SBOMPackage.create(src_doc.id, pkg.id)
+            SBOMPackage.create(tgt_doc.id, pkg.id)
+
+            Assessment.create(
+                status="affected",
+                simplified_status="Exploitable",
+                origin="custom",
+                finding_id=finding.id,
+                variant_id=source.id,
+                source="manual",
+                status_notes="Confirmed reachable.",
+                impact_statement="RCE possible.",
+            )
+            db.session.commit()
+            source_id = str(source.id)
+            target_id = str(target.id)
+
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": source_id,
+                "target_variant_id": target_id,
+                "match_mode": "exact",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["mode"] == "exact"
+        assert len(data["entries"]) == 1
+        details = data["entries"][0]["assessment_details"]
+        assert details["simplified_status"] == "Exploitable"
+        assert details["status"] == "affected"
+        assert details["status_notes"] == "Confirmed reachable."
+        assert details["impact_statement"] == "RCE possible."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webapp_tests/test_settings_endpoints.py
+++ b/tests/webapp_tests/test_settings_endpoints.py
@@ -251,7 +251,7 @@ class TestDeleteVariant:
 
 class TestCopyCustomAssessments:
 
-    def _seed_copy_data(self, app):
+    def _seed_copy_data(self, app, observe_target=True):
         from src.extensions import db
         from src.models.project import Project
         from src.models.variant import Variant
@@ -261,6 +261,7 @@ class TestCopyCustomAssessments:
         from src.models.finding import Finding
         from src.models.sbom_document import SBOMDocument
         from src.models.sbom_package import SBOMPackage
+        from src.models.observation import Observation
         from src.models.assessment import Assessment
 
         with app.app_context():
@@ -283,6 +284,14 @@ class TestCopyCustomAssessments:
             target_doc = SBOMDocument.create("/tmp/target.spdx.json", "spdx", target_scan.id)
             SBOMPackage.create(source_doc.id, source_pkg.id)
             SBOMPackage.create(target_doc.id, target_pkg.id)
+
+            # Observations put each finding into its variant's vulnerability pool.
+            # When *observe_target* is False the target package is still in the
+            # SBOM but the vulnerability was not detected there, so it must not
+            # be offered as a copy target.
+            Observation.create(source_finding.id, source_scan.id)
+            if observe_target:
+                Observation.create(target_finding.id, target_scan.id)
 
             Assessment.create(
                 status="affected",
@@ -376,6 +385,52 @@ class TestCopyCustomAssessments:
         assert group["source_package"] == "openssl@1.1.1"
         assert len(group["candidates"]) == 1
         assert group["candidates"][0]["target_package"] == "openssl@3.0.0"
+
+    def test_copy_assessments_skips_vuln_not_in_target_pool(self, app, client):
+        """A vuln whose target finding is not observed in the target's scans
+        (not in the target's vulnerability pool) must not be offered for copy."""
+        from src.models.assessment import Assessment
+
+        ids = self._seed_copy_data(app, observe_target=False)
+
+        resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["copied"] == 0
+        assert "No vulnerabilities in common" in data["message"]
+
+        with app.app_context():
+            target_assessments = Assessment.get_by_finding_and_variant(
+                ids["target_finding_id"],
+                ids["target_variant_id"],
+            )
+            assert not any(a.origin == "custom" for a in target_assessments)
+
+    def test_copy_assessments_preview_skips_vuln_not_in_target_pool(self, app, client):
+        """Preview must not list a candidate when the vuln is absent from the
+        target's pool, even though the package is in the target SBOM."""
+        ids = self._seed_copy_data(app, observe_target=False)
+
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": ids["source_variant_id"],
+                "target_variant_id": ids["target_variant_id"],
+                "match_mode": "ignore_version",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["count"] == 0
+        assert data.get("groups", []) == []
+        assert "No vulnerabilities in common" in data["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -1467,6 +1522,7 @@ class TestCopyAssessmentsEdgeCases:
         from src.models.assessment import Assessment
         from src.models.sbom_document import SBOMDocument
         from src.models.sbom_package import SBOMPackage
+        from src.models.observation import Observation
 
         with app.app_context():
             project = Project.create("NonCommonProject")
@@ -1490,6 +1546,12 @@ class TestCopyAssessmentsEdgeCases:
             tgt_scan = Scan.create("", target.id, scan_type="sbom")
             tgt_doc = SBOMDocument.create("/tmp/tgt_nc.spdx.json", "spdx", tgt_scan.id)
             SBOMPackage.create(tgt_doc.id, pkg_shared.id)
+
+            # The shared finding is detected in both variants' pools; the
+            # source-only finding only in the source.
+            Observation.create(finding_sx.id, src_scan.id)
+            Observation.create(finding_oy.id, src_scan.id)
+            Observation.create(finding_sx.id, tgt_scan.id)
 
             Assessment.create(
                 status="affected", origin="custom", finding_id=finding_sx.id,
@@ -1608,6 +1670,7 @@ class TestCopyAssessmentsMatchModes:
         from src.models.finding import Finding
         from src.models.sbom_document import SBOMDocument
         from src.models.sbom_package import SBOMPackage
+        from src.models.observation import Observation
         from src.models.assessment import Assessment
 
         with app.app_context():
@@ -1638,6 +1701,11 @@ class TestCopyAssessmentsMatchModes:
             SBOMPackage.create(source_doc.id, src_pkg.id)
             for pkg in (tgt_major_ok, tgt_major_diff, tgt_other_name, tgt_minor_ok):
                 SBOMPackage.create(target_doc.id, pkg.id)
+
+            # Put each finding into its variant's vulnerability pool.
+            Observation.create(src_finding.id, source_scan.id)
+            for f in (f_major_ok, f_major_diff, f_other_name, f_minor_ok):
+                Observation.create(f.id, target_scan.id)
 
             Assessment.create(
                 status="not_affected",
@@ -2052,6 +2120,7 @@ class TestCopyAssessmentsMatchModes:
         from src.models.finding import Finding
         from src.models.sbom_document import SBOMDocument
         from src.models.sbom_package import SBOMPackage
+        from src.models.observation import Observation
         from src.models.assessment import Assessment
 
         with app.app_context():
@@ -2072,6 +2141,10 @@ class TestCopyAssessmentsMatchModes:
             tgt_doc = SBOMDocument.create("/tmp/exd_tgt.spdx.json", "spdx", tgt_scan.id)
             SBOMPackage.create(src_doc.id, pkg.id)
             SBOMPackage.create(tgt_doc.id, pkg.id)
+
+            # Vulnerability observed in both variants' pools.
+            Observation.create(finding.id, src_scan.id)
+            Observation.create(finding.id, tgt_scan.id)
 
             Assessment.create(
                 status="affected",

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,10 @@ disallow_incomplete_defs = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 
+[mypy-src.helpers.version_match]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+
 # Phase 1b: models, extensions, controllers._base
 
 [mypy-src.models.cvss]


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

The "copy assessment" feature was moved from settings to a separate tab. It now offers the following options:
- Exact: Same package name and version
- Ignore minor version: Same name, major version must match (with options for )
Major only: 6.x → 6.y
Major.Minor: 6.5.x → 6.5.y
- Ignore version: Same package name, any version

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open the web dashboard in a project with common packages. Go to the Transfer tab and try different transfer scenatios.

<img width="1904" height="675" alt="image" src="https://github.com/user-attachments/assets/6784b921-1cbb-4a43-867f-1c4786e382a4" />

<img width="793" height="280" alt="image" src="https://github.com/user-attachments/assets/a2471fb8-7649-4c91-b5d2-a63bca539fee" />


## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


