### PR TITLE
feat(export): import custom report templates from the Export tab

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -835,7 +835,8 @@ type VariantScopedSnapshot = {
     type StatusRow = { variant: Variant; pkg: string | null; assessment: Assessment | null; deprecated: boolean };
 
     const allStatusRows: StatusRow[] = availableVariants.flatMap((variant): StatusRow[] => {
-        const variantPkgs = variantPackageMap[variant.id] ?? [];
+        const variantActivePkgs = variantPackageMap[variant.id];
+        const variantPkgs = variantActivePkgs ?? [];
         // Packages affected by this vuln that still exist in the variant's active SBOM.
         const activeAffected = projectPackages.filter(p => variantPkgs.includes(p));
         // Packages referenced by the variant's assessments may include older,
@@ -846,6 +847,7 @@ type VariantScopedSnapshot = {
                 .flatMap(a => a.packages)
         )];
         const allPkgs = [...new Set([...activeAffected, ...assessmentPkgs])];
+        const hasActivePkgData = variantPackageMapLoaded && variantActivePkgs !== undefined;
         if (allPkgs.length === 0) {
             return [{ variant, pkg: null, assessment: latestAssessmentFor(variant.id, null), deprecated: false }];
         }
@@ -855,7 +857,7 @@ type VariantScopedSnapshot = {
             assessment: latestAssessmentFor(variant.id, pkg),
             // A package is deprecated once it's no longer in the variant's active
             // SBOM. Until that list has loaded, keep it in the current table.
-            deprecated: variantPackageMapLoaded && !variantPkgs.includes(pkg),
+            deprecated: hasActivePkgData && !variantPkgs.includes(pkg),
         }));
     });
 

--- a/frontend/src/pages/Exports.tsx
+++ b/frontend/src/pages/Exports.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faThumbTack, faFolderOpen, faFileShield, faBoxes } from "@fortawesome/free-solid-svg-icons";
+import {
+    faThumbTack, faFolderOpen, faFileShield, faBoxes, faCloudArrowUp, faSpinner, faXmark,
+} from "@fortawesome/free-solid-svg-icons";
 import FileTag from "../components/FileTag";
 import PopupExportOptions from "../components/PopupExportOptions";
 import type { Options as PopupOptions } from "../components/PopupExportOptions";
@@ -35,8 +37,13 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
     const [docs, setDocs] = useState<ExportDoc[]>([]);
     const [openDl, setOpenDl] = useState<string | null>(null);
     const [popupOptions, setPopupOptions] = useState<PopupOptions|undefined>(undefined);
+    const [dragActive, setDragActive] = useState<boolean>(false);
+    const [uploading, setUploading] = useState<boolean>(false);
+    const [uploadError, setUploadError] = useState<string | null>(null);
+    const [uploadSuccess, setUploadSuccess] = useState<string | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
 
-    useEffect(() => {
+    const loadDocs = useCallback(() => {
         fetch(import.meta.env.VITE_API_URL + "/api/documents", {
             mode: 'cors'
         })
@@ -50,6 +57,51 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
             console.error('Error:', error);
         })
     }, []);
+
+    useEffect(() => {
+        loadDocs();
+    }, [loadDocs]);
+
+    const uploadTemplate = useCallback((file: File) => {
+        setUploadError(null);
+        setUploadSuccess(null);
+        setUploading(true);
+        const body = new FormData();
+        body.append("file", file);
+        fetch(import.meta.env.VITE_API_URL + "/api/documents/templates", {
+            mode: 'cors',
+            method: 'POST',
+            body,
+        })
+        .then(async (res) => {
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                throw new Error(data?.error || `Import failed (${res.status})`);
+            }
+            setUploadSuccess(`Imported "${data?.id ?? file.name}".`);
+            setTab("custom");
+            loadDocs();
+        })
+        .catch((error) => {
+            setUploadError(error instanceof Error ? error.message : String(error));
+        })
+        .finally(() => {
+            setUploading(false);
+        });
+    }, [loadDocs]);
+
+    const onFilesSelected = useCallback((files: FileList | null) => {
+        if (files && files.length > 0) {
+            uploadTemplate(files[0]);
+        }
+    }, [uploadTemplate]);
+
+    const onDrop = useCallback((e: React.DragEvent<HTMLElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setDragActive(false);
+        onFilesSelected(e.dataTransfer.files);
+    }, [onFilesSelected]);
 
 
     return (<>
@@ -116,6 +168,68 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
     )}
   </div>
 </div>
