### PR TITLE
fix: frontend display the full list of status

### DIFF
--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -177,13 +177,8 @@ const getVulnerabilityStatusSummary = (vulnerability: Pick<Vulnerability, 'statu
     return vulnerability.status_summary ?? buildFallbackStatusSummary(vulnerability.simplified_status);
 }
 
-const getTopStatusSummaryLabel = (summary: StatusSummary, maxItems = 2): string => {
-    const top = summary.ordered.slice(0, maxItems).map((entry) => entry.status);
-    const hiddenCount = summary.ordered.length - top.length;
-    if (hiddenCount > 0) {
-        top.push(`+${hiddenCount} more`);
-    }
-    return top.join(', ');
+const getTopStatusSummaryLabel = (summary: StatusSummary): string => {
+    return summary.ordered.map((entry) => entry.status).join(', ');
 }
 
 const isVulnerabilityActive = (vulnerability: Vulnerability): boolean => {

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -806,7 +806,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                             <div className="space-y-1 text-gray-100">
                                 <p>Status aggregates all assessment outcomes for the vulnerability in the current scope.</p>
                                 <p>Scope follows your active project, variant, and compare selection.</p>
-                                <p>Display shows top outcomes, for example: Exploitable, Pending Assessment.</p>
+                                <p>Display lists every distinct outcome, for example: Exploitable, Pending Assessment.</p>
                                 <p>Filtering matches vulnerabilities when any selected status is present in the summary.</p>
                             </div>
                         </div>
@@ -816,9 +816,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
             cell: info => {
                 const summary = getVulnerabilityStatusSummary(info.row.original);
                 const label = getTopStatusSummaryLabel(summary);
-                const details = summary.ordered.map(entry => entry.status).join(', ');
                 return (
-                    <div className="flex items-center justify-center h-full text-center" title={details}>
+                    <div className="flex items-center justify-center h-full text-center" title={label}>
                         <code>{label}</code>
                     </div>
                 );

--- a/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
+++ b/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
@@ -537,8 +537,7 @@ describe('getTopStatusSummaryLabel', () => {
     expect(getTopStatusSummaryLabel(summary)).toBe('Fixed');
   });
 
-  test('appends +N more when more than 2 entries', () => {
-    // Force a summary with 3 entries
+  test('lists every status without any "+N more" placeholder', () => {
     const summary = {
       counts: { 'Exploitable': 1, 'Pending Assessment': 1, 'Fixed': 1 },
       ordered: [
@@ -551,12 +550,11 @@ describe('getTopStatusSummaryLabel', () => {
       has_active_status: true,
     };
     const label = getTopStatusSummaryLabel(summary);
-    expect(label).toContain('+1 more');
-    expect(label).toContain('Exploitable');
-    expect(label).toContain('Pending Assessment');
+    expect(label).toBe('Exploitable, Pending Assessment, Fixed');
+    expect(label).not.toContain('more');
   });
 
-  test('custom maxItems parameter', () => {
+  test('never truncates even with many statuses', () => {
     const summary = {
       counts: { 'A': 1, 'B': 1, 'C': 1, 'D': 1 },
       ordered: [
@@ -569,9 +567,9 @@ describe('getTopStatusSummaryLabel', () => {
       dominant_status: 'A',
       has_active_status: false,
     };
-    const label = getTopStatusSummaryLabel(summary, 3);
-    expect(label).toContain('+1 more');
-    expect(label).not.toContain('D');
+    const label = getTopStatusSummaryLabel(summary);
+    expect(label).toBe('A, B, C, D');
+    expect(label).not.toContain('more');
   });
 });
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

No need to display "+X more" status when a vulnerability have too much state.
The list is restricted to a fixed set of values (Exploitable, Pending Assessment, Not Affected, Fixed) and didn't need this "+X more" status.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Before this fix:

<img width="1278" height="147" alt="image" src="https://github.com/user-attachments/assets/c3c616ac-1536-4d6b-9d9c-69d3ee7114b3" />

After this fix:

<img width="1278" height="147" alt="image" src="https://github.com/user-attachments/assets/328d82c6-de5d-463d-bbae-0cc234f2cdef" />
