### PR TITLE
frontend: Renamed VulnModal labels for clarity

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -1572,13 +1572,13 @@ type VariantScopedSnapshot = {
                             <h3 className="font-bold mb-2">Assessments</h3>
                             {currentAssessmentRows.length > 0 && (
                                 <div className="mb-4 p-3 rounded-lg bg-gray-800/70 border border-gray-600">
-                                    <h4 className="font-semibold text-gray-200 mb-2">Current assessments</h4>
+                                    <h4 className="font-semibold text-gray-200 mb-2">Assessments on current SBOMs packages</h4>
                                     {renderStatusTable(sortStatusRows(currentAssessmentRows))}
                                 </div>
                             )}
                             {deprecatedAssessmentRows.length > 0 && (
                                 <div className="mb-4 p-3 rounded-lg bg-gray-800/70 border border-gray-600">
-                                    <h4 className="font-semibold text-gray-200 mb-2">Deprecated assessments</h4>
+                                    <h4 className="font-semibold text-gray-200 mb-2">Assessments on old packages (not present in current SBOMs)</h4>
                                     {renderStatusTable(sortStatusRows(deprecatedAssessmentRows))}
                                 </div>
                             )}

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2140,7 +2140,7 @@ describe('Vulnerability Modal', () => {
         render(<VulnModal vuln={multiPkgVuln} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} projectId="proj1" />);
 
         // Wait for the deprecated split to appear once variant-active-packages loads.
-        const deprecatedHeading = await screen.findByText('Deprecated assessments');
+        const deprecatedHeading = await screen.findByText('Assessments on old packages (not present in current SBOMs)');
         const deprecated = deprecatedHeading.parentElement as HTMLElement;
         // The stale package version is broken out into the deprecated table.
         expect(within(deprecated).getByText('pkgOld@0.9.0')).toBeInTheDocument();
@@ -2148,7 +2148,7 @@ describe('Vulnerability Modal', () => {
         expect(within(deprecated).queryByText('pkgA@1.0.0')).not.toBeInTheDocument();
 
         // The active (variant, package) pair stays in the current table.
-        const current = screen.getByText('Current assessments').parentElement as HTMLElement;
+        const current = screen.getByText('Assessments on current SBOMs packages').parentElement as HTMLElement;
         expect(within(current).getByText('pkgA@1.0.0')).toBeInTheDocument();
         expect(within(current).getByText('Exploitable')).toBeInTheDocument();
         expect(within(current).queryByText('pkgOld@0.9.0')).not.toBeInTheDocument();
@@ -2342,7 +2342,7 @@ describe('Vulnerability Modal', () => {
 
         render(<VulnModal vuln={{ ...vulnerability, assessments: [] }} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
-        const recapHeading = await screen.findByText('Current assessments');
+        const recapHeading = await screen.findByText('Assessments on current SBOMs packages');
         const recap = recapHeading.parentElement as HTMLElement;
         // Production reflects its most recent assessment (Not affected), not the older Exploitable
         expect(within(recap).getByText('Production')).toBeInTheDocument();
@@ -2377,7 +2377,7 @@ describe('Vulnerability Modal', () => {
 
         render(<VulnModal vuln={{ ...vulnerability, assessments: [] }} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
-        const recapHeading = await screen.findByText('Current assessments');
+        const recapHeading = await screen.findByText('Assessments on current SBOMs packages');
         const recap = recapHeading.parentElement as HTMLElement;
         // Staging has no assessment yet, so it is flagged as "No status"
         expect(within(recap).getByText('Staging')).toBeInTheDocument();


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Rename the two assessment section headers in the vulnerability modal so it is explicit which packages each table covers:

- "Current assessments" -> "Assessments on current SBOMs packages"
- "Deprecated assessments" -> "Assessments on old packages (not present in current SBOMs)"


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

<img width="862" height="539" alt="image" src="https://github.com/user-attachments/assets/1c75d612-7e20-4f22-974c-63077fe758ad" />