+
+{(tab === 'custom' || tab === 'all') && (
+<div className="w-full pt-4 flex justify-center">
+  <div className="w-[70%]">
+    <input
+      ref={fileInputRef}
+      type="file"
+      className="hidden"
+      accept=".adoc,.asciidoc,.html,.htm,.md,.markdown,.csv,.txt,.json,.xml,.tex,.j2,.jinja,.jinja2"
+      onChange={(e) => { onFilesSelected(e.target.files); e.target.value = ""; }}
+    />
+    <button
+      type="button"
+      onClick={() => !uploading && fileInputRef.current?.click()}
+      onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true); }}
+      onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true); }}
+      onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(false); }}
+      onDrop={onDrop}
+      aria-label="Import a custom report template"
+      className={[
+        "w-full flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed",
+        "px-6 py-8 text-center transition-colors duration-150 cursor-pointer",
+        dragActive
+          ? "border-sky-400 bg-sky-900/40 text-white"
+          : "border-white/20 bg-gray-700/40 text-white/70 hover:border-white/35 hover:text-white",
+        uploading && "cursor-wait opacity-70",
+      ].filter(Boolean).join(" ")}
+      disabled={uploading}
+    >
+      <FontAwesomeIcon
+        icon={uploading ? faSpinner : faCloudArrowUp}
+        className={["text-2xl", uploading && "animate-spin"].filter(Boolean).join(" ")}
+        aria-hidden="true"
+      />
+      <div className="text-base font-medium">
+        {uploading ? "Importing template…" : "Drag & drop a custom template here, or click to browse"}
+      </div>
+      <div className="text-xs text-white/60">
+        Accepted: .adoc, .html, .md, .csv, .txt, .json, .xml, .tex, .j2
+      </div>
+    </button>
+    {uploadError && (
+      <div role="alert" className="mt-3 text-sm text-red-300 bg-red-900/40 border border-red-700 rounded-lg px-4 py-2">
+        {uploadError}
+      </div>
+    )}
+    {uploadSuccess && (
+      <div role="status" className="mt-3 flex items-start justify-between gap-2 text-sm text-green-300 bg-green-900/40 border border-green-700 rounded-lg px-4 py-2">
+        <span>{uploadSuccess}</span>
+        <button
+          type="button"
+          onClick={() => setUploadSuccess(null)}
+          aria-label="Dismiss message"
+          className="shrink-0 text-green-300/80 hover:text-white transition-colors"
+        >
+          <FontAwesomeIcon icon={faXmark} className="w-4 h-4" />
+        </button>
+      </div>
+    )}
+  </div>
+</div>
+)}
 
 
 

--- a/src/routes/documents.py
+++ b/src/routes/documents.py
@@ -24,6 +24,50 @@ from typing import Dict, List, Optional
 CategoriesDictionary: Dict[str, List[str]] = {}
 
 
+# Directories searched for user-provided templates, most-preferred first. This
+# mirrors ``Templates.external_loader`` so an imported template is picked up by
+# the renderer. The first writable location is used when importing.
+TEMPLATE_UPLOAD_DIRS: List[str] = [
+    "/cache/vulnscout/templates",
+    ".vulnscout/templates",
+    "templates",
+    "/scan/templates",
+]
+
+# Extensions accepted when importing a custom report template.
+ALLOWED_TEMPLATE_EXTENSIONS = {
+    "adoc", "asciidoc", "html", "htm", "md", "markdown",
+    "csv", "txt", "json", "xml", "tex", "j2", "jinja", "jinja2",
+}
+
+
+def sanitize_template_filename(filename: Optional[str]) -> Optional[str]:
+    """Return a safe basename for an uploaded template, or ``None`` if invalid.
+
+    Strips any directory components (guarding against path traversal) and only
+    accepts a known set of template extensions.
+    """
+    name = os.path.basename((filename or "").strip())
+    if not name or name.startswith(".") or ".." in name:
+        return None
+    ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+    if ext not in ALLOWED_TEMPLATE_EXTENSIONS:
+        return None
+    return name
+
+
+def writable_templates_dir() -> Optional[str]:
+    """Return the first templates directory that can be created and written to."""
+    for candidate in TEMPLATE_UPLOAD_DIRS:
+        try:
+            os.makedirs(candidate, exist_ok=True)
+        except OSError:
+            continue
+        if os.access(candidate, os.W_OK):
+            return candidate
+    return None
+
+
 def guess_mime_type(doc_name: Optional[str]) -> Optional[str]:
     if doc_name is None:
         return None
