### PR TITLE
Block assessment on non-existent packages

### DIFF
--- a/.github/skills/cve-assessment/SKILL.md
+++ b/.github/skills/cve-assessment/SKILL.md
@@ -437,7 +437,7 @@ If, after a successful `vulnscout-write_assessment` call (or a confirmed `vulnsc
 | Parameter | Source | Notes |
 |---|---|---|
 | `vuln_id` | CVE/GHSA ID | e.g., `CVE-2021-23337` |
-| `packages` | Phase 2: component + version | Array: `["<component-name>@<installed-version>"]` |
+| `packages` | Phase 2: component + version | Array: `["<component-name>@<installed-version>"]`. **The package must already exist in VulnScout** — `write_assessment` is rejected (no package is created) if it does not. Use the exact component name/version known to the target variant; do not invent one. |
 | `status` | Phase 3.5 confidence gate + `strict_mode` | One of: `affected`, `fixed`, `not_affected`, `under_investigation`; MEDIUM confidence yields a determined status unless `strict_mode = true`; LOW always yields `under_investigation` |
 | `variant_id` | Phase -1 `resolved_variant_id` | **Required.** UUID from Tier 1 MCP response or prompt-provided UUID. If unresolved, abort submission (see Prerequisites) |
 | `status_notes` | Phase 4/3.5 composed value | 1-2 sentences; always provided |
@@ -470,7 +470,7 @@ If, after a successful `vulnscout-write_assessment` call (or a confirmed `vulnsc
 | `WebFetch` | Retrieve NVD page, GitHub advisory | Fetch `https://nvd.nist.gov/vuln/detail/CVE-2021-23337` |
 | `Read` / `Grep` / `Glob` | Read package manifests, lock files, recipe files, or any platform-specific artifact inventory | Platform context determines exact files |
 | `vulnscout-has_ai_assessment` | Check for an existing AI assessment before writing (dedup) | Call with `vuln_id` and `variant_id` before Phase 5 write |
-| `vulnscout-write_assessment` | Submit the completed assessment via MCP | Call with `vuln_id`, `packages`, `status`, `variant_id`, `status_notes`, etc. |
+| `vulnscout-write_assessment` | Submit the completed assessment via MCP | Call with `vuln_id`, `packages`, `status`, `variant_id`, `status_notes`, etc. **Rejected if a referenced package does not already exist in VulnScout** (no package is created); if any package is missing the whole call is blocked and nothing is written. |
 | `vulnscout-update_ai_assessment` | Revise an existing **AI-generated** assessment (only `status`/`status_notes`/`justification`/`impact_statement`/`workaround` — not `vuln_id`/`packages`/`variant_id`) | Call with `assessment_id` when a dedup mismatch is confirmed by the caller, or when the caller gives corrective feedback about an assessment this run just submitted (before the run ends) |
 
 ### Recommended Tool Sequence
@@ -590,6 +590,7 @@ Before completing a CVE assessment, verify:
 - ✅ `vulnscout-has_ai_assessment` checked before writing; matching existing AI assessment → skip write and report it
 - ✅ **If the existing AI assessment's status/finding differs from the new one, caller was asked for confirmation before calling `vulnscout-update_ai_assessment`; if declined, write was skipped and the existing assessment reported unchanged**
 - ✅ `vulnscout-write_assessment` called with correct `vuln_id`, `packages` (name@version), `status`, and `variant_id`
+- ✅ **Each package in `packages` already exists in VulnScout (exact name@version known to the target variant) — a missing package causes the whole write to be rejected with no package created**
 - ✅ **`assessment_id` retained after a successful `vulnscout-write_assessment` call, for possible in-run revision**
 - ✅ **Any post-submission correction requested before the run ends used `vulnscout-update_ai_assessment` with the retained/confirmed `assessment_id` — not a duplicate `vulnscout-write_assessment` call**
 - ✅ `status_notes` is concise (1-2 sentences)

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -51,13 +51,15 @@ def _is_scanner_author(author: str | None) -> bool:
     return False
 
 
-def _resolve_package(pkg_string_id: str) -> "Package":
-    """Parse 'name@version::supplier' and look up or create the Package record."""
-    _parts = pkg_string_id.split("::", 1)
-    _base = _parts[0]
-    _supplier = _parts[1] if len(_parts) > 1 else ""
-    name, version = _base.rsplit("@", 1) if "@" in _base else (_base, "")
-    return Package.find_or_create(name, version, supplier=_supplier)
+def _resolve_package(pkg_string_id: str) -> "Package | None":
+    """Look up an existing Package for 'name@version::supplier'.
+
+    Returns ``None`` when no matching package exists. Writing an assessment must
+    never create a package, so callers block the write when this returns
+    ``None``. Matching is on name + version + supplier (with the same supplier
+    normalization used by :meth:`Package.find_or_create`).
+    """
+    return Package.get_by_string_id(pkg_string_id)
 
 
 def _create_assessment_record(
@@ -741,12 +743,27 @@ def init_app(app: Flask) -> None:
         # across multiple requests); fall back to server time.
         from datetime import datetime as _dt, timezone as _tz
         shared_timestamp = getattr(assessment, 'timestamp', None) or _dt.now(_tz.utc)
+
+        # Resolve every package up front. Assessments must never create a
+        # package: if any referenced package is missing, block the whole request.
+        resolved_packages: list[Package] = []
+        missing_packages: list[str] = []
+        for pkg_string_id in (assessment.packages or []):
+            db_pkg = _resolve_package(pkg_string_id)
+            if db_pkg is None:
+                missing_packages.append(pkg_string_id)
+            else:
+                resolved_packages.append(db_pkg)
+        if missing_packages:
+            return {
+                "error": "Package not found: " + ", ".join(missing_packages)
+                + ". Assessments can only be written for existing packages."
+            }, 400
+
         created = []
         try:
             with batch_session():
-                for pkg_string_id in (assessment.packages or []):
-                    # find_or_create handles both lookup and creation in one query
-                    db_pkg = _resolve_package(pkg_string_id)
+                for db_pkg in resolved_packages:
                     # Ensure vulnerability record exists before creating Finding (FK constraint)
                     DBVuln.get_or_create(vuln_id)
                     finding = Finding.get_or_create(db_pkg.id, vuln_id)
@@ -809,13 +826,32 @@ def init_app(app: Flask) -> None:
                 if not pkg_list:
                     errors.append({"vuln_id": vuln_id, "error": "No valid package found"})
                     continue
+
+                # Assessments must never create a package. Resolve every package
+                # for this item up front; if any is missing, reject the whole
+                # item (other items in the batch are unaffected).
+                item_packages: list[Package] = []
+                item_missing: list[str] = []
                 for pkg_string_id in pkg_list:
-                    try:
-                        # Resolve package from cache first, then DB
-                        db_pkg = pkg_cache.get(pkg_string_id)
-                        if db_pkg is None:
-                            db_pkg = _resolve_package(pkg_string_id)
+                    db_pkg = pkg_cache.get(pkg_string_id)
+                    if db_pkg is None:
+                        db_pkg = _resolve_package(pkg_string_id)
+                        if db_pkg is not None:
                             pkg_cache[pkg_string_id] = db_pkg
+                    if db_pkg is None:
+                        item_missing.append(pkg_string_id)
+                    else:
+                        item_packages.append(db_pkg)
+                if item_missing:
+                    errors.append({
+                        "vuln_id": vuln_id,
+                        "error": "Package not found: " + ", ".join(item_missing)
+                        + ". Assessments can only be written for existing packages.",
+                    })
+                    continue
+
+                for db_pkg in item_packages:
+                    try:
                         # Ensure vulnerability record exists before creating Finding (FK constraint)
                         DBVuln.get_or_create(vuln_id)
                         # Resolve finding from cache first, then DB

--- a/tests/webapp_tests/__init__.py
+++ b/tests/webapp_tests/__init__.py
@@ -8,8 +8,13 @@ import uuid
 from datetime import datetime, timezone
 
 
-def setup_demo_db(app):
-    """Create all DB tables and insert demo data into the test in-memory DB."""
+def setup_demo_db(app, extra_packages=None):
+    """Create all DB tables and insert demo data into the test in-memory DB.
+
+    *extra_packages* is an optional list of ``"name@version"`` strings to seed as
+    standalone packages. Assessment-write endpoints refuse to create packages,
+    so tests that post assessments for arbitrary package names must seed them.
+    """
     from src.extensions import db
     from src.models.package import Package
     from src.models.vulnerability import Vulnerability
@@ -26,6 +31,11 @@ def setup_demo_db(app):
     with app.app_context():
         db.drop_all()
         db.create_all()
+
+        for pkg_str in (extra_packages or []):
+            _name, _sep, _version = pkg_str.partition("@")
+            Package.find_or_create(_name, _version if _sep else "")
+        db.session.commit()
 
         # Demo package: cairo 1.16.0
         pkg = Package.find_or_create(

--- a/tests/webapp_tests/test_ai_assessments.py
+++ b/tests/webapp_tests/test_ai_assessments.py
@@ -48,7 +48,7 @@ def app(init_files):
             "OPENVEX_FILE": init_files["openvex"],
             "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
         })
-        setup_demo_db(application)
+        setup_demo_db(application, extra_packages=["abc@1.2.3"])
         yield application
     finally:
         os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)

