### PR TITLE
Flag custom assessments as Outdated when package version changes

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -1651,6 +1651,19 @@ type VariantScopedSnapshot = {
                                     const isNewlyAdded = group.assessments.some(assess => newAssessmentIds.has(assess.id));
                                     const isBeingEdited = editingAssessmentId === firstAssess.id;
                                     const groupOrigins = [...new Set(group.assessments.map(a => a.origin).filter(Boolean))];
+                                    // Per-package staleness: map each stale package reference to the
+                                    // version(s) that supersede it, so the "Outdated" pill can be shown
+                                    // next to the specific affected package rather than the whole group.
+                                    const supersededMap: Record<string, string[]> = {};
+                                    for (const a of group.assessments) {
+                                        if (a.outdated && a.superseded_map) {
+                                            for (const [ref, versions] of Object.entries(a.superseded_map)) {
+                                                // Union the replacement versions when several assessments
+                                                // in the group flag the same package reference.
+                                                supersededMap[ref] = [...new Set([...(supersededMap[ref] ?? []), ...versions])].sort();
+                                            }
+                                        }
+                                    }
 
                                     return (
                                         <li key={encodeURIComponent(group.key)} className={`mb-10 ms-4 ${isNewlyAdded ? 'new-element-glow' : ''}`}>
@@ -1667,11 +1680,18 @@ type VariantScopedSnapshot = {
                                                 {group.packages.map(pkg => {
                                                     const { nameVersion, supplier } = splitPkgId(pkg);
                                                     const supplierName = extractSupplierName(supplier);
+                                                    const supersededVersions = supersededMap[pkg];
+                                                    const pkgOutdated = Array.isArray(supersededVersions) && supersededVersions.length > 0;
                                                     return (
-                                                        <span key={pkg} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300" title={supplierName ? `Supplier: ${supplierName}` : undefined}>
+                                                        <span key={pkg} className={`inline-flex items-center px-2.5 py-0.5 rounded-full font-medium ${pkgOutdated ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300' : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300'}`} title={pkgOutdated ? `Assessed against an older version — now present as ${supersededVersions.join(', ')}` : (supplierName ? `Supplier: ${supplierName}` : undefined)}>
                                                             <FontAwesomeIcon icon={faBox} className="w-3 h-3 mr-1" />
                                                             {nameVersion}
                                                             {supplierName && <span className="ml-1 opacity-70 text-xs">({supplierName})</span>}
+                                                            {pkgOutdated && (
+                                                                <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-amber-200 text-amber-900 dark:bg-amber-700 dark:text-amber-100">
+                                                                    Outdated
+                                                                </span>
+                                                            )}
                                                         </span>
                                                     );
                                                 })}

--- a/frontend/src/handlers/assessments.ts
+++ b/frontend/src/handlers/assessments.ts
@@ -32,6 +32,10 @@ type Assessment = {
     last_update?: string;
     responses: string[];
     vuln_texts?: VulnText[];
+    outdated?: boolean;
+    superseded_by?: string[];
+    stale_packages?: string[];
+    superseded_map?: Record<string, string[]>;
 };
 
 export type { Assessment };
@@ -99,6 +103,16 @@ const asAssessment = (data: any): Assessment | [] => {
     if (typeof data?.workaround_timestamp === "string") item.workaround_timestamp = data.workaround_timestamp;
     if (typeof data?.last_update === "string") item.last_update = data.last_update;
     if (Array.isArray(data?.vuln_texts)) item.vuln_texts = data.vuln_texts;
+    if (data?.outdated === true) item.outdated = true;
+    if (Array.isArray(data?.superseded_by)) item.superseded_by = data.superseded_by.filter((s: any) => typeof s === "string");
+    if (Array.isArray(data?.stale_packages)) item.stale_packages = data.stale_packages.filter((s: any) => typeof s === "string");
+    if (data?.superseded_map && typeof data.superseded_map === "object" && !Array.isArray(data.superseded_map)) {
+        const map: Record<string, string[]> = {};
+        for (const [key, value] of Object.entries(data.superseded_map)) {
+            if (Array.isArray(value)) map[key] = value.filter((s: any) => typeof s === "string");
+        }
+        item.superseded_map = map;
+    }
     return item
 }
 

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -779,11 +779,41 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         columnHelper.accessor("simplified_status", {
             header: () => <div className="flex items-center justify-center">Status</div>,
             size: 110,
-            cell: info => (
-                <div className="flex items-center justify-center h-full">
-                    <code>{info.getValue()}</code>
-                </div>
-            ),
+            cell: info => {
+                const row = info.row.original as ReviewRow;
+                const rawAssessments = row._assessments ?? [row];
+                // Per-package staleness: union each stale package reference to the
+                // version(s) that supersede it, matching the detail shown in VulnModal.
+                const supersededMap: Record<string, string[]> = {};
+                for (const a of rawAssessments) {
+                    if (a.outdated && a.superseded_map) {
+                        for (const [ref, versions] of Object.entries(a.superseded_map)) {
+                            supersededMap[ref] = [...new Set([...(supersededMap[ref] ?? []), ...versions])].sort();
+                        }
+                    }
+                }
+                // The row is only flagged outdated once every package it covers is
+                // stale — a row spanning some current and some superseded packages
+                // is not fully outdated yet.
+                const isOutdated = row.packages.length > 0 && row.packages.every(p => p in supersededMap);
+                const supersededEntries = Object.entries(supersededMap);
+                const supersededTitle = supersededEntries.length > 0
+                    ? `Assessed against an older version — now present as ${supersededEntries.map(([ref, versions]) => `${ref} → ${versions.join(', ')}`).join('; ')}`
+                    : 'Assessed against an older version that is no longer in the active SBOM';
+                return (
+                    <div className="flex flex-col items-center justify-center gap-1 h-full">
+                        <code>{info.getValue()}</code>
+                        {isOutdated && (
+                            <span
+                                className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300"
+                                title={supersededTitle}
+                            >
+                                Outdated
+                            </span>
+                        )}
+                    </div>
+                );
+            },
         }),
         columnHelper.accessor("justification", {
             header: () => <div className="flex items-center justify-center">Justification</div>,

--- a/frontend/tests/unit_tests/test_assessments_handler.ts
+++ b/frontend/tests/unit_tests/test_assessments_handler.ts
@@ -297,3 +297,86 @@ describe('Assessments API', () => {
     expect(url.searchParams.get('project_id')).toBe('proj-4');
   });
 });
+
+describe('asAssessment outdated flag', () => {
+  const base = {
+    id: 'out-1',
+    vuln_id: 'CVE-OUTDATED',
+    status: 'not_affected',
+    timestamp: '2024-01-01T00:00:00',
+    packages: ['firefox@1.0'],
+    responses: [],
+    origin: 'custom',
+    variant_id: 'v-uuid',
+  };
+
+  test('outdated=true and superseded_by parsed when present', () => {
+    const data = { ...base, outdated: true, superseded_by: ['firefox@2.0'] };
+    const result = asAssessment(data as any) as any;
+    expect(result.outdated).toBe(true);
+    expect(result.superseded_by).toEqual(['firefox@2.0']);
+  });
+
+  test('outdated=false when server returns false leaves field absent', () => {
+    // outdated:false is the default — we don't store it. An explicit empty
+    // superseded_by array is stored as [] (valid array, just empty).
+    const data = { ...base, outdated: false, superseded_by: [] };
+    const result = asAssessment(data as any) as any;
+    expect(result.outdated).toBeUndefined();
+    expect(result.superseded_by).toEqual([]);
+  });
+
+  test('outdated absent when server omits it', () => {
+    const result = asAssessment(base as any) as any;
+    expect(result.outdated).toBeUndefined();
+    expect(result.superseded_by).toBeUndefined();
+  });
+
+  test('superseded_by non-string entries are filtered out', () => {
+    const data = { ...base, outdated: true, superseded_by: ['firefox@2.0', 42, null, 'pkg@3.0'] };
+    const result = asAssessment(data as any) as any;
+    expect(result.superseded_by).toEqual(['firefox@2.0', 'pkg@3.0']);
+  });
+
+  test('superseded_by non-array is ignored', () => {
+    const data = { ...base, outdated: true, superseded_by: 'firefox@2.0' };
+    const result = asAssessment(data as any) as any;
+    expect(result.superseded_by).toBeUndefined();
+  });
+
+  test('stale_packages and superseded_map parsed when present', () => {
+    const data = {
+      ...base,
+      packages: ['firefox@1.0', 'chrome@1.0'],
+      outdated: true,
+      superseded_by: ['firefox@2.0'],
+      stale_packages: ['firefox@1.0'],
+      superseded_map: { 'firefox@1.0': ['firefox@2.0'] },
+    };
+    const result = asAssessment(data as any) as any;
+    expect(result.stale_packages).toEqual(['firefox@1.0']);
+    expect(result.superseded_map).toEqual({ 'firefox@1.0': ['firefox@2.0'] });
+  });
+
+  test('stale_packages non-string entries are filtered out', () => {
+    const data = { ...base, outdated: true, stale_packages: ['firefox@1.0', 7, null, 'pkg@3.0'] };
+    const result = asAssessment(data as any) as any;
+    expect(result.stale_packages).toEqual(['firefox@1.0', 'pkg@3.0']);
+  });
+
+  test('superseded_map array or non-object is ignored', () => {
+    const data = { ...base, outdated: true, superseded_map: ['firefox@2.0'] };
+    const result = asAssessment(data as any) as any;
+    expect(result.superseded_map).toBeUndefined();
+  });
+
+  test('superseded_map non-array values are filtered out', () => {
+    const data = {
+      ...base,
+      outdated: true,
+      superseded_map: { 'firefox@1.0': ['firefox@2.0'], 'bad@1.0': 'not-an-array' },
+    };
+    const result = asAssessment(data as any) as any;
+    expect(result.superseded_map).toEqual({ 'firefox@1.0': ['firefox@2.0'] });
+  });
+});

--- a/src/helpers/assessment_staleness.py
+++ b/src/helpers/assessment_staleness.py
@@ -1,0 +1,362 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Helpers for determining whether a custom assessment has been superseded.
+
+An assessment is *outdated* when the package it was written against has been
+replaced by a newer version in the active SBOM **and** that newer version
+is still affected by the same CVE.  This indicates the analyst's verdict may
+no longer apply to the component that is actually shipped.
+
+Precise semantics
+-----------------
+A custom assessment (``origin == 'custom'``, ``variant_id`` set) is outdated
+when **any** package name it covers has been superseded, i.e. all four
+conditions hold for that name:
+
+1. None of the assessed versions of that package *name* (name@version pairs,
+   supplier suffix ignored) are present in the variant's current active SBOM.
+2. That package *name* is present in the active SBOM at a *different* version.
+3. That newer version has a Finding for the same CVE (``vulnerability_id``).
+4. That Finding is observed in the variant's active scan set (latest SBOM
+   scan plus the latest tool scan per source — nvd, osv, grype, scc, …).
+   CVE findings are recorded by *tool* scans, so restricting this check to
+   SBOM scans would miss every real-world case.
+
+Staleness is evaluated **per package name**.  An assessment covering several
+different packages (e.g. ``firefox@1.0`` and ``chrome@1.0``) is flagged as
+soon as *one* of them is superseded (``firefox@2.0`` appears and is still
+affected) — even if the other package (``chrome@1.0``) is unchanged.  A name
+referenced at multiple versions (``firefox@1.0`` and ``firefox@2.0``) stays
+current while any of those versions is still active.
+
+Non-custom assessments (scanner / SBOM origin) are left unchanged — they are
+regenerated from scratch on every scan.
+
+Performance
+-----------
+The annotation always executes exactly **three** SQL queries regardless of
+how many variants appear in the input list.  Earlier versions ran 3 queries
+per variant, which was noticeable when a single vulnerability had assessments
+across many variants (e.g. opening VulnModal on a widely-shared CVE).
+
+Usage
+-----
+::
+
+    dicts = [a.to_dict() for a in db_assessments]
+    annotate_assessments_outdated(dicts)
+    # dicts now have "outdated": bool, "superseded_by": list[str],
+    # "stale_packages": list[str] and "superseded_map": dict[str, list[str]]
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+
+from ..extensions import db
+from ..models.finding import Finding
+from ..models.observation import Observation
+from ..models.package import Package
+from ..models.sbom_document import SBOMDocument
+from ..models.sbom_package import SBOMPackage
+from ..models.scan import Scan
+
+
+def _parse_pkg_name_version(pkg_string_id: str) -> tuple[str, str]:
+    """Extract ``(name, version)`` from ``'name@version'`` or ``'name@version::supplier'``."""
+    base = pkg_string_id.split("::", 1)[0]
+    if "@" in base:
+        name, version = base.rsplit("@", 1)
+    else:
+        name, version = base, ""
+    return name, version
+
+
+def annotate_assessments_outdated(assessment_dicts: list[dict]) -> None:
+    """Mutate *assessment_dicts* in-place, adding ``outdated`` and ``superseded_by``.
+
+    Keys added to every dict:
+    - ``"outdated"``: ``True`` when the assessment has been superseded per the
+      semantics described in the module docstring, ``False`` otherwise.
+    - ``"superseded_by"``: sorted list of ``"name@version"`` strings for the
+      package versions that replace the stale ones (empty when not outdated).
+    - ``"stale_packages"``: sorted list of the assessment's *own* package
+      references (exactly as they appear in ``packages``) that are outdated —
+      i.e. the specific packages the UI should flag (empty when not outdated).
+    - ``"superseded_map"``: mapping of each stale package reference to the
+      sorted ``"name@version"`` list that supersedes it (empty when not
+      outdated).
+
+    The function is a no-op (sets defaults) when there are no custom assessments
+    with a ``variant_id``, so it is safe to call unconditionally.
+
+    Exactly three SQL queries are issued regardless of the number of variants.
+    """
+    # Always initialise so every dict has predictable keys.
+    for d in assessment_dicts:
+        d["outdated"] = False
+        d["superseded_by"] = []
+        d["stale_packages"] = []
+        d["superseded_map"] = {}
+
+    # Only custom assessments with a variant scope can be outdated.
+    candidates = [
+        d for d in assessment_dicts
+        if d.get("origin") == "custom" and d.get("variant_id")
+    ]
+    if not candidates:
+        return
+
+    # ------------------------------------------------------------------
+    # Validate variant UUIDs and group assessments by variant.
+    # ------------------------------------------------------------------
+    valid_variants: dict[uuid.UUID, list[dict]] = {}
+    for d in candidates:
+        try:
+            vid = uuid.UUID(d["variant_id"])
+        except (ValueError, AttributeError, TypeError):
+            continue
+        valid_variants.setdefault(vid, []).append(d)
+
+    if not valid_variants:
+        return
+
+    # Collect all (name, version) pairs and vuln_ids referenced across
+    # every candidate assessment (used to constrain the queries below).
+    all_referenced_names: set[str] = set()
+    all_vuln_ids: set[str] = set()
+    for group in valid_variants.values():
+        for d in group:
+            vuln_id_val = d.get("vuln_id", "")
+            if vuln_id_val:
+                all_vuln_ids.add(vuln_id_val)
+            for p in d.get("packages", []):
+                name, _ = _parse_pkg_name_version(p)
+                all_referenced_names.add(name)
+
+    if not all_referenced_names:
+        return
+
+    # ------------------------------------------------------------------
+    # QUERY 1 (of 3): every scan for the candidate variants, in one
+    # round-trip.  From this we derive two per-variant scan sets in
+    # Python (no per-variant helper calls):
+    #
+    #   * SBOM active scan   — the single latest SBOM scan.  Packages
+    #     come exclusively from SBOM scans, so conditions 1-2 use this.
+    #   * Full active set    — latest SBOM + latest tool scan per source
+    #     (nvd, osv, grype, scc, …).  CVE findings are observed in TOOL
+    #     scans, so conditions 3-4 must use this — mirroring the logic in
+    #     ``active_scans.active_scan_ids_for_variant``.
+    # ------------------------------------------------------------------
+    scan_rows = db.session.execute(
+        db.select(Scan.id, Scan.variant_id, Scan.scan_type, Scan.scan_source, Scan.timestamp)
+        .where(Scan.variant_id.in_(list(valid_variants.keys())))
+        .order_by(Scan.variant_id, Scan.timestamp.desc())
+    ).all()
+
+    # variant_id -> latest SBOM scan id (packages)
+    sbom_scan_by_variant: dict[uuid.UUID, uuid.UUID] = {}
+    # variant_id -> list of active scan ids (SBOM + latest tool per source)
+    full_active_scans_by_variant: dict[uuid.UUID, list[uuid.UUID]] = defaultdict(list)
+    # scan_id -> variant_id, for every scan in the full active set
+    scan_to_variant: dict[uuid.UUID, uuid.UUID] = {}
+    _seen_keys: dict[uuid.UUID, set[str]] = defaultdict(set)
+
+    for scan_id, var_id, scan_type, scan_source, _ts in scan_rows:
+        st = scan_type or "sbom"
+        key = f"tool:{scan_source}" if st == "tool" else "sbom"
+        if key in _seen_keys[var_id]:
+            continue  # already have a newer scan for this source
+        _seen_keys[var_id].add(key)
+        full_active_scans_by_variant[var_id].append(scan_id)
+        scan_to_variant[scan_id] = var_id
+        if key == "sbom":
+            sbom_scan_by_variant[var_id] = scan_id
+
+    if not sbom_scan_by_variant:
+        return
+
+    # SBOM scans only (for the package queries).
+    sbom_active_scan_ids = list(sbom_scan_by_variant.values())
+    # Full active set (for the finding-observation query).
+    full_active_scan_ids: list[uuid.UUID] = []
+    for scan_id_list in full_active_scans_by_variant.values():
+        full_active_scan_ids.extend(scan_id_list)
+
+    # ------------------------------------------------------------------
+    # QUERY 2 (of 3): active SBOM packages across all variants at once,
+    # restricted to the package names referenced by our assessments.
+    # Packages come from SBOM scans, so this is scoped to SBOM scans.
+    # ------------------------------------------------------------------
+    active_pkg_rows = db.session.execute(
+        db.select(SBOMDocument.scan_id, Package.name, Package.version, Package.id)
+        .join(SBOMPackage, SBOMPackage.package_id == Package.id)
+        .join(SBOMDocument, SBOMDocument.id == SBOMPackage.sbom_document_id)
+        .where(SBOMDocument.scan_id.in_(sbom_active_scan_ids))
+        .where(Package.name.in_(list(all_referenced_names)))
+        .distinct()
+    ).all()
+
+    # Per-variant indexes built from query 2.
+    # variant_id → name → set of active versions
+    active_versions_by_name: dict[uuid.UUID, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    # variant_id → (name, version) → set of package_ids
+    active_pkg_ids_by_nv: dict[uuid.UUID, dict[tuple[str, str], set[uuid.UUID]]] = (
+        defaultdict(lambda: defaultdict(set))
+    )
+
+    for scan_id, pkg_name, pkg_version, pkg_id in active_pkg_rows:
+        var_id = scan_to_variant.get(scan_id)
+        if var_id is None:
+            continue
+        active_versions_by_name[var_id][pkg_name].add(pkg_version)
+        active_pkg_ids_by_nv[var_id][(pkg_name, pkg_version)].add(pkg_id)
+
+    # ------------------------------------------------------------------
+    # QUERY 3 (of 3): observed findings for all active packages ×
+    # all relevant vuln IDs across all variants at once.
+    #
+    # Scoped to the FULL active set (SBOM + tool scans): a CVE finding
+    # for the new package version is observed in a *tool* scan, never in
+    # the SBOM scan, so restricting to SBOM scans here would miss every
+    # real-world case.
+    # ------------------------------------------------------------------
+    # variant_id → set of (package_id, vuln_id) pairs confirmed in that variant
+    observed_pairs_by_variant: dict[uuid.UUID, set[tuple[uuid.UUID, str]]] = defaultdict(set)
+
+    if all_vuln_ids:
+        all_active_pkg_ids: set[uuid.UUID] = set()
+        for by_nv in active_pkg_ids_by_nv.values():
+            for pkg_id_set in by_nv.values():
+                all_active_pkg_ids.update(pkg_id_set)
+
+        if all_active_pkg_ids:
+            finding_rows = db.session.execute(
+                db.select(Finding.package_id, Finding.vulnerability_id, Observation.scan_id)
+                .join(Observation, Observation.finding_id == Finding.id)
+                .where(Finding.package_id.in_(list(all_active_pkg_ids)))
+                .where(Finding.vulnerability_id.in_(list(all_vuln_ids)))
+                .where(Observation.scan_id.in_(full_active_scan_ids))
+                .distinct()
+            ).all()
+            for pkg_id, vuln_id, scan_id in finding_rows:
+                var_id = scan_to_variant.get(scan_id)
+                if var_id is not None:
+                    observed_pairs_by_variant[var_id].add((pkg_id, vuln_id))
+
+    # ------------------------------------------------------------------
+    # Annotate each assessment using the per-variant indexes.
+    # ------------------------------------------------------------------
+    for variant_uuid, group in valid_variants.items():
+        if variant_uuid not in sbom_scan_by_variant:
+            continue  # no active SBOM scan for this variant
+
+        v_active_versions = active_versions_by_name[variant_uuid]
+        v_active_pkg_ids = active_pkg_ids_by_nv[variant_uuid]
+        v_observed = observed_pairs_by_variant[variant_uuid]
+
+        for d in group:
+            _annotate_one(d, v_active_versions, v_active_pkg_ids, v_observed)
+
+
+def _annotate_one(
+    d: dict,
+    v_active_versions: dict[str, set[str]],
+    v_active_pkg_ids: dict[tuple[str, str], set[uuid.UUID]],
+    v_observed: set[tuple[uuid.UUID, str]],
+) -> None:
+    """Annotate a single assessment dict *d* in-place with staleness info.
+
+    Staleness is decided *per package name*.  A name is still current — and
+    therefore cannot be superseded — when either a version-less reference
+    matches any active version, or one of its assessed versions is still in the
+    active SBOM.  A name that is NOT current is superseded when the active SBOM
+    carries a different, still-affected version of it.  The assessment is
+    outdated as soon as ANY covered name is superseded, regardless of whether
+    its other packages remain current.
+    """
+    vuln_id = d.get("vuln_id", "")
+    orig_refs = d.get("packages", [])
+    if not orig_refs:
+        return
+
+    # Group the assessed references by package name.  A name may be referenced
+    # at several concrete versions and/or version-lessly.  Also remember the
+    # *original* package strings per name so the exact stale references can be
+    # reported back to the UI.
+    assessed_versions_by_name: dict[str, set[str]] = defaultdict(set)
+    versionless_names: set[str] = set()
+    orig_refs_by_name: dict[str, list[str]] = defaultdict(list)
+    for ref in orig_refs:
+        name, ver = _parse_pkg_name_version(ref)
+        orig_refs_by_name[name].append(ref)
+        if ver:
+            assessed_versions_by_name[name].add(ver)
+        else:
+            versionless_names.add(name)
+
+    superseded_by: list[str] = []
+    stale_packages: list[str] = []
+    superseded_map: dict[str, list[str]] = {}
+    for name in set(assessed_versions_by_name) | versionless_names:
+        name_superseded_by = _superseding_versions_for_name(
+            name,
+            assessed_versions_by_name.get(name, set()),
+            name in versionless_names,
+            vuln_id,
+            v_active_versions,
+            v_active_pkg_ids,
+            v_observed,
+        )
+        if not name_superseded_by:
+            continue
+        for label in name_superseded_by:
+            if label not in superseded_by:
+                superseded_by.append(label)
+        # Every original reference for this name is now stale.
+        for ref in orig_refs_by_name[name]:
+            if ref not in stale_packages:
+                stale_packages.append(ref)
+            superseded_map[ref] = sorted(name_superseded_by)
+
+    if superseded_by:
+        d["outdated"] = True
+        d["superseded_by"] = sorted(superseded_by)
+        d["stale_packages"] = sorted(stale_packages)
+        d["superseded_map"] = superseded_map
+
+
+def _superseding_versions_for_name(
+    name: str,
+    old_versions: set[str],
+    versionless: bool,
+    vuln_id: str,
+    v_active_versions: dict[str, set[str]],
+    v_active_pkg_ids: dict[tuple[str, str], set[uuid.UUID]],
+    v_observed: set[tuple[uuid.UUID, str]],
+) -> list[str]:
+    """Return the ``"name@version"`` labels that supersede *name*, or ``[]``.
+
+    Empty when the name is still current (an assessed version — or a
+    version-less reference — is still active) or when no newer, still-affected
+    version of it exists in the active SBOM.
+    """
+    active_versions = v_active_versions.get(name, set())
+    if versionless and name in v_active_versions:
+        return []  # version-less reference keeps this name current
+    if active_versions & old_versions:
+        return []  # an assessed version is still active → current
+
+    result: list[str] = []
+    for new_version in active_versions:
+        if new_version in old_versions:
+            continue
+        new_pkg_ids = v_active_pkg_ids.get((name, new_version), set())
+        if any((pid, vuln_id) in v_observed for pid in new_pkg_ids):
+            label = f"{name}@{new_version}"
+            if label not in result:
+                result.append(label)
+    return result

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -22,6 +22,7 @@ from ..helpers.assessment_io import (
     build_custom_data_export,
     import_custom_data,
 )
+from ..helpers.assessment_staleness import annotate_assessments_outdated
 
 from flask import request, Flask
 from flask.typing import ResponseReturnValue
@@ -118,6 +119,7 @@ def init_app(app: Flask) -> None:
                 assessments = []
         else:
             assessments = [a.to_dict() for a in _get_all_db_assessments()]
+        annotate_assessments_outdated(assessments)
         if request.args.get('format', 'list') == "dict":
             return {a["id"]: a for a in assessments}
         return assessments
@@ -164,6 +166,7 @@ def init_app(app: Flask) -> None:
             a_ser["vuln_texts"] = list(map(VulnerabilityText.to_dict, vuln_texts[a.vuln_id]))
             assessments_serialized.append(a_ser)
 
+        annotate_assessments_outdated(assessments_serialized)
         return assessments_serialized
 
     @app.route('/api/assessments/review/export')
@@ -551,6 +554,7 @@ def init_app(app: Flask) -> None:
         for f in findings:
             for a in DBAssessment.get_by_finding(f.id):
                 assessments.append(a.to_dict())
+        annotate_assessments_outdated(assessments)
         if request.args.get('format', 'list') == "dict":
             return {a["id"]: a for a in assessments}
         return assessments, 200

--- a/tests/webapp_tests/test_assessment_outdated.py
+++ b/tests/webapp_tests/test_assessment_outdated.py
@@ -1,0 +1,430 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Integration tests for the 'Outdated' assessment flag.
+
+Scenario: a custom assessment is written against firefox@1.0.  A new SBOM
+scan then introduces firefox@2.0, which is also affected by the same CVE.
+The old assessment should be flagged as outdated.
+"""
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+from src.models.assessment import Assessment
+from src.models.finding import Finding
+from src.models.observation import Observation
+from src.models.package import Package
+from src.models.project import Project
+from src.models.sbom_document import SBOMDocument
+from src.models.sbom_package import SBOMPackage
+from src.models.scan import Scan
+from src.models.variant import Variant
+from src.models.vulnerability import Vulnerability
+
+
+# ------------------------------------------------------------------
+# Shared UUIDs
+# ------------------------------------------------------------------
+PROJECT_ID = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+VARIANT_ID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+SCAN_V1_ID = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+SCAN_V2_ID = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+TOOL_SCAN_V2_ID = uuid.UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+CVE_ID = "CVE-2024-99999"
+
+
+def _build_outdated_db(app, *, include_v2_finding: bool = True, include_v2_in_active: bool = True,
+                       include_unchanged_second_pkg: bool = False):
+    """Populate in-memory DB for outdated-assessment tests.
+
+    ``include_v2_finding``  – when False the v2 package has no Finding, so
+                               condition 4 fails (should NOT be outdated).
+    ``include_v2_in_active``– when False scan_v2 is absent (package removed
+                               entirely), so condition 2 fails.
+    ``include_unchanged_second_pkg`` – when True, chrome@1.0 is added to both
+                               the old and the active SBOM scan (i.e. it stays
+                               current across the version bump).  Used to test
+                               a multi-package assessment where only firefox is
+                               superseded.
+    """
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        # --- Project / Variant ---
+        project = Project(id=PROJECT_ID, name="test")
+        _db.session.add(project)
+        variant = Variant(id=VARIANT_ID, name="default", project_id=PROJECT_ID)
+        _db.session.add(variant)
+
+        # --- Vulnerability ---
+        Vulnerability.create_record(id=CVE_ID, description="Test vuln", status="high")
+        _db.session.commit()
+
+        # --- Packages ---
+        pkg_v1 = Package.find_or_create("firefox", "1.0", [], [], "")
+        pkg_v2 = Package.find_or_create("firefox", "2.0", [], [], "")
+        pkg_chrome = None
+        if include_unchanged_second_pkg:
+            pkg_chrome = Package.find_or_create("chrome", "1.0", [], [], "")
+        _db.session.commit()
+
+        # --- Findings ---
+        finding_v1 = Finding.get_or_create(pkg_v1.id, CVE_ID)
+        if pkg_chrome is not None:
+            Finding.get_or_create(pkg_chrome.id, CVE_ID)
+        _db.session.commit()
+
+        finding_v2 = None
+        if include_v2_finding:
+            finding_v2 = Finding.get_or_create(pkg_v2.id, CVE_ID)
+            _db.session.commit()
+
+        # --- Scan v1 (older SBOM, firefox@1.0) ---
+        scan_v1 = Scan(
+            id=SCAN_V1_ID,
+            variant_id=VARIANT_ID,
+            scan_type="sbom",
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        _db.session.add(scan_v1)
+        sbom_v1 = SBOMDocument(
+            id=uuid.UUID("e1111111-1111-1111-1111-111111111111"),
+            path="/scan/v1.spdx.json",
+            source_name="v1.spdx.json",
+            format="spdx",
+            scan_id=SCAN_V1_ID,
+        )
+        _db.session.add(sbom_v1)
+        _db.session.add(SBOMPackage(sbom_document_id=sbom_v1.id, package_id=pkg_v1.id))
+        if pkg_chrome is not None:
+            _db.session.add(SBOMPackage(sbom_document_id=sbom_v1.id, package_id=pkg_chrome.id))
+        _db.session.add(Observation(finding_id=finding_v1.id, scan_id=SCAN_V1_ID))
+        _db.session.commit()
+
+        # --- Custom assessment on firefox@1.0 ---
+        assess_id = uuid.UUID("f1111111-1111-1111-1111-111111111111")
+        assessment = Assessment(
+            id=assess_id,
+            status="not_affected",
+            simplified_status="Not affected",
+            origin="custom",
+            source="analyst",
+            status_notes="No network access on this build",
+            justification="vulnerable_code_not_in_execute_path",
+            impact_statement="",
+            responses=[],
+            workaround="",
+            finding_id=finding_v1.id,
+            variant_id=VARIANT_ID,
+            timestamp=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        )
+        _db.session.add(assessment)
+        _db.session.commit()
+
+        if include_v2_in_active:
+            # --- Scan v2 (newer SBOM, firefox@2.0) — this is the active scan ---
+            scan_v2 = Scan(
+                id=SCAN_V2_ID,
+                variant_id=VARIANT_ID,
+                scan_type="sbom",
+                timestamp=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            )
+            _db.session.add(scan_v2)
+            sbom_v2 = SBOMDocument(
+                id=uuid.UUID("e2222222-2222-2222-2222-222222222222"),
+                path="/scan/v2.spdx.json",
+                source_name="v2.spdx.json",
+                format="spdx",
+                scan_id=SCAN_V2_ID,
+            )
+            _db.session.add(sbom_v2)
+            _db.session.add(SBOMPackage(sbom_document_id=sbom_v2.id, package_id=pkg_v2.id))
+            if pkg_chrome is not None:
+                _db.session.add(SBOMPackage(sbom_document_id=sbom_v2.id, package_id=pkg_chrome.id))
+            if include_v2_finding and finding_v2 is not None:
+                # A CVE finding for the new package version is observed in a
+                # *tool* scan (nvd/osv/grype/scc), NOT the SBOM scan — this
+                # mirrors the real ingestion pipeline.  The staleness helper
+                # must look at the full active set (SBOM + tool scans) to see
+                # it, so observing it here in a tool scan is the realistic case.
+                tool_scan_v2 = Scan(
+                    id=TOOL_SCAN_V2_ID,
+                    variant_id=VARIANT_ID,
+                    scan_type="tool",
+                    scan_source="nvd",
+                    timestamp=datetime(2024, 6, 2, tzinfo=timezone.utc),
+                )
+                _db.session.add(tool_scan_v2)
+                _db.session.add(Observation(finding_id=finding_v2.id, scan_id=TOOL_SCAN_V2_ID))
+            _db.session.commit()
+
+        return assess_id
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+@pytest.fixture()
+def _status_file(tmp_path):
+    """Create a scan-status file that satisfies the scan-finished middleware."""
+    f = tmp_path / "status.txt"
+    f.write_text("__END_OF_SCAN_SCRIPT__")
+    return f
+
+
+@pytest.fixture()
+def app_factory(_status_file):
+    """Return a factory that creates a fresh test Flask app."""
+    def _make():
+        os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        application = create_app()
+        application.config.update({
+            "TESTING": True,
+            "SCAN_FILE": _status_file,
+        })
+        return application
+    yield _make
+    os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+class TestOutdatedFlag:
+    """Main scenario: assessment becomes outdated after version bump."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, app_factory):
+        self.app = app_factory()
+        self.assess_id = _build_outdated_db(self.app)
+        self.client = self.app.test_client()
+
+    def test_index_assess_variant_returns_outdated(self):
+        """GET /api/assessments?variant_id=... marks the outdated assessment."""
+        resp = self.client.get(f"/api/assessments?variant_id={VARIANT_ID}")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        custom = [a for a in data if a.get("origin") == "custom"]
+        assert len(custom) == 1
+        assert custom[0]["outdated"] is True
+        assert custom[0]["superseded_by"] == ["firefox@2.0"]
+
+    def test_index_assess_variant_reports_stale_package(self):
+        """The response identifies the specific stale package and its replacement."""
+        resp = self.client.get(f"/api/assessments?variant_id={VARIANT_ID}")
+        data = json.loads(resp.data)
+        custom = [a for a in data if a.get("origin") == "custom"]
+        assert custom[0]["stale_packages"] == ["firefox@1.0"]
+        assert custom[0]["superseded_map"] == {"firefox@1.0": ["firefox@2.0"]}
+
+    def test_list_assess_by_vuln_returns_outdated(self):
+        """GET /api/vulnerabilities/<id>/assessments marks the outdated assessment."""
+        resp = self.client.get(f"/api/vulnerabilities/{CVE_ID}/assessments")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        custom = [a for a in data if a.get("origin") == "custom"]
+        assert len(custom) == 1
+        assert custom[0]["outdated"] is True
+        assert custom[0]["superseded_by"] == ["firefox@2.0"]
+
+    def test_outdated_flag_always_present(self):
+        """Every assessment dict returned has the 'outdated' key."""
+        resp = self.client.get(f"/api/assessments?variant_id={VARIANT_ID}")
+        data = json.loads(resp.data)
+        for item in data:
+            assert "outdated" in item, f"Missing 'outdated' key in {item!r}"
+            assert "superseded_by" in item
+            assert "stale_packages" in item
+            assert "superseded_map" in item
+
+
+class TestNotOutdated_VersionStillActive:
+    """Not outdated when the assessed package version is still in the active SBOM."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, app_factory):
+        self.app = app_factory()
+        # Build standard scenario but mark scan_v1 as the LATEST (no v2 scan).
+        self.assess_id = _build_outdated_db(
+            self.app,
+            include_v2_finding=True,
+            include_v2_in_active=False,  # no v2 scan → v1 is still active
+        )
+        self.client = self.app.test_client()
+
+    def test_not_outdated_when_package_still_active(self):
+        """Assessment is NOT outdated when firefox@1.0 is the current active package."""
+        resp = self.client.get(f"/api/assessments?variant_id={VARIANT_ID}")
+        data = json.loads(resp.data)
+        custom = [a for a in data if a.get("origin") == "custom"]
+        assert len(custom) == 1
+        assert custom[0]["outdated"] is False
+        assert custom[0]["superseded_by"] == []
+
+
+class TestNotOutdated_NewVersionNotAffected:
+    """Not outdated when the new package version does not have a finding for the CVE."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, app_factory):
+        self.app = app_factory()
+        self.assess_id = _build_outdated_db(
+            self.app,
+            include_v2_finding=False,  # v2 has no Finding → condition 4 fails
+            include_v2_in_active=True,
+        )
+        self.client = self.app.test_client()
+
+    def test_not_outdated_when_new_version_unaffected(self):
+        """Assessment is NOT outdated when firefox@2.0 is not affected by the CVE."""
+        resp = self.client.get(f"/api/assessments?variant_id={VARIANT_ID}")
+        data = json.loads(resp.data)
+        custom = [a for a in data if a.get("origin") == "custom"]
+        assert len(custom) == 1
+        assert custom[0]["outdated"] is False
+        assert custom[0]["superseded_by"] == []
+
+
+class TestNotOutdated_NonCustomOrigin:
+    """Assessments with origin other than 'custom' are never flagged outdated."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, app_factory):
+        self.app = app_factory()
+        # Build the full outdated scenario, then flip origin to 'sbom'.
+        _build_outdated_db(self.app)
+        with self.app.app_context():
+            assess = _db.session.get(
+                Assessment, uuid.UUID("f1111111-1111-1111-1111-111111111111")
+            )
+            assert assess is not None
+            assess.origin = "sbom"
+            _db.session.commit()
+        self.client = self.app.test_client()
+
+    def test_non_custom_assessment_not_flagged(self):
+        """SBOM-origin assessment is not marked outdated regardless of package changes."""
+        resp = self.client.get(f"/api/assessments?variant_id={VARIANT_ID}")
+        data = json.loads(resp.data)
+        assert all(not a.get("outdated") for a in data)
+
+
+class TestHelperEdgeCases:
+    """Direct tests of annotate_assessments_outdated for inputs the routes can't produce."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, app_factory):
+        self.app = app_factory()
+        _build_outdated_db(self.app)
+
+    def _annotate(self, dicts):
+        from src.helpers.assessment_staleness import annotate_assessments_outdated
+        with self.app.app_context():
+            annotate_assessments_outdated(dicts)
+        return dicts
+
+    def _base_dict(self, **overrides):
+        d = {
+            "id": "x",
+            "origin": "custom",
+            "variant_id": str(VARIANT_ID),
+            "vuln_id": CVE_ID,
+            "packages": ["firefox@1.0"],
+        }
+        d.update(overrides)
+        return d
+
+    def test_versionless_package_reference_is_current(self):
+        """A 'name'-only package reference matches any active version — never outdated."""
+        dicts = [self._base_dict(packages=["firefox"])]
+        self._annotate(dicts)
+        assert dicts[0]["outdated"] is False
+        assert dicts[0]["superseded_by"] == []
+
+    def test_invalid_variant_id_is_skipped(self):
+        """A malformed variant_id doesn't raise and leaves defaults."""
+        dicts = [self._base_dict(variant_id="not-a-uuid")]
+        self._annotate(dicts)
+        assert dicts[0]["outdated"] is False
+
+    def test_empty_packages_left_untouched(self):
+        """An assessment with no packages keeps the defaults."""
+        dicts = [self._base_dict(packages=[])]
+        self._annotate(dicts)
+        assert dicts[0]["outdated"] is False
+
+    def test_mixed_current_and_stale_packages_is_current(self):
+        """A name referenced at several versions stays current while any is active."""
+        dicts = [self._base_dict(packages=["firefox@1.0", "firefox@2.0"])]
+        self._annotate(dicts)
+        assert dicts[0]["outdated"] is False
+
+    def test_supplier_suffix_is_ignored_for_matching(self):
+        """'name@version::supplier' matches the same way as 'name@version'."""
+        dicts = [self._base_dict(packages=["firefox@1.0::Organization: Mozilla"])]
+        self._annotate(dicts)
+        assert dicts[0]["outdated"] is True
+        assert dicts[0]["superseded_by"] == ["firefox@2.0"]
+
+
+class TestOutdated_MultiPackageOneSuperseded:
+    """A multi-package assessment is outdated when one package is superseded.
+
+    Assessment covers firefox@1.0 AND chrome@1.0.  firefox is bumped to 2.0
+    (still affected) while chrome@1.0 stays in the active SBOM.  The assessment
+    must be flagged outdated because the firefox portion no longer applies,
+    even though chrome@1.0 is unchanged.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, app_factory):
+        self.app = app_factory()
+        _build_outdated_db(self.app, include_unchanged_second_pkg=True)
+        self.client = self.app.test_client()
+
+    def _annotate(self, dicts):
+        from src.helpers.assessment_staleness import annotate_assessments_outdated
+        with self.app.app_context():
+            annotate_assessments_outdated(dicts)
+        return dicts
+
+    def test_outdated_when_one_of_several_packages_superseded(self):
+        """firefox@1.0 superseded by firefox@2.0 while chrome@1.0 stays current."""
+        dicts = [{
+            "id": "x",
+            "origin": "custom",
+            "variant_id": str(VARIANT_ID),
+            "vuln_id": CVE_ID,
+            "packages": ["firefox@1.0", "chrome@1.0"],
+        }]
+        self._annotate(dicts)
+        assert dicts[0]["outdated"] is True
+        assert dicts[0]["superseded_by"] == ["firefox@2.0"]
+        # Only firefox@1.0 is flagged; chrome@1.0 stays current.
+        assert dicts[0]["stale_packages"] == ["firefox@1.0"]
+        assert dicts[0]["superseded_map"] == {"firefox@1.0": ["firefox@2.0"]}
+
+    def test_current_when_all_packages_still_active(self):
+        """No package superseded → assessment stays current."""
+        dicts = [{
+            "id": "x",
+            "origin": "custom",
+            "variant_id": str(VARIANT_ID),
+            "vuln_id": CVE_ID,
+            "packages": ["firefox@2.0", "chrome@1.0"],
+        }]
+        self._annotate(dicts)
+        assert dicts[0]["outdated"] is False
+        assert dicts[0]["superseded_by"] == []


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

When a new SBOM scan introduces a new version of a package that is still affected by the same CVE, any custom assessment that was written against the old version is now marked as outdated.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

SBOM files:
[sbom_v2_openssl-3.3.0.spdx.json](https://github.com/user-attachments/files/30060592/sbom_v2_openssl-3.3.0.spdx.json)
[sbom_v1_openssl-3.0.7.spdx.json](https://github.com/user-attachments/files/30060593/sbom_v1_openssl-3.0.7.spdx.json)

Test instructions:
1. Create a project / variant
2. Upload the first SBOM and launch NVD CPE scan
3. Make an assessment
4. Upload the second SBOM and launch NVD CPE scan
5. You should observe that the assessment is outdated given the unique package of our SBOM got upgraded

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


