### PR TITLE
Select-all checkbox selects current page only

### DIFF
--- a/frontend/src/components/TableGeneric.tsx
+++ b/frontend/src/components/TableGeneric.tsx
@@ -505,6 +505,7 @@ function TableGeneric<DataType> ({
                 value={itemsPerPage}
                 onChange={(e) => {
                     setPagination({ pageIndex: 0, pageSize: Number(e.target.value) })
+                    updateSelected({})
                 }}
                 className="bg-slate-700 text-white border border-slate-500 rounded px-2 py-1"
                 >

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -667,9 +667,12 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                     <div className="flex items-center justify-center h-full">
                     <input
                         type="checkbox"
-                        title={table.getIsAllRowsSelected() ? "Unselect all" : "Select all"}
-                        checked={table.getIsAllRowsSelected()}
-                        onChange={table.getToggleAllRowsSelectedHandler()}
+                        ref={el => {
+                            if (el) el.indeterminate = table.getIsSomePageRowsSelected();
+                        }}
+                        title={table.getIsAllPageRowsSelected() ? "Unselect all" : "Select all"}
+                        checked={table.getIsAllPageRowsSelected()}
+                        onChange={table.getToggleAllPageRowsSelectedHandler()}
                     />
                     </div>
                 ),


### PR DESCRIPTION
### Changes proposed in this pull request:

This PR fixes an issue where the select-all checkbox in the vulnerability table always selects all vulnerabilities across all pages, regardless of the selected page size. 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Go to the vulnerability table and click the select-all checkbox. The selected count matches the current page size.

<img width="377" height="785" alt="image" src="https://github.com/user-attachments/assets/3eab88c3-fb2c-470c-94dd-734f522b5122" />

The select-all toggle now shows a dash state when only some (not all) of the vulnerabilities in the current page are selected.

<img width="413" height="317" alt="image" src="https://github.com/user-attachments/assets/3dfa966c-11a5-47d5-98d5-fa5d3367b182" />

### Additional notes

* Changing the page size resets the selection state to prevent confusion (Some entries stay selected after changing the page size).
* Users now need to choose the `All` option in the page size selector, then check the select-all checkbox to select all entries. 

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


