### PR TITLE
fix: exclude old packages assessments from vuln status

### DIFF
--- a/frontend/src/components/MultiEditBar.tsx
+++ b/frontend/src/components/MultiEditBar.tsx
@@ -311,7 +311,7 @@ function MultiEditBar ({vulnerabilities, selectedVulns, resetVulns, appendAssess
                     const vuln = vulnerabilities.find(v => v.id === vuln_id);
                     if (vuln) {
                         const updatedAssessments = [...vuln.assessments, ...newAssessments];
-                        const statusSummary = buildStatusSummary(updatedAssessments);
+                        const statusSummary = buildStatusSummary(updatedAssessments, vuln.packages_current);
                         patchVuln(vuln_id, {
                             ...vuln,
                             assessments: updatedAssessments,

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -562,7 +562,7 @@ type VariantScopedSnapshot = {
 
             if (!anyError) {
                 const updatedAssessments = [...vuln.assessments];
-                const statusSummary = buildStatusSummary(updatedAssessments);
+                const statusSummary = buildStatusSummary(updatedAssessments, vuln.packages_current);
                 vuln.simplified_status = statusSummary.dominant_status;
                 vuln.status_summary = statusSummary;
 
@@ -745,7 +745,7 @@ type VariantScopedSnapshot = {
 
         if (!anyError) {
             const updatedAssessments = [...vuln.assessments];
-            const statusSummary = buildStatusSummary(updatedAssessments);
+            const statusSummary = buildStatusSummary(updatedAssessments, vuln.packages_current);
             vuln.simplified_status = statusSummary.dominant_status;
             vuln.status_summary = statusSummary;
             patchVuln(vuln.id, {
@@ -1046,7 +1046,7 @@ type VariantScopedSnapshot = {
 
         if (lastCasted) {
             const updatedAssessments = [...vuln.assessments];
-            const statusSummary = buildStatusSummary(updatedAssessments);
+            const statusSummary = buildStatusSummary(updatedAssessments, vuln.packages_current);
             patchVuln(vuln.id, {
                 ...vuln,
                 assessments: updatedAssessments,

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -105,7 +105,17 @@ const getStatusSummaryEntries = (counts: Record<string, number>): { status: stri
         });
 }
 
-const buildStatusSummary = (assessments: Assessment[]): StatusSummary => {
+const buildStatusSummary = (assessments: Assessment[], currentPackages?: string[]): StatusSummary => {
+    if (currentPackages && currentPackages.length > 0 && assessments.length > 0) {
+        const currentSet = new Set(currentPackages);
+        const filtered = assessments.filter(a =>
+            a.packages.length === 0 || a.packages.some(p => currentSet.has(p))
+        );
+        if (filtered.length > 0) {
+            assessments = filtered;
+        }
+    }
+
     if (assessments.length === 0) {
         return {
             counts: { unknown: 1 },
@@ -343,7 +353,7 @@ class Vulnerabilities {
                 return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
             });
             const vulnAssessments = assessments_per_vuln[vuln.id];
-            const statusSummary = buildStatusSummary(vulnAssessments);
+            const statusSummary = buildStatusSummary(vulnAssessments, vuln.packages_current);
             return {
                 ...vuln,
                 simplified_status: statusSummary.dominant_status,
@@ -359,7 +369,7 @@ class Vulnerabilities {
                 const assessments = [...vuln.assessments, assessment].sort((a, b) => {
                     return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
                 });
-                const statusSummary = buildStatusSummary(assessments);
+                const statusSummary = buildStatusSummary(assessments, vuln.packages_current);
                 return {
                     ...vuln,
                     simplified_status: statusSummary.dominant_status,

--- a/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
+++ b/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
@@ -484,6 +484,49 @@ describe('buildStatusSummary helpers', () => {
     expect(summary.dominant_status).toBe('Fixed');
     expect(Object.keys(summary.counts)).toHaveLength(1);
   });
+
+  const makePkgAssessment = (
+    simplified_status: string, timestamp: string, variant_id: string, packages: string[],
+  ) => ({ ...makeAssessment(simplified_status, timestamp, variant_id), packages });
+
+  test('ignores assessments on deprecated packages when current packages given', () => {
+    // Active package is linux-yocto@6.6.129 (Pending). The deprecated
+    // linux-yocto@6.6.122 (Not affected) is more recent but must not count.
+    const assessments = [
+      makePkgAssessment('Pending Assessment', '2024-01-01T00:00:00', 'v1', ['linux-yocto@6.6.129']),
+      makePkgAssessment('Not affected', '2024-02-01T00:00:00', 'v1', ['linux-yocto@6.6.122']),
+    ];
+    const summary = buildStatusSummary(assessments, ['linux-yocto@6.6.129']);
+    expect(summary.dominant_status).toBe('Pending Assessment');
+    expect(summary.counts['Not affected']).toBeUndefined();
+  });
+
+  test('keeps assessments without packages when current packages given', () => {
+    const assessments = [
+      makePkgAssessment('Pending Assessment', '2024-01-01T00:00:00', 'v1', []),
+    ];
+    const summary = buildStatusSummary(assessments, ['linux-yocto@6.6.129']);
+    expect(summary.dominant_status).toBe('Pending Assessment');
+  });
+
+  test('falls back to all assessments when none reference a current package', () => {
+    // All packages are deprecated → do not collapse to "unknown".
+    const assessments = [
+      makePkgAssessment('Not affected', '2024-01-01T00:00:00', 'v1', ['linux-yocto@6.6.111']),
+    ];
+    const summary = buildStatusSummary(assessments, ['linux-yocto@6.6.129']);
+    expect(summary.dominant_status).toBe('Not affected');
+  });
+
+  test('empty current packages disables filtering', () => {
+    const assessments = [
+      makePkgAssessment('Pending Assessment', '2024-01-01T00:00:00', 'v1', ['linux-yocto@6.6.129']),
+      makePkgAssessment('Not affected', '2024-02-01T00:00:00', 'v2', ['linux-yocto@6.6.122']),
+    ];
+    const summary = buildStatusSummary(assessments, []);
+    expect(summary.counts['Pending Assessment']).toBe(1);
+    expect(summary.counts['Not affected']).toBe(1);
+  });
 });
 
 describe('getTopStatusSummaryLabel', () => {


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The combined "current status" of a vulnerability was computed from all of its assessments, including ones targeting package versions no longer present in the active SBOM. When a old version carried a more recent assessment than the active one, that stale status leaked into the summary

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Take a vulnerability with an old version and a different status than the current active package. 

It is not visible in the package status column anymore. 

Example:

<img width="1819" height="357" alt="image" src="https://github.com/user-attachments/assets/3cb78ed8-bd7e-4afa-bf94-7d566bbb9a31" />

<img width="858" height="553" alt="image" src="https://github.com/user-attachments/assets/a76a7294-6124-47b4-874c-179d9aa93f3e" />

Does display "pending assessment" and not "pending assessment, not affected"