--- a/tests/webapp_tests/test_assessments_coverage.py
+++ b/tests/webapp_tests/test_assessments_coverage.py
@@ -35,7 +35,7 @@ def app(init_files):
             "OPENVEX_FILE": init_files["openvex"],
             "NVD_DB_PATH": "webapp_tests/mini_nvd.db"
         })
-        setup_demo_db(application)
+        setup_demo_db(application, extra_packages=["test@1.0.0", "pkg@1.0.0", "pkg1@1.0.0", "pkg2@2.0.0", "pkg3@3.0.0"])
         yield application
     finally:
         os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)

--- a/tests/webapp_tests/test_post_endpoints.py
+++ b/tests/webapp_tests/test_post_endpoints.py
@@ -56,7 +56,7 @@ def runner(app):
 
 def test_post_minimal_assessment(client):
     response = client.post("/api/vulnerabilities/CVE-1999-12345/assessments", json={
-        'packages': ['abc@1.2.3', 'cairo@1.16.0'],
+        'packages': ['cairo@1.16.0'],
         'status': 'exploitable',
         'workaround': 'Disable option X in configuration',
         'variant_id': '22222222-2222-2222-2222-222222222222',
@@ -67,7 +67,7 @@ def test_post_minimal_assessment(client):
     assert response.status_code == 200
     data = json.loads(response.data)
     data_str = response.get_data(as_text=True)
-    assert len(data) == 3
+    assert len(data) == 2
     assert "CVE-1999-12345" in data_str
     assert "Disable option X in configuration" in data_str
 
@@ -75,7 +75,7 @@ def test_post_minimal_assessment(client):
 def test_post_detailled_assessment(client):
     response = client.post("/api/vulnerabilities/CVE-1999-12345/assessments", json={
         'vuln_id': 'CVE-1999-12345',
-        'packages': ['abc@1.2.3', 'cairo@1.16.0'],
+        'packages': ['cairo@1.16.0'],
         'status': 'exploitable',
         'status_notes': 'Demonstration assessment',
         'responses': ['can_not_fix'],
@@ -92,7 +92,7 @@ def test_post_detailled_assessment(client):
     assert response.status_code == 200
     data = json.loads(response.data)
     data_str = response.get_data(as_text=True)
-    assert len(data) == 3
+    assert len(data) == 2
     assert "CVE-1999-12345" in data_str
     assert "Demonstration assessment" in data_str
 
@@ -148,6 +148,82 @@ def test_post_assessment_invalid_payloads(client):
     assert response.status_code == 400
 
 
+def test_post_assessment_missing_package_blocked(client):
+    # A package that does not exist in the DB must not be auto-created; the
+    # whole write is blocked with a 400 and no assessment is recorded.
+    from src.models.package import Package
+
+    before = client.get("/api/assessments?format=list")
+    before_count = len(json.loads(before.data))
+
+    response = client.post("/api/vulnerabilities/CVE-1999-12345/assessments", json={
+        'packages': ['does-not-exist@9.9.9'],
+        'status': 'exploitable',
+        'variant_id': '22222222-2222-2222-2222-222222222222',
+    })
+    assert response.status_code == 400
+    assert "does-not-exist@9.9.9" in response.get_data(as_text=True)
+
+    # No package was created and no assessment was written.
+    with client.application.app_context():
+        assert Package.get_by_string_id("does-not-exist@9.9.9") is None
+    after = client.get("/api/assessments?format=list")
+    assert len(json.loads(after.data)) == before_count
+
+
+def test_post_assessment_any_missing_package_blocks_all(client):
+    # If ANY referenced package is missing, the whole request is rejected even
+    # when other packages exist.
+    from src.models.package import Package
+
+    before = client.get("/api/assessments?format=list")
+    before_count = len(json.loads(before.data))
+
+    response = client.post("/api/vulnerabilities/CVE-1999-12345/assessments", json={
+        'packages': ['cairo@1.16.0', 'missing@1.0.0'],
+        'status': 'exploitable',
+        'variant_id': '22222222-2222-2222-2222-222222222222',
+    })
+    assert response.status_code == 400
+    assert "missing@1.0.0" in response.get_data(as_text=True)
+
+    with client.application.app_context():
+        assert Package.get_by_string_id("missing@1.0.0") is None
+    after = client.get("/api/assessments?format=list")
+    assert len(json.loads(after.data)) == before_count
+
+
+def test_batch_missing_package_skips_item_only(client):
+    # In a batch, an item referencing a missing package is rejected with a
+    # per-item error while valid items still succeed.
+    from src.models.package import Package
+
+    response = client.post("/api/assessments/batch", json={
+        'assessments': [
+            {
+                'vuln_id': 'CVE-1999-12345',
+                'packages': ['cairo@1.16.0'],
+                'status': 'exploitable',
+                'variant_id': '22222222-2222-2222-2222-222222222222',
+            },
+            {
+                'vuln_id': 'CVE-1999-12345',
+                'packages': ['ghost@0.0.1'],
+                'status': 'exploitable',
+                'variant_id': '22222222-2222-2222-2222-222222222222',
+            },
+        ]
+    })
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data["count"] == 1
+    assert data.get("error_count") == 1
+    assert any("ghost@0.0.1" in e.get("error", "") for e in data["errors"])
+
+    with client.application.app_context():
+        assert Package.get_by_string_id("ghost@0.0.1") is None
+
+
 def test_patch_vulnerability_empty(client):
     response = client.patch("/api/vulnerabilities/CVE-2020-35492", json={})
     assert response.status_code == 200
@@ -201,7 +277,7 @@ def test_patch_vulnerability_invalids(client):
 def test_update_assessment(client):
     # First create an assessment
     response = client.post("/api/vulnerabilities/CVE-1999-12345/assessments", json={
-        'packages': ['abc@1.2.3'],
+        'packages': ['cairo@1.16.0'],
         'status': 'exploitable',
         'status_notes': 'Initial assessment',
         'workaround': 'No workaround available',
@@ -243,7 +319,7 @@ def test_update_assessment_not_found(client):
 def test_update_assessment_invalid_status(client):
     # First create an assessment
     response = client.post("/api/vulnerabilities/CVE-1999-12345/assessments", json={
-        'packages': ['abc@1.2.3'],
+        'packages': ['cairo@1.16.0'],
         'status': 'exploitable',
         'variant_id': '22222222-2222-2222-2222-222222222222',
     })
@@ -265,7 +341,7 @@ def test_update_assessment_invalid_status(client):
 def test_delete_assessment(client):
     # First create an assessment
     response = client.post("/api/vulnerabilities/CVE-1999-12345/assessments", json={
-        'packages': ['abc@1.2.3'],
+        'packages': ['cairo@1.16.0'],
         'status': 'exploitable',
         'status_notes': 'Assessment to be deleted',
         'variant_id': '22222222-2222-2222-2222-222222222222',

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -51,7 +51,7 @@ def app(init_files):
             "OPENVEX_FILE": str(init_files["openvex"]),
             "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
         })
-        setup_demo_db(application)
+        setup_demo_db(application, extra_packages=["custompkg@2.0.0", "glibc@2.39", "scannerpkg@1.0.0", "abc@1.2.3"])
         yield application
     finally:
         os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)


### PR DESCRIPTION
> This PR depends on https://github.com/savoirfairelinux/vulnscout/pull/462 (merged)

### Changes proposed in this pull request:

Previously, new packages could be created when writing assessments. However, there is no such use case anymore. The packages in the payload will be compared against the database to see if an exact match is found. This means the entire package string must match: name, version, and supplier.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

It is better to verify this via an external tool that can send HTTP requests, for example, `curl`. Since the UI doesn't allow submitting an assessment without checking a package fetched from the database.

### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


