### PR TITLE
Transfer: multiple source-target modes

### DIFF
--- a/frontend/src/pages/Transfer.tsx
+++ b/frontend/src/pages/Transfer.tsx
@@ -217,7 +217,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                                     disabled={!customProjectId}
                                 >
                                     <option value="">— select a variant —</option>
-                                    {customProjectVariants.map((v) => (
+                                    {customProjectVariants.filter((v) => v.id !== copySourceId).map((v) => (
                                         <option key={v.id} value={v.id}>{v.name}</option>
                                     ))}
                                 </select>

--- a/frontend/src/pages/Transfer.tsx
+++ b/frontend/src/pages/Transfer.tsx
@@ -26,6 +26,8 @@ type Props = {
     onDataChanged?: (message?: string) => void;
 };
 
+type CopyRoute = "within" | "between";
+
 function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
     // ---- Unmount guard for async operations ----
     const unmountedRef = useRef(false);
@@ -39,9 +41,10 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
 
     // ---- Copy Custom Assessments state ----
     const [customProjectVariants, setCustomProjectVariants] = useState<Variant[]>([]);
+    const [copyRoute, setCopyRoute] = useState<CopyRoute>("within");
     const [copySourceId, setCopySourceId] = useState<string>("");
     const [copyTargetId, setCopyTargetId] = useState<string>("");
-    const [copyMatchMode, setCopyMatchMode] = useState<CopyMatchMode>("exact");
+    const [copyMatchMode, setCopyMatchMode] = useState<CopyMatchMode>("ignore_version");
     const [copyVersionPrecision, setCopyVersionPrecision] = useState<number>(1);
     const [copyCondition, setCopyCondition] = useState<CopyCondition>("no_custom");
     const [copyBusy, setCopyBusy] = useState(false);
@@ -53,11 +56,15 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
     const [copyReviewOpen, setCopyReviewOpen] = useState(false);
     const [copyReviewGroups, setCopyReviewGroups] = useState<CopyAssessmentsPreviewGroup[]>([]);
     const [reviewKey, setReviewKey] = useState(0);
+    const copyWithinVariant = copyRoute === "within";
+    const copySelectionReady = Boolean(
+        copySourceId && copyTargetId && (copyWithinVariant || copySourceId !== copyTargetId)
+    );
 
     // ---- Handlers ----
     const handleCopyFromReview = async (selections: CopyAssessmentsSelection[]) => {
         setCopyReviewOpen(false);
-        if (!copySourceId || !copyTargetId || copyBusy) return;
+        if (!copySelectionReady || copyBusy) return;
         setCopyBusy(true);
         setCopyMsg(null);
         try {
@@ -126,7 +133,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
     }, [customProjectId]);
 
     useEffect(() => {
-        if (!customProjectId || !copySourceId || !copyTargetId || copySourceId === copyTargetId) {
+        if (!customProjectId || !copySelectionReady) {
             setCopyPreview(null);
             setCopyPreviewError(null);
             setCopyPreviewUnavailableMsg(null);
@@ -161,7 +168,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
             });
 
         return () => { cancelled = true; };
-    }, [customProjectId, copySourceId, copyTargetId, copyMatchMode, copyVersionPrecision, copyCondition]);
+    }, [customProjectId, copySelectionReady, copySourceId, copyTargetId, copyMatchMode, copyVersionPrecision, copyCondition]);
 
     // ---- Styles ----
     const inputClass =
@@ -191,7 +198,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                     </div>
                     <div className={cardBody + " space-y-4"}>
                         <p className="text-sm text-zinc-400">
-                            Copy custom assessments from a source variant to a target variant in the selected project.
+                            Copy custom assessments between matching packages within a variant or across two variants.
                         </p>
 
                         {!customProjectId && (
@@ -200,36 +207,59 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                             </p>
                         )}
 
-                        {/* ---- Source / Target selectors ---- */}
-                        <div className="relative space-y-3">
+                        <div className="space-y-2">
+                            <p className="text-sm font-semibold text-zinc-300">I want to copy…</p>
+                            <div className="grid grid-cols-1 gap-2">
+                                {([
+                                    { value: "within", label: "Within the same variant", desc: "Copy assessments from previous package versions within a variant." },
+                                    { value: "between", label: "Between two variants", desc: "Copy assessments from a source variant to a target variant." },
+                                ] as { value: CopyRoute; label: string; desc: string }[]).map(({ value, label, desc }) => (
+                                    <label
+                                        key={value}
+                                        className={[
+                                            "flex items-start gap-2 rounded-lg border px-3 py-2 cursor-pointer transition-colors",
+                                            copyRoute === value
+                                                ? "border-cyan-500 bg-cyan-950/40 text-white"
+                                                : "border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500",
+                                            (!customProjectId || copyBusy) ? "opacity-50 cursor-not-allowed" : "",
+                                        ].join(" ")}
+                                    >
+                                        <input
+                                            type="radio"
+                                            name="copy-route"
+                                            value={value}
+                                            checked={copyRoute === value}
+                                            disabled={!customProjectId || copyBusy}
+                                            onChange={() => {
+                                                setCopyRoute(value);
+                                                setCopySourceId("");
+                                                setCopyTargetId("");
+                                                setCopyMatchMode(value === "within" ? "ignore_version" : "exact");
+                                                setCopyVersionPrecision(1);
+                                                setCopyMsg(null);
+                                                setCopyPreview(null);
+                                                setCopyPreviewError(null);
+                                                setCopyPreviewUnavailableMsg(null);
+                                            }}
+                                            className="mt-0.5 accent-cyan-500"
+                                        />
+                                        <span className="flex flex-col">
+                                            <span className="text-sm font-medium">{label}</span>
+                                            <span className="text-xs text-zinc-400">{desc}</span>
+                                        </span>
+                                    </label>
+                                ))}
+                            </div>
+                        </div>
+
+                        {copyWithinVariant ? (
                             <div className="space-y-2">
-                                <label htmlFor="copy-source-select" className="block text-sm text-zinc-300 font-semibold">Source</label>
+                                <label htmlFor="copy-variant-select" className="block text-sm text-zinc-300 font-semibold">Variant</label>
                                 <select
-                                    id="copy-source-select"
+                                    id="copy-variant-select"
                                     value={copySourceId}
                                     onChange={(e) => {
                                         setCopySourceId(e.target.value);
-                                        setCopyMsg(null);
-                                        setCopyPreviewError(null);
-                                        setCopyPreviewUnavailableMsg(null);
-                                    }}
-                                    className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
-                                    disabled={!customProjectId}
-                                >
-                                    <option value="">— select a variant —</option>
-                                    {customProjectVariants.filter((v) => v.id !== copySourceId).map((v) => (
-                                        <option key={v.id} value={v.id}>{v.name}</option>
-                                    ))}
-                                </select>
-                            </div>
-                            {/* Spacer that reserves room for the absolutely-centered Swap button */}
-                            <div className="h-9" aria-hidden="true" />
-                            <div className="space-y-2">
-                                <label htmlFor="copy-target-select" className="block text-sm text-zinc-300 font-semibold">Target</label>
-                                <select
-                                    id="copy-target-select"
-                                    value={copyTargetId}
-                                    onChange={(e) => {
                                         setCopyTargetId(e.target.value);
                                         setCopyMsg(null);
                                         setCopyPreviewError(null);
@@ -244,25 +274,69 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                                     ))}
                                 </select>
                             </div>
-                            <button
-                                type="button"
-                                onClick={() => {
-                                    if (!customProjectId || copyBusy) return;
-                                    setCopySourceId(copyTargetId);
-                                    setCopyTargetId(copySourceId);
-                                    setCopyMsg(null);
-                                    setCopyPreviewError(null);
-                                    setCopyPreviewUnavailableMsg(null);
-                                }}
-                                disabled={!customProjectId || copyBusy || !copySourceId || !copyTargetId}
-                                className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
-                                title="Swap source and target variants"
-                                aria-label="Swap source and target variants"
-                            >
-                                <FontAwesomeIcon icon={faArrowsUpDown} className="mr-2" aria-hidden="true" />
-                                Swap
-                            </button>
-                        </div>
+                        ) : (
+                            <div className="relative space-y-3">
+                                <div className="space-y-2">
+                                    <label htmlFor="copy-source-select" className="block text-sm text-zinc-300 font-semibold">Source</label>
+                                    <select
+                                        id="copy-source-select"
+                                        value={copySourceId}
+                                        onChange={(e) => {
+                                            setCopySourceId(e.target.value);
+                                            setCopyMsg(null);
+                                            setCopyPreviewError(null);
+                                            setCopyPreviewUnavailableMsg(null);
+                                        }}
+                                        className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
+                                        disabled={!customProjectId}
+                                    >
+                                        <option value="">— select a variant —</option>
+                                        {customProjectVariants.filter((v) => v.id !== copyTargetId).map((v) => (
+                                            <option key={v.id} value={v.id}>{v.name}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div className="h-9" aria-hidden="true" />
+                                <div className="space-y-2">
+                                    <label htmlFor="copy-target-select" className="block text-sm text-zinc-300 font-semibold">Target</label>
+                                    <select
+                                        id="copy-target-select"
+                                        value={copyTargetId}
+                                        onChange={(e) => {
+                                            setCopyTargetId(e.target.value);
+                                            setCopyMsg(null);
+                                            setCopyPreviewError(null);
+                                            setCopyPreviewUnavailableMsg(null);
+                                        }}
+                                        className={selectClass + " disabled:opacity-50 disabled:cursor-not-allowed"}
+                                        disabled={!customProjectId}
+                                    >
+                                        <option value="">— select a variant —</option>
+                                        {customProjectVariants.filter((v) => v.id !== copySourceId).map((v) => (
+                                            <option key={v.id} value={v.id}>{v.name}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        if (!customProjectId || copyBusy) return;
+                                        setCopySourceId(copyTargetId);
+                                        setCopyTargetId(copySourceId);
+                                        setCopyMsg(null);
+                                        setCopyPreviewError(null);
+                                        setCopyPreviewUnavailableMsg(null);
+                                    }}
+                                    disabled={!customProjectId || copyBusy || !copySourceId || !copyTargetId}
+                                    className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 px-3 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150"
+                                    title="Swap source and target variants"
+                                    aria-label="Swap source and target variants"
+                                >
+                                    <FontAwesomeIcon icon={faArrowsUpDown} className="mr-2" aria-hidden="true" />
+                                    Swap
+                                </button>
+                            </div>
+                        )}
 
                         {/* ---- Copy condition ---- */}
                         <div className="space-y-2">
@@ -315,7 +389,9 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                                     { value: "ignore_minor_version", precision: 2, label: "Same Major and Minor Versions", desc: "Major and minor must match; patch may differ (e.g. 6.5.1 \u2192 6.5.9)" },
                                     { value: "ignore_minor_version", precision: 1, label: "Same Major Versions",           desc: "Major must match; minor and patch may differ (e.g. 6.5.1 \u2192 6.9.0)" },
                                     { value: "ignore_version",       precision: 1, label: "Any Versions",                  desc: "Same name; version is ignored (e.g. 6.5.1 \u2192 7.0.0)" },
-                                ] as { value: CopyMatchMode; precision: number; label: string; desc: string }[]).map(({ value, precision, label, desc }) => {
+                                ] as { value: CopyMatchMode; precision: number; label: string; desc: string }[])
+                                    .filter(({ value }) => !copyWithinVariant || value !== "exact")
+                                    .map(({ value, precision, label, desc }) => {
                                     const selected = copyMatchMode === value && (value === "ignore_minor_version" ? copyVersionPrecision === precision : true);
                                     return (
                                     <label
@@ -380,8 +456,7 @@ function Transfer({ projectId, onDataChanged }: Readonly<Props>) {
                         <button
                                 onClick={handleOpenReview}
                                 disabled={
-                                    !customProjectId || !copySourceId || !copyTargetId ||
-                                    copySourceId === copyTargetId || copyBusy ||
+                                    !customProjectId || !copySelectionReady || copyBusy ||
                                     copyPreviewBusy || !!copyPreviewError || !!copyPreviewUnavailableMsg || !copyPreview
                                 }
                                 className={btnPrimary}

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -491,9 +491,6 @@ def init_app(app: Flask) -> None:
             return None, err
         target_uuid = cast(uuid.UUID, target_uuid)
 
-        if source_uuid == target_uuid:
-            return None, (jsonify({"error": "Source and target variants must be different."}), 400)
-
         source = VariantController.get(source_id)
         target = VariantController.get(target_id)
         if source is None or target is None:
@@ -546,6 +543,8 @@ def init_app(app: Flask) -> None:
                     continue
                 # Exact mode: same package_id → same Finding row shared across variants
                 target_finding = source_finding
+                if source_uuid == target_uuid:
+                    continue
                 # Only propose the copy if this vulnerability is actually part of
                 # the target variant's pool (observed in its active scans).
                 if target_finding.id not in target_observed_finding_ids:
@@ -631,6 +630,8 @@ def init_app(app: Flask) -> None:
             candidates = []
 
             for tf in potential_targets:
+                if source_uuid == target_uuid and tf.id == source_finding.id:
+                    continue
                 if source_pkg is None or tf.package is None:
                     continue
                 if source_pkg.name != tf.package.name:
@@ -893,6 +894,7 @@ def init_app(app: Flask) -> None:
                     src_finding = assessment.finding
                     if (
                         src_finding is None
+                        or (source_uuid == target_uuid and tgt_finding.id == src_finding.id)
                         or tgt_finding.vulnerability_id != src_finding.vulnerability_id
                     ):
                         continue

--- a/tests/webapp_tests/test_settings_endpoints.py
+++ b/tests/webapp_tests/test_settings_endpoints.py
@@ -386,6 +386,83 @@ class TestCopyCustomAssessments:
         assert len(group["candidates"]) == 1
         assert group["candidates"][0]["target_package"] == "openssl@3.0.0"
 
+    def test_copy_assessments_preview_within_variant_excludes_source_finding(self, app, client):
+        from src.extensions import db
+        from src.models.assessment import Assessment
+        from src.models.finding import Finding
+        from src.models.observation import Observation
+        from src.models.package import Package
+        from src.models.project import Project
+        from src.models.scan import Scan
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.variant import Variant
+        from src.models.vulnerability import Vulnerability
+
+        with app.app_context():
+            project = Project.create("WithinVariantProject")
+            variant = Variant.create("WithinVariant", project.id)
+            scan = Scan.create("within variant sbom", variant.id, scan_type="sbom")
+            source_pkg = Package.find_or_create("openssl", "1.1.1")
+            target_pkg = Package.find_or_create("openssl", "3.0.0")
+            vuln = Vulnerability.create_record(id="CVE-WITHIN-0001", description="Copy within")
+            db.session.commit()
+
+            source_finding = Finding.get_or_create(source_pkg.id, vuln.id)
+            target_finding = Finding.get_or_create(target_pkg.id, vuln.id)
+            document = SBOMDocument.create("/tmp/within.spdx.json", "spdx", scan.id)
+            SBOMPackage.create(document.id, source_pkg.id)
+            SBOMPackage.create(document.id, target_pkg.id)
+            Observation.create(source_finding.id, scan.id)
+            Observation.create(target_finding.id, scan.id)
+            Assessment.create(
+                status="affected",
+                origin="custom",
+                finding_id=source_finding.id,
+                variant_id=variant.id,
+                source="manual",
+            )
+            db.session.commit()
+            variant_id = str(variant.id)
+            source_finding_id = str(source_finding.id)
+            target_finding_id = str(target_finding.id)
+
+        resp = client.post(
+            "/api/variants/copy-assessments/preview",
+            json={
+                "source_variant_id": variant_id,
+                "target_variant_id": variant_id,
+                "match_mode": "ignore_version",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["count"] == 1
+        assert len(data["groups"]) == 1
+        candidates = data["groups"][0]["candidates"]
+        assert [candidate["target_finding_id"] for candidate in candidates] == [target_finding_id]
+        assert source_finding_id not in [candidate["target_finding_id"] for candidate in candidates]
+
+        copy_resp = client.post(
+            "/api/variants/copy-assessments",
+            json={
+                "source_variant_id": variant_id,
+                "target_variant_id": variant_id,
+                "match_mode": "ignore_version",
+                "selections": [{
+                    "source_assessment_id": data["groups"][0]["source_assessment_id"],
+                    "target_finding_id": target_finding_id,
+                }],
+            },
+        )
+
+        assert copy_resp.status_code == 200
+        assert copy_resp.get_json()["copied"] == 1
+        with app.app_context():
+            copied = Assessment.get_by_finding_and_variant(target_finding_id, variant_id)
+            assert any(assessment.origin == "custom" for assessment in copied)
+
     def test_copy_assessments_skips_vuln_not_in_target_pool(self, app, client):
         """A vuln whose target finding is not observed in the target's scans
         (not in the target's vulnerability pool) must not be offered for copy."""
@@ -1377,15 +1454,6 @@ class TestCopyAssessmentsValidation:
             json={"source_variant_id": str(uuid.uuid4()), "target_variant_id": "not-a-uuid"},
         )
         assert resp.status_code == 400
-
-    def test_same_source_and_target_variant(self, client):
-        vid = str(uuid.uuid4())
-        resp = client.post(
-            "/api/variants/copy-assessments",
-            json={"source_variant_id": vid, "target_variant_id": vid},
-        )
-        assert resp.status_code == 400
-        assert "different" in resp.get_json()["error"].lower()
 
     def test_variant_not_found(self, client):
         resp = client.post(


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

1. Adding a reflexive option to copy within the same variant, we will have:
- Copy to a different variant
- Copy within the same variant

2. Fix the bug where it showed the source variant in the target list

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open the web dashboard, go to the Transfer tab then use the new "I want to copy…" selector

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


