### PR TITLE
Add searchable Packages filter to vulnerabilities table

### DIFF
--- a/frontend/src/components/FilterOption.tsx
+++ b/frontend/src/components/FilterOption.tsx
@@ -12,13 +12,27 @@ type Props = {
     customFilterName?: string;
     showCustomFilterComponent?: boolean;
     setShowCustomFilterComponent?: (show: boolean) => void;
+    /** Render a search input at the top of the dropdown to narrow the option list */
+    searchable?: boolean;
+    /** Format an option value for display; checkbox values stay raw */
+    formatLabel?: (value: string) => string;
 };
 
-function FilterOption({ label, options, selected, setSelected, parentRef, CustomFilterComponent, customFilterName = 'custom', showCustomFilterComponent, setShowCustomFilterComponent }: Readonly<Props>) {
+function FilterOption({ label, options, selected, setSelected, parentRef, CustomFilterComponent, customFilterName = 'custom', showCustomFilterComponent, setShowCustomFilterComponent, searchable = false, formatLabel }: Readonly<Props>) {
     const [isOpen, setIsOpen] = useState(false);
     const [maxHeight, setMaxHeight] = useState<string>('500px'); 
+    const [optionSearch, setOptionSearch] = useState('');
     const dropdownRef = useRef<HTMLDivElement>(null);
     const isActive = selected.length > 0 || showCustomFilterComponent;
+
+    const displayLabel = (value: string) => formatLabel ? formatLabel(value) : value;
+
+    const visibleOptions = searchable && optionSearch.trim() !== ''
+        ? options.filter(option => {
+            const needle = optionSearch.trim().toLowerCase();
+            return option.toLowerCase().includes(needle) || displayLabel(option).toLowerCase().includes(needle);
+        })
+        : options;
 
     const toggleOption = (value: string) => {
         if (selected.includes(value)) {
@@ -53,6 +67,11 @@ function FilterOption({ label, options, selected, setSelected, parentRef, Custom
         }
     }, [parentRef, isOpen]);
 
+    // Reset the option search whenever the dropdown closes
+    useEffect(() => {
+        if (!isOpen) setOptionSearch('');
+    }, [isOpen]);
+
     return (
         <div ref={dropdownRef} className="ml-4 relative inline-block text-left">
             <button
@@ -69,11 +88,21 @@ function FilterOption({ label, options, selected, setSelected, parentRef, Custom
 
             {isOpen && (
                 <div 
-                    className="absolute mt-1 w-48 bg-sky-900 text-white border border-sky-800 rounded-md shadow-lg z-50"
+                    className={`absolute mt-1 ${searchable ? 'w-72' : 'w-48'} bg-sky-900 text-white border border-sky-800 rounded-md shadow-lg z-50`}
                     style={{ maxHeight, overflowY: 'auto' }} // <-- dynamic max-height
                 >
                     <div className="p-2 space-y-1">
-                        {options.map(option => (
+                        {searchable && (
+                            <input
+                                type="search"
+                                value={optionSearch}
+                                onChange={(event) => setOptionSearch(event.target.value)}
+                                placeholder={`Search ${label.toLowerCase()}...`}
+                                aria-label={`Search ${label.toLowerCase()}`}
+                                className="w-full mb-1 py-1 px-2 rounded bg-sky-800 focus:bg-sky-950 placeholder-gray-400 text-sm"
+                            />
+                        )}
+                        {visibleOptions.map(option => (
                             <label key={option} className="flex items-center space-x-2">
                                 <input
                                     type="checkbox"
@@ -84,9 +113,12 @@ function FilterOption({ label, options, selected, setSelected, parentRef, Custom
                                     }}
                                     className="form-checkbox text-sky-500 bg-sky-800 border-sky-600 focus:ring-0"
                                 />
-                                <span>{option}</span>
+                                <span>{displayLabel(option)}</span>
                             </label>
                         ))}
+                        {searchable && visibleOptions.length === 0 && (
+                            <span className="text-xs text-gray-400 italic">No match found</span>
+                        )}
                         {CustomFilterComponent && 
                             <label key={`custom-filter-${customFilterName}`} className="flex items-center space-x-2">
                                 <input

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -71,7 +71,7 @@ function useRefreshProgressEffect(
     }, [progress, onRefreshComplete]);
 }
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes, faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
+import { faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
 import RangeSlider from "../components/RangeSlider";
 
 type Props = {
@@ -613,6 +613,22 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
     const setSelectedVariants = useCallback((values: string[]) => {
         setDeselectedVariants(variants_list.filter(v => !values.includes(v)));
     }, [variants_list]);
+
+    // Distinct raw package ids across all vulnerabilities, sorted by display label.
+    // Currently selected packages are always included so a stale or absent
+    // preselection (e.g. from filterValue) can still be unchecked by the user.
+    const packages_list = useMemo(() => {
+        const pkgSet = new Set<string>();
+        vulnerabilities.forEach(vuln => {
+            vuln.packages_current.forEach(pkg => {
+                if (pkg !== '') pkgSet.add(pkg);
+            });
+        });
+        selectedPackages.forEach(pkg => {
+            if (pkg !== '') pkgSet.add(pkg);
+        });
+        return Array.from(pkgSet).sort((a, b) => formatPkgId(a).localeCompare(formatPkgId(b)));
+    }, [vulnerabilities, selectedPackages]);
 
     const handleEditClick = useCallback((vuln: Vulnerability) => {
         const index = searchFilteredData.findIndex(v => v.id === vuln.id);
@@ -1437,6 +1453,15 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 setSelected={setSelectedStatuses}
             />
 
+            <FilterOption
+                label="Packages"
+                options={packages_list}
+                selected={selectedPackages}
+                setSelected={setSelectedPackages}
+                searchable
+                formatLabel={formatPkgId}
+            />
+
             {variants_list.length > 0 && (
                 <FilterOption
                     label="Variants"
@@ -1575,20 +1600,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, appe
                 )}
             </div>
 
-            {/* Package indicator (no dropdown, just display) */}
-            {selectedPackages.length > 0 && (
-                <div className="flex items-center gap-1 bg-sky-900 px-2 py-1 rounded text-white border border-sky-700">
-                    <span className="font-semibold">Package:</span>
-                    <span>{selectedPackages.join(', ')}</span>
-                    <button
-                        className="ml-1 text-white hover:text-red-400"
-                        title="Clear package filter"
-                        onClick={() => setSelectedPackages([])}
-                    >
-                        <FontAwesomeIcon icon={faTimes} />
-                    </button>
-                </div>
-            )}
+            {/* Package selection is handled by the Packages filter dropdown above */}
 
             <div className="ml-auto flex items-center gap-2 relative">
                 <button

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -1014,6 +1014,91 @@ describe('Vulnerability Table', () => {
         });
     })
 
+    test('filter by packages dropdown', async () => {
+        // ARRANGE
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const user = userEvent.setup();
+        const packagesBtn = await screen.getByRole('button', { name: /^packages$/i });
+        expect(packagesBtn).toBeInTheDocument();
+        await user.click(packagesBtn);
+
+        // All packages from the vulnerabilities are listed as options
+        const pkgCheckbox = await screen.getByRole('checkbox', { name: 'aaabbbccc@1.0.0' });
+        expect(await screen.getByRole('checkbox', { name: 'xxxyyyzzz@2.0.0' })).toBeInTheDocument();
+        expect(await screen.getByRole('checkbox', { name: 'linux-yocto@6.6.21' })).toBeInTheDocument();
+
+        // ACT - Select one package
+        await user.click(pkgCheckbox);
+
+        // ASSERT - Only the vulnerability affecting that package remains
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).toBeNull();
+            expect(screen.queryByRole('cell', {name: /CVE-2024-56730/})).toBeNull();
+        }, { timeout: 5000 });
+
+        expect(await screen.getByRole('cell', {name: /CVE-2010-1234/})).toBeInTheDocument();
+    })
+
+    test('search inside packages filter narrows options', async () => {
+        // ARRANGE
+        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const user = userEvent.setup();
+        const packagesBtn = await screen.getByRole('button', { name: /^packages$/i });
+        await user.click(packagesBtn);
+
+        // ACT - Search inside the dropdown
+        const pkgSearch = await screen.getByRole('searchbox', { name: /search packages/i });
+        await user.type(pkgSearch, 'linux');
+
+        // ASSERT - Only matching package options are shown
+        expect(await screen.getByRole('checkbox', { name: 'linux-yocto@6.6.21' })).toBeInTheDocument();
+        expect(screen.queryByRole('checkbox', { name: 'aaabbbccc@1.0.0' })).toBeNull();
+        expect(screen.queryByRole('checkbox', { name: 'xxxyyyzzz@2.0.0' })).toBeNull();
+
+        // No-match search shows an empty-state message
+        await user.clear(pkgSearch);
+        await user.type(pkgSearch, 'does-not-exist');
+        expect(await screen.findByText(/no match found/i)).toBeInTheDocument();
+        expect(screen.queryByRole('checkbox', { name: 'linux-yocto@6.6.21' })).toBeNull();
+    })
+
+    test('package from SBOM table show vulnerabilities is pre-checked', async () => {
+        // ARRANGE - Same props the SBOM table handoff produces (raw package id)
+        render(
+            <TableVulnerabilities
+                vulnerabilities={vulnerabilities}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
+                filterLabel="Package"
+                filterValue="xxxyyyzzz@2.0.0"
+            />
+        );
+
+        const user = userEvent.setup();
+
+        // ASSERT - Table is filtered to the vulnerability of that package
+        await waitFor(() => {
+            expect(screen.getByRole('cell', {name: /CVE-2018-5678/})).toBeInTheDocument();
+            expect(screen.queryByRole('cell', {name: /CVE-2010-1234/})).not.toBeInTheDocument();
+        });
+
+        // ASSERT - The package is checked inside the Packages filter dropdown
+        const packagesBtn = await screen.getByRole('button', { name: /^packages$/i });
+        await user.click(packagesBtn);
+        const pkgCheckbox = await screen.getByRole('checkbox', { name: 'xxxyyyzzz@2.0.0' });
+        expect(pkgCheckbox).toBeChecked();
+        expect(screen.getByRole('checkbox', { name: 'aaabbbccc@1.0.0' })).not.toBeChecked();
+
+        // Unchecking it restores the full table
+        await user.click(pkgCheckbox);
+        await waitFor(() => {
+            expect(screen.getByRole('cell', {name: /CVE-2010-1234/})).toBeInTheDocument();
+        });
+    })
+
     test('multiple source selection works', async () => {
         // ARRANGE
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
@@ -2931,7 +3016,7 @@ describe('Status helper, banner close, package filter, modal navigation, first s
         }
     });
 
-    test('package filter indicator shown when filterLabel is Package', async () => {
+    test('packages filter dropdown reflects active Package filter prop', async () => {
         render(
             <TableVulnerabilities
                 vulnerabilities={vulnerabilities}
@@ -2943,15 +3028,20 @@ describe('Status helper, banner close, package filter, modal navigation, first s
             />
         );
 
-        // Package indicator label should be visible
-        const packageLabel = await screen.findByText('Package:');
-        expect(packageLabel).toBeInTheDocument();
+        // Table is filtered down to the package's vulnerability
+        await waitFor(() => {
+            expect(screen.getByRole('cell', {name: /CVE-2010-1234/})).toBeInTheDocument();
+            expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).not.toBeInTheDocument();
+        });
 
-        // The filter value appears in the indicator badge (may also appear in table cells)
-        expect(screen.getAllByText('aaabbbccc@1.0.0').length).toBeGreaterThan(0);
+        // The Packages dropdown shows the package as checked
+        const user = userEvent.setup();
+        const packagesBtn = await screen.getByRole('button', { name: /^packages$/i });
+        await user.click(packagesBtn);
+        expect(screen.getByRole('checkbox', { name: 'aaabbbccc@1.0.0' })).toBeChecked();
     });
 
-    test('package filter indicator clear button removes the filter', async () => {
+    test('unchecking package in dropdown removes the filter', async () => {
         render(
             <TableVulnerabilities
                 vulnerabilities={vulnerabilities}
@@ -2964,14 +3054,18 @@ describe('Status helper, banner close, package filter, modal navigation, first s
         );
 
         const user = userEvent.setup();
-        await screen.findByText('Package:');
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).not.toBeInTheDocument();
+        });
 
-        // Click the times/clear button next to the package filter
-        const clearBtn = screen.getByTitle(/clear package filter/i);
-        await user.click(clearBtn);
+        // Uncheck the package inside the Packages dropdown
+        const packagesBtn = await screen.getByRole('button', { name: /^packages$/i });
+        await user.click(packagesBtn);
+        const pkgCheckbox = screen.getByRole('checkbox', { name: 'aaabbbccc@1.0.0' });
+        await user.click(pkgCheckbox);
 
         await waitFor(() => {
-            expect(screen.queryByText('Package:')).not.toBeInTheDocument();
+            expect(screen.getByRole('cell', {name: /CVE-2018-5678/})).toBeInTheDocument();
         });
     });
 


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Add searchable Packages filter to vulnerabilities table

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Open the web dashboard and go to the Vulnerabilities tab
2. Find the Package filter, select some packages, perform search on them.
3. Go to SBOM tab, pick a package and observe that it's selected in the Package filter

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


