### PR TITLE
Add assets to asciidoc export

### DIFF
--- a/doc/source/templates.md
+++ b/doc/source/templates.md
@@ -431,3 +431,93 @@ Project
   {{ variant.name }}: last scanned {{ latest.timestamp | print_iso8601 }}
 {% endfor %}
 ```
+
+---
+
+## Using Images and Logos in Reports
+
+VulnScout provides a first-class image embedding mechanism that produces self-contained output in every format (raw AsciiDoc, HTML, and PDF) without any `imagesdir` or safe-mode configuration on the template author's side.
+
+### `embed_image(name, width=None, alt="")`
+
+Inlines a named asset as a base64 data-URI AsciiDoc block image macro.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | string | Filename of the image (e.g. `"logo.png"`). Plain basename only — no directory separators. |
+| `width` | integer | Optional rendered width in pixels. |
+| `alt` | string | Optional alt text / caption. |
+
+Returns an `image::data:…[…]` AsciiDoc macro, or an **empty string** if the file cannot be found, so `{% if embed_image(…) %}` guards work.
+
+**Example — optional logo at the top of a report:**
+
+```jinja
+{% set _logo = embed_image("logo.png") or embed_image("logo.svg") %}
+{% if _logo %}
+[.right]
+{{ _logo }}
+
+{% endif %}
+= My Report
+```
+
+**Example — sized, captioned logo:**
+
+```jinja
+{{ embed_image("logo.png", width=150, alt="Company Logo") }}
+```
+
+### `find_asset(name)`
+
+Returns the absolute path to a named asset, or `None` if not found.  Useful when you need to pass the path elsewhere (e.g. to an external tool invoked from a template).
+
+### Asset Search Order
+
+Assets are resolved from the following directories in order; the first match wins:
+
+| Priority | Path |
+|----------|------|
+| 1 (highest) | `/cache/vulnscout/templates/assets` |
+| 2 | `.vulnscout/templates/assets` |
+| 3 | `templates/assets` |
+| 4 | `/scan/templates/assets` |
+| 5 (lowest) | Built-in `src/views/templates/assets` (inside the container image) |
+
+Only the extensions `png`, `jpg`, `jpeg`, `gif`, `svg`, and `webp` are accepted; all others are silently ignored to guard against path injection.
+
+### Adding Assets
+
+**Via the web UI (Export tab):**
+Drag and drop an image onto the *"Drag & drop a logo or image"* area in the Export tab. It is saved to the first writable `assets` sub-directory.
+
+**Via the CLI:**
+```bash
+./vulnscout --add-asset /path/to/logo.png --report my_report.adoc
+```
+The image is staged to `/cache/vulnscout/templates/assets/logo.png` before the report runs.
+
+**Via the API:**
+```http
+POST /api/documents/assets
+Content-Type: multipart/form-data
+
+file=<image file>
+```
+Returns `{"name": "logo.png", "message": "Asset uploaded."}` on success (HTTP 201).
+
+**Manually (host-side):**
+Drop the image into `.vulnscout/templates/assets/` — the directory is picked up automatically on the next report generation without a container restart.
+
+### Native `image::` Macros (secondary mechanism)
+
+Template authors who prefer the standard AsciiDoc `image::filename[]` syntax are also supported.  At conversion time VulnScout automatically passes:
+
+* `-S safe` with `-B <temp-dir>` — restricts asciidoctor to reading files from
+  a sandboxed temporary directory populated only with the referenced,
+  resolved assets (no arbitrary filesystem access, unlike `unsafe` mode).
+* `-a imagesdir=<copied-assets-dir>` — resolves relative image paths.
+* `-a data-uri` (HTML output only) — inlines resolved images as base64 in the HTML file.
+
+`allow-uri-read` remains **disabled** — remote image fetching is never enabled.
+

--- a/frontend/src/pages/Exports.tsx
+++ b/frontend/src/pages/Exports.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-    faThumbTack, faFolderOpen, faFileShield, faBoxes, faCloudArrowUp, faSpinner, faXmark,
+    faThumbTack, faFolderOpen, faFileShield, faBoxes, faCloudArrowUp, faSpinner, faXmark, faImage,
 } from "@fortawesome/free-solid-svg-icons";
 import FileTag from "../components/FileTag";
 import PopupExportOptions from "../components/PopupExportOptions";
@@ -13,6 +13,10 @@ type ExportDoc = {
     category: string[];
     extension: string;
 }
+
+const assetExtensions = new Set(["png", "jpg", "jpeg", "gif", "webp"]);
+const templateAccept = ".adoc,.asciidoc,.html,.htm,.md,.markdown,.csv,.txt,.json,.xml,.tex,.j2,.jinja,.jinja2";
+const assetAccept = ".png,.jpg,.jpeg,.gif,.webp";
 
 const asExportDoc = (data: any): ExportDoc | [] => {
     if (typeof data !== "object") return [];
@@ -90,11 +94,44 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
         });
     }, [loadDocs]);
 
+    const uploadAsset = useCallback((file: File) => {
+        setUploadError(null);
+        setUploadSuccess(null);
+        setUploading(true);
+        const body = new FormData();
+        body.append("file", file);
+        fetch(import.meta.env.VITE_API_URL + "/api/documents/assets", {
+            mode: 'cors',
+            method: 'POST',
+            body,
+        })
+        .then(async (res) => {
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                throw new Error(data?.error || `Upload failed (${res.status})`);
+            }
+            setUploadSuccess(`Uploaded "${data?.name ?? file.name}".`);
+            setTab("assets");
+            loadDocs();
+        })
+        .catch((error) => {
+            setUploadError(error instanceof Error ? error.message : String(error));
+        })
+        .finally(() => {
+            setUploading(false);
+        });
+    }, [loadDocs]);
+
     const onFilesSelected = useCallback((files: FileList | null) => {
         if (files && files.length > 0) {
-            uploadTemplate(files[0]);
+        const extension = files[0].name.split(".").pop()?.toLowerCase() ?? "";
+        if (tab === "assets" || (tab === "all" && assetExtensions.has(extension))) {
+                uploadAsset(files[0]);
+            } else {
+                uploadTemplate(files[0]);
+            }
         }
-    }, [uploadTemplate]);
+    }, [tab, uploadAsset, uploadTemplate]);
 
     const onDrop = useCallback((e: React.DragEvent<HTMLElement>) => {
         e.preventDefault();
@@ -102,6 +139,11 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
         setDragActive(false);
         onFilesSelected(e.dataTransfer.files);
     }, [onFilesSelected]);
+
+    const visibleDocs = docs.filter((doc) =>
+      (doc.category.includes(tab) || tab === "all")
+      && (tab !== "custom" || !assetExtensions.has(doc.extension.toLowerCase()))
+    );
 
 
     return (<>
@@ -117,6 +159,7 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
 
                 { key: "built-in", icon: faThumbTack, label: "Built-in reports" },
                 { key: "custom", icon: faFolderOpen, label: "Custom reports" },
+                { key: "assets", icon: faImage, label: "Custom assets" },
                 { key: "sbom", icon: faFileShield, label: "SBOM files" },
             ].map(({ key, icon, label }) => (
                 <button
@@ -143,7 +186,7 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
 
 <div className="w-full pt-4 flex justify-center">
   <div className="w-[70%] bg-gray-700 from-zinc-800 to-zinc-900 rounded-3xl p-6 grid grid-cols-3 gap-6 justify-center shadow-xl border border-white/10 backdrop-blur-sm">
-    {docs.filter((doc) => doc.category.includes(tab) || tab === 'all').map((doc) => (
+    {visibleDocs.map((doc) => (
       <FileTag
         name={doc.id}
         key={encodeURIComponent(doc.id)}
@@ -155,7 +198,7 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
       />
     ))}
 
-    {docs.filter((doc) => doc.category.includes(tab) || tab === 'all').length === 0 && (
+    {visibleDocs.length === 0 && (
       <div className="col-span-2 flex flex-col items-center justify-center text-white/70 w-full py-10">
         <div className="text-lg font-medium">No documents found</div>
         {tab === 'custom' && (
@@ -169,14 +212,14 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
   </div>
 </div>
 
-{(tab === 'custom' || tab === 'all') && (
+{(tab === 'custom' || tab === 'assets' || tab === 'all') && (
 <div className="w-full pt-4 flex justify-center">
   <div className="w-[70%]">
     <input
       ref={fileInputRef}
       type="file"
       className="hidden"
-      accept=".adoc,.asciidoc,.html,.htm,.md,.markdown,.csv,.txt,.json,.xml,.tex,.j2,.jinja,.jinja2"
+      accept={tab === "assets" ? assetAccept : tab === "all" ? `${templateAccept},${assetAccept}` : templateAccept}
       onChange={(e) => { onFilesSelected(e.target.files); e.target.value = ""; }}
     />
     <button
@@ -186,7 +229,7 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
       onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true); }}
       onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(false); }}
       onDrop={onDrop}
-      aria-label="Import a custom report template"
+      aria-label="Upload a custom report or asset"
       className={[
         "w-full flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed",
         "px-6 py-8 text-center transition-colors duration-150 cursor-pointer",
@@ -203,10 +246,14 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
         aria-hidden="true"
       />
       <div className="text-base font-medium">
-        {uploading ? "Importing template…" : "Drag & drop a custom template here, or click to browse"}
+        {uploading ? "Uploading file…" : "Drag & drop a custom report or asset here, or click to browse"}
       </div>
       <div className="text-xs text-white/60">
-        Accepted: .adoc, .html, .md, .csv, .txt, .json, .xml, .tex, .j2
+        {tab === "assets"
+          ? "Assets: .png, .jpg, .webp, .gif (SVG is not accepted for upload)"
+          : tab === "custom"
+            ? "Reports: .adoc, .html, .md, .csv, .txt, .json, .xml, .tex, .j2"
+            : "Reports: .adoc, .html, .md, .csv, .txt, .json, .xml, .tex, .j2 · Assets: .png, .jpg, .webp, .gif"}
       </div>
     </button>
     {uploadError && (
@@ -227,6 +274,7 @@ function Exports ({ variantId, projectId }: Readonly<{ variantId?: string; proje
         </button>
       </div>
     )}
+
   </div>
 </div>
 )}

--- a/frontend/tests/unit_tests/test_export_docs.tsx
+++ b/frontend/tests/unit_tests/test_export_docs.tsx
@@ -136,6 +136,25 @@ describe('Exports Page', () => {
         expect(screen.queryByText(/report\.adoc/i)).not.toBeInTheDocument();
     })
 
+    test('keeps custom assets separate from custom reports', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: "report.adoc", category: ['built-in'], extension: "adoc" },
+            { id: "custom.pdf", category: ['custom'], extension: "pdf" }
+        ]));
+
+        const { container } = render(<Exports />);
+        await screen.findByText(/custom\.pdf/i);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Custom assets' }));
+
+        expect(screen.queryByText(/report\.adoc/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/custom\.pdf/i)).not.toBeInTheDocument();
+        expect(screen.getByText('No documents found')).toBeInTheDocument();
+        expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
+        expect(screen.getByText(/Assets: \.png, \.jpg, \.webp, \.gif/i)).toBeInTheDocument();
+    })
+
     test('filters documents by sbom tab', async () => {
         fetchMock.resetMocks();
         fetchMock.mockResponseOnce(JSON.stringify([
@@ -263,5 +282,196 @@ describe('Exports Page', () => {
 
         // Clicking again should close it
         fireEvent.click(fileButton);
+    })
+
+    const uploadInput = (container: HTMLElement): HTMLInputElement =>
+        container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    test('renders one upload dropzone for reports and assets', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        const { container } = render(<Exports />);
+
+        await screen.findByText(/export/i);
+        expect(screen.getByRole('button', { name: /Upload a custom report or asset/i }))
+            .toBeInTheDocument();
+        expect(screen.getByText(/Drag & drop a custom report or asset here, or click to browse/i)).toBeInTheDocument();
+        expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
+    })
+
+    test('routes report uploads through the shared file input', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        const { container } = render(<Exports />);
+        await screen.findByText(/export/i);
+
+        fetchMock.mockResponseOnce(JSON.stringify({ id: 'report.adoc' }));
+        fireEvent.change(uploadInput(container), {
+            target: { files: [new File(['report'], 'report.adoc', { type: 'text/asciidoc' })] }
+        });
+
+        await screen.findByText(/Imported "report\.adoc"/i);
+        const [url] = fetchMock.mock.calls[fetchMock.mock.calls.length - 2];
+        expect(url).toContain('/api/documents/templates');
+    })
+
+    test('uploads an image asset successfully via the file input', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        const { container } = render(<Exports />);
+        await screen.findByText(/export/i);
+
+        fetchMock.mockResponseOnce(JSON.stringify({ name: 'logo.png' }));
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'logo.png', category: ['assets'], extension: 'png' }
+        ]));
+
+        const file = new File(['binary'], 'logo.png', { type: 'image/png' });
+        fireEvent.change(uploadInput(container), { target: { files: [file] } });
+
+        await screen.findByText(/Uploaded "logo\.png"/i);
+    await screen.findByRole('button', { name: /logo\.png/i });
+
+        const [url, options] = fetchMock.mock.calls[1];
+        expect(url).toContain('/api/documents/assets');
+        expect(options?.method).toBe('POST');
+        const body = options?.body as FormData;
+        expect(body.get('file')).toBeInstanceOf(File);
+    })
+
+    test('shows the server error message when asset upload fails', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        const { container } = render(<Exports />);
+        await screen.findByText(/export/i);
+
+        fetchMock.mockResponseOnce(JSON.stringify({ error: 'Invalid file type' }), { status: 400 });
+
+        const file = new File(['data'], 'bad.exe', { type: 'application/octet-stream' });
+        fireEvent.change(uploadInput(container), { target: { files: [file] } });
+
+        await screen.findByRole('alert');
+        expect(screen.getByText('Invalid file type')).toBeInTheDocument();
+    })
+
+    test('shows a generic error message when asset upload fails without a JSON body', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        const { container } = render(<Exports />);
+        await screen.findByText(/export/i);
+
+        fetchMock.mockResponseOnce('', { status: 500 });
+
+        const file = new File(['data'], 'bad.png', { type: 'image/png' });
+        fireEvent.change(uploadInput(container), { target: { files: [file] } });
+
+        await screen.findByText(/Upload failed \(500\)/i);
+    })
+
+    test('shows an error message when asset upload fails due to a network error', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        const { container } = render(<Exports />);
+        await screen.findByText(/export/i);
+
+        fetchMock.mockRejectOnce(new Error('Network down'));
+
+        const file = new File(['data'], 'logo.png', { type: 'image/png' });
+        fireEvent.change(uploadInput(container), { target: { files: [file] } });
+
+        await screen.findByText('Network down');
+    })
+
+    test('shows an uploading state while the asset upload is in progress', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        const { container } = render(<Exports />);
+        await screen.findByText(/export/i);
+
+        let resolveUpload: (response: Response) => void = () => {};
+        fetchMock.mockImplementationOnce(() => new Promise((resolve) => { resolveUpload = resolve; }));
+
+        const file = new File(['binary'], 'logo.png', { type: 'image/png' });
+        fireEvent.change(uploadInput(container), { target: { files: [file] } });
+
+        await screen.findByText(/Uploading file…/i);
+
+        resolveUpload({
+            ok: true,
+            json: () => Promise.resolve({ name: 'logo.png' })
+        } as Response);
+
+        await screen.findByText(/Uploaded "logo\.png"/i);
+    })
+
+    test('dismisses the asset upload success message', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        const { container } = render(<Exports />);
+        await screen.findByText(/export/i);
+
+        fetchMock.mockResponseOnce(JSON.stringify({ name: 'logo.png' }));
+
+        const file = new File(['binary'], 'logo.png', { type: 'image/png' });
+        fireEvent.change(uploadInput(container), { target: { files: [file] } });
+
+        await screen.findByText(/Uploaded "logo\.png"/i);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Dismiss message' }));
+
+        await waitFor(() => {
+            expect(screen.queryByText(/Uploaded "logo\.png"/i)).not.toBeInTheDocument();
+        });
+    })
+
+    test('drag and drop uploads an image asset and toggles the active drag style', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        render(<Exports />);
+        await screen.findByText(/export/i);
+
+        fetchMock.mockResponseOnce(JSON.stringify({ name: 'dropped.png' }));
+
+        const dropzone = screen.getByRole('button', { name: /Upload a custom report or asset/i });
+        const file = new File(['binary'], 'dropped.png', { type: 'image/png' });
+
+        fireEvent.dragEnter(dropzone);
+        expect(dropzone.className).toContain('border-sky-400');
+
+        fireEvent.dragLeave(dropzone);
+        expect(dropzone.className).not.toContain('border-sky-400');
+
+        fireEvent.dragOver(dropzone);
+        expect(dropzone.className).toContain('border-sky-400');
+
+        fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+
+        await screen.findByText(/Uploaded "dropped\.png"/i);
+        expect(dropzone.className).not.toContain('border-sky-400');
+    })
+
+    test('clicking the asset dropzone opens the file browser', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([]));
+
+        render(<Exports />);
+        await screen.findByText(/export/i);
+
+        const clickSpy = jest.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {});
+
+        const dropzone = screen.getByRole('button', { name: /Upload a custom report or asset/i });
+        fireEvent.click(dropzone);
+
+        expect(clickSpy).toHaveBeenCalled();
+        clickSpy.mockRestore();
     })
 });

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,3 +10,4 @@ Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.1.0
 psycopg2-binary==2.9.9
 sbom_cve_check==1.3.1
+Pillow==10.4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,3 +19,4 @@ sphinx==9.1.0
 myst-parser==5.0.0
 sphinx-rtd-theme==3.1.0
 sbom_cve_check==1.3.1
+Pillow==10.4.0

--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -9,6 +9,7 @@ from ..helpers.add_middleware import FlaskWithMiddleware as Flask
 from ..helpers.env_vars import get_bool_env
 from ..extensions import db, migrate, setup_write_serialization
 from ..routes import init_app
+from ..routes.documents import MAX_ASSET_UPLOAD_BYTES
 from .. import models  # noqa: F401
 from .merger_ci import init_app as init_merger_cli, post_treatment
 import sys
@@ -20,6 +21,7 @@ import signal
 MAX_SCRIPT_STEPS = 8
 SCAN_FILE = "/scan/status.txt"
 DEFAULT_DB_URI = "sqlite:////cache/vulnscout/vulnscout.db"
+MAX_UPLOAD_REQUEST_BYTES = MAX_ASSET_UPLOAD_BYTES + 64 * 1024
 
 
 def _launch_enrichment(app):
@@ -85,6 +87,9 @@ def _warm_scan_list_cache(app):
 def create_app():
     app = Flask(__name__, static_folder="../static")
     app.config.from_prefixed_env()
+    # Allow multipart headers while ensuring Werkzeug rejects oversized bodies
+    # before parsing and spooling uploaded files.
+    app.config["MAX_CONTENT_LENGTH"] = MAX_UPLOAD_REQUEST_BYTES
     app._INT_SCAN_FINISHED = False
     if "SCAN_FILE" not in app.config:
         app.config["SCAN_FILE"] = SCAN_FILE

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -111,6 +111,7 @@ Input commands:
   --perform-nvd-scan        Run an NVD CPE-based vulnerability scan
   --perform-osv-scan        Run an OSV PURL-based vulnerability scan
   --perform-sbom-cve-check-scan  Run a sbom-cve-check vulnerability scan
+  --add-asset <path>        Stage an image asset for use in report templates
 
 Scan & output commands:
   --serve                   Run scan then start interactive web UI (port 7275)
@@ -209,6 +210,21 @@ cmd_add_file() {
         cp "$src" "$dest"
         echo "Added $type input: $dest"
     fi
+}
+
+cmd_add_asset() {
+    local src="$1"
+    local dest_name
+    dest_name="$(basename "$src")"
+    dest_name="${dest_name#vulnscout_stage_}"  # strip staging prefix added by the wrapper
+    local ext="${dest_name##*.}"
+    case "$ext" in
+        png|jpg|jpeg|gif|svg|webp) ;;
+        *) echo "Warning: '$dest_name' has an unsupported image extension, skipping." >&2; return 0 ;;
+    esac
+    mkdir -p "/cache/vulnscout/templates/assets"
+    cp "$src" "/cache/vulnscout/templates/assets/$dest_name"
+    echo "Added report asset: /cache/vulnscout/templates/assets/$dest_name" >&2
 }
 
 cmd_add_report_template() {
@@ -706,6 +722,8 @@ while [[ $# -gt 0 ]]; do
             cmd_add_file yocto_vex "$2"; SCAN_REQUIRED=true; shift 2 ;;
         --add-grype)
             cmd_add_file grype "$2"; SCAN_REQUIRED=true; shift 2 ;;
+        --add-asset)
+            cmd_add_asset "$2"; shift 2 ;;
         --perform-grype-scan)
             GRYPE_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --perform-nvd-scan)

--- a/src/routes/documents.py
+++ b/src/routes/documents.py
@@ -1,15 +1,17 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
-from flask import Flask, request, make_response
+from flask import Flask, request, make_response, send_file
 from flask.typing import ResponseReturnValue
+import io
 import json
 import os
 import mimetypes
 import traceback
 from datetime import date
+from PIL import Image
 from ..controllers import ControllersCache
-from ..views.templates import Templates
+from ..views.templates import Templates, find_asset
 from ..views.cyclonedx import CycloneDx
 from ..views.spdx import SPDX
 from ..views.spdx3 import SPDX3
@@ -68,6 +70,108 @@ def writable_templates_dir() -> Optional[str]:
     return None
 
 
+def writable_assets_dir() -> Optional[str]:
+    """Return the first ``<templates>/assets`` directory that is writable."""
+    for candidate in TEMPLATE_UPLOAD_DIRS:
+        assets_candidate = os.path.join(candidate, "assets")
+        try:
+            os.makedirs(assets_candidate, exist_ok=True)
+        except OSError:
+            continue
+        if os.access(assets_candidate, os.W_OK):
+            return assets_candidate
+    return None
+
+
+def list_assets() -> List[Dict[str, object]]:
+    """Return the image assets found in template asset directories.
+
+    Directories follow the same preference order as template loading. An asset
+    with the same name in a higher-priority directory is listed only once.
+    """
+    assets: List[Dict[str, object]] = []
+    seen_names = set()
+    for candidate in TEMPLATE_UPLOAD_DIRS:
+        assets_dir = os.path.join(candidate, "assets")
+        try:
+            names = os.listdir(assets_dir)
+        except OSError:
+            continue
+        for name in sorted(names):
+            path = os.path.join(assets_dir, name)
+            extension = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+            if (
+                name in seen_names
+                or extension not in UPLOADABLE_ASSET_EXTENSIONS
+                or not os.path.isfile(path)
+            ):
+                continue
+            seen_names.add(name)
+            assets.append({"id": name, "extension": extension, "is_template": False, "category": ["assets"]})
+    return assets
+
+
+# Maximum size accepted for an uploaded report image asset. Flask's
+# MAX_CONTENT_LENGTH rejects oversized multipart bodies before parsing; the
+# bounded stream read below is a secondary guard for this per-file limit.
+MAX_ASSET_UPLOAD_BYTES = 5 * 1024 * 1024  # 5 MiB
+
+# Raster formats accepted for *uploads*, mapped to the format name Pillow
+# reports back after decoding. SVG is deliberately excluded here: as XML it
+# can carry <script>, external entity references and other active content
+# that a filename-extension or even a well-formedness check would not catch.
+# (Manually placed SVG assets outside this upload endpoint are unaffected —
+# see ALLOWED_ASSET_EXTENSIONS in views.templates.)
+_UPLOAD_RASTER_FORMATS: Dict[str, str] = {
+    "png": "PNG",
+    "jpg": "JPEG",
+    "jpeg": "JPEG",
+    "gif": "GIF",
+    "webp": "WEBP",
+}
+UPLOADABLE_ASSET_EXTENSIONS = frozenset(_UPLOAD_RASTER_FORMATS)
+
+
+def sanitize_asset_filename(filename: Optional[str]) -> Optional[str]:
+    """Return a safe basename for an uploaded asset, or ``None`` if invalid.
+
+    Only a plain filename with an allowed raster-image extension is accepted.
+    Any directory component or path-traversal sequence is rejected.
+    """
+    name = os.path.basename((filename or "").strip())
+    if not name or name.startswith(".") or ".." in name:
+        return None
+    ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+    if ext not in UPLOADABLE_ASSET_EXTENSIONS:
+        return None
+    return name
+
+
+def validate_raster_image(data: bytes, ext: str) -> bool:
+    """Decode *data* and confirm it is a genuine raster image matching *ext*.
+
+    Trusting a file's declared extension alone lets an attacker persist
+    arbitrary content (or an oversized decompression-bomb-style payload) that
+    is then handed to downstream image/PDF converters. Decoding the pixel
+    data with Pillow's ``verify()`` and cross-checking the detected format
+    against the declared extension ensures only well-formed images of the
+    expected type are accepted.
+    """
+    expected_format = _UPLOAD_RASTER_FORMATS.get(ext)
+    if expected_format is None:
+        return False
+    try:
+        with Image.open(io.BytesIO(data)) as probe:
+            probe.verify()
+        # verify() leaves the file object unusable for further access, so a
+        # fresh handle is needed to read back the detected format safely.
+        with Image.open(io.BytesIO(data)) as probe:
+            probe.load()
+            return probe.format == expected_format
+    except Exception:
+        return False
+
+
 def guess_mime_type(doc_name: Optional[str]) -> Optional[str]:
     if doc_name is None:
         return None
@@ -98,6 +202,7 @@ def init_app(app: Flask) -> None:
             docs.append({"id": "CycloneDX 1.5", "extension": "json", "is_template": False, "category": ["sbom"]})
             docs.append({"id": "CycloneDX 1.6", "extension": "json", "is_template": False, "category": ["sbom"]})
             docs.append({"id": "OpenVex", "extension": "json", "is_template": False, "category": ["sbom"]})
+            docs.extend(list_assets())
 
             for doc in docs:
                 if "extension" not in doc:
@@ -150,6 +255,58 @@ def init_app(app: Flask) -> None:
 
         return {"id": safe_name, "category": ["custom"], "message": "Template imported."}, 201
 
+    @app.route('/api/documents/assets', methods=['POST'])
+    def upload_asset() -> ResponseReturnValue:
+        """Upload an image asset for use in report templates.
+
+        Expects a ``multipart/form-data`` request with a single ``file`` field.
+        Accepted extensions: png, jpg, jpeg, gif, webp (SVG is not accepted
+        through this endpoint, see :data:`UPLOADABLE_ASSET_EXTENSIONS`).
+
+        The upload is capped at :data:`MAX_ASSET_UPLOAD_BYTES` and the decoded
+        content must be a genuine raster image matching the declared
+        extension (see :func:`validate_raster_image`) before it is persisted.
+
+        The file is saved into the first writable
+        ``<templates_dir>/assets/`` directory so :func:`~src.views.templates.find_asset`
+        and :func:`~src.views.templates.embed_image` can locate it at render time.
+        """
+        if not (request.content_type and 'multipart/form-data' in request.content_type):
+            return {"error": "Expected multipart/form-data with a file upload."}, 400
+
+        uploaded = request.files.get('file')
+        if uploaded is None or not uploaded.filename:
+            return {"error": "No file uploaded."}, 400
+
+        safe_name = sanitize_asset_filename(uploaded.filename)
+        if safe_name is None:
+            allowed = ", ".join(sorted(UPLOADABLE_ASSET_EXTENSIONS))
+            return {"error": f"Unsupported image file. Allowed extensions: {allowed}."}, 400
+
+        # MAX_CONTENT_LENGTH bounds multipart parsing and temporary storage.
+        # Keep a per-file bound as a secondary guard for this endpoint.
+        data = uploaded.stream.read(MAX_ASSET_UPLOAD_BYTES + 1)
+        if len(data) > MAX_ASSET_UPLOAD_BYTES:
+            max_mib = MAX_ASSET_UPLOAD_BYTES // (1024 * 1024)
+            return {"error": f"Image exceeds the maximum allowed size of {max_mib} MiB."}, 413
+
+        ext = safe_name.rsplit(".", 1)[-1].lower()
+        if not validate_raster_image(data, ext):
+            return {"error": "Uploaded file is not a valid image matching its extension."}, 400
+
+        target_dir = writable_assets_dir()
+        if target_dir is None:
+            return {"error": "No writable assets directory available on the server."}, 500
+
+        try:
+            with open(os.path.join(target_dir, safe_name), "wb") as f:
+                f.write(data)
+        except OSError as e:
+            print(e, flush=True)
+            return {"error": f"Failed to save asset: {e}"}, 500
+
+        return {"name": safe_name, "message": "Asset uploaded."}, 201
+
     @app.route('/api/documents/<doc_name>', methods=['GET'])
     def doc_by_name(doc_name: str) -> ResponseReturnValue:
         try:
@@ -157,6 +314,16 @@ def init_app(app: Flask) -> None:
             if base_mime is None:
                 return {"error": "Unsupported document type"}, 400
             expected_mime = guess_mime_type(request.args.get("ext")) or base_mime
+
+            asset_path = find_asset(doc_name)
+            if asset_path is not None:
+                return send_file(
+                    asset_path,
+                    mimetype=base_mime,
+                    as_attachment=True,
+                    download_name=doc_name,
+                )
+
             metadata: Dict[str, str | float] = {
                 "author": request.args.get("author") or os.getenv('AUTHOR_NAME', 'Savoir-faire Linux') or '',
                 "client_name": request.args.get("client_name") or os.getenv('CLIENT_NAME', "") or '',

--- a/src/views/templates.py
+++ b/src/views/templates.py
@@ -4,11 +4,12 @@
 from html.parser import HTMLParser
 from html import unescape as html_unescape
 from jinja2 import sandbox, FileSystemLoader, ChoiceLoader
+import base64
+import shutil
 import subprocess
+import tempfile
 import os
-import random
 import re
-import string
 from datetime import datetime, timezone
 from typing import Any, Callable, List, Optional
 from ..models.iso8601_duration import Iso8601Duration
@@ -23,6 +24,101 @@ from ..controllers import (
     ScanController,
     SBOMDocumentController,
 )
+
+# Directories searched for image assets, most-preferred first.
+# The built-in assets directory is appended at runtime (depends on __file__).
+_ASSET_SEARCH_DIRS: List[str] = [
+    "/cache/vulnscout/templates/assets",
+    ".vulnscout/templates/assets",
+    "templates/assets",
+    "/scan/templates/assets",
+]
+
+# Image extensions accepted by find_asset / embed_image.
+ALLOWED_ASSET_EXTENSIONS: frozenset = frozenset({"png", "jpg", "jpeg", "gif", "svg", "webp"})
+
+_MIME_BY_EXT: dict = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "svg": "image/svg+xml",
+    "webp": "image/webp",
+}
+
+
+def _asset_search_dirs() -> List[str]:
+    """Return the ordered list of asset directories, including the built-in one."""
+    builtin = os.path.join(os.path.dirname(__file__), "templates", "assets")
+    return _ASSET_SEARCH_DIRS + [builtin]
+
+
+def find_asset(name: str) -> Optional[str]:
+    """Return the absolute path of a named asset file, or ``None`` if not found.
+
+    Only a plain filename (no directory separators, no ``..``) whose extension
+    is in :data:`ALLOWED_ASSET_EXTENSIONS` is accepted — anything else returns
+    ``None`` without raising.
+    """
+    safe_name = os.path.basename((name or "").strip())
+    if not safe_name or safe_name != name or "/" in name or ".." in name:
+        return None
+    ext = safe_name.rsplit(".", 1)[-1].lower() if "." in safe_name else ""
+    if ext not in ALLOWED_ASSET_EXTENSIONS:
+        return None
+    for directory in _asset_search_dirs():
+        candidate = os.path.join(directory, safe_name)
+        if os.path.isfile(candidate):
+            return os.path.realpath(candidate)
+    return None
+
+
+# Matches AsciiDoc block (``image::``) and inline (``image:``) macro targets,
+# e.g. ``image::logo.png[Alt]`` or ``image:icon.svg[]``. Used to discover
+# which named assets a rendered document actually references so only those
+# (already validated through find_asset) are copied into the sandboxed
+# temporary directory passed to asciidoctor.
+_IMAGE_MACRO_RE = re.compile(r"image::?([^\[\]\s]+)\[")
+
+
+def _referenced_asset_names(adoc: str) -> set[str]:
+    """Return the set of plain asset filenames referenced by image macros in *adoc*."""
+    names: set[str] = set()
+    for match in _IMAGE_MACRO_RE.finditer(adoc):
+        target = match.group(1)
+        if target.startswith("data:"):
+            continue  # already an inlined data URI (e.g. from embed_image)
+        names.add(os.path.basename(target))
+    return names
+
+
+def embed_image(name: str, width: Optional[int] = None, alt: str = "") -> str:
+    """Return an AsciiDoc block image macro with the image inlined as a base64 data URI.
+
+    If the asset cannot be resolved an empty string is returned so callers may
+    use ``{% if embed_image(...) %}`` guards without raising errors.
+
+    The emitted syntax is self-contained in every asciidoctor output format
+    (raw adoc, HTML, PDF) — no ``imagesdir`` or safe-mode setting is required.
+
+    Example usage in a Jinja template::
+
+        {{ embed_image("logo.png", width=150, alt="Company Logo") }}
+    """
+    path = find_asset(name)
+    if path is None:
+        return ""
+    ext = name.rsplit(".", 1)[-1].lower()
+    mime = _MIME_BY_EXT.get(ext, "application/octet-stream")
+    try:
+        with open(path, "rb") as fh:
+            b64 = base64.b64encode(fh.read()).decode("ascii")
+    except OSError:
+        return ""
+    attrs = alt
+    if width is not None:
+        attrs = f"{alt},{width}"
+    return f"image::data:{mime};base64,{b64}[{attrs}]"
 
 
 class Templates:
@@ -55,6 +151,8 @@ class Templates:
             autoescape=False
         )
         self.env.globals['env'] = TemplatesExtensions.get_env_var
+        self.env.globals['embed_image'] = embed_image
+        self.env.globals['find_asset'] = find_asset
         self.extensions = TemplatesExtensions(self.env)
 
     def render(self, template_name, **kwargs):
@@ -222,31 +320,70 @@ class Templates:
         return template.render(**kwargs)
 
     def _run_asciidoctor(self, adoc: str, command: list[str], output_ext: str) -> bytes:
-        """Run an asciidoctor command on *adoc* text and return the converted bytes."""
-        random_name = ''.join(random.choices(string.ascii_lowercase, k=8))
-        adoc_path = f"{random_name}.adoc"
-        output_path = f"{random_name}.{output_ext}"
+        """Run an asciidoctor command on *adoc* text and return the converted bytes.
 
-        with open(adoc_path, "w+") as f:
-            f.write(adoc)
+        The conversion runs inside a freshly created temporary directory so the
+        working directory is always predictable.  Extra attributes are injected
+        automatically:
 
-        execution = subprocess.run(command + [adoc_path], capture_output=True)
-        if execution.returncode != 0:
-            print(execution.stdout)
-            print(execution.stderr)
-            try:
-                if os.path.exists(adoc_path):
-                    os.remove(adoc_path)
-                if os.path.exists(output_path):
-                    os.remove(output_path)
-            finally:
-                raise RuntimeError(f"Error converting adoc to {output_ext}: asciidoctor returned non-zero exit code")
+        * ``-S safe`` with ``-B <tmp_dir>`` — restricts asciidoctor to reading
+          files from within the temporary directory only. Combined with
+          copying only the resolved, referenced assets into that directory
+          (see :func:`_referenced_asset_names`), this prevents directives such
+          as ``include::/etc/passwd[]`` from disclosing arbitrary server
+          files while still allowing legitimate template assets to resolve.
+        * ``-a imagesdir=<path>`` — set to the copied assets directory so
+          native ``image::name.png[]`` macros resolve without a full path.
+        * ``-a data-uri`` (HTML only) — inlines resolved images as base64 data
+          URIs, making the HTML file self-contained.
 
-        with open(output_path, "rb") as f:
-            result = f.read()
-        os.remove(adoc_path)
-        os.remove(output_path)
-        return result
+        The primary :func:`embed_image` Jinja global already emits data-URI
+        macros directly in the AsciiDoc source, so these attributes are a
+        secondary aid for template authors who prefer native image macros.
+        """
+        tmp_dir = tempfile.mkdtemp(prefix="vulnscout_adoc_")
+        try:
+            adoc_path = os.path.join(tmp_dir, "report.adoc")
+            output_path = os.path.join(tmp_dir, f"report.{output_ext}")
+
+            # Copy only the specific assets the document actually references
+            # (resolved through the existing find_asset allow-list, which
+            # already rejects path traversal and disallowed extensions) into
+            # a directory inside tmp_dir. Asciidoctor never needs to read
+            # from the real assets directories directly.
+            images_dir = os.path.join(tmp_dir, "assets")
+            os.makedirs(images_dir, exist_ok=True)
+            for name in _referenced_asset_names(adoc):
+                resolved = find_asset(name)
+                if resolved is not None:
+                    try:
+                        shutil.copyfile(resolved, os.path.join(images_dir, name))
+                    except OSError:
+                        pass
+
+            extra: list[str] = [
+                "-S", "safe",
+                "-B", tmp_dir,
+                "-a", f"imagesdir={images_dir}",
+            ]
+            if output_ext == "html":
+                extra += ["-a", "data-uri"]
+
+            with open(adoc_path, "w+") as f:
+                f.write(adoc)
+
+            execution = subprocess.run(command + extra + [adoc_path], capture_output=True)
+            if execution.returncode != 0:
+                print(execution.stdout)
+                print(execution.stderr)
+                raise RuntimeError(
+                    f"Error converting adoc to {output_ext}: asciidoctor returned non-zero exit code"
+                )
+
+            with open(output_path, "rb") as f:
+                return f.read()
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
     def adoc_to_pdf(self, adoc: str) -> bytes:
         return self._run_asciidoctor(adoc, ["asciidoctor-pdf"], "pdf")

--- a/tests/unit_tests/test_templates.py
+++ b/tests/unit_tests/test_templates.py
@@ -3,9 +3,11 @@
 # Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
+import base64
+import os
 import pytest
 from unittest.mock import MagicMock, patch, mock_open
-from src.views.templates import Templates, TemplatesExtensions
+from src.views.templates import Templates, TemplatesExtensions, find_asset, embed_image, ALLOWED_ASSET_EXTENSIONS
 from src.models.package import Package
 from src.models.vulnerability import Vulnerability
 from src.models.assessment import Assessment
@@ -127,12 +129,10 @@ class TestAdocToPdfErrors:
     """Test error handling in adoc_to_pdf method"""
 
     @patch('subprocess.run')
+    @patch('shutil.rmtree')
     @patch('builtins.open', new_callable=mock_open)
-    @patch('os.remove')
-    @patch('os.path.exists', return_value=True)
-    def test_adoc_to_pdf_subprocess_failure(self, mock_exists, mock_remove, mock_file, mock_subprocess, templates_instance):
-        """Test adoc_to_pdf when subprocess returns non-zero exit code (lines 104-110)"""
-        # Mock subprocess to return non-zero exit code
+    def test_adoc_to_pdf_subprocess_failure(self, mock_file, mock_rmtree, mock_subprocess, templates_instance):
+        """Test adoc_to_pdf when subprocess returns non-zero exit code."""
         mock_result = MagicMock()
         mock_result.returncode = 1
         mock_result.stdout = b"stdout output"
@@ -142,68 +142,55 @@ class TestAdocToPdfErrors:
         with pytest.raises(Exception, match="Error converting adoc to pdf"):
             templates_instance.adoc_to_pdf("= Test Document")
 
-        # Verify cleanup was attempted
-        assert mock_remove.called
+        # Temp directory must be cleaned up even on failure
+        assert mock_rmtree.called
 
     @patch('subprocess.run')
     @patch('builtins.open', new_callable=mock_open)
-    @patch('os.remove')
-    def test_adoc_to_pdf_success(self, mock_remove, mock_file, mock_subprocess, templates_instance):
-        """Test successful adoc_to_pdf conversion"""
-        # Mock subprocess to return success
+    def test_adoc_to_pdf_success(self, mock_file, mock_subprocess, templates_instance):
+        """Test successful adoc_to_pdf conversion."""
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_subprocess.return_value = mock_result
 
-        # Mock reading the PDF file
         mock_file.return_value.read.return_value = b"PDF content"
 
         result = templates_instance.adoc_to_pdf("= Test Document")
         assert result == b"PDF content"
-        assert mock_remove.call_count == 2  # Should remove both .adoc and .pdf files
 
 
 class TestAdocToHtmlErrors:
     """Test error handling in adoc_to_html method"""
 
     @patch('subprocess.run')
+    @patch('shutil.rmtree')
     @patch('builtins.open', new_callable=mock_open)
-    @patch('os.remove')
-    @patch('os.path.exists')
-    def test_adoc_to_html_subprocess_failure(self, mock_exists, mock_remove, mock_file, mock_subprocess, templates_instance):
-        """Test adoc_to_html when subprocess returns non-zero exit code (lines 128-136)"""
-        # Mock subprocess to return non-zero exit code
+    def test_adoc_to_html_subprocess_failure(self, mock_file, mock_rmtree, mock_subprocess, templates_instance):
+        """Test adoc_to_html when subprocess returns non-zero exit code."""
         mock_result = MagicMock()
         mock_result.returncode = 1
         mock_result.stdout = b"stdout output"
         mock_result.stderr = b"stderr output"
         mock_subprocess.return_value = mock_result
 
-        # Mock that both files exist for cleanup
-        mock_exists.return_value = True
-
         with pytest.raises(Exception, match="Error converting adoc to html"):
             templates_instance.adoc_to_html("= Test Document")
 
-        # Verify cleanup was attempted
-        assert mock_remove.called
+        # Temp directory must be cleaned up even on failure
+        assert mock_rmtree.called
 
     @patch('subprocess.run')
     @patch('builtins.open', new_callable=mock_open)
-    @patch('os.remove')
-    def test_adoc_to_html_success(self, mock_remove, mock_file, mock_subprocess, templates_instance):
-        """Test successful adoc_to_html conversion"""
-        # Mock subprocess to return success
+    def test_adoc_to_html_success(self, mock_file, mock_subprocess, templates_instance):
+        """Test successful adoc_to_html conversion."""
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_subprocess.return_value = mock_result
 
-        # Mock reading the HTML file
         mock_file.return_value.read.return_value = b"HTML content"
 
         result = templates_instance.adoc_to_html("= Test Document")
         assert result == b"HTML content"
-        assert mock_remove.call_count == 2  # Should remove both .adoc and .html files
 
 
 class TestListDocumentsError:
@@ -553,3 +540,232 @@ class TestEscapeAdoc:
                 assert line.startswith("\u200b"), (
                     f"AsciiDoc fence not neutralised: {line!r}"
                 )
+# find_asset — path safety and extension filtering
+# ---------------------------------------------------------------------------
+
+class TestFindAsset:
+    def test_returns_none_for_missing_file(self, tmp_path):
+        with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(tmp_path)]):
+            assert find_asset("logo.png") is None
+
+    def test_returns_path_when_file_exists(self, tmp_path):
+        img = tmp_path / "logo.png"
+        img.write_bytes(b"\x89PNG")
+        with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(tmp_path)]):
+            result = find_asset("logo.png")
+            assert result is not None
+            assert result.endswith("logo.png")
+
+    def test_rejects_path_traversal(self, tmp_path):
+        assert find_asset("../etc/passwd") is None
+        assert find_asset("../../secret.png") is None
+
+    def test_rejects_directory_separator(self, tmp_path):
+        assert find_asset("subdir/logo.png") is None
+
+    def test_rejects_disallowed_extension(self, tmp_path):
+        assert find_asset("script.js") is None
+        assert find_asset("shell.sh") is None
+
+    def test_rejects_empty_and_none(self):
+        assert find_asset("") is None  # type: ignore[arg-type]
+
+    def test_all_allowed_extensions_accepted(self, tmp_path):
+        for ext in ALLOWED_ASSET_EXTENSIONS:
+            fname = f"asset.{ext}"
+            (tmp_path / fname).write_bytes(b"data")
+            with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(tmp_path)]):
+                assert find_asset(fname) is not None, f"Expected {ext} to be allowed"
+
+    def test_searches_dirs_in_order(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        (dir_b / "logo.png").write_bytes(b"from_b")
+        with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(dir_a), str(dir_b)]):
+            result = find_asset("logo.png")
+            assert result is not None
+            assert os.path.realpath(str(dir_b / "logo.png")) == result
+
+
+# ---------------------------------------------------------------------------
+# embed_image — data-URI generation
+# ---------------------------------------------------------------------------
+
+class TestEmbedImage:
+    def test_returns_empty_string_when_asset_missing(self, tmp_path):
+        with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(tmp_path)]):
+            assert embed_image("logo.png") == ""
+
+    def test_returns_data_uri_macro_for_png(self, tmp_path):
+        img_bytes = b"\x89PNG\r\n\x1a\n"
+        (tmp_path / "logo.png").write_bytes(img_bytes)
+        with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(tmp_path)]):
+            result = embed_image("logo.png")
+        expected_b64 = base64.b64encode(img_bytes).decode("ascii")
+        assert result.startswith("image::data:image/png;base64,")
+        assert expected_b64 in result
+
+    def test_includes_alt_text(self, tmp_path):
+        (tmp_path / "logo.svg").write_bytes(b"<svg/>")
+        with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(tmp_path)]):
+            result = embed_image("logo.svg", alt="My Logo")
+        assert "[My Logo]" in result
+
+    def test_includes_width(self, tmp_path):
+        (tmp_path / "logo.jpg").write_bytes(b"\xff\xd8\xff")
+        with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(tmp_path)]):
+            result = embed_image("logo.jpg", width=150)
+        assert ",150]" in result
+
+    def test_correct_mime_for_each_extension(self, tmp_path):
+        cases = {
+            "img.png": "image/png",
+            "img.jpg": "image/jpeg",
+            "img.jpeg": "image/jpeg",
+            "img.gif": "image/gif",
+            "img.svg": "image/svg+xml",
+            "img.webp": "image/webp",
+        }
+        for fname, expected_mime in cases.items():
+            (tmp_path / fname).write_bytes(b"data")
+            with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(tmp_path)]):
+                result = embed_image(fname)
+            assert expected_mime in result, f"Expected {expected_mime} in output for {fname}"
+
+    def test_embed_image_registered_as_jinja_global(self, templates_instance):
+        assert "embed_image" in templates_instance.env.globals
+        assert templates_instance.env.globals["embed_image"] is embed_image
+
+    def test_find_asset_registered_as_jinja_global(self, templates_instance):
+        assert "find_asset" in templates_instance.env.globals
+        assert templates_instance.env.globals["find_asset"] is find_asset
+
+
+# ---------------------------------------------------------------------------
+# _run_asciidoctor — stable tempdir, attributes, cleanup
+# ---------------------------------------------------------------------------
+
+class TestRunAsciidoctor:
+    def _make_subprocess_mock(self, returncode: int = 0, output: bytes = b"result") -> MagicMock:
+        mock_proc = MagicMock()
+        mock_proc.returncode = returncode
+        mock_proc.stdout = b""
+        mock_proc.stderr = b""
+        return mock_proc
+
+    @patch("subprocess.run")
+    @patch("shutil.rmtree")
+    @patch("tempfile.mkdtemp", return_value="/tmp/vulnscout_adoc_test")
+    def test_uses_tempdir_not_cwd(self, mock_mkdtemp, mock_rmtree, mock_run, templates_instance, tmp_path):
+        mock_run.return_value = self._make_subprocess_mock()
+        adoc_path = "/tmp/vulnscout_adoc_test/report.adoc"
+        output_path = "/tmp/vulnscout_adoc_test/report.pdf"
+
+        with patch("builtins.open", mock_open(read_data=b"PDF")):
+            with patch("os.path.isdir", return_value=True):
+                try:
+                    templates_instance.adoc_to_pdf("= Test")
+                except Exception:
+                    pass  # file reading may fail in mock context
+
+        # The .adoc file must be inside the temp dir, not CWD
+        call_args = mock_run.call_args[0][0]
+        assert any("/tmp/vulnscout_adoc_test" in str(a) for a in call_args)
+
+    @patch("subprocess.run")
+    def test_passes_safe_mode_and_imagesdir(self, mock_run, templates_instance, tmp_path):
+        """``-S safe`` (never ``unsafe``) and ``-a imagesdir`` must be in the asciidoctor call."""
+        mock_run.return_value = self._make_subprocess_mock()
+        assets = tmp_path / "assets"
+        assets.mkdir()
+
+        with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(assets)]):
+            with patch("builtins.open", mock_open(read_data=b"PDF")):
+                try:
+                    templates_instance.adoc_to_pdf("= Test")
+                except Exception:
+                    pass
+
+        call_args = mock_run.call_args[0][0]
+        joined = " ".join(str(a) for a in call_args)
+        assert "-S" in joined and "safe" in joined
+        assert "unsafe" not in joined
+        assert "imagesdir" in joined
+
+    @patch("subprocess.run")
+    @patch("shutil.rmtree")
+    def test_referenced_assets_copied_into_tempdir(self, mock_rmtree, mock_run, templates_instance, tmp_path):
+        """Only assets referenced by an image macro are copied into the sandboxed tempdir."""
+        mock_run.return_value = self._make_subprocess_mock()
+        assets = tmp_path / "assets"
+        assets.mkdir()
+        (assets / "logo.png").write_bytes(b"PNGDATA")
+        (assets / "unused.png").write_bytes(b"PNGDATA")
+
+        with patch("src.views.templates._ASSET_SEARCH_DIRS", [str(assets)]):
+            try:
+                templates_instance.adoc_to_pdf("image::logo.png[Logo]")
+            except Exception:
+                pass  # the real asciidoctor binary is not actually invoked
+
+        call_args = [str(a) for a in mock_run.call_args[0][0]]
+        imagesdir_value = next(a for a in call_args if a.startswith("imagesdir=")).split("=", 1)[1]
+        assert os.path.isfile(os.path.join(imagesdir_value, "logo.png"))
+        assert not os.path.isfile(os.path.join(imagesdir_value, "unused.png"))
+
+    @patch("subprocess.run")
+    def test_base_dir_restricted_to_tempdir(self, mock_run, templates_instance):
+        """``-B`` must point at the temporary directory, not the real filesystem root."""
+        mock_run.return_value = self._make_subprocess_mock()
+
+        with patch("builtins.open", mock_open(read_data=b"PDF")):
+            try:
+                templates_instance.adoc_to_pdf("= Test")
+            except Exception:
+                pass
+
+        call_args = [str(a) for a in mock_run.call_args[0][0]]
+        assert "-B" in call_args
+        base_dir = call_args[call_args.index("-B") + 1]
+        assert "vulnscout_adoc_" in base_dir
+
+    @patch("subprocess.run")
+    def test_html_gets_data_uri_attribute(self, mock_run, templates_instance, tmp_path):
+        """HTML conversions must include -a data-uri; PDF must not."""
+        mock_run.return_value = self._make_subprocess_mock()
+
+        with patch("builtins.open", mock_open(read_data=b"HTML")):
+            try:
+                templates_instance.adoc_to_html("= Test")
+            except Exception:
+                pass
+
+        call_args_html = " ".join(str(a) for a in mock_run.call_args[0][0])
+        assert "data-uri" in call_args_html
+
+    @patch("subprocess.run")
+    def test_pdf_does_not_get_data_uri(self, mock_run, templates_instance, tmp_path):
+        mock_run.return_value = self._make_subprocess_mock()
+
+        with patch("builtins.open", mock_open(read_data=b"PDF")):
+            try:
+                templates_instance.adoc_to_pdf("= Test")
+            except Exception:
+                pass
+
+        call_args_pdf = " ".join(str(a) for a in mock_run.call_args[0][0])
+        assert "data-uri" not in call_args_pdf
+
+    @patch("subprocess.run")
+    @patch("shutil.rmtree")
+    def test_tempdir_cleaned_up_on_error(self, mock_rmtree, mock_run, templates_instance):
+        """shutil.rmtree must be called even when asciidoctor fails."""
+        mock_run.return_value = self._make_subprocess_mock(returncode=1)
+
+        with patch("builtins.open", mock_open()):
+            with pytest.raises(RuntimeError):
+                templates_instance.adoc_to_pdf("= Bad")
+
+        assert mock_rmtree.called

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -9,6 +9,24 @@ from src.bin.webapp import create_app
 from . import write_demo_files, setup_demo_db
 
 
+def _make_png_bytes() -> bytes:
+    """Return the raw bytes of a genuine, tiny, valid 1x1 PNG image."""
+    from io import BytesIO
+    from PIL import Image
+    buf = BytesIO()
+    Image.new("RGB", (1, 1), color=(255, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_jpeg_bytes() -> bytes:
+    """Return the raw bytes of a genuine, tiny, valid 1x1 JPEG image."""
+    from io import BytesIO
+    from PIL import Image
+    buf = BytesIO()
+    Image.new("RGB", (1, 1), color=(0, 255, 0)).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
 @pytest.fixture()
 def init_files(tmp_path):
     files = {
@@ -494,3 +512,171 @@ def test_upload_template_missing_file(client):
     )
     assert response.status_code == 400
     assert json.loads(response.data)["error"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/documents/assets
+# ---------------------------------------------------------------------------
+
+def test_upload_asset_success(tmp_path, monkeypatch, client):
+    """POST /api/documents/assets saves a valid image and returns 201."""
+    from io import BytesIO
+    monkeypatch.setattr("src.routes.documents.TEMPLATE_UPLOAD_DIRS", [str(tmp_path)])
+    monkeypatch.setattr("src.views.templates._ASSET_SEARCH_DIRS", [str(tmp_path / "assets")])
+
+    png_bytes = _make_png_bytes()
+    response = client.post(
+        "/api/documents/assets",
+        data={"file": (BytesIO(png_bytes), "logo.png")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 201
+    data = json.loads(response.data)
+    assert data["name"] == "logo.png"
+    saved = tmp_path / "assets" / "logo.png"
+    assert saved.exists()
+    assert saved.read_bytes() == png_bytes
+
+    documents = client.get("/api/documents")
+    assert documents.status_code == 200
+    assets = [item for item in json.loads(documents.data) if item["id"] == "logo.png"]
+    assert assets == [{"id": "logo.png", "extension": "png", "is_template": False, "category": ["assets"]}]
+
+    download = client.get("/api/documents/logo.png?ext=png")
+    assert download.status_code == 200
+    assert download.data == png_bytes
+    assert download.headers["Content-Type"] == "image/png"
+    assert "attachment; filename=logo.png" in download.headers["Content-Disposition"]
+
+
+def test_upload_asset_rejects_bad_extension(tmp_path, monkeypatch, client):
+    """POST /api/documents/assets rejects non-image extensions with 400."""
+    from io import BytesIO
+    monkeypatch.setattr("src.routes.documents.TEMPLATE_UPLOAD_DIRS", [str(tmp_path)])
+
+    response = client.post(
+        "/api/documents/assets",
+        data={"file": (BytesIO(b"script"), "evil.js")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    error = json.loads(response.data)["error"]
+    assert error
+    assert not (tmp_path / "assets" / "evil.js").exists()
+
+
+def test_upload_asset_rejects_svg(tmp_path, monkeypatch, client):
+    """POST /api/documents/assets rejects SVG uploads (excluded to avoid active content)."""
+    from io import BytesIO
+    monkeypatch.setattr("src.routes.documents.TEMPLATE_UPLOAD_DIRS", [str(tmp_path)])
+
+    svg_bytes = b"<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>"
+    response = client.post(
+        "/api/documents/assets",
+        data={"file": (BytesIO(svg_bytes), "logo.svg")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert json.loads(response.data)["error"]
+    assert not (tmp_path / "assets" / "logo.svg").exists()
+
+
+def test_upload_asset_rejects_content_extension_mismatch(tmp_path, monkeypatch, client):
+    """POST /api/documents/assets rejects a file whose decoded format doesn't match its extension."""
+    from io import BytesIO
+    monkeypatch.setattr("src.routes.documents.TEMPLATE_UPLOAD_DIRS", [str(tmp_path)])
+
+    # A genuine JPEG renamed with a .png extension must be rejected: the
+    # declared extension is trusted only after the decoded content confirms it.
+    jpeg_bytes = _make_jpeg_bytes()
+    response = client.post(
+        "/api/documents/assets",
+        data={"file": (BytesIO(jpeg_bytes), "logo.png")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert json.loads(response.data)["error"]
+    assert not (tmp_path / "assets" / "logo.png").exists()
+
+
+def test_upload_asset_rejects_non_image_content(tmp_path, monkeypatch, client):
+    """POST /api/documents/assets rejects a file with an image extension but non-image bytes."""
+    from io import BytesIO
+    monkeypatch.setattr("src.routes.documents.TEMPLATE_UPLOAD_DIRS", [str(tmp_path)])
+
+    response = client.post(
+        "/api/documents/assets",
+        data={"file": (BytesIO(b"not actually an image"), "fake.png")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert json.loads(response.data)["error"]
+    assert not (tmp_path / "assets" / "fake.png").exists()
+
+
+def test_upload_asset_rejects_oversized_upload(tmp_path, monkeypatch, client):
+    """POST /api/documents/assets rejects a file bigger than the configured size cap."""
+    from io import BytesIO
+    import src.routes.documents as documents_module
+    monkeypatch.setattr("src.routes.documents.TEMPLATE_UPLOAD_DIRS", [str(tmp_path)])
+    monkeypatch.setattr(documents_module, "MAX_ASSET_UPLOAD_BYTES", 16)
+
+    response = client.post(
+        "/api/documents/assets",
+        data={"file": (BytesIO(_make_png_bytes()), "logo.png")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 413
+    assert json.loads(response.data)["error"]
+    assert not (tmp_path / "assets" / "logo.png").exists()
+
+
+def test_upload_asset_rejects_request_larger_than_content_limit(app, client):
+    """Werkzeug rejects oversized multipart bodies before the route parses files."""
+    request_limit = app.config["MAX_CONTENT_LENGTH"]
+    response = client.post(
+        "/api/documents/assets",
+        data=b"x" * (request_limit + 1),
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 413
+
+
+def test_upload_asset_rejects_path_traversal(tmp_path, monkeypatch, client):
+    """POST /api/documents/assets strips directory components from the filename."""
+    from io import BytesIO
+    monkeypatch.setattr("src.routes.documents.TEMPLATE_UPLOAD_DIRS", [str(tmp_path)])
+
+    png_bytes = _make_png_bytes()
+    response = client.post(
+        "/api/documents/assets",
+        data={"file": (BytesIO(png_bytes), "../../escape.png")},
+        content_type="multipart/form-data",
+    )
+    # basename keeps "escape.png" and it must not leave the assets directory.
+    assert response.status_code == 201
+    data = json.loads(response.data)
+    assert data["name"] == "escape.png"
+    assert (tmp_path / "assets" / "escape.png").exists()
+    assert not (tmp_path.parent.parent / "escape.png").exists()
+
+
+def test_upload_asset_missing_file(client):
+    """POST /api/documents/assets without a file returns 400."""
+    response = client.post(
+        "/api/documents/assets",
+        data={},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 400
+    assert json.loads(response.data)["error"]
+
+
+def test_upload_asset_no_multipart(client):
+    """POST /api/documents/assets without multipart content type returns 400."""
+    response = client.post(
+        "/api/documents/assets",
+        data=b"\x89PNG",
+        content_type="application/octet-stream",
+    )
+    assert response.status_code == 400

--- a/vulnscout
+++ b/vulnscout
@@ -74,6 +74,7 @@ Scan & output commands:
   --serve                         Run scan then start web UI (port 7275)
   --report <template>             Generate a report from a template
   --report <path>                 Stage a local report template file and generate a report from it
+  --add-asset <path>              Stage a local image asset for use in report templates
   --export-spdx                   Export project as SPDX 3.0 SBOM
   --export-cdx                    Export project as CycloneDX 1.6 SBOM
   --export-openvex                Export project as OpenVEX document
@@ -319,6 +320,8 @@ parse_and_run() {
                 MATCH_CONDITION="$2"; shift 2 ;;
             add-spdx|--add-spdx|add-cve-check|--add-cve-check|add-yocto-vex|--add-yocto-vex|add-openvex|--add-openvex|add-cdx|--add-cdx|add-grype|--add-grype)
                 ensure_running; add_input "${1#--}" "$2"; shift 2 ;;
+            add-asset|--add-asset)
+                ensure_running; add_input add-asset "$2"; shift 2 ;;
             perform-grype-scan|--perform-grype-scan)
                 ensure_running; PENDING_ARGS+=(--perform-grype-scan); shift ;;
             perform-nvd-scan|--perform-nvd-scan)


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

Allow users to add image assets to their reports. Images are converted to base64 which means they are self-contained, once report is generated you don't need to include the image with the output file.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

**Add the image inside a report template**

A template must reference any added image by filename to make it appear in the output.

* Option A — `embed_image()`
```jinja
{{ embed_image("logo.png") }}                          {# basic #}
{{ embed_image("logo.png", width=150, alt="Company Logo") }}  {# sized + alt #}
```

* Option B — native `image::` macro

Reference the bare filename; at conversion time VulnScout injects `-S unsafe`, `-a imagesdir=<assets-dir>`, and (HTML only) `-a data-uri`:

```asciidoc
image::logo.png[Company Logo,150]
```

**CLI**

```bash
./vulnscout --report summary.adoc --add-asset ./logo.png
```

**Web dashboard**
1. Open the Export tab in the web UI.
2. Drag / click-to-browse an image onto the "Drag & drop a logo or image" area.
4. Upload a non-image and confirm the error banner shows the server message.
5. Generate a report and confirm the uploaded logo appears.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


