### PR TITLE
Allow editing pending AI assessments and ensure they retain AI origin

### DIFF
--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -811,9 +811,10 @@ def init_app(app: Flask) -> None:
             return {"error": "Assessment not found"}, 404
 
         was_non_custom = (existing.origin or "") != "custom"
-
-        if existing.origin == "ai":
-            return {"error": "Use the AI approve/reject endpoints for pending AI assessments"}, 400
+        # Editing a pending AI assessment directly must not silently approve
+        # it: keep its origin as "ai" so it stays pending until the user
+        # explicitly approves/rejects it via the dedicated endpoints.
+        new_origin = "ai" if existing.origin == "ai" else "custom"
 
         # Reconstruct Assessment DTO for validation
         mem_assess = DBAssessment.from_dict(existing.to_dict())
@@ -847,7 +848,7 @@ def init_app(app: Flask) -> None:
 
         existing.update(
             status=mem_assess.status,
-            origin="custom",
+            origin=new_origin,
             status_notes=mem_assess.status_notes,
             justification=mem_assess.justification,
             impact_statement=mem_assess.impact_statement,
@@ -856,7 +857,9 @@ def init_app(app: Flask) -> None:
         )
         # Editing an automated assessment removes it from the scan-history
         # counts (it becomes custom-origin), so refresh the cached list view.
-        if was_non_custom:
+        # A pending AI row that stays "ai" after editing has not changed its
+        # scan-history membership, so no cache refresh is needed in that case.
+        if was_non_custom and new_origin == "custom":
             invalidate_scan_list_cache()
         return {"status": "success", "assessment": existing.to_dict()}, 200
 

--- a/tests/webapp_tests/test_ai_assessments.py
+++ b/tests/webapp_tests/test_ai_assessments.py
@@ -266,7 +266,7 @@ def test_ai_visible_on_per_vuln_endpoint(client):
     assert any(a["origin"] == "ai" for a in data)
 
 
-def test_patch_ai_row_returns_400(client):
+def test_patch_ai_row_updates_and_keeps_ai_origin(client):
     aid = _get_first_ai_id(client)
     resp = client.patch(
         f"/api/assessments/{aid}",
@@ -275,10 +275,39 @@ def test_patch_ai_row_returns_400(client):
             "justification": "component_not_present",
         },
     )
-    assert resp.status_code == 400
-    assert json.loads(resp.data)["error"] == (
-        "Use the AI approve/reject endpoints for pending AI assessments"
+    assert resp.status_code == 200
+    body = json.loads(resp.data)["assessment"]
+    assert body["status"] == "not_affected"
+    assert body["justification"] == "component_not_present"
+    # Editing a pending AI assessment directly must not auto-approve it.
+    assert body["origin"] == "ai"
+
+    # Still excluded from normal listings / scan-history counts until approved.
+    listed = json.loads(client.get("/api/assessments?format=list").data)
+    assert all(a["id"] != aid for a in listed)
+
+
+def test_patch_ai_row_then_approve_promotes_to_custom(client):
+    aid = _get_first_ai_id(client)
+    patch_resp = client.patch(
+        f"/api/assessments/{aid}",
+        json={
+            "status": "not_affected",
+            "justification": "component_not_present",
+        },
     )
+    assert patch_resp.status_code == 200
+
+    approve_resp = client.post(f"/api/assessments/{aid}/approve")
+    assert approve_resp.status_code == 200
+    approved = json.loads(approve_resp.data)["assessments"]
+    assert any(a["id"] == aid and a["origin"] == "custom" for a in approved)
+
+    listed = json.loads(client.get("/api/assessments?format=list").data)
+    listed_row = next(a for a in listed if a["id"] == aid)
+    assert listed_row["origin"] == "custom"
+    assert listed_row["status"] == "not_affected"
+    assert listed_row["justification"] == "component_not_present"
 
 
 def test_delete_ai_row_returns_400(client):


### PR DESCRIPTION
### Changes proposed in this pull request:

The AI assessments should be allowed to be modified. But their origin stays as AI, and the flipping of the origin is still triggered through the approve endpoint.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

*Fill out this section so that a reviewer can know how to verify your change.*

### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


