### PR TITLE
bugfix test: Exclude templates from the tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ per-file-ignores =
 [coverage:run]
 omit =
     */migrations/env.py
+    */views/templates/*
 
 [mypy]
 files = src


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

all_assessments.adoc contains an AsciiDoc literal-block delimiter ''' on line 89, which is invalid Python.  

Added */views/templates/* to the [coverage:run] omit list in tox.ini so the templates are never measured/tokenized as Python

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Tests pass correctly