@@ -73,6 +117,38 @@ def init_app(app: Flask) -> None:
         except Exception as e:
             print(e)
             return {"error": str(e)}, 500
+
+    @app.route('/api/documents/templates', methods=['POST'])
+    def upload_template() -> ResponseReturnValue:
+        """Import a custom report template uploaded from the Export tab.
+
+        Expects a ``multipart/form-data`` request with a single ``file`` field.
+        The template is saved under the first writable templates directory so it
+        becomes available as a "custom" report.
+        """
+        if not (request.content_type and 'multipart/form-data' in request.content_type):
+            return {"error": "Expected multipart/form-data with a file upload."}, 400
+
+        uploaded = request.files.get('file')
+        if uploaded is None or not uploaded.filename:
+            return {"error": "No file uploaded."}, 400
+
+        safe_name = sanitize_template_filename(uploaded.filename)
+        if safe_name is None:
+            allowed = ", ".join(sorted(ALLOWED_TEMPLATE_EXTENSIONS))
+            return {"error": f"Unsupported template file. Allowed extensions: {allowed}."}, 400
+
+        target_dir = writable_templates_dir()
+        if target_dir is None:
+            return {"error": "No writable templates directory available on the server."}, 500
+
+        try:
+            uploaded.save(os.path.join(target_dir, safe_name))
+        except OSError as e:
+            print(e, flush=True)
+            return {"error": f"Failed to save template: {e}"}, 500
+
+        return {"id": safe_name, "category": ["custom"], "message": "Template imported."}, 201
 
     @app.route('/api/documents/<doc_name>', methods=['GET'])
     def doc_by_name(doc_name: str) -> ResponseReturnValue:

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -431,3 +431,66 @@ def test_packages_project_no_active_scans(app, client):
     assert response.status_code == 200
     data = json.loads(response.data)
     assert isinstance(data, list)
+
+
+def test_upload_template_success(tmp_path, monkeypatch, client):
+    """POST /api/documents/templates saves a valid template and returns 201."""
+    from io import BytesIO
+    monkeypatch.setattr("src.routes.documents.TEMPLATE_UPLOAD_DIRS", [str(tmp_path)])
+
+    response = client.post(
+        "/api/documents/templates",
+        data={"file": (BytesIO(b"= My custom report\n"), "my_report.adoc")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 201
+    data = json.loads(response.data)
+    assert data["id"] == "my_report.adoc"
+    assert "custom" in data["category"]
+    saved = tmp_path / "my_report.adoc"
+    assert saved.exists()
+    assert saved.read_bytes() == b"= My custom report\n"
+
+
+def test_upload_template_rejects_bad_extension(tmp_path, monkeypatch, client):
+    """POST /api/documents/templates rejects unsupported extensions with 400."""
+    from io import BytesIO
+    monkeypatch.setattr("src.routes.documents.TEMPLATE_UPLOAD_DIRS", [str(tmp_path)])
+
+    response = client.post(
+        "/api/documents/templates",
+        data={"file": (BytesIO(b"MZ..."), "evil.exe")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert json.loads(response.data)["error"]
+    assert not (tmp_path / "evil.exe").exists()
+
+
+def test_upload_template_rejects_path_traversal(tmp_path, monkeypatch, client):
+    """POST /api/documents/templates strips directory components from the name."""
+    from io import BytesIO
+    monkeypatch.setattr("src.routes.documents.TEMPLATE_UPLOAD_DIRS", [str(tmp_path)])
+
+    response = client.post(
+        "/api/documents/templates",
+        data={"file": (BytesIO(b"data"), "../../escape.adoc")},
+        content_type="multipart/form-data",
+    )
+    # basename keeps "escape.adoc"; it must not escape the target directory.
+    assert response.status_code == 201
+    data = json.loads(response.data)
+    assert data["id"] == "escape.adoc"
+    assert (tmp_path / "escape.adoc").exists()
+    assert not (tmp_path.parent.parent / "escape.adoc").exists()
+
+
+def test_upload_template_missing_file(client):
+    """POST /api/documents/templates without a file returns 400."""
+    response = client.post(
+        "/api/documents/templates",
+        data={},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert json.loads(response.data)["error"]


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Add a drag-and-drop / browse area in the Export tab (shown on the All and Custom reports views) to import a custom Jinja report template, backed by a new POST /api/documents/templates endpoint that sanitizes the filename, enforces an extension whitelist and saves it to the first writable templates directory. Include backend tests for success, bad extension, path traversal and missing file.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Go in Export tab