### PR TITLE
Implement context import/export

### DIFF
--- a/frontend/src/handlers/context.ts
+++ b/frontend/src/handlers/context.ts
@@ -126,6 +126,17 @@ class Context {
         return data as ContextExport;
     }
 
+    static async exportSelected(variantIds: string[]): Promise<ContextExport> {
+        const query = encodeURIComponent(variantIds.join(','));
+        const res = await fetch(
+            `${import.meta.env.VITE_API_URL}/api/context/export?variant_ids=${query}`,
+            { mode: 'cors' }
+        );
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || `Failed to export context (${res.status})`);
+        return data as ContextExport;
+    }
+
     static async importContext(entries: unknown): Promise<ImportResult> {
         const res = await fetch(
             `${import.meta.env.VITE_API_URL}/api/context/import`,

--- a/frontend/src/handlers/context.ts
+++ b/frontend/src/handlers/context.ts
@@ -18,17 +18,22 @@ type VariantContext = VariantContextData & {
 
 type MergedContext = ProjectContext & VariantContext;
 
-/** One variant's full context, as used by the import/export file format. */
-type ContextEntry = {
-    project_name: string;
+/** One variant's context, as used by the import/export file format. */
+type VariantEntry = {
     variant_name: string;
-    description: string | null;
     variant_description: string | null;
     codebase_path: string | null;
     environment: string | null;
     threat_model: string | null;
     risks: string | null;
     other_info: string | null;
+};
+
+/** One project with its variants nested underneath. */
+type ProjectEntry = {
+    project_name: string;
+    project_description: string | null;
+    variants: VariantEntry[];
 };
 
 type ImportResultItem = {
@@ -47,7 +52,7 @@ type ImportResult = {
 type ContextExport = {
     version: string;
     exported_at: string;
-    entries: ContextEntry[];
+    projects: ProjectEntry[];
 };
 
 export type {
@@ -55,7 +60,8 @@ export type {
     VariantContext,
     VariantContextData,
     MergedContext,
-    ContextEntry,
+    VariantEntry,
+    ProjectEntry,
     ImportResultItem,
     ImportResult,
     ContextExport,
@@ -115,14 +121,6 @@ class Context {
             `${import.meta.env.VITE_API_URL}/api/context/export`,
             { mode: 'cors' }
         );
-        const data = await res.json();
-        if (!res.ok) throw new Error(data.error || `Failed to export context (${res.status})`);
-        return data as ContextExport;
-    }
-
-    static async exportVariant(projectId: string, variantId: string): Promise<ContextExport> {
-        const url = `${import.meta.env.VITE_API_URL}/api/context/export?project_id=${encodeURIComponent(projectId)}&variant_id=${encodeURIComponent(variantId)}`;
-        const res = await fetch(url, { mode: 'cors' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || `Failed to export context (${res.status})`);
         return data as ContextExport;

--- a/frontend/src/handlers/context.ts
+++ b/frontend/src/handlers/context.ts
@@ -43,6 +43,13 @@ type ImportResult = {
     failed: ImportResultItem[];
 };
 
+/** Versioned export envelope produced by the backend. */
+type ContextExport = {
+    version: string;
+    exported_at: string;
+    entries: ContextEntry[];
+};
+
 export type {
     ProjectContext,
     VariantContext,
@@ -51,6 +58,7 @@ export type {
     ContextEntry,
     ImportResultItem,
     ImportResult,
+    ContextExport,
 };
 
 class Context {
@@ -102,22 +110,22 @@ class Context {
         return data as VariantContext;
     }
 
-    static async exportAll(): Promise<ContextEntry[]> {
+    static async exportAll(): Promise<ContextExport> {
         const res = await fetch(
             `${import.meta.env.VITE_API_URL}/api/context/export`,
             { mode: 'cors' }
         );
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || `Failed to export context (${res.status})`);
-        return data as ContextEntry[];
+        return data as ContextExport;
     }
 
-    static async exportVariant(projectId: string, variantId: string): Promise<ContextEntry[]> {
+    static async exportVariant(projectId: string, variantId: string): Promise<ContextExport> {
         const url = `${import.meta.env.VITE_API_URL}/api/context/export?project_id=${encodeURIComponent(projectId)}&variant_id=${encodeURIComponent(variantId)}`;
         const res = await fetch(url, { mode: 'cors' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || `Failed to export context (${res.status})`);
-        return data as ContextEntry[];
+        return data as ContextExport;
     }
 
     static async importContext(entries: unknown): Promise<ImportResult> {

--- a/frontend/src/handlers/context.ts
+++ b/frontend/src/handlers/context.ts
@@ -14,18 +14,44 @@ type VariantContextData = {
 
 type VariantContext = VariantContextData & {
     variant_id: string;
-    files: ContextFile[];
 };
 
 type MergedContext = ProjectContext & VariantContext;
 
-type ContextFile = {
-    id: string;
-    original_name: string;
+/** One variant's full context, as used by the import/export file format. */
+type ContextEntry = {
+    project_name: string;
+    variant_name: string;
     description: string | null;
+    variant_description: string | null;
+    codebase_path: string | null;
+    environment: string | null;
+    threat_model: string | null;
+    risks: string | null;
+    other_info: string | null;
 };
 
-export type { ProjectContext, VariantContext, VariantContextData, MergedContext, ContextFile };
+type ImportResultItem = {
+    project_name: string | null;
+    variant_name: string | null;
+    reason?: string;
+};
+
+type ImportResult = {
+    imported: ImportResultItem[];
+    ignored: ImportResultItem[];
+    failed: ImportResultItem[];
+};
+
+export type {
+    ProjectContext,
+    VariantContext,
+    VariantContextData,
+    MergedContext,
+    ContextEntry,
+    ImportResultItem,
+    ImportResult,
+};
 
 class Context {
     static async get(projectId: string, variantId: string): Promise<MergedContext> {
@@ -76,30 +102,37 @@ class Context {
         return data as VariantContext;
     }
 
-    static async uploadFile(variantId: string, file: File, description?: string | null): Promise<ContextFile> {
-        const formData = new FormData();
-        formData.append('file', file);
-        if (description != null && description !== '') {
-            formData.append('description', description);
-        }
+    static async exportAll(): Promise<ContextEntry[]> {
         const res = await fetch(
-            `${import.meta.env.VITE_API_URL}/api/variants/${encodeURIComponent(variantId)}/context/files`,
-            { mode: 'cors', method: 'POST', body: formData }
+            `${import.meta.env.VITE_API_URL}/api/context/export`,
+            { mode: 'cors' }
         );
         const data = await res.json();
-        if (!res.ok) throw new Error(data.error || `Failed to upload file (${res.status})`);
-        return data as ContextFile;
+        if (!res.ok) throw new Error(data.error || `Failed to export context (${res.status})`);
+        return data as ContextEntry[];
     }
 
-    static async deleteFile(variantId: string, fileId: string): Promise<void> {
+    static async exportVariant(projectId: string, variantId: string): Promise<ContextEntry[]> {
+        const url = `${import.meta.env.VITE_API_URL}/api/context/export?project_id=${encodeURIComponent(projectId)}&variant_id=${encodeURIComponent(variantId)}`;
+        const res = await fetch(url, { mode: 'cors' });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || `Failed to export context (${res.status})`);
+        return data as ContextEntry[];
+    }
+
+    static async importContext(entries: unknown): Promise<ImportResult> {
         const res = await fetch(
-            `${import.meta.env.VITE_API_URL}/api/variants/${encodeURIComponent(variantId)}/context/files/${encodeURIComponent(fileId)}`,
-            { mode: 'cors', method: 'DELETE' }
+            `${import.meta.env.VITE_API_URL}/api/context/import`,
+            {
+                mode: 'cors',
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(entries),
+            }
         );
-        if (!res.ok) {
-            const data = await res.json().catch(() => ({}));
-            throw new Error(data.error || `Failed to delete file (${res.status})`);
-        }
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || `Failed to import context (${res.status})`);
+        return data as ImportResult;
     }
 }
 

--- a/frontend/src/handlers/variant.ts
+++ b/frontend/src/handlers/variant.ts
@@ -112,7 +112,7 @@ class Variants {
             import.meta.env.VITE_API_URL + `/api/variants`,
             { mode: "cors" }
         );
-        if (!response.ok) return [];
+        if (!response.ok) throw new Error(`Failed to load variants (${response.status})`);
         const data = await response.json();
         if (!Array.isArray(data)) return [];
         return data.filter(

--- a/frontend/src/pages/AIContext.tsx
+++ b/frontend/src/pages/AIContext.tsx
@@ -1,13 +1,47 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSpinner, faRobot, faBook, faFileExport, faFileImport, faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { faSpinner, faRobot, faBook, faFileExport, faFileImport, faChevronDown, faCircleQuestion } from "@fortawesome/free-solid-svg-icons";
 import type { Project } from "../handlers/project";
 import type { Variant } from "../handlers/variant";
 import Variants from "../handlers/variant";
 import Context from "../handlers/context";
-import type { VariantContextData, ContextEntry, ImportResult } from "../handlers/context";
+import type { VariantContextData, ContextExport, ImportResult } from "../handlers/context";
 import MessageBanner from "../components/MessageBanner";
 import { useDocUrl } from "../helpers/useDocUrl";
+import type { RefObject } from "react";
+
+/**
+ * Dismisses an open popover/menu when the user clicks outside of `ref` or
+ * (optionally) presses Escape. No-op while `open` is false.
+ */
+function useDismissable(
+    open: boolean,
+    ref: RefObject<HTMLElement | null>,
+    onDismiss: () => void,
+    options: { escape?: boolean } = {}
+): void {
+    const { escape = false } = options;
+    useEffect(() => {
+        if (!open) return;
+        const onClick = (ev: MouseEvent) => {
+            if (ref.current && !ref.current.contains(ev.target as Node)) {
+                onDismiss();
+            }
+        };
+        document.addEventListener("mousedown", onClick);
+        let onKey: ((ev: KeyboardEvent) => void) | undefined;
+        if (escape) {
+            onKey = (ev: KeyboardEvent) => {
+                if (ev.key === "Escape") onDismiss();
+            };
+            document.addEventListener("keydown", onKey);
+        }
+        return () => {
+            document.removeEventListener("mousedown", onClick);
+            if (onKey) document.removeEventListener("keydown", onKey);
+        };
+    }, [open, ref, onDismiss, escape]);
+}
 
 // Throwing fetch helpers for selector loads (existing handlers swallow HTTP errors)
 async function fetchProjectList(): Promise<Project[]> {
@@ -68,7 +102,9 @@ function AIContext() {
     const [exportSelection, setExportSelection] = useState<Set<string>>(new Set());
     const [ioBusy, setIoBusy] = useState(false);
     const [importDetails, setImportDetails] = useState<ImportResult | null>(null);
+    const [importHelpOpen, setImportHelpOpen] = useState(false);
     const exportMenuRef = useRef<HTMLDivElement | null>(null);
+    const importHelpRef = useRef<HTMLDivElement | null>(null);
     const importInputRef = useRef<HTMLInputElement | null>(null);
 
     const showBanner = (msg: string, type: 'success' | 'error') => {
@@ -211,8 +247,8 @@ function AIContext() {
         }
     };
 
-    const handleFileDownload = (entries: ContextEntry[], filename: string) => {
-        const blob = new Blob([JSON.stringify(entries, null, 2)], { type: "application/json" });
+    const handleFileDownload = (document_: ContextExport, filename: string) => {
+        const blob = new Blob([JSON.stringify(document_, null, 2)], { type: "application/json" });
         const url = URL.createObjectURL(blob);
         const a = document.createElement("a");
         a.href = url;
@@ -239,8 +275,8 @@ function AIContext() {
                     .filter(v => exportSelection.has(v.id))
                     .map(v => `${projectNameById(v.project_id)}\u0000${v.name}`)
             );
-            const chosen = all.filter(e => keys.has(`${e.project_name}\u0000${e.variant_name}`));
-            handleFileDownload(chosen, "vulnscout-context.json");
+            const chosen = all.entries.filter(e => keys.has(`${e.project_name}\u0000${e.variant_name}`));
+            handleFileDownload({ ...all, entries: chosen }, "vulnscout-context.json");
             if (!unmountedRef.current) setExportMenuOpen(false);
         } catch (e: any) {
             if (!unmountedRef.current) showBanner(e?.message || "Failed to export context.", "error");
@@ -253,9 +289,9 @@ function AIContext() {
         if (ioBusy || !selectedProjectId || !selectedVariantId) return;
         setIoBusy(true);
         try {
-            const entries = await Context.exportVariant(selectedProjectId, selectedVariantId);
+            const doc = await Context.exportVariant(selectedProjectId, selectedVariantId);
             const variantName = variants.find(v => v.id === selectedVariantId)?.name ?? "variant";
-            handleFileDownload(entries, `vulnscout-context-${variantName}.json`);
+            handleFileDownload(doc, `vulnscout-context-${variantName}.json`);
         } catch (e: any) {
             if (!unmountedRef.current) showBanner(e?.message || "Failed to export context.", "error");
         } finally {
@@ -276,9 +312,6 @@ function AIContext() {
                 parsed = JSON.parse(text);
             } catch {
                 throw new Error("The selected file is not valid JSON.");
-            }
-            if (!Array.isArray(parsed)) {
-                throw new Error("The file must contain a JSON array of context entries.");
             }
             const result = await Context.importContext(parsed);
             if (unmountedRef.current) return;
@@ -309,16 +342,9 @@ function AIContext() {
     const clearAllExport = () => setExportSelection(new Set());
 
     // Close the export menu on outside click
-    useEffect(() => {
-        if (!exportMenuOpen) return;
-        const onClick = (ev: MouseEvent) => {
-            if (exportMenuRef.current && !exportMenuRef.current.contains(ev.target as Node)) {
-                setExportMenuOpen(false);
-            }
-        };
-        document.addEventListener("mousedown", onClick);
-        return () => document.removeEventListener("mousedown", onClick);
-    }, [exportMenuOpen]);
+    useDismissable(exportMenuOpen, exportMenuRef, useCallback(() => setExportMenuOpen(false), []));
+    // Close the import-help popover on outside click or Escape
+    useDismissable(importHelpOpen, importHelpRef, useCallback(() => setImportHelpOpen(false), []), { escape: true });
 
     const variantSelected = Boolean(selectedVariantId);
     const projectSelected = Boolean(selectedProjectId);
@@ -441,6 +467,29 @@ function AIContext() {
                         className="hidden"
                         onChange={handleImportFile}
                     />
+                    <div className="relative" ref={importHelpRef}>
+                        <button
+                            type="button"
+                            aria-label="Import help"
+                            title="Import help"
+                            onClick={() => setImportHelpOpen(o => !o)}
+                            className="text-sky-300 hover:text-sky-100 transition-colors"
+                        >
+                            <FontAwesomeIcon icon={faCircleQuestion} />
+                        </button>
+                        {importHelpOpen && (
+                            <div
+                                role="tooltip"
+                                className="absolute top-full mt-1 right-0 bg-sky-900 border border-sky-700 rounded-lg shadow-lg p-3 z-50 w-[320px] text-sm text-left font-normal"
+                            >
+                                Importing overwrites the existing context for each matching
+                                project/variant. Entries whose project or variant does not exist
+                                are ignored; entries missing mandatory fields (description, threat
+                                model) fail. Accepts an exported file or a plain JSON array of
+                                entries.
+                            </div>
+                        )}
+                    </div>
                 </div>
             </div>
 

--- a/frontend/src/pages/AIContext.tsx
+++ b/frontend/src/pages/AIContext.tsx
@@ -259,31 +259,12 @@ function AIContext() {
         URL.revokeObjectURL(url);
     };
 
-    const projectNameById = useCallback(
-        (projectId: string) => projects.find(p => p.id === projectId)?.name ?? '',
-        [projects]
-    );
-
     const handleExportSelected = async () => {
         if (ioBusy || exportSelection.size === 0) return;
         setIoBusy(true);
         try {
-            const all = await Context.exportAll();
-            // Keep only variants whose id is checked in the selector.
-            const chosenKeys = new Set(
-                allVariants
-                    .filter(v => exportSelection.has(v.id))
-                    .map(v => `${projectNameById(v.project_id)}\u0000${v.name}`)
-            );
-            const projects = all.projects
-                .map(p => ({
-                    ...p,
-                    variants: p.variants.filter(
-                        v => chosenKeys.has(`${p.project_name}\u0000${v.variant_name}`)
-                    ),
-                }))
-                .filter(p => p.variants.length > 0);
-            handleFileDownload({ ...all, projects }, "vulnscout-context.json");
+            const doc = await Context.exportSelected([...exportSelection]);
+            handleFileDownload(doc, "vulnscout-context.json");
             if (!unmountedRef.current) setExportMenuOpen(false);
         } catch (e: any) {
             if (!unmountedRef.current) showBanner(e?.message || "Failed to export context.", "error");

--- a/frontend/src/pages/AIContext.tsx
+++ b/frontend/src/pages/AIContext.tsx
@@ -1,14 +1,13 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faXmark, faSpinner, faRobot, faBook } from "@fortawesome/free-solid-svg-icons";
+import { faSpinner, faRobot, faBook, faFileExport, faFileImport, faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import type { Project } from "../handlers/project";
 import type { Variant } from "../handlers/variant";
+import Variants from "../handlers/variant";
 import Context from "../handlers/context";
-import type { ContextFile, VariantContextData } from "../handlers/context";
+import type { VariantContextData, ContextEntry, ImportResult } from "../handlers/context";
 import MessageBanner from "../components/MessageBanner";
 import { useDocUrl } from "../helpers/useDocUrl";
-
-const MAX_FILE_BYTES = 10 * 1024 * 1024;
 
 // Throwing fetch helpers for selector loads (existing handlers swallow HTTP errors)
 async function fetchProjectList(): Promise<Project[]> {
@@ -44,6 +43,7 @@ function AIContext() {
     // Selectors
     const [projects, setProjects] = useState<Project[]>([]);
     const [variants, setVariants] = useState<Variant[]>([]);
+    const [allVariants, setAllVariants] = useState<Variant[]>([]);
     const [selectedProjectId, setSelectedProjectId] = useState<string>('');
     const [selectedVariantId, setSelectedVariantId] = useState<string>('');
 
@@ -55,16 +55,21 @@ function AIContext() {
     const [threatModel, setThreatModel] = useState<string>('');
     const [risks, setRisks] = useState<string>('');
     const [otherInfo, setOtherInfo] = useState<string>('');
-    const [files, setFiles] = useState<ContextFile[]>([]);
-    const [fileDescription, setFileDescription] = useState<string>('');
 
     // UI state
     const [busy, setBusy] = useState(false);
-    const [fileError, setFileError] = useState<string | null>(null);
     const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
     const [bannerMsg, setBannerMsg] = useState<string>('');
     const [bannerType, setBannerType] = useState<'success' | 'error'>('success');
     const [bannerVisible, setBannerVisible] = useState(false);
+
+    // Import/Export state
+    const [exportMenuOpen, setExportMenuOpen] = useState(false);
+    const [exportSelection, setExportSelection] = useState<Set<string>>(new Set());
+    const [ioBusy, setIoBusy] = useState(false);
+    const [importDetails, setImportDetails] = useState<ImportResult | null>(null);
+    const exportMenuRef = useRef<HTMLDivElement | null>(null);
+    const importInputRef = useRef<HTMLInputElement | null>(null);
 
     const showBanner = (msg: string, type: 'success' | 'error') => {
         setBannerMsg(msg);
@@ -82,6 +87,21 @@ function AIContext() {
      
     }, []);
 
+    // Load all variants for the export selector (lazily, when the menu first opens)
+    const [allVariantsLoaded, setAllVariantsLoaded] = useState(false);
+    const loadAllVariants = useCallback(() => {
+        if (allVariantsLoaded) return;
+        Variants.listAll().then(vs => {
+            if (unmountedRef.current) return;
+            setAllVariants(vs);
+            setAllVariantsLoaded(true);
+        }).catch((e: any) => {
+            // Leave allVariantsLoaded false so reopening the menu retries.
+            if (!unmountedRef.current)
+                showBanner(e?.message || "Failed to load variants for export.", "error");
+        });
+    }, [allVariantsLoaded]);
+
     const clearVariantFields = () => {
         setVariantDescription('');
         setCodebasePath('');
@@ -89,8 +109,6 @@ function AIContext() {
         setThreatModel('');
         setRisks('');
         setOtherInfo('');
-        setFiles([]);
-        setFileDescription('');
     };
 
     // Load variants when project changes
@@ -121,7 +139,6 @@ function AIContext() {
                     setThreatModel(ctx.threat_model ?? '');
                     setRisks(ctx.risks ?? '');
                     setOtherInfo(ctx.other_info ?? '');
-                    setFiles(ctx.files);
                 }).catch((e: any) => {
                     if (!unmountedRef.current)
                         showBanner(e?.message || "Failed to load context.", "error");
@@ -194,36 +211,114 @@ function AIContext() {
         }
     };
 
-    const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        e.target.value = '';
-        if (!file || !selectedVariantId) return;
-        setFileError(null);
-        if (file.size > MAX_FILE_BYTES) {
-            setFileError("File exceeds the 10 MB maximum size.");
-            return;
-        }
-        const desc = fileDescription.trim() || null;
+    const handleFileDownload = (entries: ContextEntry[], filename: string) => {
+        const blob = new Blob([JSON.stringify(entries, null, 2)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    };
+
+    const projectNameById = useCallback(
+        (projectId: string) => projects.find(p => p.id === projectId)?.name ?? '',
+        [projects]
+    );
+
+    const handleExportSelected = async () => {
+        if (ioBusy || exportSelection.size === 0) return;
+        setIoBusy(true);
         try {
-            const uploaded = await Context.uploadFile(selectedVariantId, file, desc);
-            if (!unmountedRef.current) {
-                setFiles(prev => [...prev, uploaded]);
-                setFileDescription('');
-            }
+            const all = await Context.exportAll();
+            // Keep only entries whose variant is checked in the selector.
+            const keys = new Set(
+                allVariants
+                    .filter(v => exportSelection.has(v.id))
+                    .map(v => `${projectNameById(v.project_id)}\u0000${v.name}`)
+            );
+            const chosen = all.filter(e => keys.has(`${e.project_name}\u0000${e.variant_name}`));
+            handleFileDownload(chosen, "vulnscout-context.json");
+            if (!unmountedRef.current) setExportMenuOpen(false);
         } catch (e: any) {
-            if (!unmountedRef.current) setFileError(e?.message || "Upload failed.");
+            if (!unmountedRef.current) showBanner(e?.message || "Failed to export context.", "error");
+        } finally {
+            if (!unmountedRef.current) setIoBusy(false);
         }
     };
 
-    const handleDeleteFile = async (fileId: string) => {
-        if (!selectedVariantId) return;
+    const handleExportVariant = async () => {
+        if (ioBusy || !selectedProjectId || !selectedVariantId) return;
+        setIoBusy(true);
         try {
-            await Context.deleteFile(selectedVariantId, fileId);
-            if (!unmountedRef.current) setFiles(prev => prev.filter(f => f.id !== fileId));
+            const entries = await Context.exportVariant(selectedProjectId, selectedVariantId);
+            const variantName = variants.find(v => v.id === selectedVariantId)?.name ?? "variant";
+            handleFileDownload(entries, `vulnscout-context-${variantName}.json`);
         } catch (e: any) {
-            if (!unmountedRef.current) showBanner(e?.message || "Failed to delete file.", "error");
+            if (!unmountedRef.current) showBanner(e?.message || "Failed to export context.", "error");
+        } finally {
+            if (!unmountedRef.current) setIoBusy(false);
         }
     };
+
+    const handleImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = '';
+        if (!file || ioBusy) return;
+        setIoBusy(true);
+        setImportDetails(null);
+        try {
+            const text = await file.text();
+            let parsed: unknown;
+            try {
+                parsed = JSON.parse(text);
+            } catch {
+                throw new Error("The selected file is not valid JSON.");
+            }
+            if (!Array.isArray(parsed)) {
+                throw new Error("The file must contain a JSON array of context entries.");
+            }
+            const result = await Context.importContext(parsed);
+            if (unmountedRef.current) return;
+            setImportDetails(result);
+            const total = result.imported.length + result.ignored.length + result.failed.length;
+            const msg =
+                `Import complete: ${result.imported.length} of ${total} imported, ` +
+                `${result.ignored.length} ignored, ${result.failed.length} failed.`;
+            showBanner(msg, result.failed.length > 0 ? "error" : "success");
+            loadContext();
+        } catch (err: any) {
+            if (!unmountedRef.current) showBanner(err?.message || "Import failed.", "error");
+        } finally {
+            if (!unmountedRef.current) setIoBusy(false);
+        }
+    };
+
+    const toggleExportVariant = (variantId: string) => {
+        setExportSelection(prev => {
+            const next = new Set(prev);
+            if (next.has(variantId)) next.delete(variantId);
+            else next.add(variantId);
+            return next;
+        });
+    };
+
+    const selectAllExport = () => setExportSelection(new Set(allVariants.map(v => v.id)));
+    const clearAllExport = () => setExportSelection(new Set());
+
+    // Close the export menu on outside click
+    useEffect(() => {
+        if (!exportMenuOpen) return;
+        const onClick = (ev: MouseEvent) => {
+            if (exportMenuRef.current && !exportMenuRef.current.contains(ev.target as Node)) {
+                setExportMenuOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", onClick);
+        return () => document.removeEventListener("mousedown", onClick);
+    }, [exportMenuOpen]);
 
     const variantSelected = Boolean(selectedVariantId);
     const projectSelected = Boolean(selectedProjectId);
@@ -235,6 +330,8 @@ function AIContext() {
         "rounded px-2 py-1.5 text-sm bg-slate-900/60 border border-slate-600 text-white focus:outline-none focus:border-cyan-400 disabled:opacity-40 disabled:cursor-not-allowed";
     const btnPrimary =
         "px-4 py-2 rounded-lg bg-cyan-800 hover:bg-cyan-700 focus:ring-4 focus:outline-none focus:ring-blue-800 text-white text-sm font-semibold disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150";
+    const btnSecondary =
+        "px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 focus:ring-4 focus:outline-none focus:ring-slate-500 text-white text-sm font-semibold disabled:opacity-40 disabled:cursor-not-allowed transition-colors duration-150";
     const cardHeader =
         "bg-gradient-to-r from-slate-700 to-slate-800 px-4 py-2.5 flex items-center gap-2 rounded-t-lg border-b border-slate-600/60";
     const cardBody =
@@ -261,7 +358,116 @@ function AIContext() {
                     >
                     <FontAwesomeIcon icon={faBook} size='lg' />
                 </a>
+
+                {/* Import / Export controls */}
+                <div className="ml-auto flex items-center gap-2">
+                    <div className="relative" ref={exportMenuRef}>
+                        <button
+                            type="button"
+                            aria-label="Export context"
+                            aria-haspopup="true"
+                            aria-expanded={exportMenuOpen}
+                            onClick={() => setExportMenuOpen(o => { const next = !o; if (next) loadAllVariants(); return next; })}
+                            disabled={ioBusy}
+                            className={btnSecondary + " flex items-center gap-2"}
+                        >
+                            <FontAwesomeIcon icon={faFileExport} />
+                            Export
+                            <FontAwesomeIcon icon={faChevronDown} size="xs" />
+                        </button>
+                        {exportMenuOpen && (
+                            <div
+                                role="menu"
+                                className="absolute right-0 z-20 mt-2 w-72 max-h-96 overflow-auto rounded-lg bg-slate-800 border border-slate-600 shadow-xl shadow-black/40 p-3"
+                            >
+                                <div className="flex items-center justify-between mb-2">
+                                    <span className="text-sm font-semibold text-white">Select variants</span>
+                                    <div className="flex gap-2 text-xs">
+                                        <button type="button" onClick={selectAllExport} className="text-cyan-400 hover:text-cyan-300">All</button>
+                                        <button type="button" onClick={clearAllExport} className="text-cyan-400 hover:text-cyan-300">None</button>
+                                    </div>
+                                </div>
+                                {projects.length === 0 && (
+                                    <p className="text-xs text-zinc-400">No projects available.</p>
+                                )}
+                                {projects.map(p => {
+                                    const pv = allVariants.filter(v => v.project_id === p.id);
+                                    return (
+                                        <div key={p.id} className="mb-2">
+                                            <p className="text-xs font-semibold text-zinc-300 mb-1">{p.name}</p>
+                                            {pv.length === 0 ? (
+                                                <p className="text-xs text-zinc-500 pl-2">No variants</p>
+                                            ) : pv.map(v => (
+                                                <label key={v.id} className="flex items-center gap-2 pl-2 py-0.5 text-sm text-zinc-200 cursor-pointer">
+                                                    <input
+                                                        type="checkbox"
+                                                        aria-label={`Export ${p.name} / ${v.name}`}
+                                                        checked={exportSelection.has(v.id)}
+                                                        onChange={() => toggleExportVariant(v.id)}
+                                                    />
+                                                    {v.name}
+                                                </label>
+                                            ))}
+                                        </div>
+                                    );
+                                })}
+                                <button
+                                    type="button"
+                                    onClick={handleExportSelected}
+                                    disabled={ioBusy || exportSelection.size === 0}
+                                    className={btnPrimary + " w-full mt-2 flex items-center justify-center gap-2"}
+                                >
+                                    {ioBusy && <FontAwesomeIcon icon={faSpinner} spin />}
+                                    Export selected ({exportSelection.size})
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                    <button
+                        type="button"
+                        aria-label="Import context"
+                        onClick={() => importInputRef.current?.click()}
+                        disabled={ioBusy}
+                        className={btnSecondary + " flex items-center gap-2"}
+                    >
+                        <FontAwesomeIcon icon={faFileImport} />
+                        Import
+                    </button>
+                    <input
+                        ref={importInputRef}
+                        type="file"
+                        accept="application/json,.json"
+                        aria-label="Import context file"
+                        className="hidden"
+                        onChange={handleImportFile}
+                    />
+                </div>
             </div>
+
+            {importDetails && (importDetails.ignored.length > 0 || importDetails.failed.length > 0) && (
+                <div className="rounded-lg bg-slate-800/60 border border-slate-600 p-3 text-sm">
+                    {importDetails.failed.length > 0 && (
+                        <div className="mb-2">
+                            <p className="font-semibold text-red-400">Failed ({importDetails.failed.length})</p>
+                            <ul className="list-disc list-inside text-zinc-300">
+                                {importDetails.failed.map((it, i) => (
+                                    <li key={`f-${i}`}>{it.project_name ?? '—'} / {it.variant_name ?? '—'}: {it.reason}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                    {importDetails.ignored.length > 0 && (
+                        <div>
+                            <p className="font-semibold text-yellow-400">Ignored ({importDetails.ignored.length})</p>
+                            <ul className="list-disc list-inside text-zinc-300">
+                                {importDetails.ignored.map((it, i) => (
+                                    <li key={`i-${i}`}>{it.project_name ?? '—'} / {it.variant_name ?? '—'}: {it.reason}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+            )}
             <div>
                 <div className={cardHeader}>
                     <FontAwesomeIcon icon={faRobot} className="text-cyan-400" />
@@ -415,52 +621,18 @@ function AIContext() {
                 />
             </div>
 
-            {/* Supplemental Files */}
-            <div>
-                <label className={labelClass} htmlFor="ai-files">
-                    Supplemental Files <span className="text-neutral-400 font-normal">(10 MB each)</span>
-                </label>
-                <input
-                    id="ai-file-description"
-                    aria-label="File Description"
-                    type="text"
-                    className={inputClass + " mb-2"}
-                    value={fileDescription}
-                    onChange={e => setFileDescription(e.target.value)}
-                    disabled={!variantSelected}
-                    placeholder={variantSelected ? "Optional description for the next uploaded file" : "Select a variant to enable"}
-                />
-                <input
-                    id="ai-files"
-                    aria-label="Supplemental Files"
-                    type="file"
-                    className="text-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                    disabled={!variantSelected}
-                    onChange={handleFileChange}
-                />
-                {fileError && <p className="text-red-500 text-xs mt-1">{fileError}</p>}
-                {files.length > 0 && (
-                    <ul className="mt-2 flex flex-col gap-2">
-                        {files.map(f => (
-                            <li key={f.id} className="flex items-start gap-1 bg-slate-900/60 border border-slate-600 rounded px-2 py-1.5 text-sm text-white">
-                                <div className="flex flex-col">
-                                    <span>{f.original_name}</span>
-                                    {f.description && (
-                                        <span className="text-xs text-zinc-400">{f.description}</span>
-                                    )}
-                                </div>
-                                <button
-                                    type="button"
-                                    aria-label={`Delete ${f.original_name}`}
-                                    onClick={() => handleDeleteFile(f.id)}
-                                    className="ml-auto text-zinc-400 hover:text-red-400"
-                                >
-                                    <FontAwesomeIcon icon={faXmark} />
-                                </button>
-                            </li>
-                        ))}
-                    </ul>
-                )}
+                {/* Export this variant */}
+                <div>
+                    <button
+                        type="button"
+                        aria-label="Export this variant"
+                        onClick={handleExportVariant}
+                        disabled={!variantSelected || ioBusy}
+                        className={btnSecondary + " flex items-center gap-2"}
+                    >
+                        <FontAwesomeIcon icon={faFileExport} />
+                        Export this variant
+                    </button>
                 </div>
 
                 {/* Save */}

--- a/frontend/src/pages/AIContext.tsx
+++ b/frontend/src/pages/AIContext.tsx
@@ -269,29 +269,22 @@ function AIContext() {
         setIoBusy(true);
         try {
             const all = await Context.exportAll();
-            // Keep only entries whose variant is checked in the selector.
-            const keys = new Set(
+            // Keep only variants whose id is checked in the selector.
+            const chosenKeys = new Set(
                 allVariants
                     .filter(v => exportSelection.has(v.id))
                     .map(v => `${projectNameById(v.project_id)}\u0000${v.name}`)
             );
-            const chosen = all.entries.filter(e => keys.has(`${e.project_name}\u0000${e.variant_name}`));
-            handleFileDownload({ ...all, entries: chosen }, "vulnscout-context.json");
+            const projects = all.projects
+                .map(p => ({
+                    ...p,
+                    variants: p.variants.filter(
+                        v => chosenKeys.has(`${p.project_name}\u0000${v.variant_name}`)
+                    ),
+                }))
+                .filter(p => p.variants.length > 0);
+            handleFileDownload({ ...all, projects }, "vulnscout-context.json");
             if (!unmountedRef.current) setExportMenuOpen(false);
-        } catch (e: any) {
-            if (!unmountedRef.current) showBanner(e?.message || "Failed to export context.", "error");
-        } finally {
-            if (!unmountedRef.current) setIoBusy(false);
-        }
-    };
-
-    const handleExportVariant = async () => {
-        if (ioBusy || !selectedProjectId || !selectedVariantId) return;
-        setIoBusy(true);
-        try {
-            const doc = await Context.exportVariant(selectedProjectId, selectedVariantId);
-            const variantName = variants.find(v => v.id === selectedVariantId)?.name ?? "variant";
-            handleFileDownload(doc, `vulnscout-context-${variantName}.json`);
         } catch (e: any) {
             if (!unmountedRef.current) showBanner(e?.message || "Failed to export context.", "error");
         } finally {
@@ -483,10 +476,10 @@ function AIContext() {
                                 className="absolute top-full mt-1 right-0 bg-sky-900 border border-sky-700 rounded-lg shadow-lg p-3 z-50 w-[320px] text-sm text-left font-normal"
                             >
                                 Importing overwrites the existing context for each matching
-                                project/variant. Entries whose project or variant does not exist
-                                are ignored; entries missing mandatory fields (description, threat
-                                model) fail. Accepts an exported file or a plain JSON array of
-                                entries.
+                                project/variant. Variants whose project or variant does not exist
+                                are ignored; variants missing mandatory fields (description, threat
+                                model) fail. Accepts an exported file, whose projects each nest
+                                their variants.
                             </div>
                         )}
                     </div>
@@ -669,20 +662,6 @@ function AIContext() {
                     placeholder={variantSelected ? "Any additional context..." : "Select a variant to enable"}
                 />
             </div>
-
-                {/* Export this variant */}
-                <div>
-                    <button
-                        type="button"
-                        aria-label="Export this variant"
-                        onClick={handleExportVariant}
-                        disabled={!variantSelected || ioBusy}
-                        className={btnSecondary + " flex items-center gap-2"}
-                    >
-                        <FontAwesomeIcon icon={faFileExport} />
-                        Export this variant
-                    </button>
-                </div>
 
                 {/* Save */}
                 <div>

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1265,6 +1265,9 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         fetchVariants.then(vs => {
             setAllVariants(vs);
             setSelectedVariantIds(new Set(vs.map(v => v.id)));
+        }).catch(() => {
+            setAllVariants([]);
+            setSelectedVariantIds(new Set());
         });
     }, [variantId, projectId]);
 

--- a/frontend/tests/unit_tests/test_ai_context_page.tsx
+++ b/frontend/tests/unit_tests/test_ai_context_page.tsx
@@ -409,9 +409,9 @@ describe('AIContext page', () => {
             const checkbox = await screen.findByLabelText('Export Project A / Variant 1');
             fireEvent.click(checkbox);
 
-            // Export selected -> exportAll, filtered to the checked variant
+            // Export selected -> server-side exportSelected(variant_ids), no client filtering
             fetchMock.mockResponseOnce(JSON.stringify({
-                version: '2.0',
+                version: '1.0',
                 exported_at: '2026-07-22T00:00:00+00:00',
                 projects: [
                     {
@@ -433,6 +433,7 @@ describe('AIContext page', () => {
             expect(createObjSpy).toHaveBeenCalled();
             const exportCall = fetchMock.mock.calls.find(c => String(c[0]).includes('/api/context/export'));
             expect(exportCall).toBeDefined();
+            expect(String(exportCall![0])).toContain('variant_ids=v1');
         });
 
 
@@ -479,7 +480,7 @@ describe('AIContext page', () => {
             }));
 
             const envelope = JSON.stringify({
-                version: '2.0',
+                version: '1.0',
                 exported_at: '2026-07-22T00:00:00+00:00',
                 projects: [
                     {
@@ -500,7 +501,7 @@ describe('AIContext page', () => {
                 c => String(c[0]).includes('/api/context/import') && (c[1] as any)?.method === 'POST'
             );
             expect(importCall).toBeDefined();
-            expect(JSON.parse((importCall![1] as any).body).version).toBe('2.0');
+            expect(JSON.parse((importCall![1] as any).body).version).toBe('1.0');
         });
 
         test('import rejects a file that is not valid JSON', async () => {

--- a/frontend/tests/unit_tests/test_ai_context_page.tsx
+++ b/frontend/tests/unit_tests/test_ai_context_page.tsx
@@ -411,13 +411,19 @@ describe('AIContext page', () => {
 
             // Export selected -> exportAll, filtered to the checked variant
             fetchMock.mockResponseOnce(JSON.stringify({
-                version: '1.0',
+                version: '2.0',
                 exported_at: '2026-07-22T00:00:00+00:00',
-                entries: [
+                projects: [
                     {
-                        project_name: 'Project A', variant_name: 'Variant 1', description: 'd',
-                        variant_description: null, codebase_path: null, environment: null,
-                        threat_model: 't', risks: null, other_info: null,
+                        project_name: 'Project A',
+                        project_description: 'd',
+                        variants: [
+                            {
+                                variant_name: 'Variant 1',
+                                variant_description: null, codebase_path: null, environment: null,
+                                threat_model: 't', risks: null, other_info: null,
+                            },
+                        ],
                     },
                 ],
             }));
@@ -429,12 +435,6 @@ describe('AIContext page', () => {
             expect(exportCall).toBeDefined();
         });
 
-        test('export this variant is enabled after selecting a variant', async () => {
-            setupWithVariant();
-            render(<AIContext />);
-            await selectProjectAndVariant();
-            expect(screen.getByRole('button', { name: /export this variant/i })).not.toBeDisabled();
-        });
 
         test('import shows summary banner and detail list', async () => {
             fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }])); // projects
@@ -448,7 +448,11 @@ describe('AIContext page', () => {
             }));
 
             const payload = JSON.stringify([
-                { project_name: 'Project A', variant_name: 'Variant 1', description: 'd', threat_model: 't' },
+                {
+                    project_name: 'Project A',
+                    project_description: 'd',
+                    variants: [{ variant_name: 'Variant 1', threat_model: 't' }],
+                },
             ]);
             const file = new File([payload], 'ctx.json', { type: 'application/json' });
             (file as any).text = () => Promise.resolve(payload);
@@ -475,10 +479,16 @@ describe('AIContext page', () => {
             }));
 
             const envelope = JSON.stringify({
-                version: '1.0',
+                version: '2.0',
                 exported_at: '2026-07-22T00:00:00+00:00',
-                entries: [
-                    { project_name: 'Project A', variant_name: 'Variant 1', description: 'd', threat_model: 't' },
+                projects: [
+                    {
+                        project_name: 'Project A',
+                        project_description: 'd',
+                        variants: [
+                            { variant_name: 'Variant 1', threat_model: 't' },
+                        ],
+                    },
                 ],
             });
             const file = new File([envelope], 'ctx.json', { type: 'application/json' });
@@ -490,7 +500,7 @@ describe('AIContext page', () => {
                 c => String(c[0]).includes('/api/context/import') && (c[1] as any)?.method === 'POST'
             );
             expect(importCall).toBeDefined();
-            expect(JSON.parse((importCall![1] as any).body).version).toBe('1.0');
+            expect(JSON.parse((importCall![1] as any).body).version).toBe('2.0');
         });
 
         test('import rejects a file that is not valid JSON', async () => {

--- a/frontend/tests/unit_tests/test_ai_context_page.tsx
+++ b/frontend/tests/unit_tests/test_ai_context_page.tsx
@@ -410,13 +410,17 @@ describe('AIContext page', () => {
             fireEvent.click(checkbox);
 
             // Export selected -> exportAll, filtered to the checked variant
-            fetchMock.mockResponseOnce(JSON.stringify([
-                {
-                    project_name: 'Project A', variant_name: 'Variant 1', description: 'd',
-                    variant_description: null, codebase_path: null, environment: null,
-                    threat_model: 't', risks: null, other_info: null,
-                },
-            ]));
+            fetchMock.mockResponseOnce(JSON.stringify({
+                version: '1.0',
+                exported_at: '2026-07-22T00:00:00+00:00',
+                entries: [
+                    {
+                        project_name: 'Project A', variant_name: 'Variant 1', description: 'd',
+                        variant_description: null, codebase_path: null, environment: null,
+                        threat_model: 't', risks: null, other_info: null,
+                    },
+                ],
+            }));
             fireEvent.click(screen.getByRole('button', { name: /export selected/i }));
 
             await waitFor(() => expect(clickSpy).toHaveBeenCalled());
@@ -459,19 +463,60 @@ describe('AIContext page', () => {
             expect(importCall).toBeDefined();
         });
 
-        test('import rejects a non-array JSON file', async () => {
+        test('import forwards an envelope object to the backend', async () => {
             fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }])); // projects
             render(<AIContext />);
             await screen.findByRole('option', { name: 'Project A' });
 
-            const file = new File([JSON.stringify({ not: 'an array' })], 'ctx.json', { type: 'application/json' });
-            (file as any).text = () => Promise.resolve(JSON.stringify({ not: 'an array' }));
+            fetchMock.mockResponseOnce(JSON.stringify({
+                imported: [{ project_name: 'Project A', variant_name: 'Variant 1' }],
+                ignored: [],
+                failed: [],
+            }));
+
+            const envelope = JSON.stringify({
+                version: '1.0',
+                exported_at: '2026-07-22T00:00:00+00:00',
+                entries: [
+                    { project_name: 'Project A', variant_name: 'Variant 1', description: 'd', threat_model: 't' },
+                ],
+            });
+            const file = new File([envelope], 'ctx.json', { type: 'application/json' });
+            (file as any).text = () => Promise.resolve(envelope);
             fireEvent.change(screen.getByLabelText('Import context file'), { target: { files: [file] } });
 
-            await waitFor(() => expect(screen.getByText(/must contain a JSON array/i)).toBeInTheDocument());
+            await waitFor(() => expect(screen.getByText(/import complete/i)).toBeInTheDocument());
+            const importCall = fetchMock.mock.calls.find(
+                c => String(c[0]).includes('/api/context/import') && (c[1] as any)?.method === 'POST'
+            );
+            expect(importCall).toBeDefined();
+            expect(JSON.parse((importCall![1] as any).body).version).toBe('1.0');
+        });
+
+        test('import rejects a file that is not valid JSON', async () => {
+            fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }])); // projects
+            render(<AIContext />);
+            await screen.findByRole('option', { name: 'Project A' });
+
+            const file = new File(['not json'], 'ctx.json', { type: 'application/json' });
+            (file as any).text = () => Promise.resolve('not json');
+            fireEvent.change(screen.getByLabelText('Import context file'), { target: { files: [file] } });
+
+            await waitFor(() => expect(screen.getByText(/not valid JSON/i)).toBeInTheDocument());
             // No import request should have been sent
             const importCall = fetchMock.mock.calls.find(c => String(c[0]).includes('/api/context/import'));
             expect(importCall).toBeUndefined();
+        });
+
+        test('import help tooltip toggles on the question-mark button', async () => {
+            fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }])); // projects
+            render(<AIContext />);
+            await screen.findByRole('option', { name: 'Project A' });
+
+            expect(screen.queryByRole('tooltip')).toBeNull();
+            fireEvent.click(screen.getByRole('button', { name: /import help/i }));
+            const tip = await screen.findByRole('tooltip');
+            expect(tip).toHaveTextContent(/overwrites the existing context/i);
         });
     });
 });

--- a/frontend/tests/unit_tests/test_ai_context_page.tsx
+++ b/frontend/tests/unit_tests/test_ai_context_page.tsx
@@ -130,25 +130,6 @@ describe('AIContext page', () => {
         });
     });
 
-    test('file input is disabled when no variant selected', async () => {
-        // Projects list
-        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
-        // Variants.list('p1')
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-        // getProject
-        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
-
-        render(<AIContext />);
-        await screen.findByRole('option', { name: 'Project A' });
-        const projectSelect = screen.getByLabelText("Project");
-        fireEvent.change(projectSelect, { target: { value: 'p1' } });
-
-        await waitFor(() => {
-            const fileInput = screen.getByLabelText(/supplemental files/i);
-            expect(fileInput).toBeDisabled();
-        });
-    });
-
     test('shows error banner when project load fails', async () => {
         fetchMock.mockRejectOnce(new Error('Network error'));
         render(<AIContext />);
@@ -244,101 +225,6 @@ describe('AIContext page', () => {
         });
     });
 
-    test('file upload adds file to list', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
-        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
-        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
-        // Context.get after variant select
-        fetchMock.mockResponseOnce(JSON.stringify({
-            project_id: 'p1', description: null, variant_id: 'v1',
-            variant_description: null, environment: null, threat_model: null,
-            risks: null, other_info: null, files: [],
-        }));
-        // upload response
-        fetchMock.mockResponseOnce(JSON.stringify({ id: 'f1', original_name: 'doc.pdf' }), { status: 201 });
-
-        render(<AIContext />);
-        await screen.findByRole('option', { name: 'Project A' });
-        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
-        await screen.findByRole('option', { name: 'Variant 1' });
-        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
-
-        await waitFor(() => expect(screen.getByLabelText(/supplemental files/i)).not.toBeDisabled());
-
-        const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
-        fireEvent.change(screen.getByLabelText(/supplemental files/i), { target: { files: [file] } });
-
-        await waitFor(() => {
-            expect(screen.getByText('doc.pdf')).toBeInTheDocument();
-        });
-    });
-
-    test('file upload sends and displays description', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
-        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
-        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
-        fetchMock.mockResponseOnce(JSON.stringify({
-            project_id: 'p1', description: null, variant_id: 'v1',
-            variant_description: null, environment: null, threat_model: null,
-            risks: null, other_info: null, files: [],
-        }));
-        fetchMock.mockResponseOnce(
-            JSON.stringify({ id: 'f1', original_name: 'doc.pdf', description: 'design notes' }),
-            { status: 201 }
-        );
-
-        render(<AIContext />);
-        await screen.findByRole('option', { name: 'Project A' });
-        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
-        await screen.findByRole('option', { name: 'Variant 1' });
-        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
-
-        await waitFor(() => expect(screen.getByLabelText(/supplemental files/i)).not.toBeDisabled());
-
-        fireEvent.change(screen.getByLabelText("File Description"), { target: { value: 'design notes' } });
-        const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
-        fireEvent.change(screen.getByLabelText(/supplemental files/i), { target: { files: [file] } });
-
-        await waitFor(() => {
-            expect(screen.getByText('design notes')).toBeInTheDocument();
-        });
-
-        const uploadCall = fetchMock.mock.calls.find(c => String(c[0]).includes('/context/files') && c[1]?.method === 'POST');
-        expect(uploadCall).toBeDefined();
-        const body = uploadCall![1]!.body as FormData;
-        expect(body.get('description')).toBe('design notes');
-
-        // description input resets after successful upload
-        expect(screen.getByLabelText("File Description")).toHaveValue('');
-    });
-
-    test('delete file button removes file from list', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
-        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
-        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
-        fetchMock.mockResponseOnce(JSON.stringify({
-            project_id: 'p1', description: null, variant_id: 'v1',
-            variant_description: null, environment: null, threat_model: null,
-            risks: null, other_info: null,
-            files: [{ id: 'f1', original_name: 'existing.txt' }],
-        }));
-        // delete response
-        fetchMock.mockResponseOnce('', { status: 204 });
-
-        render(<AIContext />);
-        await screen.findByRole('option', { name: 'Project A' });
-        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
-        await screen.findByRole('option', { name: 'Variant 1' });
-        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
-
-        await screen.findByText('existing.txt');
-        fireEvent.click(screen.getByRole('button', { name: /delete existing\.txt/i }));
-
-        await waitFor(() => {
-            expect(screen.queryByText('existing.txt')).not.toBeInTheDocument();
-        });
-    });
-
     test('clears variant fields when project changes', async () => {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
         fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
@@ -389,7 +275,7 @@ describe('AIContext page', () => {
         fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
         await screen.findByRole('option', { name: 'Variant 1' });
         fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
-        await waitFor(() => expect(screen.getByLabelText(/supplemental files/i)).not.toBeDisabled());
+        await waitFor(() => expect(screen.getByLabelText(/threat model/i)).not.toBeDisabled());
     }
 
     test('shows error banner when variant save fails', async () => {
@@ -406,61 +292,6 @@ describe('AIContext page', () => {
 
         await waitFor(() => {
             expect(screen.getByText(/variant context failed/i)).toBeInTheDocument();
-        });
-    });
-
-    test('shows file size error when file is too large', async () => {
-        setupWithVariant();
-        render(<AIContext />);
-        await selectProjectAndVariant();
-
-        const largeFile = new File([new ArrayBuffer(11 * 1024 * 1024)], 'big.bin');
-        Object.defineProperty(largeFile, 'size', { value: 11 * 1024 * 1024 });
-        fireEvent.change(screen.getByLabelText(/supplemental files/i), { target: { files: [largeFile] } });
-
-        await waitFor(() => {
-            expect(screen.getByText(/10 MB maximum/i)).toBeInTheDocument();
-        });
-    });
-
-    test('shows error when file upload fails', async () => {
-        setupWithVariant();
-        fetchMock.mockResponseOnce(JSON.stringify({ error: 'Upload failed on server' }), { status: 500 });
-
-        render(<AIContext />);
-        await selectProjectAndVariant();
-
-        const file = new File(['data'], 'test.txt');
-        fireEvent.change(screen.getByLabelText(/supplemental files/i), { target: { files: [file] } });
-
-        await waitFor(() => {
-            expect(screen.getByText(/upload failed on server/i)).toBeInTheDocument();
-        });
-    });
-
-    test('shows error banner when delete file fails', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
-        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
-        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
-        fetchMock.mockResponseOnce(JSON.stringify({
-            project_id: 'p1', description: null, variant_id: 'v1',
-            variant_description: null, environment: null, threat_model: null,
-            risks: null, other_info: null,
-            files: [{ id: 'f1', original_name: 'keep.txt' }],
-        }));
-        fetchMock.mockResponseOnce(JSON.stringify({ error: 'Delete failed' }), { status: 500 });
-
-        render(<AIContext />);
-        await screen.findByRole('option', { name: 'Project A' });
-        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
-        await screen.findByRole('option', { name: 'Variant 1' });
-        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
-        await screen.findByText('keep.txt');
-
-        fireEvent.click(screen.getByRole('button', { name: /delete keep\.txt/i }));
-
-        await waitFor(() => {
-            expect(screen.getByText(/delete failed/i)).toBeInTheDocument();
         });
     });
 
@@ -548,6 +379,99 @@ describe('AIContext page', () => {
 
         await waitFor(() => {
             expect(document.querySelector('[role="alert"]')).toBeInTheDocument();
+        });
+    });
+
+    describe('import / export', () => {
+        let createObjSpy: jest.Mock;
+        let clickSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            createObjSpy = jest.fn(() => 'blob:mock');
+            (global.URL as any).createObjectURL = createObjSpy;
+            (global.URL as any).revokeObjectURL = jest.fn();
+            clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            clickSpy.mockRestore();
+        });
+
+        test('export menu loads variants and downloads selected', async () => {
+            fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }])); // projects
+            render(<AIContext />);
+            await screen.findByRole('option', { name: 'Project A' });
+
+            // Opening the menu lazily loads all variants
+            fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));
+            fireEvent.click(screen.getByRole('button', { name: /export context/i }));
+
+            const checkbox = await screen.findByLabelText('Export Project A / Variant 1');
+            fireEvent.click(checkbox);
+
+            // Export selected -> exportAll, filtered to the checked variant
+            fetchMock.mockResponseOnce(JSON.stringify([
+                {
+                    project_name: 'Project A', variant_name: 'Variant 1', description: 'd',
+                    variant_description: null, codebase_path: null, environment: null,
+                    threat_model: 't', risks: null, other_info: null,
+                },
+            ]));
+            fireEvent.click(screen.getByRole('button', { name: /export selected/i }));
+
+            await waitFor(() => expect(clickSpy).toHaveBeenCalled());
+            expect(createObjSpy).toHaveBeenCalled();
+            const exportCall = fetchMock.mock.calls.find(c => String(c[0]).includes('/api/context/export'));
+            expect(exportCall).toBeDefined();
+        });
+
+        test('export this variant is enabled after selecting a variant', async () => {
+            setupWithVariant();
+            render(<AIContext />);
+            await selectProjectAndVariant();
+            expect(screen.getByRole('button', { name: /export this variant/i })).not.toBeDisabled();
+        });
+
+        test('import shows summary banner and detail list', async () => {
+            fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }])); // projects
+            render(<AIContext />);
+            await screen.findByRole('option', { name: 'Project A' });
+
+            fetchMock.mockResponseOnce(JSON.stringify({
+                imported: [{ project_name: 'Project A', variant_name: 'Variant 1' }],
+                ignored: [{ project_name: 'X', variant_name: 'Y', reason: 'Project not found' }],
+                failed: [],
+            }));
+
+            const payload = JSON.stringify([
+                { project_name: 'Project A', variant_name: 'Variant 1', description: 'd', threat_model: 't' },
+            ]);
+            const file = new File([payload], 'ctx.json', { type: 'application/json' });
+            (file as any).text = () => Promise.resolve(payload);
+            fireEvent.change(screen.getByLabelText('Import context file'), { target: { files: [file] } });
+
+            await waitFor(() => expect(screen.getByText(/import complete/i)).toBeInTheDocument());
+            expect(screen.getByText(/Project not found/i)).toBeInTheDocument();
+
+            const importCall = fetchMock.mock.calls.find(
+                c => String(c[0]).includes('/api/context/import') && (c[1] as any)?.method === 'POST'
+            );
+            expect(importCall).toBeDefined();
+        });
+
+        test('import rejects a non-array JSON file', async () => {
+            fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }])); // projects
+            render(<AIContext />);
+            await screen.findByRole('option', { name: 'Project A' });
+
+            const file = new File([JSON.stringify({ not: 'an array' })], 'ctx.json', { type: 'application/json' });
+            (file as any).text = () => Promise.resolve(JSON.stringify({ not: 'an array' }));
+            fireEvent.change(screen.getByLabelText('Import context file'), { target: { files: [file] } });
+
+            await waitFor(() => expect(screen.getByText(/must contain a JSON array/i)).toBeInTheDocument());
+            // No import request should have been sent
+            const importCall = fetchMock.mock.calls.find(c => String(c[0]).includes('/api/context/import'));
+            expect(importCall).toBeUndefined();
         });
     });
 });

--- a/frontend/tests/unit_tests/test_project_variant_handlers.ts
+++ b/frontend/tests/unit_tests/test_project_variant_handlers.ts
@@ -254,11 +254,11 @@ describe('Variants', () => {
         );
     });
 
-    test('Variants.listAll returns empty array when response is not ok', async () => {
+    test('Variants.listAll throws when response is not ok', async () => {
         fetchMock.mockImplementationOnce(() =>
-            Promise.resolve({ ok: false, json: () => Promise.resolve([]) } as Response)
+            Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve([]) } as Response)
         );
-        expect(await Variants.listAll()).toEqual([]);
+        await expect(Variants.listAll()).rejects.toThrow('Failed to load variants (500)');
     });
 
     test('Variants.listAll returns empty array when server returns non-array', async () => {

--- a/src/bin/cmd_context.py
+++ b/src/bin/cmd_context.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+"""AI context import/export CLI commands:
+``flask export-context`` and ``flask import-context``."""
+
+import json as _json
+
+import click
+from flask.cli import with_appcontext
+
+from ..extensions import db
+from ..helpers.context_io import (
+    build_export_document,
+    collect_entries,
+    extract_entries,
+    import_entries,
+)
+from ._common import resolve_project, resolve_project_variant
+
+
+@click.command("export-context")
+@click.option("--output", "-o", default="./context-export.json", show_default=True,
+              help="File to write the exported context to.")
+@click.option("--project", "-p", default=None,
+              help="Project name. Restricts the export to a single project's variants.")
+@click.option("--variant", "-v", default=None,
+              help="Variant name. Requires --project; restricts the export to a single variant.")
+@with_appcontext
+def export_context_command(output: str, project: str | None, variant: str | None) -> None:
+    """Export AI assessment context as a versioned JSON document."""
+    if variant and not project:
+        click.echo("Error: --variant requires --project.", err=True)
+        raise SystemExit(1)
+
+    if project and variant:
+        project_obj, variant_obj = resolve_project_variant(project, variant, create=False)
+        entries = collect_entries(project_obj.id, variant_obj.id)
+    elif project:
+        project_obj = resolve_project(project)
+        entries = [
+            entry for entry in collect_entries()
+            if entry["project_name"] == project_obj.name
+        ]
+    else:
+        entries = collect_entries()
+
+    document = build_export_document(entries)
+    with open(output, "w") as fh:
+        _json.dump(document, fh, indent=2)
+
+    click.echo(f"Context exported: {output} ({len(entries)} entr{'y' if len(entries) == 1 else 'ies'})")
+
+
+@click.command("import-context")
+@click.argument("file_path")
+@with_appcontext
+def import_context_command(file_path: str) -> None:
+    """Import AI assessment context from a JSON file.
+
+    Accepts either the versioned export envelope or a bare array of entries.
+    Existing context for each matching project/variant is overwritten. Entries
+    whose project or variant does not exist are ignored; entries missing
+    mandatory fields fail.
+    """
+    try:
+        with open(file_path) as fh:
+            data = _json.load(fh)
+    except FileNotFoundError:
+        click.echo(f"Error: file not found: {file_path}", err=True)
+        raise SystemExit(1)
+    except (ValueError, OSError):
+        click.echo("Error: invalid JSON file.", err=True)
+        raise SystemExit(1)
+
+    try:
+        entries = extract_entries(data)
+    except ValueError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1)
+
+    result = import_entries(entries)
+
+    try:
+        db.session.commit()
+    except Exception as exc:
+        db.session.rollback()
+        click.echo(f"Error: failed to import context: {exc}", err=True)
+        raise SystemExit(1)
+
+    imported = result["imported"]
+    ignored = result["ignored"]
+    failed = result["failed"]
+
+    for item in ignored:
+        click.echo(f"  Ignored {_label(item)}: {item.get('reason', '')}", err=True)
+    for item in failed:
+        click.echo(f"  Failed {_label(item)}: {item.get('reason', '')}", err=True)
+
+    click.echo(
+        f"Imported {len(imported)} context entr{'y' if len(imported) == 1 else 'ies'}"
+        f" ({len(ignored)} ignored, {len(failed)} failed)"
+    )
+
+
+def _label(item: dict) -> str:
+    project = item.get("project_name") or "?"
+    variant = item.get("variant_name") or "?"
+    return f"{project}/{variant}"

--- a/src/bin/cmd_context.py
+++ b/src/bin/cmd_context.py
@@ -34,21 +34,22 @@ def export_context_command(output: str, project: str | None, variant: str | None
 
     if project and variant:
         project_obj, variant_obj = resolve_project_variant(project, variant, create=False)
-        entries = collect_entries(project_obj.id, variant_obj.id)
+        projects = collect_entries(project_obj.id, variant_obj.id)
     elif project:
         project_obj = resolve_project(project)
-        entries = [
-            entry for entry in collect_entries()
-            if entry["project_name"] == project_obj.name
+        projects = [
+            group for group in collect_entries()
+            if group["project_name"] == project_obj.name
         ]
     else:
-        entries = collect_entries()
+        projects = collect_entries()
 
-    document = build_export_document(entries)
+    document = build_export_document(projects)
     with open(output, "w") as fh:
         _json.dump(document, fh, indent=2)
 
-    click.echo(f"Context exported: {output} ({len(entries)} entr{'y' if len(entries) == 1 else 'ies'})")
+    count = sum(len(group["variants"]) for group in projects)
+    click.echo(f"Context exported: {output} ({count} entr{'y' if count == 1 else 'ies'})")
 
 
 @click.command("import-context")

--- a/src/bin/cmd_context.py
+++ b/src/bin/cmd_context.py
@@ -102,6 +102,9 @@ def import_context_command(file_path: str) -> None:
         f" ({len(ignored)} ignored, {len(failed)} failed)"
     )
 
+    if failed:
+        raise SystemExit(1)
+
 
 def _label(item: dict) -> str:
     project = item.get("project_name") or "?"

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -34,6 +34,10 @@ from .cmd_assessments import (
     import_custom_openvex_assessments_command,
     import_custom_vulnscout_data_command,
 )
+from .cmd_context import (
+    export_context_command,
+    import_context_command,
+)
 from .cmd_scans import (
     list_projects_command,
     list_scans_command,
@@ -52,6 +56,8 @@ def init_app(app) -> None:
     app.cli.add_command(import_custom_vulnscout_data_command)
     app.cli.add_command(export_custom_openvex_assessments_command)
     app.cli.add_command(import_custom_openvex_assessments_command)
+    app.cli.add_command(export_context_command)
+    app.cli.add_command(import_context_command)
     app.cli.add_command(list_projects_command)
     app.cli.add_command(list_scans_command)
     app.cli.add_command(delete_scan_command)

--- a/src/controllers/context.py
+++ b/src/controllers/context.py
@@ -34,10 +34,11 @@ class ProjectContextController:
     def upsert(
         project_id: uuid.UUID | str,
         description: Optional[str] = None,
+        commit: bool = True,
     ) -> ProjectContext:
         pid = ensure_uuid(project_id)
         ProjectContextController._get_project(pid)
-        return ProjectContext.upsert(pid, description=description)
+        return ProjectContext.upsert(pid, description=description, commit=commit)
 
     @staticmethod
     def serialize(pc: ProjectContext) -> dict:
@@ -72,6 +73,7 @@ class VariantContextController:
         threat_model: Optional[str] = None,
         risks: Optional[str] = None,
         other_info: Optional[str] = None,
+        commit: bool = True,
     ) -> VariantContext:
         vid = ensure_uuid(variant_id)
         VariantContextController._get_variant(vid)
@@ -83,6 +85,7 @@ class VariantContextController:
             threat_model=threat_model,
             risks=risks,
             other_info=other_info,
+            commit=commit,
         )
 
     @staticmethod

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -124,6 +124,8 @@ Scan & output commands:
     --import-custom-vulnscout-data <path>  Import custom VulnScout JSON data
     --export-custom-openvex-assessments  Export custom OpenVEX assessments for --variant
     --import-custom-openvex-assessments <path>  Import custom OpenVEX assessments into --variant
+    --export-context          Export AI assessment context (project/variant description, threat model, etc.) to /scan/outputs/context-export.json
+    --import-context <path>   Import AI assessment context from a JSON file (overwrites matching project/variant)
   --match-condition <expr>  Exit code 2 if condition met (e.g. "cvss >= 9.0")
   --delete-scan <id>        Delete a past scan by its ID
 
@@ -603,6 +605,40 @@ cmd_import_custom_openvex_assessments() {
     setup_user
 }
 
+cmd_export_context() {
+    local -a export_args=(--project "$PROJECT_NAME")
+    if [[ -n "$VARIANT_NAME" ]]; then
+        export_args+=(--variant "$VARIANT_NAME")
+    fi
+
+    cd "$BASE_DIR"
+    local output_dir="${OUTPUTS_DIR:-/scan/outputs}"
+    export_args+=(--output "$output_dir/context-export.json")
+
+    flask --app src.bin.webapp db upgrade
+    flask --app src.bin.webapp export-context "${export_args[@]}"
+    setup_user
+}
+
+cmd_import_context() {
+    local file="$1"
+
+    cd "$BASE_DIR"
+    local raw_basename dest_name dest_file
+    raw_basename="$(basename "$file")"
+    dest_name="${raw_basename#vulnscout_stage_}"
+    if [[ "$dest_name" != "$raw_basename" ]]; then
+        # Strip the staging prefix added by the wrapper before importing.
+        dest_file="$(dirname "$file")/$dest_name"
+        mv "$file" "$dest_file"
+        file="$dest_file"
+    fi
+
+    flask --app src.bin.webapp db upgrade
+    flask --app src.bin.webapp import-context "$file"
+    setup_user
+}
+
 cmd_config_list() {
     if [ -f "$CONFIG_FILE" ]; then
         echo "Config ($CONFIG_FILE):"
@@ -792,6 +828,10 @@ while [[ $# -gt 0 ]]; do
             EXPORT_CUSTOM_OPENVEX_ASSESSMENTS=true; shift ;;
         --import-custom-openvex-assessments)
             IMPORT_CUSTOM_OPENVEX_ASSESSMENTS_FILE="$2"; shift 2 ;;
+        --export-context)
+            EXPORT_CONTEXT=true; shift ;;
+        --import-context)
+            IMPORT_CONTEXT_FILE="$2"; shift 2 ;;
         --list-projects|--list-scans)
             cmd_get_data "$1"; shift ;;
         --config)
@@ -840,6 +880,14 @@ if [[ "${EXPORT_CUSTOM_OPENVEX_ASSESSMENTS:-false}" == "true" ]]; then
 fi
 if [[ -n "${IMPORT_CUSTOM_OPENVEX_ASSESSMENTS_FILE:-}" ]]; then
     cmd_import_custom_openvex_assessments "$IMPORT_CUSTOM_OPENVEX_ASSESSMENTS_FILE"
+fi
+
+# Step 4b: Export/import AI assessment context
+if [[ "${EXPORT_CONTEXT:-false}" == "true" ]]; then
+    cmd_export_context
+fi
+if [[ -n "${IMPORT_CONTEXT_FILE:-}" ]]; then
+    cmd_import_context "$IMPORT_CONTEXT_FILE"
 fi
 
 # Step 5: Get data

--- a/src/helpers/context_io.py
+++ b/src/helpers/context_io.py
@@ -24,11 +24,9 @@ from ..models.variant_context import VariantContext
 EXPORT_VERSION = "1.0"
 
 
-class ContextEntry(TypedDict):
-    """One exported (project, variant) context record."""
-    project_name: str
+class VariantEntry(TypedDict):
+    """One exported variant's context (nested under its project)."""
     variant_name: str
-    description: Optional[str]
     variant_description: Optional[str]
     codebase_path: Optional[str]
     environment: Optional[str]
@@ -37,20 +35,24 @@ class ContextEntry(TypedDict):
     other_info: Optional[str]
 
 
+class ProjectEntry(TypedDict):
+    """One exported project with its variants nested underneath."""
+    project_name: str
+    project_description: Optional[str]
+    variants: list[VariantEntry]
+
+
 class ExportDocument(TypedDict):
-    """Versioned export envelope wrapping a list of context entries."""
+    """Versioned export envelope grouping variants under their project."""
     version: str
     exported_at: str
-    entries: list[ContextEntry]
+    projects: list[ProjectEntry]
 
 
-def context_entry(project: Project, variant: Variant,
-                  pc: Optional[ProjectContext], vc: Optional[VariantContext]) -> ContextEntry:
-    """Build one export entry for a (project, variant) pair."""
+def variant_entry(variant: Variant, vc: Optional[VariantContext]) -> VariantEntry:
+    """Build one export entry for a variant."""
     return {
-        "project_name": project.name,
         "variant_name": variant.name,
-        "description": pc.description if pc else None,
         "variant_description": vc.variant_description if vc else None,
         "codebase_path": vc.codebase_path if vc else None,
         "environment": vc.environment if vc else None,
@@ -60,13 +62,23 @@ def context_entry(project: Project, variant: Variant,
     }
 
 
-def collect_entries(project_id: Optional[uuid.UUID] = None,
-                    variant_id: Optional[uuid.UUID] = None) -> list[ContextEntry]:
-    """Collect export entries.
+def project_entry(project: Project, pc: Optional[ProjectContext],
+                  variants: list[VariantEntry]) -> ProjectEntry:
+    """Build one export entry for a project with its variants nested."""
+    return {
+        "project_name": project.name,
+        "project_description": pc.description if pc else None,
+        "variants": variants,
+    }
 
-    With no arguments, returns one entry per variant across every project.
-    With both *project_id* and *variant_id*, returns a single-entry list for
-    that pair.
+
+def collect_entries(project_id: Optional[uuid.UUID] = None,
+                    variant_id: Optional[uuid.UUID] = None) -> list[ProjectEntry]:
+    """Collect export entries grouped by project.
+
+    With no arguments, returns one project entry per project (each with its
+    variants nested). With both *project_id* and *variant_id*, returns a
+    single-project list containing only that variant.
 
     Raises
     ------
@@ -90,46 +102,76 @@ def collect_entries(project_id: Optional[uuid.UUID] = None,
             raise ValueError("Variant does not belong to the specified project")
         pc = ProjectContext.get_by_project(project_id)
         vc = VariantContext.get_by_variant(variant_id)
-        return [context_entry(project, variant, pc, vc)]
+        return [project_entry(project, pc, [variant_entry(variant, vc)])]
 
-    entries: list[ContextEntry] = []
+    projects: list[ProjectEntry] = []
     for project in Project.get_all():
         pc = ProjectContext.get_by_project(project.id)
+        variants: list[VariantEntry] = []
         for variant in Variant.get_by_project(project.id):
             vc = VariantContext.get_by_variant(variant.id)
-            entries.append(context_entry(project, variant, pc, vc))
-    return entries
+            variants.append(variant_entry(variant, vc))
+        if not variants:
+            continue
+        projects.append(project_entry(project, pc, variants))
+    return projects
 
 
-def build_export_document(entries: list[ContextEntry]) -> ExportDocument:
-    """Wrap *entries* in the versioned export envelope."""
+def build_export_document(projects: list[ProjectEntry]) -> ExportDocument:
+    """Wrap *projects* in the versioned export envelope."""
     return {
         "version": EXPORT_VERSION,
         "exported_at": datetime.now(timezone.utc).isoformat(),
-        "entries": entries,
+        "projects": projects,
     }
 
 
 def extract_entries(body) -> list:
-    """Normalise an import payload into a list of entries.
+    """Normalise an import payload into a flat list of per-variant records.
 
-    Accepts either the versioned envelope (a dict with an ``entries`` list) or
-    a bare list of entries. The ``version`` / ``exported_at`` fields are
-    ignored (lenient).
+    Accepts either the versioned envelope (a dict with a ``projects`` list) or
+    a bare list of project objects. Each project object carries
+    ``project_name`` / ``project_description`` and a ``variants`` list. The
+    returned records are flattened so each carries ``project_name``,
+    ``project_description`` and the variant fields, matching what
+    :func:`import_entries` consumes. The ``version`` / ``exported_at`` fields
+    are ignored (lenient).
 
     Raises
     ------
     ValueError
-        If *body* is neither a list nor a dict containing an ``entries`` list.
+        If *body* is neither a list of projects nor a dict containing a
+        ``projects`` list, or if a project's ``variants`` is not a list.
     """
     if isinstance(body, list):
-        return body
-    if isinstance(body, dict):
-        entries = body.get("entries")
-        if isinstance(entries, list):
-            return entries
-        raise ValueError("Object body must contain an 'entries' array")
-    raise ValueError("Body must be a JSON array of entries or an object with an 'entries' array")
+        projects = body
+    elif isinstance(body, dict):
+        projects = body.get("projects")
+        if not isinstance(projects, list):
+            raise ValueError("Object body must contain a 'projects' array")
+    else:
+        raise ValueError("Body must be a JSON array of projects or an object with a 'projects' array")
+
+    records: list = []
+    for project in projects:
+        if not isinstance(project, dict):
+            records.append(project)
+            continue
+        project_name = project.get("project_name")
+        project_description = project.get("project_description")
+        variants = project.get("variants")
+        if not isinstance(variants, list):
+            raise ValueError("Each project must contain a 'variants' array")
+        for variant in variants:
+            if not isinstance(variant, dict):
+                records.append(variant)
+                continue
+            records.append({
+                "project_name": project_name,
+                "description": project_description,
+                **variant,
+            })
+    return records
 
 
 def import_entries(entries: list) -> dict:

--- a/src/helpers/context_io.py
+++ b/src/helpers/context_io.py
@@ -73,23 +73,31 @@ def project_entry(project: Project, pc: Optional[ProjectContext],
 
 
 def collect_entries(project_id: Optional[uuid.UUID] = None,
-                    variant_id: Optional[uuid.UUID] = None) -> list[ProjectEntry]:
+                    variant_id: Optional[uuid.UUID] = None,
+                    variant_ids: Optional[set[uuid.UUID]] = None) -> list[ProjectEntry]:
     """Collect export entries grouped by project.
 
     With no arguments, returns one project entry per project (each with its
     variants nested). With both *project_id* and *variant_id*, returns a
-    single-project list containing only that variant.
+    single-project list containing only that variant. With *variant_ids*, only
+    variants whose id is in the set are included (projects with no matching
+    variant are dropped); *variant_ids* cannot be combined with the
+    single-variant arguments.
 
     Raises
     ------
     ValueError
-        If exactly one of *project_id* / *variant_id* is given, or the variant
-        does not belong to the project.
+        If exactly one of *project_id* / *variant_id* is given, the variant
+        does not belong to the project, or *variant_ids* is combined with the
+        single-variant arguments.
     LookupError
         If the requested project or variant does not exist.
     """
     if (project_id is None) != (variant_id is None):
         raise ValueError("Both project_id and variant_id are required for a single-variant export")
+
+    if variant_ids is not None and (project_id is not None or variant_id is not None):
+        raise ValueError("variant_ids cannot be combined with a single-variant export")
 
     if project_id is not None and variant_id is not None:
         project = Project.get_by_id(project_id)
@@ -109,6 +117,8 @@ def collect_entries(project_id: Optional[uuid.UUID] = None,
         pc = ProjectContext.get_by_project(project.id)
         variants: list[VariantEntry] = []
         for variant in Variant.get_by_project(project.id):
+            if variant_ids is not None and variant.id not in variant_ids:
+                continue
             vc = VariantContext.get_by_variant(variant.id)
             variants.append(variant_entry(variant, vc))
         if not variants:
@@ -144,11 +154,12 @@ def extract_entries(body) -> list:
         ``projects`` list, or if a project's ``variants`` is not a list.
     """
     if isinstance(body, list):
-        projects = body
+        projects: list = body
     elif isinstance(body, dict):
-        projects = body.get("projects")
-        if not isinstance(projects, list):
+        raw_projects = body.get("projects")
+        if not isinstance(raw_projects, list):
             raise ValueError("Object body must contain a 'projects' array")
+        projects = raw_projects
     else:
         raise ValueError("Body must be a JSON array of projects or an object with a 'projects' array")
 

--- a/src/helpers/context_io.py
+++ b/src/helpers/context_io.py
@@ -1,0 +1,208 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+"""Shared import/export logic for AI assessment context.
+
+Both the HTTP routes (``src/routes/context.py``) and the CLI commands
+(``src/bin/cmd_context.py``) build on these helpers so the export file format
+and import semantics stay in one place.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional, TypedDict
+
+from ..controllers.context import ProjectContextController, VariantContextController
+from ..models.project import Project
+from ..models.project_context import ProjectContext
+from ..models.variant import Variant
+from ..models.variant_context import VariantContext
+
+# Version of the export file format. Bump the major component only on a
+# breaking change to the entry shape.
+EXPORT_VERSION = "1.0"
+
+
+class ContextEntry(TypedDict):
+    """One exported (project, variant) context record."""
+    project_name: str
+    variant_name: str
+    description: Optional[str]
+    variant_description: Optional[str]
+    codebase_path: Optional[str]
+    environment: Optional[str]
+    threat_model: Optional[str]
+    risks: Optional[str]
+    other_info: Optional[str]
+
+
+class ExportDocument(TypedDict):
+    """Versioned export envelope wrapping a list of context entries."""
+    version: str
+    exported_at: str
+    entries: list[ContextEntry]
+
+
+def context_entry(project: Project, variant: Variant,
+                  pc: Optional[ProjectContext], vc: Optional[VariantContext]) -> ContextEntry:
+    """Build one export entry for a (project, variant) pair."""
+    return {
+        "project_name": project.name,
+        "variant_name": variant.name,
+        "description": pc.description if pc else None,
+        "variant_description": vc.variant_description if vc else None,
+        "codebase_path": vc.codebase_path if vc else None,
+        "environment": vc.environment if vc else None,
+        "threat_model": vc.threat_model if vc else None,
+        "risks": vc.risks if vc else None,
+        "other_info": vc.other_info if vc else None,
+    }
+
+
+def collect_entries(project_id: Optional[uuid.UUID] = None,
+                    variant_id: Optional[uuid.UUID] = None) -> list[ContextEntry]:
+    """Collect export entries.
+
+    With no arguments, returns one entry per variant across every project.
+    With both *project_id* and *variant_id*, returns a single-entry list for
+    that pair.
+
+    Raises
+    ------
+    ValueError
+        If exactly one of *project_id* / *variant_id* is given, or the variant
+        does not belong to the project.
+    LookupError
+        If the requested project or variant does not exist.
+    """
+    if (project_id is None) != (variant_id is None):
+        raise ValueError("Both project_id and variant_id are required for a single-variant export")
+
+    if project_id is not None and variant_id is not None:
+        project = Project.get_by_id(project_id)
+        if project is None:
+            raise LookupError("Project not found")
+        variant = Variant.get_by_id(variant_id)
+        if variant is None:
+            raise LookupError("Variant not found")
+        if variant.project_id != project_id:
+            raise ValueError("Variant does not belong to the specified project")
+        pc = ProjectContext.get_by_project(project_id)
+        vc = VariantContext.get_by_variant(variant_id)
+        return [context_entry(project, variant, pc, vc)]
+
+    entries: list[ContextEntry] = []
+    for project in Project.get_all():
+        pc = ProjectContext.get_by_project(project.id)
+        for variant in Variant.get_by_project(project.id):
+            vc = VariantContext.get_by_variant(variant.id)
+            entries.append(context_entry(project, variant, pc, vc))
+    return entries
+
+
+def build_export_document(entries: list[ContextEntry]) -> ExportDocument:
+    """Wrap *entries* in the versioned export envelope."""
+    return {
+        "version": EXPORT_VERSION,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "entries": entries,
+    }
+
+
+def extract_entries(body) -> list:
+    """Normalise an import payload into a list of entries.
+
+    Accepts either the versioned envelope (a dict with an ``entries`` list) or
+    a bare list of entries. The ``version`` / ``exported_at`` fields are
+    ignored (lenient).
+
+    Raises
+    ------
+    ValueError
+        If *body* is neither a list nor a dict containing an ``entries`` list.
+    """
+    if isinstance(body, list):
+        return body
+    if isinstance(body, dict):
+        entries = body.get("entries")
+        if isinstance(entries, list):
+            return entries
+        raise ValueError("Object body must contain an 'entries' array")
+    raise ValueError("Body must be a JSON array of entries or an object with an 'entries' array")
+
+
+def import_entries(entries: list) -> dict:
+    """Apply import *entries* and return a classification summary.
+
+    Upserts run with ``commit=False``; the caller is responsible for committing
+    (or rolling back) the surrounding transaction so the whole batch is atomic.
+
+    Returns
+    -------
+    dict
+        ``{"imported": [...], "ignored": [...], "failed": [...]}`` where each
+        item carries ``project_name`` / ``variant_name`` and, for ignored /
+        failed items, a ``reason``.
+    """
+    def _txt(value):
+        return value if isinstance(value, str) else None
+
+    imported: list = []
+    ignored: list = []
+    failed: list = []
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            failed.append({
+                "project_name": None,
+                "variant_name": None,
+                "reason": "Entry is not a JSON object",
+            })
+            continue
+
+        project_name = _txt(entry.get('project_name'))
+        variant_name = _txt(entry.get('variant_name'))
+        ident = {"project_name": project_name, "variant_name": variant_name}
+
+        if not project_name or not variant_name:
+            ignored.append({**ident, "reason": "Missing project_name or variant_name"})
+            continue
+
+        project = Project.get_by_name(project_name)
+        if project is None:
+            ignored.append({**ident, "reason": "Project not found"})
+            continue
+        variant = Variant.get_by_name_and_project(variant_name, project.id)
+        if variant is None:
+            ignored.append({**ident, "reason": "Variant not found"})
+            continue
+
+        description = _txt(entry.get('description'))
+        threat_model = _txt(entry.get('threat_model'))
+        missing = []
+        if not (description and description.strip()):
+            missing.append('description')
+        if not (threat_model and threat_model.strip()):
+            missing.append('threat_model')
+        if missing:
+            failed.append({
+                **ident,
+                "reason": f"Missing mandatory field(s): {', '.join(missing)}",
+            })
+            continue
+
+        ProjectContextController.upsert(project.id, description=description, commit=False)
+        VariantContextController.upsert(
+            variant.id,
+            variant_description=_txt(entry.get('variant_description')),
+            codebase_path=_txt(entry.get('codebase_path')),
+            environment=_txt(entry.get('environment')),
+            threat_model=threat_model,
+            risks=_txt(entry.get('risks')),
+            other_info=_txt(entry.get('other_info')),
+            commit=False,
+        )
+        imported.append(ident)
+
+    return {"imported": imported, "ignored": ignored, "failed": failed}

--- a/src/models/project_context.py
+++ b/src/models/project_context.py
@@ -43,13 +43,17 @@ class ProjectContext(Base):
         ).scalar_one_or_none()
 
     @staticmethod
-    def upsert(project_id: uuid.UUID, description: str | None = None) -> "ProjectContext":
+    def upsert(
+        project_id: uuid.UUID, description: str | None = None, commit: bool = True
+    ) -> "ProjectContext":
         existing = ProjectContext.get_by_project(project_id)
         if existing is not None:
             existing.description = description
-            db.session.commit()
+            if commit:
+                db.session.commit()
             return existing
         pc = ProjectContext(project_id=project_id, description=description)
         db.session.add(pc)
-        db.session.commit()
+        if commit:
+            db.session.commit()
         return pc

--- a/src/models/variant_context.py
+++ b/src/models/variant_context.py
@@ -32,7 +32,14 @@ def _delete_context_dir(variant_context_id: uuid.UUID) -> None:
 
 
 class ContextFile(Base):
-    """Supplemental file attached to a variant's context."""
+    """Supplemental file attached to a variant's context.
+
+    NOTE: The AI-context UI for managing these files was removed, so this model
+    and its ``context_files`` table are currently unused by the app. They are
+    intentionally retained for potential future reuse (see the file endpoints
+    in ``src/routes/context.py``). Remove this model and drop the table via a
+    migration only if the feature is confirmed dead.
+    """
 
     __tablename__ = "context_files"
 

--- a/src/models/variant_context.py
+++ b/src/models/variant_context.py
@@ -147,6 +147,7 @@ class VariantContext(Base):
         threat_model: str | None = None,
         risks: str | None = None,
         other_info: str | None = None,
+        commit: bool = True,
     ) -> "VariantContext":
         existing = VariantContext.get_by_variant(variant_id)
         if existing is not None:
@@ -156,7 +157,8 @@ class VariantContext(Base):
             existing.threat_model = threat_model
             existing.risks = risks
             existing.other_info = other_info
-            db.session.commit()
+            if commit:
+                db.session.commit()
             return existing
         vc = VariantContext(
             variant_id=variant_id,
@@ -168,7 +170,8 @@ class VariantContext(Base):
             other_info=other_info,
         )
         db.session.add(vc)
-        db.session.commit()
+        if commit:
+            db.session.commit()
         return vc
 
 

--- a/src/routes/context.py
+++ b/src/routes/context.py
@@ -9,6 +9,12 @@ from flask import jsonify, request
 
 from ..controllers.context import ProjectContextController, VariantContextController
 from ..extensions import db
+from ..helpers.context_io import (
+    build_export_document,
+    collect_entries,
+    extract_entries,
+    import_entries,
+)
 from ..models.project import Project
 from ..models.variant import Variant
 from ..models.variant_context import VariantContext, ContextFile
@@ -117,124 +123,40 @@ def init_app(app):
             return jsonify({"error": str(exc)}), 404
         return jsonify(VariantContextController.serialize(vc))
 
-    def _context_entry(project, variant, pc, vc) -> dict:
-        return {
-            "project_name": project.name,
-            "variant_name": variant.name,
-            "description": pc.description if pc else None,
-            "variant_description": vc.variant_description if vc else None,
-            "codebase_path": vc.codebase_path if vc else None,
-            "environment": vc.environment if vc else None,
-            "threat_model": vc.threat_model if vc else None,
-            "risks": vc.risks if vc else None,
-            "other_info": vc.other_info if vc else None,
-        }
-
     @app.route('/api/context/export', methods=['GET'])
     def export_context():
-        from ..models.project_context import ProjectContext
-
         project_id_str = request.args.get('project_id')
         variant_id_str = request.args.get('variant_id')
 
+        project_uuid = None
+        variant_uuid = None
         # Single-variant export requires both identifiers.
         if project_id_str or variant_id_str:
             project_uuid, err = parse_uuid_or_400(project_id_str or '', 'project_id')
             if err:
                 return err
-            assert project_uuid is not None
             variant_uuid, err = parse_uuid_or_400(variant_id_str or '', 'variant_id')
             if err:
                 return err
-            assert variant_uuid is not None
 
-            project = Project.get_by_id(project_uuid)
-            if project is None:
-                return jsonify({"error": "Project not found"}), 404
-            variant = Variant.get_by_id(variant_uuid)
-            if variant is None:
-                return jsonify({"error": "Variant not found"}), 404
-            if variant.project_id != project_uuid:
-                return jsonify({"error": "Variant does not belong to the specified project"}), 400
+        try:
+            entries = collect_entries(project_uuid, variant_uuid)
+        except LookupError as exc:
+            return jsonify({"error": str(exc)}), 404
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
-            pc = ProjectContext.get_by_project(project_uuid)
-            vc = VariantContext.get_by_variant(variant_uuid)
-            return jsonify([_context_entry(project, variant, pc, vc)])
-
-        # Full export: one entry per variant across all projects.
-        entries = []
-        for project in Project.get_all():
-            pc = ProjectContext.get_by_project(project.id)
-            for variant in Variant.get_by_project(project.id):
-                vc = VariantContext.get_by_variant(variant.id)
-                entries.append(_context_entry(project, variant, pc, vc))
-        return jsonify(entries)
+        return jsonify(build_export_document(entries))
 
     @app.route('/api/context/import', methods=['POST'])
     def import_context():
         body = request.get_json(silent=True)
-        if not isinstance(body, list):
-            return jsonify({"error": "Request body must be a JSON array of context entries"}), 400
+        try:
+            entries = extract_entries(body)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
-        def _txt(value):
-            return value if isinstance(value, str) else None
-
-        imported: list = []
-        ignored: list = []
-        failed: list = []
-
-        for entry in body:
-            if not isinstance(entry, dict):
-                failed.append({
-                    "project_name": None,
-                    "variant_name": None,
-                    "reason": "Entry is not a JSON object",
-                })
-                continue
-
-            project_name = _txt(entry.get('project_name'))
-            variant_name = _txt(entry.get('variant_name'))
-            ident = {"project_name": project_name, "variant_name": variant_name}
-
-            if not project_name or not variant_name:
-                ignored.append({**ident, "reason": "Missing project_name or variant_name"})
-                continue
-
-            project = Project.get_by_name(project_name)
-            if project is None:
-                ignored.append({**ident, "reason": "Project not found"})
-                continue
-            variant = Variant.get_by_name_and_project(variant_name, project.id)
-            if variant is None:
-                ignored.append({**ident, "reason": "Variant not found"})
-                continue
-
-            description = _txt(entry.get('description'))
-            threat_model = _txt(entry.get('threat_model'))
-            missing = []
-            if not (description and description.strip()):
-                missing.append('description')
-            if not (threat_model and threat_model.strip()):
-                missing.append('threat_model')
-            if missing:
-                failed.append({
-                    **ident,
-                    "reason": f"Missing mandatory field(s): {', '.join(missing)}",
-                })
-                continue
-
-            ProjectContextController.upsert(project.id, description=description, commit=False)
-            VariantContextController.upsert(
-                variant.id,
-                variant_description=_txt(entry.get('variant_description')),
-                codebase_path=_txt(entry.get('codebase_path')),
-                environment=_txt(entry.get('environment')),
-                threat_model=threat_model,
-                risks=_txt(entry.get('risks')),
-                other_info=_txt(entry.get('other_info')),
-                commit=False,
-            )
-            imported.append(ident)
+        result = import_entries(entries)
 
         # Apply all valid entries atomically: a failure part-way through must
         # not leave the database with only some entries persisted.
@@ -245,7 +167,7 @@ def init_app(app):
             logger.exception("Failed to commit context import")
             return jsonify({"error": f"Failed to import context: {exc}"}), 500
 
-        return jsonify({"imported": imported, "ignored": ignored, "failed": failed})
+        return jsonify(result)
 
     @app.route('/api/variants/<variant_id>/context/files', methods=['POST'])
     def post_context_file(variant_id):

--- a/src/routes/context.py
+++ b/src/routes/context.py
@@ -8,6 +8,7 @@ import logging
 from flask import jsonify, request
 
 from ..controllers.context import ProjectContextController, VariantContextController
+from ..extensions import db
 from ..models.project import Project
 from ..models.variant import Variant
 from ..models.variant_context import VariantContext, ContextFile
@@ -115,6 +116,136 @@ def init_app(app):
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 404
         return jsonify(VariantContextController.serialize(vc))
+
+    def _context_entry(project, variant, pc, vc) -> dict:
+        return {
+            "project_name": project.name,
+            "variant_name": variant.name,
+            "description": pc.description if pc else None,
+            "variant_description": vc.variant_description if vc else None,
+            "codebase_path": vc.codebase_path if vc else None,
+            "environment": vc.environment if vc else None,
+            "threat_model": vc.threat_model if vc else None,
+            "risks": vc.risks if vc else None,
+            "other_info": vc.other_info if vc else None,
+        }
+
+    @app.route('/api/context/export', methods=['GET'])
+    def export_context():
+        from ..models.project_context import ProjectContext
+
+        project_id_str = request.args.get('project_id')
+        variant_id_str = request.args.get('variant_id')
+
+        # Single-variant export requires both identifiers.
+        if project_id_str or variant_id_str:
+            project_uuid, err = parse_uuid_or_400(project_id_str or '', 'project_id')
+            if err:
+                return err
+            assert project_uuid is not None
+            variant_uuid, err = parse_uuid_or_400(variant_id_str or '', 'variant_id')
+            if err:
+                return err
+            assert variant_uuid is not None
+
+            project = Project.get_by_id(project_uuid)
+            if project is None:
+                return jsonify({"error": "Project not found"}), 404
+            variant = Variant.get_by_id(variant_uuid)
+            if variant is None:
+                return jsonify({"error": "Variant not found"}), 404
+            if variant.project_id != project_uuid:
+                return jsonify({"error": "Variant does not belong to the specified project"}), 400
+
+            pc = ProjectContext.get_by_project(project_uuid)
+            vc = VariantContext.get_by_variant(variant_uuid)
+            return jsonify([_context_entry(project, variant, pc, vc)])
+
+        # Full export: one entry per variant across all projects.
+        entries = []
+        for project in Project.get_all():
+            pc = ProjectContext.get_by_project(project.id)
+            for variant in Variant.get_by_project(project.id):
+                vc = VariantContext.get_by_variant(variant.id)
+                entries.append(_context_entry(project, variant, pc, vc))
+        return jsonify(entries)
+
+    @app.route('/api/context/import', methods=['POST'])
+    def import_context():
+        body = request.get_json(silent=True)
+        if not isinstance(body, list):
+            return jsonify({"error": "Request body must be a JSON array of context entries"}), 400
+
+        def _txt(value):
+            return value if isinstance(value, str) else None
+
+        imported: list = []
+        ignored: list = []
+        failed: list = []
+
+        for entry in body:
+            if not isinstance(entry, dict):
+                failed.append({
+                    "project_name": None,
+                    "variant_name": None,
+                    "reason": "Entry is not a JSON object",
+                })
+                continue
+
+            project_name = _txt(entry.get('project_name'))
+            variant_name = _txt(entry.get('variant_name'))
+            ident = {"project_name": project_name, "variant_name": variant_name}
+
+            if not project_name or not variant_name:
+                ignored.append({**ident, "reason": "Missing project_name or variant_name"})
+                continue
+
+            project = Project.get_by_name(project_name)
+            if project is None:
+                ignored.append({**ident, "reason": "Project not found"})
+                continue
+            variant = Variant.get_by_name_and_project(variant_name, project.id)
+            if variant is None:
+                ignored.append({**ident, "reason": "Variant not found"})
+                continue
+
+            description = _txt(entry.get('description'))
+            threat_model = _txt(entry.get('threat_model'))
+            missing = []
+            if not (description and description.strip()):
+                missing.append('description')
+            if not (threat_model and threat_model.strip()):
+                missing.append('threat_model')
+            if missing:
+                failed.append({
+                    **ident,
+                    "reason": f"Missing mandatory field(s): {', '.join(missing)}",
+                })
+                continue
+
+            ProjectContextController.upsert(project.id, description=description, commit=False)
+            VariantContextController.upsert(
+                variant.id,
+                variant_description=_txt(entry.get('variant_description')),
+                codebase_path=_txt(entry.get('codebase_path')),
+                environment=_txt(entry.get('environment')),
+                threat_model=threat_model,
+                risks=_txt(entry.get('risks')),
+                other_info=_txt(entry.get('other_info')),
+                commit=False,
+            )
+            imported.append(ident)
+
+        # Apply all valid entries atomically: a failure part-way through must
+        # not leave the database with only some entries persisted.
+        try:
+            db.session.commit()
+        except Exception as exc:
+            db.session.rollback()
+            logger.exception("Failed to commit context import")
+            return jsonify({"error": f"Failed to import context: {exc}"}), 500
+
+        return jsonify({"imported": imported, "ignored": ignored, "failed": failed})
 
     @app.route('/api/variants/<variant_id>/context/files', methods=['POST'])
     def post_context_file(variant_id):

--- a/src/routes/context.py
+++ b/src/routes/context.py
@@ -140,13 +140,13 @@ def init_app(app):
                 return err
 
         try:
-            entries = collect_entries(project_uuid, variant_uuid)
+            projects = collect_entries(project_uuid, variant_uuid)
         except LookupError as exc:
             return jsonify({"error": str(exc)}), 404
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
 
-        return jsonify(build_export_document(entries))
+        return jsonify(build_export_document(projects))
 
     @app.route('/api/context/import', methods=['POST'])
     def import_context():

--- a/src/routes/context.py
+++ b/src/routes/context.py
@@ -127,9 +127,11 @@ def init_app(app):
     def export_context():
         project_id_str = request.args.get('project_id')
         variant_id_str = request.args.get('variant_id')
+        variant_ids_str = request.args.get('variant_ids')
 
         project_uuid = None
         variant_uuid = None
+        variant_ids: set[uuid.UUID] | None = None
         # Single-variant export requires both identifiers.
         if project_id_str or variant_id_str:
             project_uuid, err = parse_uuid_or_400(project_id_str or '', 'project_id')
@@ -138,9 +140,21 @@ def init_app(app):
             variant_uuid, err = parse_uuid_or_400(variant_id_str or '', 'variant_id')
             if err:
                 return err
+        elif variant_ids_str is not None:
+            # Selective export: comma-separated list of variant UUIDs.
+            variant_ids = set()
+            for raw in variant_ids_str.split(','):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                vid, err = parse_uuid_or_400(raw, 'variant_ids')
+                if err:
+                    return err
+                assert vid is not None
+                variant_ids.add(vid)
 
         try:
-            projects = collect_entries(project_uuid, variant_uuid)
+            projects = collect_entries(project_uuid, variant_uuid, variant_ids)
         except LookupError as exc:
             return jsonify({"error": str(exc)}), 404
         except ValueError as exc:
@@ -169,6 +183,16 @@ def init_app(app):
 
         return jsonify(result)
 
+    # ------------------------------------------------------------------
+    # Supplemental context files (currently hidden from the UI)
+    # ------------------------------------------------------------------
+    # NOTE: The AI-context page no longer exposes a UI for uploading or
+    # deleting supplemental files, so these endpoints (and the ContextFile
+    # model / context_files table) are unused by the frontend today. They are
+    # intentionally kept for potential future reuse rather than removed, to
+    # avoid a destructive schema migration. If this feature is confirmed dead,
+    # remove these routes, the ContextFile model, and add a migration dropping
+    # the context_files table.
     @app.route('/api/variants/<variant_id>/context/files', methods=['POST'])
     def post_context_file(variant_id):
         variant_uuid, err = parse_uuid_or_400(variant_id, 'variant_id')

--- a/tests/webapp_tests/test_context_cli.py
+++ b/tests/webapp_tests/test_context_cli.py
@@ -82,7 +82,7 @@ class TestExportContextCLI:
         assert result.exit_code == 0, result.output
         assert out.exists()
         doc = json.loads(out.read_text())
-        assert doc["version"] == "2.0"
+        assert doc["version"] == "1.0"
         assert isinstance(doc["exported_at"], str) and doc["exported_at"]
         keys = {(e["project_name"], e["variant_name"]) for e in self._flat(doc)}
         assert keys == {
@@ -139,7 +139,7 @@ class TestImportContextCLI:
 
     def test_import_envelope_overwrites(self, app, tmp_path):
         payload = {
-            "version": "2.0",
+            "version": "1.0",
             "exported_at": "2026-07-22T00:00:00+00:00",
             "projects": [{
                 "project_name": "ProjectA",
@@ -187,10 +187,25 @@ class TestImportContextCLI:
         ]
         path = self._write(tmp_path, payload)
         result = app.test_cli_runner().invoke(args=["import-context", path])
-        assert result.exit_code == 0, result.output
+        # A failed entry makes the command exit non-zero.
+        assert result.exit_code != 0, result.output
         assert "1 ignored" in result.output
         assert "1 failed" in result.output
         assert "Variant not found" in result.output
+
+    def test_import_ignored_only_exits_zero(self, app, tmp_path):
+        payload = [
+            {"project_name": "ProjectA", "project_description": "d", "variants": [
+                {"variant_name": "VariantA1", "threat_model": "t"},
+                {"variant_name": "NoSuchVariant", "threat_model": "t"},
+            ]},
+        ]
+        path = self._write(tmp_path, payload)
+        result = app.test_cli_runner().invoke(args=["import-context", path])
+        # Ignored entries are not failures, so the command still succeeds.
+        assert result.exit_code == 0, result.output
+        assert "1 ignored" in result.output
+        assert "0 failed" in result.output
 
     def test_import_missing_file_errors(self, app, tmp_path):
         result = app.test_cli_runner().invoke(args=[
@@ -200,7 +215,7 @@ class TestImportContextCLI:
         assert "file not found" in result.output.lower()
 
     def test_import_malformed_body_errors(self, app, tmp_path):
-        path = self._write(tmp_path, {"version": "2.0"})  # no projects
+        path = self._write(tmp_path, {"version": "1.0"})  # no projects
         result = app.test_cli_runner().invoke(args=["import-context", path])
         assert result.exit_code != 0
         assert "projects" in result.output.lower()

--- a/tests/webapp_tests/test_context_cli.py
+++ b/tests/webapp_tests/test_context_cli.py
@@ -65,6 +65,15 @@ def ids(app):
 
 class TestExportContextCLI:
 
+    @staticmethod
+    def _flat(doc):
+        """Flatten the nested export document to (project_name, variant_name)
+        records for assertions."""
+        return [
+            {"project_name": p["project_name"], **v}
+            for p in doc["projects"] for v in p["variants"]
+        ]
+
     def test_export_all_writes_envelope(self, app, tmp_path):
         out = tmp_path / "ctx.json"
         result = app.test_cli_runner().invoke(args=[
@@ -73,9 +82,9 @@ class TestExportContextCLI:
         assert result.exit_code == 0, result.output
         assert out.exists()
         doc = json.loads(out.read_text())
-        assert doc["version"] == "1.0"
+        assert doc["version"] == "2.0"
         assert isinstance(doc["exported_at"], str) and doc["exported_at"]
-        keys = {(e["project_name"], e["variant_name"]) for e in doc["entries"]}
+        keys = {(e["project_name"], e["variant_name"]) for e in self._flat(doc)}
         assert keys == {
             ("ProjectA", "VariantA1"),
             ("ProjectA", "VariantA2"),
@@ -89,8 +98,8 @@ class TestExportContextCLI:
         ])
         assert result.exit_code == 0, result.output
         doc = json.loads(out.read_text())
-        assert {e["project_name"] for e in doc["entries"]} == {"ProjectA"}
-        assert len(doc["entries"]) == 2
+        assert {p["project_name"] for p in doc["projects"]} == {"ProjectA"}
+        assert len(self._flat(doc)) == 2
 
     def test_export_single_variant(self, app, tmp_path):
         out = tmp_path / "ctx.json"
@@ -100,8 +109,9 @@ class TestExportContextCLI:
         ])
         assert result.exit_code == 0, result.output
         doc = json.loads(out.read_text())
-        assert len(doc["entries"]) == 1
-        assert doc["entries"][0]["variant_name"] == "VariantA1"
+        flat = self._flat(doc)
+        assert len(flat) == 1
+        assert flat[0]["variant_name"] == "VariantA1"
 
     def test_export_variant_without_project_errors(self, app, tmp_path):
         out = tmp_path / "ctx.json"
@@ -129,13 +139,15 @@ class TestImportContextCLI:
 
     def test_import_envelope_overwrites(self, app, tmp_path):
         payload = {
-            "version": "1.0",
+            "version": "2.0",
             "exported_at": "2026-07-22T00:00:00+00:00",
-            "entries": [{
+            "projects": [{
                 "project_name": "ProjectA",
-                "variant_name": "VariantA1",
-                "description": "New description",
-                "threat_model": "new threat model",
+                "project_description": "New description",
+                "variants": [{
+                    "variant_name": "VariantA1",
+                    "threat_model": "new threat model",
+                }],
             }],
         }
         path = self._write(tmp_path, payload)
@@ -152,9 +164,11 @@ class TestImportContextCLI:
     def test_import_bare_array(self, app, tmp_path):
         payload = [{
             "project_name": "ProjectA",
-            "variant_name": "VariantA1",
-            "description": "d",
-            "threat_model": "t",
+            "project_description": "d",
+            "variants": [{
+                "variant_name": "VariantA1",
+                "threat_model": "t",
+            }],
         }]
         path = self._write(tmp_path, payload)
         result = app.test_cli_runner().invoke(args=["import-context", path])
@@ -163,12 +177,13 @@ class TestImportContextCLI:
 
     def test_import_reports_ignored_and_failed(self, app, tmp_path):
         payload = [
-            {"project_name": "ProjectA", "variant_name": "VariantA1",
-             "description": "d", "threat_model": "t"},
-            {"project_name": "ProjectA", "variant_name": "NoSuchVariant",
-             "description": "d", "threat_model": "t"},
-            {"project_name": "ProjectB", "variant_name": "VariantB1",
-             "description": "d"},  # missing threat_model
+            {"project_name": "ProjectA", "project_description": "d", "variants": [
+                {"variant_name": "VariantA1", "threat_model": "t"},
+                {"variant_name": "NoSuchVariant", "threat_model": "t"},
+            ]},
+            {"project_name": "ProjectB", "project_description": "d", "variants": [
+                {"variant_name": "VariantB1"},  # missing threat_model
+            ]},
         ]
         path = self._write(tmp_path, payload)
         result = app.test_cli_runner().invoke(args=["import-context", path])
@@ -185,7 +200,7 @@ class TestImportContextCLI:
         assert "file not found" in result.output.lower()
 
     def test_import_malformed_body_errors(self, app, tmp_path):
-        path = self._write(tmp_path, {"version": "1.0"})  # no entries
+        path = self._write(tmp_path, {"version": "2.0"})  # no projects
         result = app.test_cli_runner().invoke(args=["import-context", path])
         assert result.exit_code != 0
-        assert "entries" in result.output.lower()
+        assert "projects" in result.output.lower()

--- a/tests/webapp_tests/test_context_cli.py
+++ b/tests/webapp_tests/test_context_cli.py
@@ -1,0 +1,191 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the ``flask export-context`` and ``flask import-context`` CLI commands."""
+
+import json
+import os
+
+import pytest
+
+from src.bin.webapp import create_app
+
+
+def _build_db(app):
+    from src.extensions import db
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.project_context import ProjectContext
+    from src.models.variant_context import VariantContext
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        project_a = Project.create("ProjectA")
+        variant_a1 = Variant.create("VariantA1", project_a.id)
+        variant_a2 = Variant.create("VariantA2", project_a.id)
+
+        project_b = Project.create("ProjectB")
+        Variant.create("VariantB1", project_b.id)
+
+        ProjectContext.upsert(project_a.id, description="ProjectA description")
+        VariantContext.upsert(
+            variant_a1.id,
+            variant_description="A1 variant desc",
+            threat_model="A1 threat model",
+        )
+        VariantContext.upsert(variant_a2.id, threat_model="A2 threat model")
+
+        return {
+            "project_a_id": str(project_a.id),
+            "variant_a1_id": str(variant_a1.id),
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        ids = _build_db(application)
+        application._test_ids = ids
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+class TestExportContextCLI:
+
+    def test_export_all_writes_envelope(self, app, tmp_path):
+        out = tmp_path / "ctx.json"
+        result = app.test_cli_runner().invoke(args=[
+            "export-context", "--output", str(out),
+        ])
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        doc = json.loads(out.read_text())
+        assert doc["version"] == "1.0"
+        assert isinstance(doc["exported_at"], str) and doc["exported_at"]
+        keys = {(e["project_name"], e["variant_name"]) for e in doc["entries"]}
+        assert keys == {
+            ("ProjectA", "VariantA1"),
+            ("ProjectA", "VariantA2"),
+            ("ProjectB", "VariantB1"),
+        }
+
+    def test_export_filter_by_project(self, app, tmp_path):
+        out = tmp_path / "ctx.json"
+        result = app.test_cli_runner().invoke(args=[
+            "export-context", "--output", str(out), "--project", "ProjectA",
+        ])
+        assert result.exit_code == 0, result.output
+        doc = json.loads(out.read_text())
+        assert {e["project_name"] for e in doc["entries"]} == {"ProjectA"}
+        assert len(doc["entries"]) == 2
+
+    def test_export_single_variant(self, app, tmp_path):
+        out = tmp_path / "ctx.json"
+        result = app.test_cli_runner().invoke(args=[
+            "export-context", "--output", str(out),
+            "--project", "ProjectA", "--variant", "VariantA1",
+        ])
+        assert result.exit_code == 0, result.output
+        doc = json.loads(out.read_text())
+        assert len(doc["entries"]) == 1
+        assert doc["entries"][0]["variant_name"] == "VariantA1"
+
+    def test_export_variant_without_project_errors(self, app, tmp_path):
+        out = tmp_path / "ctx.json"
+        result = app.test_cli_runner().invoke(args=[
+            "export-context", "--output", str(out), "--variant", "VariantA1",
+        ])
+        assert result.exit_code != 0
+        assert "--variant requires --project" in result.output
+
+    def test_export_unknown_project_errors(self, app, tmp_path):
+        out = tmp_path / "ctx.json"
+        result = app.test_cli_runner().invoke(args=[
+            "export-context", "--output", str(out), "--project", "Nope",
+        ])
+        assert result.exit_code != 0
+        assert "project not found" in result.output.lower()
+
+
+class TestImportContextCLI:
+
+    def _write(self, tmp_path, payload):
+        path = tmp_path / "import.json"
+        path.write_text(json.dumps(payload))
+        return str(path)
+
+    def test_import_envelope_overwrites(self, app, tmp_path):
+        payload = {
+            "version": "1.0",
+            "exported_at": "2026-07-22T00:00:00+00:00",
+            "entries": [{
+                "project_name": "ProjectA",
+                "variant_name": "VariantA1",
+                "description": "New description",
+                "threat_model": "new threat model",
+            }],
+        }
+        path = self._write(tmp_path, payload)
+        result = app.test_cli_runner().invoke(args=["import-context", path])
+        assert result.exit_code == 0, result.output
+        assert "Imported 1 context entry" in result.output
+
+        with app.app_context():
+            from src.models.project_context import ProjectContext
+            import uuid
+            pc = ProjectContext.get_by_project(uuid.UUID(app._test_ids["project_a_id"]))
+            assert pc.description == "New description"
+
+    def test_import_bare_array(self, app, tmp_path):
+        payload = [{
+            "project_name": "ProjectA",
+            "variant_name": "VariantA1",
+            "description": "d",
+            "threat_model": "t",
+        }]
+        path = self._write(tmp_path, payload)
+        result = app.test_cli_runner().invoke(args=["import-context", path])
+        assert result.exit_code == 0, result.output
+        assert "Imported 1 context entr" in result.output
+
+    def test_import_reports_ignored_and_failed(self, app, tmp_path):
+        payload = [
+            {"project_name": "ProjectA", "variant_name": "VariantA1",
+             "description": "d", "threat_model": "t"},
+            {"project_name": "ProjectA", "variant_name": "NoSuchVariant",
+             "description": "d", "threat_model": "t"},
+            {"project_name": "ProjectB", "variant_name": "VariantB1",
+             "description": "d"},  # missing threat_model
+        ]
+        path = self._write(tmp_path, payload)
+        result = app.test_cli_runner().invoke(args=["import-context", path])
+        assert result.exit_code == 0, result.output
+        assert "1 ignored" in result.output
+        assert "1 failed" in result.output
+        assert "Variant not found" in result.output
+
+    def test_import_missing_file_errors(self, app, tmp_path):
+        result = app.test_cli_runner().invoke(args=[
+            "import-context", str(tmp_path / "nope.json"),
+        ])
+        assert result.exit_code != 0
+        assert "file not found" in result.output.lower()
+
+    def test_import_malformed_body_errors(self, app, tmp_path):
+        path = self._write(tmp_path, {"version": "1.0"})  # no entries
+        result = app.test_cli_runner().invoke(args=["import-context", path])
+        assert result.exit_code != 0
+        assert "entries" in result.output.lower()

--- a/tests/webapp_tests/test_context_import_export.py
+++ b/tests/webapp_tests/test_context_import_export.py
@@ -1,0 +1,272 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Tests for the bulk context export/import endpoints."""
+
+import os
+import json
+import pytest
+
+from src.bin.webapp import create_app
+
+
+def _setup_db(app):
+    """Create two projects, each with variants and some context."""
+    from src.extensions import db
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.project_context import ProjectContext
+    from src.models.variant_context import VariantContext
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        project_a = Project.create("ProjectA")
+        variant_a1 = Variant.create("VariantA1", project_a.id)
+        variant_a2 = Variant.create("VariantA2", project_a.id)
+
+        project_b = Project.create("ProjectB")
+        variant_b1 = Variant.create("VariantB1", project_b.id)
+
+        # Project without variants — should not appear in the export.
+        Project.create("EmptyProject")
+
+        ProjectContext.upsert(project_a.id, description="ProjectA description")
+        ProjectContext.upsert(project_b.id, description="ProjectB description")
+
+        VariantContext.upsert(
+            variant_a1.id,
+            variant_description="A1 variant desc",
+            codebase_path="/src/a1",
+            environment="prod",
+            threat_model="A1 threat model",
+            risks="A1 risks",
+            other_info="A1 other",
+        )
+        VariantContext.upsert(
+            variant_a2.id,
+            threat_model="A2 threat model",
+        )
+        VariantContext.upsert(
+            variant_b1.id,
+            threat_model="B1 threat model",
+        )
+
+        return {
+            "project_a_id": str(project_a.id),
+            "project_b_id": str(project_b.id),
+            "variant_a1_id": str(variant_a1.id),
+            "variant_a2_id": str(variant_a2.id),
+            "variant_b1_id": str(variant_b1.id),
+        }
+
+
+@pytest.fixture()
+def app_with_data():
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": "/dev/null"})
+        application._INT_SCAN_FINISHED = True
+        data = _setup_db(application)
+        yield application, data
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client_and_data(app_with_data):
+    application, data = app_with_data
+    return application.test_client(), data
+
+
+# ===========================================================================
+# Export
+# ===========================================================================
+
+class TestExportContext:
+
+    def test_export_all_returns_one_entry_per_variant(self, client_and_data):
+        client, _ = client_and_data
+        response = client.get("/api/context/export")
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        assert isinstance(body, list)
+        # 3 variants total; EmptyProject contributes nothing.
+        assert len(body) == 3
+        keys = {(e["project_name"], e["variant_name"]) for e in body}
+        assert keys == {
+            ("ProjectA", "VariantA1"),
+            ("ProjectA", "VariantA2"),
+            ("ProjectB", "VariantB1"),
+        }
+
+    def test_export_entry_shape_and_values(self, client_and_data):
+        client, _ = client_and_data
+        body = json.loads(client.get("/api/context/export").data)
+        entry = next(e for e in body if e["variant_name"] == "VariantA1")
+        assert entry["description"] == "ProjectA description"
+        assert entry["variant_description"] == "A1 variant desc"
+        assert entry["codebase_path"] == "/src/a1"
+        assert entry["environment"] == "prod"
+        assert entry["threat_model"] == "A1 threat model"
+        assert entry["risks"] == "A1 risks"
+        assert entry["other_info"] == "A1 other"
+
+    def test_export_single_variant(self, client_and_data):
+        client, data = client_and_data
+        response = client.get(
+            f"/api/context/export?project_id={data['project_a_id']}"
+            f"&variant_id={data['variant_a1_id']}"
+        )
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        assert isinstance(body, list)
+        assert len(body) == 1
+        assert body[0]["variant_name"] == "VariantA1"
+
+    def test_export_single_variant_mismatched_project(self, client_and_data):
+        client, data = client_and_data
+        response = client.get(
+            f"/api/context/export?project_id={data['project_b_id']}"
+            f"&variant_id={data['variant_a1_id']}"
+        )
+        assert response.status_code == 400
+
+    def test_export_single_variant_unknown(self, client_and_data):
+        client, data = client_and_data
+        response = client.get(
+            f"/api/context/export?project_id={data['project_a_id']}"
+            "&variant_id=00000000-0000-0000-0000-000000000000"
+        )
+        assert response.status_code == 404
+
+
+# ===========================================================================
+# Import
+# ===========================================================================
+
+class TestImportContext:
+
+    def _post(self, client, payload):
+        return client.post(
+            "/api/context/import",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+    def test_import_non_array_rejected(self, client_and_data):
+        client, _ = client_and_data
+        response = self._post(client, {"project_name": "ProjectA"})
+        assert response.status_code == 400
+
+    def test_import_valid_overwrites(self, client_and_data):
+        client, _ = client_and_data
+        payload = [{
+            "project_name": "ProjectA",
+            "variant_name": "VariantA1",
+            "description": "New ProjectA description",
+            "variant_description": "new variant desc",
+            "threat_model": "new threat model",
+            "risks": "new risks",
+        }]
+        response = self._post(client, payload)
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        assert body["imported"] == [
+            {"project_name": "ProjectA", "variant_name": "VariantA1"}
+        ]
+        assert body["ignored"] == []
+        assert body["failed"] == []
+
+        # Verify overwrite via export.
+        exported = json.loads(client.get("/api/context/export").data)
+        entry = next(e for e in exported if e["variant_name"] == "VariantA1")
+        assert entry["description"] == "New ProjectA description"
+        assert entry["variant_description"] == "new variant desc"
+        assert entry["threat_model"] == "new threat model"
+        assert entry["risks"] == "new risks"
+        # Field omitted from the import is cleared (full overwrite).
+        assert entry["codebase_path"] is None
+
+    def test_import_unknown_project_ignored(self, client_and_data):
+        client, _ = client_and_data
+        payload = [{
+            "project_name": "NoSuchProject",
+            "variant_name": "VariantA1",
+            "description": "d",
+            "threat_model": "t",
+        }]
+        body = json.loads(self._post(client, payload).data)
+        assert body["imported"] == []
+        assert len(body["ignored"]) == 1
+        assert body["ignored"][0]["reason"] == "Project not found"
+
+    def test_import_unknown_variant_ignored(self, client_and_data):
+        client, _ = client_and_data
+        payload = [{
+            "project_name": "ProjectA",
+            "variant_name": "NoSuchVariant",
+            "description": "d",
+            "threat_model": "t",
+        }]
+        body = json.loads(self._post(client, payload).data)
+        assert body["imported"] == []
+        assert body["ignored"][0]["reason"] == "Variant not found"
+
+    def test_import_missing_mandatory_fails(self, client_and_data):
+        client, _ = client_and_data
+        payload = [{
+            "project_name": "ProjectA",
+            "variant_name": "VariantA1",
+            "description": "  ",  # blank
+            # threat_model missing
+        }]
+        body = json.loads(self._post(client, payload).data)
+        assert body["imported"] == []
+        assert len(body["failed"]) == 1
+        reason = body["failed"][0]["reason"]
+        assert "description" in reason
+        assert "threat_model" in reason
+
+    def test_import_missing_identity_ignored(self, client_and_data):
+        client, _ = client_and_data
+        payload = [{"description": "d", "threat_model": "t"}]
+        body = json.loads(self._post(client, payload).data)
+        assert body["ignored"][0]["reason"] == "Missing project_name or variant_name"
+
+    def test_import_ignores_unknown_and_nontext_fields(self, client_and_data):
+        client, _ = client_and_data
+        payload = [{
+            "project_name": "ProjectB",
+            "variant_name": "VariantB1",
+            "description": "d",
+            "threat_model": "t",
+            "risks": 12345,          # non-text -> ignored (cleared)
+            "bogus_field": "hello",  # unknown -> ignored
+        }]
+        body = json.loads(self._post(client, payload).data)
+        assert body["imported"] == [
+            {"project_name": "ProjectB", "variant_name": "VariantB1"}
+        ]
+        exported = json.loads(client.get("/api/context/export").data)
+        entry = next(e for e in exported if e["variant_name"] == "VariantB1")
+        assert entry["risks"] is None
+
+    def test_import_mixed_batch(self, client_and_data):
+        client, _ = client_and_data
+        payload = [
+            {"project_name": "ProjectA", "variant_name": "VariantA1",
+             "description": "d", "threat_model": "t"},
+            {"project_name": "ProjectA", "variant_name": "NoSuchVariant",
+             "description": "d", "threat_model": "t"},
+            {"project_name": "ProjectB", "variant_name": "VariantB1",
+             "description": "d"},  # missing threat_model
+        ]
+        body = json.loads(self._post(client, payload).data)
+        assert len(body["imported"]) == 1
+        assert len(body["ignored"]) == 1
+        assert len(body["failed"]) == 1

--- a/tests/webapp_tests/test_context_import_export.py
+++ b/tests/webapp_tests/test_context_import_export.py
@@ -83,21 +83,38 @@ def client_and_data(app_with_data):
     return application.test_client(), data
 
 
+def _export_entries(client, url="/api/context/export"):
+    """GET the export endpoint and return the entries list from the envelope."""
+    response = client.get(url)
+    assert response.status_code == 200
+    body = json.loads(response.data)
+    assert isinstance(body, dict)
+    assert body["version"]
+    assert body["exported_at"]
+    assert isinstance(body["entries"], list)
+    return body["entries"]
+
+
 # ===========================================================================
 # Export
 # ===========================================================================
 
 class TestExportContext:
 
+    def test_export_returns_versioned_envelope(self, client_and_data):
+        client, _ = client_and_data
+        body = json.loads(client.get("/api/context/export").data)
+        assert isinstance(body, dict)
+        assert body["version"] == "1.0"
+        assert isinstance(body["exported_at"], str) and body["exported_at"]
+        assert isinstance(body["entries"], list)
+
     def test_export_all_returns_one_entry_per_variant(self, client_and_data):
         client, _ = client_and_data
-        response = client.get("/api/context/export")
-        assert response.status_code == 200
-        body = json.loads(response.data)
-        assert isinstance(body, list)
+        entries = _export_entries(client)
         # 3 variants total; EmptyProject contributes nothing.
-        assert len(body) == 3
-        keys = {(e["project_name"], e["variant_name"]) for e in body}
+        assert len(entries) == 3
+        keys = {(e["project_name"], e["variant_name"]) for e in entries}
         assert keys == {
             ("ProjectA", "VariantA1"),
             ("ProjectA", "VariantA2"),
@@ -106,8 +123,8 @@ class TestExportContext:
 
     def test_export_entry_shape_and_values(self, client_and_data):
         client, _ = client_and_data
-        body = json.loads(client.get("/api/context/export").data)
-        entry = next(e for e in body if e["variant_name"] == "VariantA1")
+        entries = _export_entries(client)
+        entry = next(e for e in entries if e["variant_name"] == "VariantA1")
         assert entry["description"] == "ProjectA description"
         assert entry["variant_description"] == "A1 variant desc"
         assert entry["codebase_path"] == "/src/a1"
@@ -118,15 +135,13 @@ class TestExportContext:
 
     def test_export_single_variant(self, client_and_data):
         client, data = client_and_data
-        response = client.get(
+        entries = _export_entries(
+            client,
             f"/api/context/export?project_id={data['project_a_id']}"
-            f"&variant_id={data['variant_a1_id']}"
+            f"&variant_id={data['variant_a1_id']}",
         )
-        assert response.status_code == 200
-        body = json.loads(response.data)
-        assert isinstance(body, list)
-        assert len(body) == 1
-        assert body[0]["variant_name"] == "VariantA1"
+        assert len(entries) == 1
+        assert entries[0]["variant_name"] == "VariantA1"
 
     def test_export_single_variant_mismatched_project(self, client_and_data):
         client, data = client_and_data
@@ -163,6 +178,33 @@ class TestImportContext:
         response = self._post(client, {"project_name": "ProjectA"})
         assert response.status_code == 400
 
+    def test_import_envelope_accepted(self, client_and_data):
+        client, _ = client_and_data
+        payload = {
+            "version": "1.0",
+            "exported_at": "2026-07-22T00:00:00+00:00",
+            "entries": [{
+                "project_name": "ProjectA",
+                "variant_name": "VariantA1",
+                "description": "From envelope",
+                "threat_model": "t",
+            }],
+        }
+        response = self._post(client, payload)
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        assert body["imported"] == [
+            {"project_name": "ProjectA", "variant_name": "VariantA1"}
+        ]
+        entries = _export_entries(client)
+        entry = next(e for e in entries if e["variant_name"] == "VariantA1")
+        assert entry["description"] == "From envelope"
+
+    def test_import_envelope_missing_entries_rejected(self, client_and_data):
+        client, _ = client_and_data
+        response = self._post(client, {"version": "1.0", "exported_at": "x"})
+        assert response.status_code == 400
+
     def test_import_valid_overwrites(self, client_and_data):
         client, _ = client_and_data
         payload = [{
@@ -183,7 +225,7 @@ class TestImportContext:
         assert body["failed"] == []
 
         # Verify overwrite via export.
-        exported = json.loads(client.get("/api/context/export").data)
+        exported = _export_entries(client)
         entry = next(e for e in exported if e["variant_name"] == "VariantA1")
         assert entry["description"] == "New ProjectA description"
         assert entry["variant_description"] == "new variant desc"
@@ -252,7 +294,7 @@ class TestImportContext:
         assert body["imported"] == [
             {"project_name": "ProjectB", "variant_name": "VariantB1"}
         ]
-        exported = json.loads(client.get("/api/context/export").data)
+        exported = _export_entries(client)
         entry = next(e for e in exported if e["variant_name"] == "VariantB1")
         assert entry["risks"] is None
 

--- a/tests/webapp_tests/test_context_import_export.py
+++ b/tests/webapp_tests/test_context_import_export.py
@@ -138,7 +138,7 @@ class TestExportContext:
         client, _ = client_and_data
         body = json.loads(client.get("/api/context/export").data)
         assert isinstance(body, dict)
-        assert body["version"] == "2.0"
+        assert body["version"] == "1.0"
         assert isinstance(body["exported_at"], str) and body["exported_at"]
         assert isinstance(body["projects"], list)
 
@@ -207,6 +207,37 @@ class TestExportContext:
         )
         assert response.status_code == 404
 
+    def test_export_selected_variant_ids_filters_server_side(self, client_and_data):
+        client, data = client_and_data
+        entries = _export_variants(
+            client,
+            f"/api/context/export?variant_ids={data['variant_a1_id']},{data['variant_b1_id']}",
+        )
+        keys = {(e["project_name"], e["variant_name"]) for e in entries}
+        assert keys == {("ProjectA", "VariantA1"), ("ProjectB", "VariantB1")}
+
+    def test_export_selected_single_project_only(self, client_and_data):
+        client, data = client_and_data
+        body = json.loads(client.get(
+            f"/api/context/export?variant_ids={data['variant_a1_id']}"
+        ).data)
+        # Only ProjectA appears; ProjectB (and EmptyProject) are dropped.
+        by_name = {p["project_name"]: p for p in body["projects"]}
+        assert set(by_name) == {"ProjectA"}
+        assert {v["variant_name"] for v in by_name["ProjectA"]["variants"]} == {"VariantA1"}
+
+    def test_export_selected_unknown_id_yields_empty(self, client_and_data):
+        client, _ = client_and_data
+        body = json.loads(client.get(
+            "/api/context/export?variant_ids=00000000-0000-0000-0000-000000000000"
+        ).data)
+        assert body["projects"] == []
+
+    def test_export_selected_invalid_id_rejected(self, client_and_data):
+        client, _ = client_and_data
+        response = client.get("/api/context/export?variant_ids=not-a-uuid")
+        assert response.status_code == 400
+
 
 # ===========================================================================
 # Import
@@ -233,7 +264,7 @@ class TestImportContext:
     def test_import_envelope_accepted(self, client_and_data):
         client, _ = client_and_data
         payload = {
-            "version": "2.0",
+            "version": "1.0",
             "exported_at": "2026-07-22T00:00:00+00:00",
             "projects": [{
                 "project_name": "ProjectA",
@@ -256,7 +287,7 @@ class TestImportContext:
 
     def test_import_envelope_missing_projects_rejected(self, client_and_data):
         client, _ = client_and_data
-        response = self._post(client, {"version": "2.0", "exported_at": "x"})
+        response = self._post(client, {"version": "1.0", "exported_at": "x"})
         assert response.status_code == 400
 
     def test_import_valid_overwrites(self, client_and_data):

--- a/tests/webapp_tests/test_context_import_export.py
+++ b/tests/webapp_tests/test_context_import_export.py
@@ -83,16 +83,49 @@ def client_and_data(app_with_data):
     return application.test_client(), data
 
 
-def _export_entries(client, url="/api/context/export"):
-    """GET the export endpoint and return the entries list from the envelope."""
+def _export_variants(client, url="/api/context/export"):
+    """GET the export endpoint and return a flat list of variant records.
+
+    Each record merges the project's ``project_name`` / ``project_description``
+    (exposed as ``description``) with the variant fields, so tests can assert
+    on a single variant regardless of the nested envelope shape.
+    """
     response = client.get(url)
     assert response.status_code == 200
     body = json.loads(response.data)
     assert isinstance(body, dict)
     assert body["version"]
     assert body["exported_at"]
-    assert isinstance(body["entries"], list)
-    return body["entries"]
+    assert isinstance(body["projects"], list)
+    flat = []
+    for project in body["projects"]:
+        for variant in project["variants"]:
+            flat.append({
+                "project_name": project["project_name"],
+                "description": project["project_description"],
+                **variant,
+            })
+    return flat
+
+
+def _nest(flat_entries):
+    """Group flat ``{project_name, description, variant...}`` dicts into the
+    nested ``projects``/``variants`` import payload."""
+    by_project: dict = {}
+    order: list = []
+    for entry in flat_entries:
+        pname = entry.get("project_name")
+        if pname not in by_project:
+            by_project[pname] = {
+                "project_name": pname,
+                "project_description": entry.get("description"),
+                "variants": [],
+            }
+            order.append(pname)
+        variant = {k: v for k, v in entry.items()
+                   if k not in ("project_name", "description")}
+        by_project[pname]["variants"].append(variant)
+    return [by_project[p] for p in order]
 
 
 # ===========================================================================
@@ -105,13 +138,28 @@ class TestExportContext:
         client, _ = client_and_data
         body = json.loads(client.get("/api/context/export").data)
         assert isinstance(body, dict)
-        assert body["version"] == "1.0"
+        assert body["version"] == "2.0"
         assert isinstance(body["exported_at"], str) and body["exported_at"]
-        assert isinstance(body["entries"], list)
+        assert isinstance(body["projects"], list)
+
+    def test_export_groups_variants_under_projects(self, client_and_data):
+        client, _ = client_and_data
+        body = json.loads(client.get("/api/context/export").data)
+        projects = body["projects"]
+        # EmptyProject contributes nothing.
+        by_name = {p["project_name"]: p for p in projects}
+        assert set(by_name) == {"ProjectA", "ProjectB"}
+        assert by_name["ProjectA"]["project_description"] == "ProjectA description"
+        a_variants = {v["variant_name"] for v in by_name["ProjectA"]["variants"]}
+        assert a_variants == {"VariantA1", "VariantA2"}
+        # Project fields are not repeated on the variant objects.
+        sample = by_name["ProjectA"]["variants"][0]
+        assert "project_name" not in sample
+        assert "description" not in sample
 
     def test_export_all_returns_one_entry_per_variant(self, client_and_data):
         client, _ = client_and_data
-        entries = _export_entries(client)
+        entries = _export_variants(client)
         # 3 variants total; EmptyProject contributes nothing.
         assert len(entries) == 3
         keys = {(e["project_name"], e["variant_name"]) for e in entries}
@@ -123,7 +171,7 @@ class TestExportContext:
 
     def test_export_entry_shape_and_values(self, client_and_data):
         client, _ = client_and_data
-        entries = _export_entries(client)
+        entries = _export_variants(client)
         entry = next(e for e in entries if e["variant_name"] == "VariantA1")
         assert entry["description"] == "ProjectA description"
         assert entry["variant_description"] == "A1 variant desc"
@@ -135,7 +183,7 @@ class TestExportContext:
 
     def test_export_single_variant(self, client_and_data):
         client, data = client_and_data
-        entries = _export_entries(
+        entries = _export_variants(
             client,
             f"/api/context/export?project_id={data['project_a_id']}"
             f"&variant_id={data['variant_a1_id']}",
@@ -173,6 +221,10 @@ class TestImportContext:
             content_type="application/json",
         )
 
+    def _post_entries(self, client, flat_entries):
+        """Nest flat variant dicts into the projects payload before posting."""
+        return self._post(client, _nest(flat_entries))
+
     def test_import_non_array_rejected(self, client_and_data):
         client, _ = client_and_data
         response = self._post(client, {"project_name": "ProjectA"})
@@ -181,13 +233,15 @@ class TestImportContext:
     def test_import_envelope_accepted(self, client_and_data):
         client, _ = client_and_data
         payload = {
-            "version": "1.0",
+            "version": "2.0",
             "exported_at": "2026-07-22T00:00:00+00:00",
-            "entries": [{
+            "projects": [{
                 "project_name": "ProjectA",
-                "variant_name": "VariantA1",
-                "description": "From envelope",
-                "threat_model": "t",
+                "project_description": "From envelope",
+                "variants": [{
+                    "variant_name": "VariantA1",
+                    "threat_model": "t",
+                }],
             }],
         }
         response = self._post(client, payload)
@@ -196,26 +250,25 @@ class TestImportContext:
         assert body["imported"] == [
             {"project_name": "ProjectA", "variant_name": "VariantA1"}
         ]
-        entries = _export_entries(client)
+        entries = _export_variants(client)
         entry = next(e for e in entries if e["variant_name"] == "VariantA1")
         assert entry["description"] == "From envelope"
 
-    def test_import_envelope_missing_entries_rejected(self, client_and_data):
+    def test_import_envelope_missing_projects_rejected(self, client_and_data):
         client, _ = client_and_data
-        response = self._post(client, {"version": "1.0", "exported_at": "x"})
+        response = self._post(client, {"version": "2.0", "exported_at": "x"})
         assert response.status_code == 400
 
     def test_import_valid_overwrites(self, client_and_data):
         client, _ = client_and_data
-        payload = [{
+        response = self._post_entries(client, [{
             "project_name": "ProjectA",
             "variant_name": "VariantA1",
             "description": "New ProjectA description",
             "variant_description": "new variant desc",
             "threat_model": "new threat model",
             "risks": "new risks",
-        }]
-        response = self._post(client, payload)
+        }])
         assert response.status_code == 200
         body = json.loads(response.data)
         assert body["imported"] == [
@@ -225,7 +278,7 @@ class TestImportContext:
         assert body["failed"] == []
 
         # Verify overwrite via export.
-        exported = _export_entries(client)
+        exported = _export_variants(client)
         entry = next(e for e in exported if e["variant_name"] == "VariantA1")
         assert entry["description"] == "New ProjectA description"
         assert entry["variant_description"] == "new variant desc"
@@ -236,38 +289,35 @@ class TestImportContext:
 
     def test_import_unknown_project_ignored(self, client_and_data):
         client, _ = client_and_data
-        payload = [{
+        body = json.loads(self._post_entries(client, [{
             "project_name": "NoSuchProject",
             "variant_name": "VariantA1",
             "description": "d",
             "threat_model": "t",
-        }]
-        body = json.loads(self._post(client, payload).data)
+        }]).data)
         assert body["imported"] == []
         assert len(body["ignored"]) == 1
         assert body["ignored"][0]["reason"] == "Project not found"
 
     def test_import_unknown_variant_ignored(self, client_and_data):
         client, _ = client_and_data
-        payload = [{
+        body = json.loads(self._post_entries(client, [{
             "project_name": "ProjectA",
             "variant_name": "NoSuchVariant",
             "description": "d",
             "threat_model": "t",
-        }]
-        body = json.loads(self._post(client, payload).data)
+        }]).data)
         assert body["imported"] == []
         assert body["ignored"][0]["reason"] == "Variant not found"
 
     def test_import_missing_mandatory_fails(self, client_and_data):
         client, _ = client_and_data
-        payload = [{
+        body = json.loads(self._post_entries(client, [{
             "project_name": "ProjectA",
             "variant_name": "VariantA1",
             "description": "  ",  # blank
             # threat_model missing
-        }]
-        body = json.loads(self._post(client, payload).data)
+        }]).data)
         assert body["imported"] == []
         assert len(body["failed"]) == 1
         reason = body["failed"][0]["reason"]
@@ -276,39 +326,38 @@ class TestImportContext:
 
     def test_import_missing_identity_ignored(self, client_and_data):
         client, _ = client_and_data
-        payload = [{"description": "d", "threat_model": "t"}]
-        body = json.loads(self._post(client, payload).data)
+        body = json.loads(self._post_entries(client, [
+            {"description": "d", "threat_model": "t"}
+        ]).data)
         assert body["ignored"][0]["reason"] == "Missing project_name or variant_name"
 
     def test_import_ignores_unknown_and_nontext_fields(self, client_and_data):
         client, _ = client_and_data
-        payload = [{
+        body = json.loads(self._post_entries(client, [{
             "project_name": "ProjectB",
             "variant_name": "VariantB1",
             "description": "d",
             "threat_model": "t",
             "risks": 12345,          # non-text -> ignored (cleared)
             "bogus_field": "hello",  # unknown -> ignored
-        }]
-        body = json.loads(self._post(client, payload).data)
+        }]).data)
         assert body["imported"] == [
             {"project_name": "ProjectB", "variant_name": "VariantB1"}
         ]
-        exported = _export_entries(client)
+        exported = _export_variants(client)
         entry = next(e for e in exported if e["variant_name"] == "VariantB1")
         assert entry["risks"] is None
 
     def test_import_mixed_batch(self, client_and_data):
         client, _ = client_and_data
-        payload = [
+        body = json.loads(self._post_entries(client, [
             {"project_name": "ProjectA", "variant_name": "VariantA1",
              "description": "d", "threat_model": "t"},
             {"project_name": "ProjectA", "variant_name": "NoSuchVariant",
              "description": "d", "threat_model": "t"},
             {"project_name": "ProjectB", "variant_name": "VariantB1",
              "description": "d"},  # missing threat_model
-        ]
-        body = json.loads(self._post(client, payload).data)
+        ]).data)
         assert len(body["imported"]) == 1
         assert len(body["ignored"]) == 1
         assert len(body["failed"]) == 1

--- a/vulnscout
+++ b/vulnscout
@@ -82,6 +82,8 @@ Scan & output commands:
     --import-custom-vulnscout-data <path>  Import custom VulnScout JSON data
     --export-custom-openvex-assessments  Export custom OpenVEX assessments for --variant
     --import-custom-openvex-assessments <path>  Import custom OpenVEX assessments into --variant
+    --export-context                 Export AI assessment context to /scan/outputs/context-export.json
+    --import-context <path>          Import AI assessment context from a JSON file (overwrites matching project/variant)
   --delete-scan <id>                Delete a past scan by its ID
 
 Data retrieval commands:
@@ -358,6 +360,17 @@ parse_and_run() {
                 import_staged="/tmp/vulnscout_stage_$(basename "$import_file")"
                 call_container_engine cp "$import_file" "$CONTAINER_NAME:$import_staged"
                 EXPORT_ARGS+=(--import-custom-openvex-assessments "$import_staged")
+                shift 2 ;;
+            export-context|--export-context)
+                ensure_running; EXPORT_ARGS+=(--export-context); shift ;;
+            import-context|--import-context)
+                ensure_running
+                local import_ctx_file
+                import_ctx_file="$(readlink -f "$2")"
+                local import_ctx_staged
+                import_ctx_staged="/tmp/vulnscout_stage_$(basename "$import_ctx_file")"
+                call_container_engine cp "$import_ctx_file" "$CONTAINER_NAME:$import_ctx_staged"
+                EXPORT_ARGS+=(--import-context "$import_ctx_staged")
                 shift 2 ;;
             delete-scan|--delete-scan)
                 ensure_running


### PR DESCRIPTION
### Changes proposed in this pull request:

Added context import/export for the existing project and variant. 

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Import and export buttons are added to the AI context page with a helper text explaining how import works.

<img width="340" height="115" alt="image" src="https://github.com/user-attachments/assets/590fe3c8-394c-47fc-b9d5-c22e2da5baa1" />

The export button opens a dropdown to select the variants to export.

<img width="460" height="365" alt="image" src="https://github.com/user-attachments/assets/7e1d03b7-43bd-427e-9d02-b15c75cb0a44" />


Example context file format for import:

```json
{
  "exported_at": "2026-07-24T15:45:55.323890+00:00",
  "projects": [
    {
      "project_description": "test",
      "project_name": "test",
      "variants": [
        {
          "codebase_path": null,
          "environment": "test",
          "other_info": null,
          "risks": null,
          "threat_model": "test",
          "variant_description": null,
          "variant_name": "default"
        },
        {
          "codebase_path": null,
          "environment": null,
          "other_info": null,
          "risks": null,
          "threat_model": "test",
          "variant_description": null,
          "variant_name": "test"
        }
      ]
    },
    {
      "project_description": "null",
      "project_name": "test",
      "variants": [
        {
          "codebase_path": null,
          "environment": null,
          "other_info": null,
          "risks": null,
          "threat_model": "test",
          "variant_description": null,
          "variant_name": "test"
        }
      ]
    }
  ],
  "version": "1.0"
}
```
The importer goes through each entry in the JSON file to validate the context. A successful import requires the following:
1. The project and the variant exist in VulnScout.
2. Required fields are present: `description`, `project_name`, `variant_name` and `threat_model`.


Support for import/export is also added to the CLI commands.

Example commands to import/export: 
```bash
# Export the context for a given project and variant
./vulnscout --project <your-project> --variant <your-variant> --export-context
# Import a context JSON file for a project
./vulnscout --project <your-project> --import-context "path/to/context.json"
```

### Additional notes

1. The import overwrites the existing context entirely when the provided project and variant match the ones in VulnScout.
2. Invalid fields will be ignored.
3. The new changes will be committed to the DB when the entire import is successful.

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


