### PR TITLE
Optimize Explorer Initial Load Performance

### DIFF
--- a/frontend/src/components/TableGeneric.tsx
+++ b/frontend/src/components/TableGeneric.tsx
@@ -29,6 +29,7 @@ type Props<DataType> = {
     hasPagination?: boolean;
     onFilteredDataChange?: (filteredData: DataType[]) => void;
     onFocusedRowChange?: (rowIndex: number | null) => void;
+    onHoverData?: (item: DataType) => Promise<DataType | null | undefined>;
     /**
      * Values checked by the `only:<term>` search operator. When provided, a row
      * is kept only if EVERY string returned here satisfies the (optionally
@@ -61,6 +62,7 @@ function TableGeneric<DataType> ({
     hasPagination = true,
     onFilteredDataChange,
     onFocusedRowChange,
+    onHoverData,
     forAllValues
 }: Readonly<Props<DataType>>) {
     const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 50 })
@@ -72,6 +74,7 @@ function TableGeneric<DataType> ({
     const rowRefs = useRef<Map<number, HTMLTableRowElement>>(new Map())
     const [tooltipInfo, setTooltipInfo] = useState<{ original: DataType; id: string; rect: DOMRect } | null>(null)
     const hideTooltipTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const tooltipRequestId = useRef(0)
 
     const fuse = useMemo(() => {
         return new Fuse(data as readonly DataType[], {
@@ -281,13 +284,26 @@ function TableGeneric<DataType> ({
         return () => document.removeEventListener('mousedown', closeHintOnOutsideClick);
     }, [hintColumnId])
 
-    function showTooltip(e: React.MouseEvent<HTMLTableRowElement>, rowOriginal: DataType, rowId: string) {
+    async function showTooltip(e: React.MouseEvent<HTMLTableRowElement>, rowOriginal: DataType, rowId: string) {
         if (hoverField === undefined) return
         if (hideTooltipTimer.current) clearTimeout(hideTooltipTimer.current)
-        setTooltipInfo({ original: rowOriginal, id: rowId, rect: e.currentTarget.getBoundingClientRect() })
+        const rect = e.currentTarget.getBoundingClientRect()
+        const requestId = ++tooltipRequestId.current
+        setTooltipInfo({ original: rowOriginal, id: rowId, rect })
+        if (onHoverData) {
+            try {
+                const resolved = await onHoverData(rowOriginal)
+                if (resolved && tooltipRequestId.current === requestId) {
+                    setTooltipInfo({ original: resolved, id: rowId, rect })
+                }
+            } catch {
+                // Keep the tooltip open with its fallback when details cannot load.
+            }
+        }
     }
 
     function hideTooltip() {
+        tooltipRequestId.current++
         hideTooltipTimer.current = setTimeout(() => setTooltipInfo(null), 100)
     }
 
@@ -661,7 +677,9 @@ function TableGeneric<DataType> ({
                                 {index < (tooltipInfo.original as any)?.[hoverField]?.length - 1 ? '\n---\n' : ''}
                             </span>
                         ))
-                        : "No description was provided"
+                        : (tooltipInfo.original as any)?.details_loaded === false
+                            ? "Loading description..."
+                            : "No description was provided"
                     }
                 </div>
                 <p className="text-xs text-gray-400 mt-1 italic">Click the CVE to see more</p>

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -186,7 +186,12 @@ type VariantScopedSnapshot = {
             .then(r => r.json())
             .then((data: any[]) => {
                 if (Array.isArray(data)) {
-                    setAllVulnAssessments(data.flatMap(asAssessment).filter((a): a is Assessment => !Array.isArray(a)));
+                    const fullAssessments = data.flatMap(asAssessment).filter((a): a is Assessment => !Array.isArray(a));
+                    const fullById = new Map(fullAssessments.map(a => [a.id, a]));
+                    // Keep the Explorer's current scope, but replace its compact
+                    // assessment rows with the full records used by the modal.
+                    vuln.assessments = vuln.assessments.map(a => fullById.get(a.id) ?? a);
+                    setAllVulnAssessments(fullAssessments);
                 }
             })
             .catch(() => {});

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -30,6 +30,8 @@ import GhsaRefreshHandler from "../handlers/ghsaRefresh";
 
 type Props = {
     vuln: Vulnerability;
+    detailsLoading?: boolean;
+    detailsError?: boolean;
     isEditing?: boolean;
     readOnly?: boolean;
     onClose: () => void;
@@ -126,7 +128,7 @@ type VariantScopedSnapshot = {
 };
 
   function VulnModal(props: Readonly<Props>) {
-    const { vuln, isEditing: initialIsEditing, readOnly = false, onClose, appendAssessment, appendCVSS, patchVuln, vulnerabilities, currentIndex, onNavigate, variantId, projectId } = props;
+        const { vuln, detailsLoading = false, detailsError = false, isEditing: initialIsEditing, readOnly = false, onClose, appendAssessment, appendCVSS, patchVuln, vulnerabilities, currentIndex, onNavigate, variantId, projectId } = props;
     const docUrl = useDocUrl("interactive-mode.html#vulnerability-details");
     const [isEditing, setIsEditing] = useState(initialIsEditing);
     const [showCustomCvss, setShowCustomCvss] = useState(false);
@@ -1623,6 +1625,17 @@ type VariantScopedSnapshot = {
                             </div>
 
                         </div>
+
+                        {detailsLoading && (
+                            <div className="mb-6 rounded-lg bg-gray-800 p-3 text-gray-300">
+                                Loading description, links, and CVSS details...
+                            </div>
+                        )}
+                        {detailsError && (
+                            <div className="mb-6 rounded-lg bg-red-900 p-3 text-red-100">
+                                Vulnerability details could not be loaded.
+                            </div>
+                        )}
 
                         <div className="mb-6 flex flex-col gap-2">
                             {vuln.texts.map((text) => {

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -196,7 +196,7 @@ type VariantScopedSnapshot = {
             })
             .catch(() => {});
         return () => controller.abort();
-    }, [vuln.id]);
+    }, [vuln]);
 
     // In all-variants mode, default to all variant targets for custom CVSS/time edits.
     useEffect(() => {

--- a/frontend/src/handlers/assessments.ts
+++ b/frontend/src/handlers/assessments.ts
@@ -36,6 +36,7 @@ type Assessment = {
     superseded_by?: string[];
     stale_packages?: string[];
     superseded_map?: Record<string, string[]>;
+    details_loaded?: boolean;
 };
 
 export type { Assessment };
@@ -71,6 +72,22 @@ const asStringArray = (data: any): string[] => {
 }
 
 const asAssessment = (data: any): Assessment | [] => {
+    if (Array.isArray(data)) {
+        const [id, vuln_id, packageId, variant_id, timestamp, status] = data;
+        if (typeof id !== "string" || typeof vuln_id !== "string"
+            || (packageId !== null && typeof packageId !== "string")
+            || (variant_id !== null && typeof variant_id !== "string")
+            || typeof timestamp !== "string" || typeof status !== "string") return [];
+        data = {
+            id,
+            vuln_id,
+            packages: packageId ? [packageId] : [],
+            variant_id,
+            timestamp,
+            status,
+            details_loaded: false,
+        };
+    }
     if (typeof data !== "object") return [];
     if (typeof data?.id !== "string") return [];
     if (typeof data?.vuln_id !== "string") return [];
@@ -113,6 +130,7 @@ const asAssessment = (data: any): Assessment | [] => {
         }
         item.superseded_map = map;
     }
+    if (typeof data?.details_loaded === "boolean") item.details_loaded = data.details_loaded;
     return item
 }
 
@@ -148,7 +166,10 @@ class Assessments {
      */
     static async list(variantId?: string, projectId?: string): Promise<Assessment[]> {
         const url = new URL(import.meta.env.VITE_API_URL + "/api/assessments", window.location.href);
-        url.searchParams.set('format', 'list');
+        // Initial Explorer rendering only needs status, timestamp, package and
+        // variant scope. Full notes/responses are fetched for one vulnerability
+        // when its modal opens.
+        url.searchParams.set('format', 'compact');
         if (variantId) url.searchParams.set('variant_id', variantId);
         else if (projectId) url.searchParams.set('project_id', projectId);
         const response = await fetch(url.toString(), {

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -74,6 +74,8 @@ type Vulnerability = {
     assessments: Assessment[];
     /** False only for compact list records whose modal-only data is deferred. */
     details_loaded?: boolean;
+    /** Atomic terms confirmed in deferred descriptions by server-side search. */
+    description_search_terms?: string;
 };
 
 export type { Vulnerability, CVSS };
@@ -373,6 +375,43 @@ class Vulnerabilities {
         }
         const parsed = asVulnerability(await response.json());
         return Array.isArray(parsed) ? null : parsed;
+    }
+
+    static async searchDescriptionTerms(
+        vulnerabilityIds: string[],
+        terms: string[],
+        variantId?: string,
+        projectId?: string,
+        signal?: AbortSignal,
+    ): Promise<Record<string, string[]>> {
+        const url = new URL(
+            import.meta.env.VITE_API_URL + '/api/vulnerabilities/search-descriptions',
+            window.location.href,
+        );
+        if (variantId) {
+            url.searchParams.set('variant_id', variantId);
+        } else if (projectId) {
+            url.searchParams.set('project_id', projectId);
+        }
+        const response = await fetch(url.toString(), {
+            method: 'POST',
+            mode: 'cors',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ vulnerability_ids: vulnerabilityIds, terms }),
+            signal,
+        });
+        if (!response.ok) {
+            throw new Error(`Failed to search vulnerability descriptions (${response.status})`);
+        }
+        const data: unknown = await response.json();
+        if (!data || typeof data !== 'object' || !('matches' in data)) return {};
+        const matches = (data as { matches?: unknown }).matches;
+        if (!matches || typeof matches !== 'object' || Array.isArray(matches)) return {};
+        return Object.fromEntries(
+            Object.entries(matches).flatMap(([term, ids]) =>
+                Array.isArray(ids) ? [[term, asStringArray(ids)]] : []
+            )
+        );
     }
 
     // Re-fetch a single vulnerability in the given (project) scope and return

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -72,6 +72,8 @@ type Vulnerability = {
     simplified_status: string;
     status_summary?: StatusSummary;
     assessments: Assessment[];
+    /** False only for compact list records whose modal-only data is deferred. */
+    details_loaded?: boolean;
 };
 
 export type { Vulnerability, CVSS };
@@ -212,6 +214,7 @@ const asCVSS = (data: any): CVSS | [] => {
         if (score.vector_string.includes("AV:L")) score.attack_vector = "LOCAL"
         if (score.vector_string.includes("AV:P")) score.attack_vector = "PHYSICAL"
     }
+    if (typeof data?.attack_vector === "string") score.attack_vector = data.attack_vector
     if (typeof data?.exploitability_score === "number") score.exploitability_score = Number(data.exploitability_score)
     if (typeof data?.impact_score === "number") score.impact_score = Number(data.impact_score)
     return score
@@ -252,6 +255,7 @@ const asVulnerability = (data: any): Vulnerability | [] => {
         },
         simplified_status: 'unknown',
         assessments: [],
+        details_loaded: data?.details_loaded !== false,
     };
     if (typeof data?.namespace === "string") vuln.namespace = data.namespace
     if (typeof data?.datasource === "string") vuln.datasource = data.datasource
@@ -327,7 +331,7 @@ class Vulnerabilities {
 
     static async list(variantId?: string, projectId?: string, compareVariantId?: string, operation?: string, variantIds?: string[], multiOperation?: string): Promise<Vulnerability[]> {
         const url = new URL(import.meta.env.VITE_API_URL + "/api/vulnerabilities", window.location.href);
-        url.searchParams.set('format', 'list');
+        url.searchParams.set('format', 'compact');
         if (variantId && compareVariantId) {
             url.searchParams.set('variant_id', variantId);
             url.searchParams.set('compare_variant_id', compareVariantId);
@@ -346,6 +350,27 @@ class Vulnerabilities {
         });
         const data = await response.json();
         return data.flatMap(asVulnerability);
+    }
+
+    static async getDetails(
+        vulnId: string,
+        variantId?: string,
+        projectId?: string,
+        signal?: AbortSignal,
+    ): Promise<Vulnerability | null> {
+        const url = new URL(
+            import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vulnId)}`,
+            window.location.href,
+        );
+        if (variantId) {
+            url.searchParams.set('variant_id', variantId);
+        } else if (projectId) {
+            url.searchParams.set('project_id', projectId);
+        }
+        const response = await fetch(url.toString(), { mode: 'cors', signal });
+        if (!response.ok) return null;
+        const parsed = asVulnerability(await response.json());
+        return Array.isArray(parsed) ? null : parsed;
     }
 
     // Re-fetch a single vulnerability in the given (project) scope and return

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -368,7 +368,9 @@ class Vulnerabilities {
             url.searchParams.set('project_id', projectId);
         }
         const response = await fetch(url.toString(), { mode: 'cors', signal });
-        if (!response.ok) return null;
+        if (!response.ok) {
+            throw new Error(`Failed to load vulnerability details (${response.status})`);
+        }
         const parsed = asVulnerability(await response.json());
         return Array.isArray(parsed) ? null : parsed;
     }

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -83,36 +83,40 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         setIsLoadingData(true);
 
         const multiActive = !!(variantIds && variantIds.length >= 2);
-        let assessPromise: Promise<Assessment[]>;
-        if (multiActive) {
-            assessPromise = Promise.all(
-                variantIds!.map(id => Assessments.list(id, projectId)),
-            ).then(lists => removeDuplicateAssessments(lists.flat()));
-        } else if (compareVariantId && variantId) {
-            assessPromise = Promise.all([
-                Assessments.list(variantId, projectId),
-                Assessments.list(compareVariantId, projectId),
-              ]).then(([a1, a2]) => removeDuplicateAssessments([...a1, ...a2]));
-        } else {
-            assessPromise = Assessments.list(variantId, projectId);
-        }
-
         Promise.allSettled([
             Packages.list(variantId, projectId, compareVariantId, operation, variantIds, multiOperation),
             Vulnerabilities.list(variantId, projectId, compareVariantId, operation, variantIds, multiOperation),
-            assessPromise,
-        ]).then(([pkgsResult, vulnsResult, assessResult]) => {
+        ]).then(async ([pkgsResult, vulnsResult]) => {
+            if (pkgsResult.status === 'rejected' || vulnsResult.status === 'rejected') {
+                throw new Error("Failed to load packages or vulnerabilities");
+            }
+            let assessments: Assessment[];
+            if (multiActive) {
+                const lists = await Promise.all(
+                    variantIds!.map(id => Assessments.list(id, projectId)),
+                );
+                assessments = removeDuplicateAssessments(lists.flat());
+            } else if (compareVariantId && variantId) {
+                const [a1, a2] = await Promise.all([
+                    Assessments.list(variantId, projectId),
+                    Assessments.list(compareVariantId, projectId),
+                ]);
+                assessments = removeDuplicateAssessments([...a1, ...a2]);
+            } else {
+                assessments = await Assessments.list(variantId, projectId);
+            }
+
             setIsLoadingData(false);
             setLoadingMessage("Loading data...");
-            if (pkgsResult.status === 'rejected' || vulnsResult.status === 'rejected' || assessResult.status === 'rejected') {
-                console.error(pkgsResult, vulnsResult);
-                triggerBanner("Failed to load data", "error");
-                return;
-            }
-            const enriched_vulns = Vulnerabilities.enrich_with_assessments(vulnsResult.value, assessResult.value);
+            const enriched_vulns = Vulnerabilities.enrich_with_assessments(vulnsResult.value, assessments);
             setVulns(enriched_vulns);
             const enrichedPkgs = Packages.enrich_with_vulns(pkgsResult.value, enriched_vulns);
             setPkgs(enrichedPkgs);
+        }).catch(error => {
+            console.error(error);
+            setIsLoadingData(false);
+            setLoadingMessage("Loading data...");
+            triggerBanner("Failed to load data", "error");
         });
     }, []);
 

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -151,8 +151,20 @@ const sortAttackVectorFn: SortingFn<Vulnerability> = (rowA, rowB) => {
 const fuseKeys = [
     'id',
     'packages',
-    'texts.content'
+    'texts.content',
+    'description_search_terms'
 ]
+
+const descriptionSearchTerms = (rawSearch: string): string[] => {
+    const terms = rawSearch
+        .split('|')
+        .flatMap(group => group.trim().split(/\s+/))
+        .filter(token => token && !/^only:/i.test(token))
+        .map(token => token.startsWith('-') ? token.slice(1) : token)
+        .filter(Boolean)
+        .map(token => token.toLocaleLowerCase());
+    return [...new Set(terms)];
+};
 
 type PublishedDateFilterProps = {
     filterType: string;
@@ -420,6 +432,10 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
     }, [modalVuln, variantId, projectId]);
     const [isEditing, setIsEditing] = useState<boolean>(false);
     const [search, setSearch] = useState<string>('');
+    const [draftSearch, setDraftSearch] = useState<string>('');
+    const [descriptionMatches, setDescriptionMatches] = useState<Record<string, Set<string>>>({});
+    const [descriptionSearchLoading, setDescriptionSearchLoading] = useState(false);
+    const [descriptionSearchError, setDescriptionSearchError] = useState(false);
     const [selectedSeverities, setSelectedSeverities] = useState<string[]>([]);
     const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
@@ -464,6 +480,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
     const [aiSuggestionVulnIds, setAiSuggestionVulnIds] = useState<Set<string>>(new Set());
 
     const searchInputRef = useRef<HTMLInputElement>(null);
+    const descriptionSearchController = useRef<AbortController | null>(null);
     const shortcutButtonRef = useRef<HTMLButtonElement>(null);
     const shortcutDropdownRef = useRef<HTMLDivElement>(null);
     const searchHelperButtonRef = useRef<HTMLButtonElement>(null);
@@ -684,13 +701,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         setEuvdBanner(null);
         setGeneralBanner(null);
     };
-
-    const updateSearch = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
-        if (event.target.value.length < 2) {
-            if (search != '') setSearch('');
-        }
-        setSearch(event.target.value);
-    }, 750, { maxWait: 5000 });
 
     const updateCustomSeverityFilter = debounce((value: { min: number; max: number }) => {
         setSeverityRange(value);
@@ -1378,6 +1388,56 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         });
     }, [vulnerabilities, filterVulnerabilityIds, selectedSeverities, selectedStatuses, selectedSources, selectedPackages, selectedVariants, publishedDateFilterType, publishedDateValue, publishedDaysValue, publishedDateFrom, publishedDateTo, showCustomSeverityFilter, severityRange, showCustomEpssFilter, epssRange, selectedAttackVectors, selectedFirstScanDates, aiSuggestionFilter, aiSuggestionVulnIds]);
 
+    const searchableData = useMemo(() => dataToDisplay.map(vuln => ({
+        ...vuln,
+        description_search_terms: Object.entries(descriptionMatches)
+            .filter(([, ids]) => ids.has(vuln.id))
+            .map(([term]) => term)
+            .join(' ') || '\0',
+    })), [dataToDisplay, descriptionMatches]);
+
+    const applySearch = useCallback(async () => {
+        const nextSearch = draftSearch.trim();
+        const terms = descriptionSearchTerms(nextSearch);
+        descriptionSearchController.current?.abort();
+        setDescriptionSearchError(false);
+
+        if (nextSearch.length <= 2 || terms.length === 0 ||
+            vulnerabilities.every(vuln => vuln.details_loaded !== false)) {
+            if (!nextSearch) setDescriptionMatches({});
+            setSearch(nextSearch);
+            setDescriptionSearchLoading(false);
+            return;
+        }
+
+        const controller = new AbortController();
+        descriptionSearchController.current = controller;
+        setDescriptionSearchLoading(true);
+        try {
+            const matches = await Vulnerabilities.searchDescriptionTerms(
+                vulnerabilities.map(vuln => vuln.id),
+                terms,
+                variantId,
+                projectId,
+                controller.signal,
+            );
+            if (controller.signal.aborted) return;
+            setDescriptionMatches(Object.fromEntries(
+                Object.entries(matches).map(([term, ids]) => [term, new Set(ids)])
+            ));
+            setSearch(nextSearch);
+        } catch (error: any) {
+            if (error?.name === 'AbortError' || controller.signal.aborted) return;
+            setDescriptionMatches({});
+            setDescriptionSearchError(true);
+            setSearch(nextSearch);
+        } finally {
+            if (!controller.signal.aborted) setDescriptionSearchLoading(false);
+        }
+    }, [draftSearch, vulnerabilities, variantId, projectId]);
+
+    useEffect(() => () => descriptionSearchController.current?.abort(), []);
+
     const selectedVulns = useMemo(() => {
         return Object.entries(selectedRows).flatMap(([id, selected]) => selected ? [id] : [])
     }, [selectedRows])
@@ -1399,7 +1459,12 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
     };
 
     function resetFilters() {
+        descriptionSearchController.current?.abort();
         setSearch('');
+        setDraftSearch('');
+        setDescriptionMatches({});
+        setDescriptionSearchError(false);
+        setDescriptionSearchLoading(false);
         setSelectedSources([]);
         setSelectedSeverities([]);
         setSelectedStatuses([]);
@@ -1528,8 +1593,37 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         )}
 
         <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2 flex-wrap">
-            <div>Search</div>
-            <input ref={searchInputRef} onInput={updateSearch} type="search" className="py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[250px] grow max-w-[800px]" placeholder="Search by ID, packages, description, ..." />
+            <div className="contents">
+                <label htmlFor="vulnerability-search">Search</label>
+                <input
+                    id="vulnerability-search"
+                    ref={searchInputRef}
+                    value={draftSearch}
+                    onChange={event => setDraftSearch(event.target.value)}
+                    onKeyDown={event => {
+                        if (event.key === 'Enter') {
+                            event.preventDefault();
+                            void applySearch();
+                        }
+                    }}
+                    type="search"
+                    className="py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[250px] grow max-w-[800px]"
+                    placeholder="Search by ID, packages, description, ..."
+                />
+                <button
+                    type="button"
+                    disabled={descriptionSearchLoading}
+                    onClick={() => void applySearch()}
+                    className="py-1 px-3 rounded bg-cyan-700 hover:bg-cyan-600 disabled:cursor-wait disabled:opacity-60"
+                >
+                    {descriptionSearchLoading ? 'Searching…' : 'Apply'}
+                </button>
+            </div>
+            {descriptionSearchError && (
+                <span role="alert" className="text-sm text-red-200">
+                    Description search failed; ID and package matches are still available.
+                </span>
+            )}
 
             <div className="relative">
                 <button
@@ -1871,7 +1965,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
                     `calc(100vh - 44px - 64px - 48px - 16px - 48px - 16px - 8px - ${visibleBannerCount * 64}px)` :
                     'calc(100vh - 44px - 64px - 48px - 16px - 48px - 16px - 8px)'
             }
-            data={dataToDisplay}
+            data={searchableData}
             estimateRowHeight={66}
             selected={selectedRows}
             updateSelected={setSelectedRows}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -1,4 +1,4 @@
-import type { Vulnerability } from "../handlers/vulnerabilities";
+import Vulnerabilities, { type Vulnerability } from "../handlers/vulnerabilities";
 import type { CVSS } from "../handlers/vulnerabilities";
 import type { Assessment } from "../handlers/assessments";
 import Assessments from "../handlers/assessments";
@@ -355,6 +355,69 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);
     const [modalVulnIndex, setModalVulnIndex] = useState<number | undefined>(undefined);
     const [modalVulnSnapshot, setModalVulnSnapshot] = useState<Vulnerability[]>([]);
+    const [modalDetailsLoading, setModalDetailsLoading] = useState(false);
+    const [modalDetailsError, setModalDetailsError] = useState(false);
+    const hoverDetailsCache = useRef(new Map<string, Vulnerability>());
+
+    const loadHoverDetails = useCallback(async (summary: Vulnerability): Promise<Vulnerability> => {
+        if (summary.details_loaded !== false) return summary;
+        const cacheKey = `${summary.id}:${variantId ?? ''}:${projectId ?? ''}`;
+        const cached = hoverDetailsCache.current.get(cacheKey);
+        if (cached) return cached;
+        const details = await Vulnerabilities.getDetails(summary.id, variantId, projectId);
+        const resolved = details ? {
+            ...summary,
+            texts: details.texts,
+            urls: details.urls,
+            severity: { ...summary.severity, cvss: details.severity.cvss },
+            details_loaded: true,
+        } : { ...summary, details_loaded: true };
+        hoverDetailsCache.current.set(cacheKey, resolved);
+        return resolved;
+    }, [variantId, projectId]);
+
+    useEffect(() => {
+        if (!modalVuln || modalVuln.details_loaded !== false) {
+            setModalDetailsLoading(false);
+            setModalDetailsError(false);
+            return;
+        }
+
+        const controller = new AbortController();
+        const vulnId = modalVuln.id;
+        setModalDetailsLoading(true);
+        setModalDetailsError(false);
+        Vulnerabilities.getDetails(vulnId, variantId, projectId, controller.signal)
+            .then((details) => {
+                if (!details || controller.signal.aborted) return;
+                const mergeDetails = (summary: Vulnerability): Vulnerability => ({
+                    ...summary,
+                    texts: details.texts,
+                    urls: details.urls,
+                    severity: {
+                        ...summary.severity,
+                        cvss: details.severity.cvss,
+                    },
+                    details_loaded: true,
+                });
+                setModalVuln((current) => (
+                    current?.id === vulnId ? mergeDetails(current) : current
+                ));
+                setModalVulnSnapshot((current) => current.map((vuln) => (
+                    vuln.id === vulnId ? mergeDetails(vuln) : vuln
+                )));
+            })
+            .catch((error) => {
+                if (error?.name !== 'AbortError' && !controller.signal.aborted) {
+                    setModalDetailsError(true);
+                }
+            })
+            .finally(() => {
+                if (!controller.signal.aborted) setModalDetailsLoading(false);
+            });
+
+        return () => controller.abort();
+    }, [modalVuln?.id, modalVuln?.details_loaded, variantId, projectId]);
     const [isEditing, setIsEditing] = useState<boolean>(false);
     const [search, setSearch] = useState<string>('');
     const [selectedSeverities, setSelectedSeverities] = useState<string[]>([]);
@@ -1814,10 +1877,13 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
             updateSelected={setSelectedRows}
             onFilteredDataChange={setSearchFilteredData}
             onFocusedRowChange={setFocusedRowIndex}
+            onHoverData={loadHoverDetails}
         />
 
         {modalVuln != undefined && <VulnModal
             vuln={modalVuln}
+            detailsLoading={modalDetailsLoading}
+            detailsError={modalDetailsError}
             isEditing={isEditing}
             onClose={() => {
                 setModalVuln(undefined);

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -417,7 +417,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
             });
 
         return () => controller.abort();
-    }, [modalVuln?.id, modalVuln?.details_loaded, variantId, projectId]);
+    }, [modalVuln, variantId, projectId]);
     const [isEditing, setIsEditing] = useState<boolean>(false);
     const [search, setSearch] = useState<string>('');
     const [selectedSeverities, setSelectedSeverities] = useState<string[]>([]);

--- a/frontend/tests/unit_tests/test_assessments_handler.ts
+++ b/frontend/tests/unit_tests/test_assessments_handler.ts
@@ -205,7 +205,7 @@ describe('Assessments API', () => {
     const result = await Assessments.list();
     expect(result).toHaveLength(2);
     const url = new URL(fetchMock.mock.calls[0][0] as string);
-    expect(url.searchParams.get('format')).toBe('list');
+    expect(url.searchParams.get('format')).toBe('compact');
   });
 
   test('list with variantId sets variant_id param', async () => {

--- a/frontend/tests/unit_tests/test_handlers.ts
+++ b/frontend/tests/unit_tests/test_handlers.ts
@@ -267,6 +267,8 @@ describe('Vulnerabilities', () => {
 
         const assessments = await Assessments.list();
         expect(assessments.length).toEqual(3);
+        const assessmentsUrl = new URL(fetchMock.mock.calls[0][0] as string);
+        expect(assessmentsUrl.searchParams.get('format')).toBe('compact');
         expect(thisFetch).toHaveBeenCalledTimes(1);
 
         const enrichedvuln = Vulnerabilities.enrich_with_assessments(vulnerabilities, assessments);
@@ -297,6 +299,31 @@ describe('Assessments', () => {
         const assessments = await Assessments.list();
         expect(assessments).toEqual([]);
         expect(thisFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('parses compact assessment tuples', async () => {
+        fetchMock.mockImplementationOnce(() => Promise.resolve({
+            json: () => Promise.resolve([[
+                'assessment-id',
+                'CVE-2026-0001',
+                'demo@1.0',
+                'variant-id',
+                '2026-07-21T19:00:00+00:00',
+                'fixed',
+            ]])
+        } as Response));
+
+        const assessments = await Assessments.list();
+        expect(assessments).toHaveLength(1);
+        expect(assessments[0]).toMatchObject({
+            id: 'assessment-id',
+            vuln_id: 'CVE-2026-0001',
+            packages: ['demo@1.0'],
+            variant_id: 'variant-id',
+            status: 'fixed',
+            simplified_status: 'Fixed',
+            details_loaded: false,
+        });
     });
 });
 

--- a/frontend/tests/unit_tests/test_project_variant_handlers.ts
+++ b/frontend/tests/unit_tests/test_project_variant_handlers.ts
@@ -455,7 +455,7 @@ describe('Vulnerabilities.list with filtering params', () => {
 
         const calledUrl: string = (fetchMock.mock.calls[0] as any[])[0];
         expect(calledUrl).toContain('/api/vulnerabilities');
-        expect(calledUrl).toContain('format=list');
+        expect(calledUrl).toContain('format=compact');
         expect(calledUrl).not.toContain('variant_id');
         expect(calledUrl).not.toContain('project_id');
     });

--- a/frontend/tests/unit_tests/test_project_variant_handlers.ts
+++ b/frontend/tests/unit_tests/test_project_variant_handlers.ts
@@ -570,7 +570,7 @@ describe('Assessments.list with filtering params', () => {
 
         const calledUrl: string = (fetchMock.mock.calls[0] as any[])[0];
         expect(calledUrl).toContain('/api/assessments');
-        expect(calledUrl).toContain('format=list');
+        expect(calledUrl).toContain('format=compact');
         expect(calledUrl).not.toContain('variant_id');
         expect(calledUrl).not.toContain('project_id');
     });

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -524,13 +524,13 @@ describe('Vulnerability Table', () => {
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
 
-        // Capture the row that should disappear before triggering the search.
-        const rowToRemove = await screen.findByRole('cell', {name: /CVE-2010-1234/});
-
         await user.type(search_bar, '2018-5678');
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-        // Allow for debounce + filter render (debounce is 750ms in component)
-        await waitForElementToBeRemoved(rowToRemove, { timeout: 2000 });
+        // Allow the applied filter to render.
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2010-1234/})).not.toBeInTheDocument();
+        }, { timeout: 2000 });
 
         const vuln_xyz = await screen.getByRole('cell', {name: /CVE-2018-5678/});
         expect(vuln_xyz).toBeInTheDocument();
@@ -543,11 +543,12 @@ describe('Vulnerability Table', () => {
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
 
-        const rowToRemove = await screen.findByRole('cell', {name: /CVE-2010-1234/});
-
         await user.type(search_bar, 'yyy');
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-        await waitForElementToBeRemoved(rowToRemove, { timeout: 2000 });
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2010-1234/})).not.toBeInTheDocument();
+        }, { timeout: 2000 });
 
         const vuln_xyz = await screen.getByRole('cell', {name: /CVE-2018-5678/});
         expect(vuln_xyz).toBeInTheDocument();
@@ -560,11 +561,12 @@ describe('Vulnerability Table', () => {
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
 
-        const rowToRemove = await screen.findByRole('cell', {name: /CVE-2010-1234/});
-
         await user.type(search_bar, '-2010');
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-        await waitForElementToBeRemoved(rowToRemove, { timeout: 2000 });
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2010-1234/})).not.toBeInTheDocument();
+        }, { timeout: 2000 });
 
         const vuln_xyz = await screen.getByRole('cell', {name: /CVE-2018-5678/});
         expect(vuln_xyz).toBeInTheDocument();
@@ -578,6 +580,7 @@ describe('Vulnerability Table', () => {
         const search_bar = await screen.getByRole('searchbox');
 
         await user.type(search_bar, '-2010 2024');
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
         // Better use waitFor for a combined check instead of using waitForElementToBeRemoved in sequence, because the items are filtered out after the user.type() is completed, which may lead to the success of the first check and failure of the rest.
         await waitFor(() => {
@@ -596,14 +599,44 @@ describe('Vulnerability Table', () => {
         const user = userEvent.setup();
         const search_bar = await screen.getByRole('searchbox');
 
-        const rowToRemove = await screen.findByRole('cell', {name: /CVE-2018-5678/});
-
         await user.type(search_bar, 'authentification process');
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-        await waitForElementToBeRemoved(rowToRemove, { timeout: 2000 });
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).not.toBeInTheDocument();
+        }, { timeout: 2000 });
 
         const vuln_abc = await screen.getByRole('cell', {name: /CVE-2010-1234/});
         expect(vuln_abc).toBeInTheDocument();
+    })
+
+    test('applies server-side description matches for compact vulnerabilities', async () => {
+        const compactVulnerabilities = vulnerabilities.map(vuln => ({
+            ...vuln,
+            texts: [],
+            details_loaded: false,
+        }));
+        fetchMock.mockResponseOnce(JSON.stringify({
+            matches: {
+                authentification: ['CVE-2010-1234'],
+                process: ['CVE-2010-1234'],
+            },
+        }));
+        render(<TableVulnerabilities vulnerabilities={compactVulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        const user = userEvent.setup();
+        const searchBar = await screen.getByRole('searchbox');
+        await user.type(searchBar, 'authentification process');
+        expect(screen.getByRole('cell', {name: /CVE-2018-5678/})).toBeInTheDocument();
+        await user.keyboard('{Enter}');
+
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).not.toBeInTheDocument();
+        });
+        expect(screen.getByRole('cell', {name: /CVE-2010-1234/})).toBeInTheDocument();
+        expect(JSON.parse(fetchMock.mock.calls[0][1]?.body as string)).toMatchObject({
+            terms: ['authentification', 'process'],
+        });
     })
 
     test('filter by source', async () => {
@@ -1012,6 +1045,7 @@ describe('Vulnerability Table', () => {
         // Set search
         const search_bar = await screen.getByRole('searchbox');
         await user.type(search_bar, '2018-5678');
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
         // Wait for filters to take effect
         await waitFor(() => {
@@ -1030,8 +1064,7 @@ describe('Vulnerability Table', () => {
             expect(vuln2).toBeInTheDocument();
         });
 
-        // Search bar should be cleared (it doesn't have a value attribute when cleared)
-        expect(search_bar.getAttribute('value')).toBeNull();
+        expect(search_bar).toHaveValue('');
     })
 
     test('initial filter props set correct filters', async () => {
@@ -1162,7 +1195,7 @@ describe('Vulnerability Table', () => {
         expect(vuln2).toBeInTheDocument();
     })
 
-    test('search debounce functionality', async () => {
+    test('search remains unapplied while typing', async () => {
         // ARRANGE
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -62,6 +62,21 @@ const getDOMRect = (width: number, height: number) => ({
     toJSON: () => {},
 })
 
+const formatAssessmentDate = (value: string) => new Date(value).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZoneName: 'shortOffset',
+});
+
+const formatPublishedDate = (value: string) => new Date(value).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+});
+
 
 describe('Vulnerability Table', () => {
 
@@ -1231,7 +1246,7 @@ describe('Vulnerability Table', () => {
 
         // ACT & ASSERT
         // First vulnerability should show formatted date
-        const formattedDate = await screen.getByText(/january 15, 2024/i);
+        const formattedDate = await screen.getByText(formatAssessmentDate('2024-01-15T10:30:00Z'));
         expect(formattedDate).toBeInTheDocument();
 
         // Second vulnerability should still show "No assessment"
@@ -1263,7 +1278,7 @@ describe('Vulnerability Table', () => {
         render(<TableVulnerabilities vulnerabilities={vulnWithUpdatedAssessments} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         // ACT & ASSERT - Should show the more recent last_update date
-        const formattedDate = await screen.getByText(/february 20, 2024/i);
+        const formattedDate = await screen.getByText(formatAssessmentDate('2024-02-20T14:45:00Z'));
         expect(formattedDate).toBeInTheDocument();
     })
 
@@ -1310,7 +1325,7 @@ describe('Vulnerability Table', () => {
         render(<TableVulnerabilities vulnerabilities={vulnWithMultipleAssessments} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         // ACT & ASSERT - Should show the most recent assessment date (March 10)
-        const formattedDate = await screen.getByText(/march 10, 2024/i);
+        const formattedDate = await screen.getByText(formatAssessmentDate('2024-03-10T16:20:00Z'));
         expect(formattedDate).toBeInTheDocument();
     })
 
@@ -2111,8 +2126,8 @@ describe('Vulnerability Table', () => {
 
         // Check that dates are rendered (formatted as short month)
         await waitFor(() => {
-            [/May 15, 2010/, /Jul 22, 2018/].forEach(date => {
-            expect(screen.queryByText(date)).toBeInTheDocument();
+            ['2010-05-15T08:00:00Z', '2018-07-22T14:30:00Z'].forEach(date => {
+                expect(screen.queryByText(formatPublishedDate(date))).toBeInTheDocument();
             });
         });
     });

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -868,6 +868,33 @@ describe('Vulnerability Table', () => {
         });
     })
 
+    test('loads a compact vulnerability description when hovering', async () => {
+        const compactVuln: Vulnerability = {
+            ...vulnerabilities[0],
+            texts: [],
+            urls: [],
+            details_loaded: false,
+        };
+        fetchMock.mockResponse((request) => {
+            if (new URL(request.url).pathname !== '/api/vulnerabilities/CVE-2010-1234') {
+                return Promise.resolve(JSON.stringify([]));
+            }
+            return Promise.resolve(JSON.stringify({
+                id: compactVuln.id,
+                texts: [{ title: 'description', content: 'Lazily loaded hover description' }],
+                urls: [],
+                severity: compactVuln.severity,
+            }));
+        });
+        const { container } = render(<TableVulnerabilities vulnerabilities={[compactVuln]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        fireEvent.mouseEnter(container.querySelector('tr.row-with-hover-effect')!);
+
+        await waitFor(() => {
+            expect(screen.getByRole('tooltip').textContent).toContain('Lazily loaded hover description');
+        });
+    });
+
     test('filter by severity', async () => {
         // ARRANGE
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
@@ -1453,6 +1480,36 @@ describe('Vulnerability Table', () => {
         await waitFor(() => {
             expect(screen.getAllByText('CVE-2010-1234').length).toBeGreaterThan(1);
         });
+    });
+
+    test('opening a compact vulnerability loads its deferred description', async () => {
+        const compactVuln: Vulnerability = {
+            ...vulnerabilities[0],
+            texts: [],
+            urls: [],
+            details_loaded: false,
+        };
+        fetchMock.mockResponse((request) => {
+            if (new URL(request.url).pathname !== '/api/vulnerabilities/CVE-2010-1234') {
+                return Promise.resolve(JSON.stringify([]));
+            }
+            return Promise.resolve(JSON.stringify({
+                id: compactVuln.id,
+                texts: [{ title: 'description', content: 'Deferred vulnerability description' }],
+                urls: ['https://example.com/deferred'],
+                severity: compactVuln.severity,
+            }));
+        });
+
+        render(<TableVulnerabilities vulnerabilities={[compactVuln]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        await userEvent.click(await screen.findByText('CVE-2010-1234'));
+
+        expect((await screen.findAllByText('Deferred vulnerability description')).length).toBeGreaterThan(0);
+        expect(fetchMock.mock.calls.some(([request]) => request != null && (
+            new URL(typeof request === 'string' ? request : request.url).pathname ===
+            '/api/vulnerabilities/CVE-2010-1234'
+        ))).toBe(true);
     });
 
     // =========================================================================

--- a/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
+++ b/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
@@ -113,6 +113,14 @@ describe('Vulnerabilities parsing CVSS branches', () => {
     expect(calledUrl.searchParams.has('project_id')).toBe(false);
   });
 
+  test('getDetails rejects non-success responses with the status', async () => {
+    fetchMock.mockResponseOnce('', { status: 503 });
+
+    await expect(Vulnerabilities.getDetails('CVE-TEST-1')).rejects.toThrow(
+      'Failed to load vulnerability details (503)',
+    );
+  });
+
   test('list with compareVariantId but no operation omits operation param', async () => {
     fetchMock.mockResponseOnce(JSON.stringify([rawVuln()]));
     const vulns = await Vulnerabilities.list('variant-1', undefined, 'variant-2');

--- a/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
+++ b/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
@@ -78,6 +78,39 @@ describe('Vulnerabilities parsing CVSS branches', () => {
     expect(calledUrl.searchParams.get('variant_id')).toBe('variant-1');
     expect(calledUrl.searchParams.get('compare_variant_id')).toBe('variant-2');
     expect(calledUrl.searchParams.get('operation')).toBe('difference');
+    expect(calledUrl.searchParams.get('format')).toBe('compact');
+  });
+
+  test('parses compact records and preserves explicit attack vectors', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify([rawVuln({
+      details_loaded: false,
+      texts: undefined,
+      urls: undefined,
+      severity: {
+        severity: 'high',
+        min_score: 8.1,
+        max_score: 8.1,
+        cvss: [{ version: '3.1', base_score: 8.1, attack_vector: 'ADJACENT' }],
+      },
+    })]));
+
+    const [vuln] = await Vulnerabilities.list();
+    expect(vuln.details_loaded).toBe(false);
+    expect(vuln.texts).toEqual([]);
+    expect(vuln.urls).toEqual([]);
+    expect(vuln.severity.cvss[0].attack_vector).toBe('ADJACENT');
+  });
+
+  test('getDetails requests a scoped full vulnerability', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(rawVuln()));
+
+    const details = await Vulnerabilities.getDetails('CVE-TEST-1', 'variant-1', 'project-1');
+
+    expect(details?.details_loaded).toBe(true);
+    const calledUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(calledUrl.pathname).toContain('/api/vulnerabilities/CVE-TEST-1');
+    expect(calledUrl.searchParams.get('variant_id')).toBe('variant-1');
+    expect(calledUrl.searchParams.has('project_id')).toBe(false);
   });
 
   test('list with compareVariantId but no operation omits operation param', async () => {

--- a/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
+++ b/frontend/tests/unit_tests/test_vulnerabilities_handler.ts
@@ -121,6 +121,35 @@ describe('Vulnerabilities parsing CVSS branches', () => {
     );
   });
 
+  test('searchDescriptionTerms posts IDs and terms in variant scope', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({
+      matches: { kernel: ['CVE-TEST-1', 42], overflow: [] },
+    }));
+
+    const matches = await Vulnerabilities.searchDescriptionTerms(
+      ['CVE-TEST-1'], ['kernel', 'overflow'], 'variant-1', 'project-1',
+    );
+
+    expect(matches).toEqual({ kernel: ['CVE-TEST-1'], overflow: [] });
+    const [requestUrl, request] = fetchMock.mock.calls[0];
+    const calledUrl = new URL(requestUrl as string);
+    expect(calledUrl.pathname).toContain('/api/vulnerabilities/search-descriptions');
+    expect(calledUrl.searchParams.get('variant_id')).toBe('variant-1');
+    expect(calledUrl.searchParams.has('project_id')).toBe(false);
+    expect(request?.method).toBe('POST');
+    expect(JSON.parse(request?.body as string)).toEqual({
+      vulnerability_ids: ['CVE-TEST-1'],
+      terms: ['kernel', 'overflow'],
+    });
+  });
+
+  test('searchDescriptionTerms rejects non-success responses with the status', async () => {
+    fetchMock.mockResponseOnce('', { status: 502 });
+
+    await expect(Vulnerabilities.searchDescriptionTerms(['CVE-TEST-1'], ['kernel']))
+      .rejects.toThrow('Failed to search vulnerability descriptions (502)');
+  });
+
   test('list with compareVariantId but no operation omits operation param', async () => {
     fetchMock.mockResponseOnce(JSON.stringify([rawVuln()]));
     const vulns = await Vulnerabilities.list('variant-1', undefined, 'variant-2');

--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -22,6 +22,7 @@ MAX_SCRIPT_STEPS = 8
 SCAN_FILE = "/scan/status.txt"
 DEFAULT_DB_URI = "sqlite:////cache/vulnscout/vulnscout.db"
 MAX_UPLOAD_REQUEST_BYTES = MAX_ASSET_UPLOAD_BYTES + 64 * 1024
+DEFAULT_BACKGROUND_TASK_DELAY = 120.0
 
 
 def _launch_enrichment(app):
@@ -82,6 +83,32 @@ def _warm_scan_list_cache(app):
                 print(f"[cache-warm/scan-list] {e}", flush=True)
 
     threading.Thread(target=_warm, name="cache-warm-scan-list", daemon=True).start()
+
+
+def _schedule_background_tasks(app):
+    """Start post-scan work after the initial Explorer data request burst.
+
+    Starting both jobs from the status-poll response makes them compete with
+    the immediately following packages, vulnerabilities, and assessments
+    requests.  The delay keeps that work asynchronous in practice, not merely
+    in implementation.  It must also cover large Explorer responses, which
+    can take well over 30 seconds on production-sized databases, while
+    retaining automatic enrichment and cache warming when no browser is
+    connected.
+    """
+    try:
+        delay = float(app.config.get("BACKGROUND_TASK_DELAY", DEFAULT_BACKGROUND_TASK_DELAY))
+    except (TypeError, ValueError):
+        delay = DEFAULT_BACKGROUND_TASK_DELAY
+
+    def _start():
+        _launch_enrichment(app)
+        _warm_scan_list_cache(app)
+
+    timer = threading.Timer(max(0.0, delay), _start)
+    timer.name = "post-scan-background-scheduler"
+    timer.daemon = True
+    timer.start()
 
 
 def create_app():
@@ -152,8 +179,7 @@ def create_app():
                     app.config["SCAN_DATE"] = datetime.now(timezone.utc).strftime("%Y-%m-%d at %H:%M (UTC)")
                 app._INT_SCAN_FINISHED = True
                 if not app.config.get("TESTING"):
-                    _launch_enrichment(app)
-                    _warm_scan_list_cache(app)
+                    _schedule_background_tasks(app)
                 return True
         return False
 

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -5,6 +5,7 @@ import gzip
 import json
 import re
 from datetime import datetime
+from typing import Any, Literal, overload
 from uuid import UUID
 
 from ..models import Assessment as DBAssessment, Package, Finding
@@ -41,6 +42,9 @@ _SCANNER_AUTHORS = {
     "cna@cloudflare.com",
 }
 _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+AssessmentDict = dict[str, Any]
+CompactAssessment = list[str | None]
 
 
 def _is_scanner_author(author: str | None) -> bool:
@@ -146,10 +150,24 @@ def _resolve_ai_group(
 
 def init_app(app: Flask) -> None:
 
+    @overload
+    def _get_db_assessment_dicts(
+        variant_ids: list[UUID] | None = None,
+        compact: Literal[False] = False,
+    ) -> list[AssessmentDict]:
+        ...
+
+    @overload
+    def _get_db_assessment_dicts(
+        variant_ids: list[UUID] | None,
+        compact: Literal[True],
+    ) -> list[CompactAssessment]:
+        ...
+
     def _get_db_assessment_dicts(
         variant_ids: list[UUID] | None = None,
         compact: bool = False,
-    ) -> list[dict | list]:
+    ) -> list[AssessmentDict] | list[CompactAssessment]:
         """Serialize assessments with one lightweight joined query.
 
         The Explorer endpoint previously materialized tens of thousands of
@@ -230,7 +248,8 @@ def init_app(app: Flask) -> None:
                     return []
                 query = query.where(DBAssessment.variant_id.in_(variant_ids))
 
-        result = []
+        full_result: list[AssessmentDict] = []
+        compact_result: list[CompactAssessment] = []
         for row in db.session.execute(query):
             package_id = ""
             if row.name is not None:
@@ -242,7 +261,7 @@ def init_app(app: Flask) -> None:
                 # Positional encoding avoids repeating six field names for
                 # every row in this high-volume Explorer-only response:
                 # [id, vulnerability, package, variant, timestamp, status].
-                result.append([
+                compact_result.append([
                     str(row.id),
                     row.vulnerability_id or "",
                     package_id or None,
@@ -251,7 +270,7 @@ def init_app(app: Flask) -> None:
                     row.status or "",
                 ])
                 continue
-            result.append({
+            full_result.append({
                 "id": str(row.id),
                 "source": row.source or "",
                 "origin": row.origin or "sbom",
@@ -267,20 +286,21 @@ def init_app(app: Flask) -> None:
                 "responses": list(row.responses or []),
                 "workaround": row.workaround or "",
             })
-        return result
+        return compact_result if compact else full_result
 
     @app.route('/api/assessments')
     def index_assess() -> ResponseReturnValue:
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
         compact = request.args.get('format') == 'compact'
+        scoped_variant_ids: list[UUID] | None
         if variant_id:
             variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:
                 return err
             if variant_uuid is None:
                 return {"error": "Internal error"}, 500
-            assessments = _get_db_assessment_dicts([variant_uuid], compact=compact)
+            scoped_variant_ids = [variant_uuid]
         elif project_id:
             from ..models.variant import Variant as DBVariant
             project_uuid, err = parse_uuid_or_400(project_id, "project_id")
@@ -289,22 +309,24 @@ def init_app(app: Flask) -> None:
             if project_uuid is None:
                 return {"error": "Internal error"}, 500
             variants = DBVariant.get_by_project(project_uuid)
-            variant_ids = [v.id for v in variants]
-            assessments = _get_db_assessment_dicts(variant_ids, compact=compact)
+            scoped_variant_ids = [v.id for v in variants]
         else:
-            assessments = _get_db_assessment_dicts(compact=compact)
-        if not compact:
-            annotate_assessments_outdated(assessments)
-        if request.args.get('format', 'list') == "dict":
-            return {a["id"]: a for a in assessments}
+            scoped_variant_ids = None
+
         if compact:
-            payload = json.dumps(assessments, separators=(",", ":")).encode()
+            compact_assessments = _get_db_assessment_dicts(scoped_variant_ids, compact=True)
+            payload = json.dumps(compact_assessments, separators=(",", ":")).encode()
             response = app.response_class(payload, mimetype="application/json")
             if "gzip" in request.headers.get("Accept-Encoding", "") and len(payload) > 1024:
                 response.set_data(gzip.compress(payload, compresslevel=1))
                 response.headers["Content-Encoding"] = "gzip"
                 response.headers["Vary"] = "Accept-Encoding"
             return response
+
+        assessments = _get_db_assessment_dicts(scoped_variant_ids, compact=False)
+        annotate_assessments_outdated(assessments)
+        if request.args.get('format', 'list') == "dict":
+            return {a["id"]: a for a in assessments}
         return assessments
 
     def _review_assessments_by_origin(origin: str) -> ResponseReturnValue:

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
+import gzip
+import json
 import re
 from datetime import datetime
 from uuid import UUID
@@ -13,6 +15,7 @@ from ..models.variant import Variant as DBVariant
 from ._scan_helpers import parse_uuid_or_400
 from ._scan_queries import VulnerabilityText, fetch_vulnerabilities_texts
 from ._scan_diff import invalidate_scan_list_cache
+from ..helpers.datetime_utils import ensure_utc_iso
 from ..helpers.assessment_io import (
     build_openvex_archive,
     is_openvex_doc,
@@ -26,7 +29,7 @@ from ..helpers.assessment_staleness import annotate_assessments_outdated
 
 from flask import request, Flask
 from flask.typing import ResponseReturnValue
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 _SCANNER_AUTHORS = {
     "nvd",
@@ -143,20 +146,141 @@ def _resolve_ai_group(
 
 def init_app(app: Flask) -> None:
 
-    def _get_all_db_assessments() -> list["DBAssessment"]:
-        return DBAssessment.get_all()
+    def _get_db_assessment_dicts(
+        variant_ids: list[UUID] | None = None,
+        compact: bool = False,
+    ) -> list[dict | list]:
+        """Serialize assessments with one lightweight joined query.
+
+        The Explorer endpoint previously materialized tens of thousands of
+        Assessment, Finding, and Package ORM objects only to immediately turn
+        them into dictionaries.  Selecting the response columns directly
+        avoids that object-graph cost and also lets project scope use one query
+        instead of one query per variant.
+        """
+        if compact:
+            ranked = (
+                db.select(
+                    DBAssessment.id.label("id"),
+                    DBAssessment.variant_id.label("variant_id"),
+                    DBAssessment.timestamp.label("timestamp"),
+                    DBAssessment.status.label("status"),
+                    Finding.vulnerability_id.label("vulnerability_id"),
+                    Package.name.label("name"),
+                    Package.version.label("version"),
+                    Package.supplier.label("supplier"),
+                    func.row_number().over(
+                        partition_by=(
+                            Finding.vulnerability_id,
+                            DBAssessment.variant_id,
+                            Finding.package_id,
+                        ),
+                        order_by=(DBAssessment.timestamp.desc(), DBAssessment.id.desc()),
+                    ).label("assessment_rank"),
+                )
+                .outerjoin(Finding, DBAssessment.finding_id == Finding.id)
+                .outerjoin(Package, Finding.package_id == Package.id)
+                .where(db.or_(DBAssessment.origin.is_(None), DBAssessment.origin != "ai"))
+            )
+            if variant_ids is not None:
+                if not variant_ids:
+                    return []
+                ranked = ranked.where(DBAssessment.variant_id.in_(variant_ids))
+            ranked = ranked.subquery()
+            query = (
+                db.select(
+                    ranked.c.id,
+                    ranked.c.variant_id,
+                    ranked.c.timestamp,
+                    ranked.c.status,
+                    ranked.c.vulnerability_id,
+                    ranked.c.name,
+                    ranked.c.version,
+                    ranked.c.supplier,
+                )
+                .where(ranked.c.assessment_rank == 1)
+                .order_by(ranked.c.timestamp)
+            )
+        else:
+            query = (
+                db.select(
+                    DBAssessment.id,
+                    DBAssessment.source,
+                    DBAssessment.origin,
+                    DBAssessment.variant_id,
+                    DBAssessment.timestamp,
+                    DBAssessment.status,
+                    DBAssessment.status_notes,
+                    DBAssessment.justification,
+                    DBAssessment.impact_statement,
+                    DBAssessment.responses,
+                    DBAssessment.workaround,
+                    Finding.vulnerability_id,
+                    Package.name,
+                    Package.version,
+                    Package.supplier,
+                )
+                .outerjoin(Finding, DBAssessment.finding_id == Finding.id)
+                .outerjoin(Package, Finding.package_id == Package.id)
+                .where(db.or_(DBAssessment.origin.is_(None), DBAssessment.origin != "ai"))
+                .order_by(DBAssessment.timestamp)
+            )
+            if variant_ids is not None:
+                if not variant_ids:
+                    return []
+                query = query.where(DBAssessment.variant_id.in_(variant_ids))
+
+        result = []
+        for row in db.session.execute(query):
+            package_id = ""
+            if row.name is not None:
+                package_id = f"{row.name}@{row.version}"
+                if row.supplier:
+                    package_id += f"::{row.supplier}"
+            timestamp = ensure_utc_iso(row.timestamp)
+            if compact:
+                # Positional encoding avoids repeating six field names for
+                # every row in this high-volume Explorer-only response:
+                # [id, vulnerability, package, variant, timestamp, status].
+                result.append([
+                    str(row.id),
+                    row.vulnerability_id or "",
+                    package_id or None,
+                    str(row.variant_id) if row.variant_id else None,
+                    timestamp,
+                    row.status or "",
+                ])
+                continue
+            result.append({
+                "id": str(row.id),
+                "source": row.source or "",
+                "origin": row.origin or "sbom",
+                "vuln_id": row.vulnerability_id or "",
+                "packages": [package_id] if package_id else [],
+                "variant_id": str(row.variant_id) if row.variant_id else None,
+                "timestamp": timestamp,
+                "last_update": timestamp or "",
+                "status": row.status or "",
+                "status_notes": row.status_notes or "",
+                "justification": row.justification or "",
+                "impact_statement": row.impact_statement or "",
+                "responses": list(row.responses or []),
+                "workaround": row.workaround or "",
+            })
+        return result
 
     @app.route('/api/assessments')
     def index_assess() -> ResponseReturnValue:
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
+        compact = request.args.get('format') == 'compact'
         if variant_id:
             variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:
                 return err
             if variant_uuid is None:
                 return {"error": "Internal error"}, 500
-            assessments = [a.to_dict() for a in DBAssessment.get_by_variant(variant_uuid)]
+            assessments = _get_db_assessment_dicts([variant_uuid], compact=compact)
         elif project_id:
             from ..models.variant import Variant as DBVariant
             project_uuid, err = parse_uuid_or_400(project_id, "project_id")
@@ -166,18 +290,21 @@ def init_app(app: Flask) -> None:
                 return {"error": "Internal error"}, 500
             variants = DBVariant.get_by_project(project_uuid)
             variant_ids = [v.id for v in variants]
-            if variant_ids:
-                assessments = []
-                for vid in variant_ids:
-                    assessments.extend(a.to_dict() for a in DBAssessment.get_by_variant(vid))
-            else:
-                assessments = []
+            assessments = _get_db_assessment_dicts(variant_ids, compact=compact)
         else:
-            assessments = [a.to_dict() for a in _get_all_db_assessments()]
-        annotate_assessments_outdated(assessments)
-        assessments = [a for a in assessments if a.get("origin") != "ai"]
+            assessments = _get_db_assessment_dicts(compact=compact)
+        if not compact:
+            annotate_assessments_outdated(assessments)
         if request.args.get('format', 'list') == "dict":
             return {a["id"]: a for a in assessments}
+        if compact:
+            payload = json.dumps(assessments, separators=(",", ":")).encode()
+            response = app.response_class(payload, mimetype="application/json")
+            if "gzip" in request.headers.get("Accept-Encoding", "") and len(payload) > 1024:
+                response.set_data(gzip.compress(payload, compresslevel=1))
+                response.headers["Content-Encoding"] = "gzip"
+                response.headers["Vary"] = "Accept-Encoding"
+            return response
         return assessments
 
     def _review_assessments_by_origin(origin: str) -> ResponseReturnValue:

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -171,47 +171,58 @@ def init_app(app: Flask) -> None:
         # Enrich each package with its variants and sources derived from the
         # SBOMPackage → SBOMDocument → Scan → Variant chain so that the
         # frontend can display them even for packages with 0 vulnerabilities.
-        # Restrict to the current project/variant scope to avoid showing
-        # variant names from other projects.
+        # Fetch the comparatively small document metadata first, then fetch
+        # only package/document UUID pairs.  The previous five-table DISTINCT
+        # query repeated text metadata for every package/document association
+        # and made SQLAlchemy materialize a very large joined result.
         pkg_ids = [pkg.id for pkg in pkgs]
         if pkg_ids:
-            enrich_query = (
+            document_query = (
                 db.select(
-                    Package.id.label("package_id"),
-                    Package.name,
-                    Package.version,
+                    SBOMDocument.id.label("document_id"),
                     Variant.name.label("variant_name"),
                     SBOMDocument.format.label("doc_format"),
                     SBOMDocument.source_name.label("doc_source_name"),
                 )
-                .join(SBOMPackage, Package.id == SBOMPackage.package_id)
-                .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
                 .join(Scan, SBOMDocument.scan_id == Scan.id)
                 .join(Variant, Scan.variant_id == Variant.id)
-                .where(Package.id.in_(pkg_ids))
             )
             # Restrict to active (non-deprecated) scan documents only
             if active_scan_ids:
-                enrich_query = enrich_query.where(SBOMDocument.scan_id.in_(active_scan_ids))
+                document_query = document_query.where(SBOMDocument.scan_id.in_(active_scan_ids))
             if variant_id:
                 _v = db.session.get(Variant, uuid.UUID(variant_id))
                 if _v and _v.project_id:
-                    enrich_query = enrich_query.where(
+                    document_query = document_query.where(
                         Variant.project_id == _v.project_id
                     )
                 else:
-                    enrich_query = enrich_query.where(
+                    document_query = document_query.where(
                         Scan.variant_id == uuid.UUID(variant_id)
                     )
             elif project_id:
-                enrich_query = enrich_query.where(Variant.project_id == uuid.UUID(project_id))
-            rows = db.session.execute(enrich_query).all()
+                document_query = document_query.where(Variant.project_id == uuid.UUID(project_id))
+
+            document_rows = db.session.execute(document_query).all()
+            document_meta = {
+                row.document_id: row
+                for row in document_rows
+            }
+            document_ids = list(document_meta)
+            association_rows = db.session.execute(
+                db.select(SBOMPackage.package_id, SBOMPackage.sbom_document_id)
+                .where(SBOMPackage.sbom_document_id.in_(document_ids))
+            ).all() if document_ids else []
 
             # Build lookup by package UUID to avoid conflating similarly-named
             # package rows (e.g. different supplier or near-identical versions).
             meta: dict = {}
-            for row in rows:
-                key = str(row.package_id)
+            selected_package_ids = {str(package_id) for package_id in pkg_ids}
+            for package_id, document_id in association_rows:
+                row = document_meta[document_id]
+                key = str(package_id)
+                if key not in selected_package_ids:
+                    continue
                 if key not in meta:
                     meta[key] = {"variants": set(), "sources": set(), "sbom_documents": set()}
                 if row.variant_name:

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -840,6 +840,85 @@ def init_app(app: Flask) -> None:
             case _ as fmt:
                 raise ValueError("Unknown format", fmt)
 
+    @app.post('/api/vulnerabilities/search-descriptions')
+    def search_vulnerability_descriptions() -> ResponseReturnValue:
+        """Return vulnerability IDs whose scoped descriptions contain each term."""
+        payload = request.get_json(silent=True)
+        if not isinstance(payload, dict):
+            return {"error": "Expected a JSON object"}, 400
+
+        raw_vuln_ids = payload.get("vulnerability_ids")
+        raw_terms = payload.get("terms")
+        if not isinstance(raw_vuln_ids, list) or not all(
+            isinstance(vuln_id, str) for vuln_id in raw_vuln_ids
+        ):
+            return {"error": "vulnerability_ids must be a list of strings"}, 400
+        if not isinstance(raw_terms, list) or not all(
+            isinstance(term, str) for term in raw_terms
+        ):
+            return {"error": "terms must be a list of strings"}, 400
+        if len(raw_vuln_ids) > 100_000:
+            return {"error": "Too many vulnerability IDs"}, 400
+        if len(raw_terms) > 50 or any(len(term) > 256 for term in raw_terms):
+            return {"error": "Too many or excessively long search terms"}, 400
+
+        vuln_ids = list(dict.fromkeys(raw_vuln_ids))
+        terms = list(dict.fromkeys(term.casefold() for term in raw_terms if term))
+        matches: dict[str, set[str]] = {term: set() for term in terms}
+        if not vuln_ids or not terms:
+            return {"matches": {term: [] for term in terms}}
+
+        scan_ids: list[uuid.UUID] | None = None
+        variant_id = request.args.get("variant_id")
+        project_id = request.args.get("project_id")
+        if variant_id:
+            variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
+            if err:
+                return err
+            if variant_uuid is None:
+                return {"error": "Internal error"}, 500
+            scan_ids = active_scan_ids_for_variant(variant_uuid)
+        elif project_id:
+            project_uuid, err = parse_uuid_or_400(project_id, "project_id")
+            if err:
+                return err
+            if project_uuid is None:
+                return {"error": "Internal error"}, 500
+            scan_ids = active_scan_ids_for_project(project_uuid)
+
+        description_rows = db.session.execute(
+            db.select(Vulnerability.id, Vulnerability.description)
+            .where(Vulnerability.id.in_(vuln_ids))
+            .where(Vulnerability.description.is_not(None))
+        ).all()
+
+        observation_query = (
+            db.select(SBOMObservation.vulnerability_id, SBOMObservation.description)
+            .where(SBOMObservation.vulnerability_id.in_(vuln_ids))
+        )
+        if scan_ids is not None:
+            observation_query = (
+                observation_query
+                .join(SBOMDocument, SBOMObservation.sbom_document_id == SBOMDocument.id)
+                .where(SBOMDocument.scan_id.in_(scan_ids))
+            )
+        observation_rows = db.session.execute(observation_query).all()
+
+        for vuln_id, content in (*description_rows, *observation_rows):
+            if not isinstance(content, str):
+                continue
+            folded_content = content.casefold()
+            for term in terms:
+                if term in folded_content:
+                    matches[term].add(str(vuln_id))
+
+        return {
+            "matches": {
+                term: sorted(matched_ids)
+                for term, matched_ids in matches.items()
+            }
+        }
+
     @app.get('/api/vulnerabilities/<id>')
     def get_vuln(id: str) -> ResponseReturnValue:
         record = Vulnerability.get_by_id(id)

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -12,7 +12,7 @@ import uuid
 from flask import jsonify, request, Flask
 from flask.typing import ResponseReturnValue
 from sqlalchemy import func, select, ColumnElement
-from sqlalchemy.orm import selectinload, aliased, attributes as orm_attrs
+from sqlalchemy.orm import joinedload, selectinload, aliased, attributes as orm_attrs
 from ..models import (
     Vulnerability,
     Finding,
@@ -53,6 +53,19 @@ TIME_ESTIMATES_PATH = "/scan/outputs/time_estimates.json"
 MATCH_CONDITION_MAX_LENGTH = 1_000
 MATCH_CONDITION_MAX_ITEMS = 50_000
 _GHSA_RE = re.compile(r'^GHSA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$')
+
+
+def _attack_vector_from_vector(vector: str) -> str | None:
+    """Return the normalized CVSS attack vector used by Explorer filters."""
+    for token, label in (
+        ("AV:N", "NETWORK"),
+        ("AV:A", "ADJACENT"),
+        ("AV:L", "LOCAL"),
+        ("AV:P", "PHYSICAL"),
+    ):
+        if token in vector:
+            return label
+    return None
 
 
 def _sbom_pkg_filter(pkg_ids: set[uuid.UUID]) -> "ColumnElement[bool] | None":
@@ -257,34 +270,47 @@ def _populate_found_by(
 
     unresolved_vuln_ids = [vid for vid in vuln_ids if vid not in found_by_map]
 
-    # 2) Fallback: derive from observing scans/documents in scope.
+    # 2) Fallback: derive from observing scans/documents in scope. Fetch the
+    # observation-to-scan rows separately from document metadata: joining
+    # every finding observation to every document in its scan creates a very
+    # large intermediate result on scans with many findings and documents.
     if unresolved_vuln_ids:
         fallback_q = (
             db.select(
                 Finding.vulnerability_id,
+                Scan.id.label("scan_id"),
                 Scan.scan_source,
-                SBOMDocument.format.label("doc_format"),
             )
             .select_from(Finding)
             .join(Observation, Observation.finding_id == Finding.id)
             .join(Scan, Scan.id == Observation.scan_id)
-            .outerjoin(
-                SBOMDocument,
-                db.and_(
-                    SBOMDocument.scan_id == Scan.id,
-                    SBOMDocument.format.isnot(None),
-                ),
-            )
             .where(Finding.vulnerability_id.in_(unresolved_vuln_ids))
         )
         if active_scan_ids:
             fallback_q = fallback_q.where(Observation.scan_id.in_(active_scan_ids))
         fallback_rows = db.session.execute(fallback_q.distinct()).all()
 
-        for vuln_id, scan_source, doc_format in fallback_rows:
-            if isinstance(doc_format, str):
-                mapped = _FORMAT_TO_FOUND_BY.get(doc_format, doc_format)
-                found_by_map.setdefault(vuln_id, set()).add(mapped)
+        fallback_scan_ids = {scan_id for _, scan_id, _ in fallback_rows}
+        formats_by_scan: dict[uuid.UUID, set[str]] = {}
+        if fallback_scan_ids:
+            format_rows = db.session.execute(
+                db.select(SBOMDocument.scan_id, SBOMDocument.format)
+                .where(
+                    SBOMDocument.scan_id.in_(fallback_scan_ids),
+                    SBOMDocument.format.isnot(None),
+                )
+                .distinct()
+            ).all()
+            for scan_id, doc_format in format_rows:
+                if isinstance(doc_format, str):
+                    formats_by_scan.setdefault(scan_id, set()).add(doc_format)
+
+        for vuln_id, scan_id, scan_source in fallback_rows:
+            doc_formats = formats_by_scan.get(scan_id, set())
+            if doc_formats:
+                for doc_format in doc_formats:
+                    mapped = _FORMAT_TO_FOUND_BY.get(doc_format, doc_format)
+                    found_by_map.setdefault(vuln_id, set()).add(mapped)
             elif isinstance(scan_source, str):
                 mapped = _TOOL_SOURCE_TO_FOUND_BY.get(scan_source, scan_source)
                 found_by_map.setdefault(vuln_id, set()).add(mapped)
@@ -335,6 +361,7 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/vulnerabilities')
     def index_vulns() -> ResponseReturnValue:
+        response_format = request.args.get('format', 'list')
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
         compare_variant_id = request.args.get('compare_variant_id')
@@ -364,6 +391,7 @@ def init_app(app: Flask) -> None:
                 selectinload(Vulnerability.findings).selectinload(Finding.package),
                 selectinload(Vulnerability.findings).selectinload(Finding.time_estimates),
                 selectinload(Vulnerability.metrics),
+                joinedload(Vulnerability.refresh),
             )
 
             base_ids = _vuln_ids_for_scans(base_latest_ids)
@@ -420,6 +448,7 @@ def init_app(app: Flask) -> None:
                 selectinload(Vulnerability.findings).selectinload(Finding.package),
                 selectinload(Vulnerability.findings).selectinload(Finding.time_estimates),
                 selectinload(Vulnerability.metrics),
+                joinedload(Vulnerability.refresh),
             )
             per_variant_scan_ids = {u: active_scan_ids_for_variant(u) for u in parsed_uuids}
             current_scan_ids = []
@@ -461,6 +490,7 @@ def init_app(app: Flask) -> None:
                         selectinload(Vulnerability.findings).selectinload(Finding.package),
                         selectinload(Vulnerability.findings).selectinload(Finding.time_estimates),
                         selectinload(Vulnerability.metrics),
+                        joinedload(Vulnerability.refresh),
                     )
                     .join(Finding, Vulnerability.id == Finding.vulnerability_id)
                     .join(Observation, Finding.id == Observation.finding_id)
@@ -539,6 +569,7 @@ def init_app(app: Flask) -> None:
 
                 records = list(db.session.execute(
                     select(Vulnerability)
+                    .options(joinedload(Vulnerability.refresh))
                     .where(Vulnerability.id.in_(vuln_ids_subq))
                     .order_by(Vulnerability.id)
                 ).scalars().all())
@@ -675,6 +706,12 @@ def init_app(app: Flask) -> None:
         _populate_found_by(records, _scope_variant, _scope_project,
                            active_scan_ids=current_scan_ids or None)
         vulns = {r.id: r.to_dict() for r in records}
+        # The frontend consumes the richer ``texts`` field and never reads the
+        # legacy top-level description.  Omitting this duplicate from the list
+        # response saves substantial transfer and JSON parsing on large scans;
+        # the single-vulnerability endpoint still returns the complete record.
+        for vuln in vulns.values():
+            vuln.pop("description", None)
         _apply_variant_scoped_overrides_to_vuln_dicts(vulns, variant_scoped_overrides)
         vuln_ids = vulns.keys()
 
@@ -764,14 +801,39 @@ def init_app(app: Flask) -> None:
             for vuln_id, vuln in vulns.items():
                 vuln["first_scan_date"] = first_scan_by_vuln.get(vuln_id)
 
-            # Enrich with observation statuses
-            all_vuln_texts = fetch_vulnerabilities_texts(vuln_ids, include_packages=True, scan_ids=active_scan_ids)
-            for vuln_id, vuln_texts in all_vuln_texts.items():
-                vuln = vulns[vuln_id]
-                vuln["texts"] = list(map(VulnerabilityText.to_dict, vuln_texts))
+            # Descriptions are only needed by the detail modal.  The compact
+            # Explorer response deliberately skips this relatively expensive
+            # query and lets the single-vulnerability endpoint load them when
+            # a row is opened.
+            if response_format != "compact":
+                all_vuln_texts = fetch_vulnerabilities_texts(
+                    vuln_ids,
+                    include_packages=True,
+                    scan_ids=active_scan_ids,
+                )
+                for vuln_id, vuln_texts in all_vuln_texts.items():
+                    vuln = vulns[vuln_id]
+                    vuln["texts"] = list(map(VulnerabilityText.to_dict, vuln_texts))
 
-        match request.args.get('format', 'list'):
+        match response_format:
             case "list":
+                return list(vulns.values())
+            case "compact":
+                for vuln in vulns.values():
+                    vuln.pop("texts", None)
+                    vuln.pop("urls", None)
+                    vuln["details_loaded"] = False
+                    cvss_entries = vuln.get("severity", {}).get("cvss", [])
+                    vuln["severity"]["cvss"] = [
+                        {
+                            "version": cvss.get("version", ""),
+                            "base_score": cvss.get("base_score", 0.0),
+                            "attack_vector": _attack_vector_from_vector(
+                                cvss.get("vector_string", "")
+                            ),
+                        }
+                        for cvss in cvss_entries
+                    ]
                 return list(vulns.values())
             case "dict":
                 return vulns
@@ -785,7 +847,9 @@ def init_app(app: Flask) -> None:
             return "Not found", 404
 
         variant_id = request.args.get("variant_id")
+        project_id = request.args.get("project_id")
         response = record.to_dict()
+        text_variant_ids: list[uuid.UUID] | None = None
         if variant_id:
             variant_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:
@@ -794,12 +858,35 @@ def init_app(app: Flask) -> None:
                 return {"error": "Internal error"}, 500
             overrides = _variant_scoped_metrics_and_effort_overrides([record], variant_uuid)
             _apply_variant_scoped_overrides_to_vuln_dicts({response["id"]: response}, overrides)
+            text_variant_ids = [variant_uuid]
+        elif project_id:
+            project_uuid, err = parse_uuid_or_400(project_id, "project_id")
+            if err:
+                return err
+            if project_uuid is None:
+                return {"error": "Internal error"}, 500
+            text_variant_ids = [v.id for v in Variant.get_by_project(project_uuid)]
+            metric_filter = Metrics.variant_id.is_(None)
+            if text_variant_ids:
+                metric_filter = db.or_(
+                    Metrics.variant_id.in_(text_variant_ids),
+                    Metrics.variant_id.is_(None),
+                )
+            scoped_metrics = db.session.execute(
+                db.select(Metrics).where(
+                    Metrics.vulnerability_id == record.id,
+                    metric_filter,
+                )
+            ).scalars().all()
+            response.setdefault("severity", {})["cvss"] = [
+                metric.to_dict() for metric in scoped_metrics
+            ]
         else:
             variant_uuid = None
 
         vuln_texts = fetch_vulnerabilities_texts(
             [id],
-            variant_ids=[variant_uuid] if variant_uuid else None,
+            variant_ids=text_variant_ids,
             include_packages=True,
         )
         response["texts"] = list(map(VulnerabilityText.to_dict, vuln_texts[id]))

--- a/tests/unit_tests/test_webapp_coverage_boost.py
+++ b/tests/unit_tests/test_webapp_coverage_boost.py
@@ -61,7 +61,7 @@ def test_launch_enrichment_catches_and_logs_failures(monkeypatch, capsys):
     assert "[enrichment/epss]" in out
 
 
-def test_create_app_triggers_enrichment_when_scan_finished(monkeypatch, tmp_path):
+def test_create_app_schedules_background_tasks_when_scan_finished(monkeypatch, tmp_path):
     status_file = tmp_path / "status.txt"
     status_file.write_text("__END_OF_SCAN_SCRIPT__")
 
@@ -76,7 +76,7 @@ def test_create_app_triggers_enrichment_when_scan_finished(monkeypatch, tmp_path
             return {"ok": True}
 
     monkeypatch.setenv("FLASK_SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
-    monkeypatch.setattr(webapp_mod, "_launch_enrichment", _record_launch)
+    monkeypatch.setattr(webapp_mod, "_schedule_background_tasks", _record_launch)
     monkeypatch.setattr(webapp_mod, "init_app", _register_api_ping)
     monkeypatch.setattr(webapp_mod, "init_merger_cli", lambda _app: None)
 
@@ -89,6 +89,30 @@ def test_create_app_triggers_enrichment_when_scan_finished(monkeypatch, tmp_path
 
     assert response.status_code == 200
     assert calls == ["launched"]
+
+
+def test_schedule_background_tasks_starts_both_jobs(monkeypatch):
+    calls: list[str] = []
+
+    class _InlineTimer:
+        def __init__(self, delay, target):
+            assert delay == 0
+            self._target = target
+            self.name = None
+            self.daemon = False
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(webapp_mod.threading, "Timer", _InlineTimer)
+    monkeypatch.setattr(webapp_mod, "_launch_enrichment", lambda _app: calls.append("epss"))
+    monkeypatch.setattr(webapp_mod, "_warm_scan_list_cache", lambda _app: calls.append("cache"))
+
+    app = Flask(__name__)
+    app.config["BACKGROUND_TASK_DELAY"] = 0
+    webapp_mod._schedule_background_tasks(app)
+
+    assert calls == ["epss", "cache"]
 
 
 def test_create_app_swallows_pragma_setup_error(monkeypatch):

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -306,6 +306,7 @@ def test_render_document_pdf(client):
     else:
         assert response.status_code == 200
 
+
 def test_render_document_html(client):
     import shutil
     response = client.get("/api/documents/summary.adoc?ext=html")
@@ -337,6 +338,7 @@ def test_render_document_invalid_ext(client):
     data = json.loads(response.data)
     assert data["error"] is not None
 
+
 def test_render_spdx_json(client):
     response = client.get("/api/documents/SPDX 2.3?ext=json")
     assert response.status_code == 200
@@ -350,6 +352,7 @@ def test_render_spdx_json(client):
     assert data["spdxVersion"] == "SPDX-2.3"
     assert data["dataLicense"] == "CC0-1.0"
     assert "packages" in data
+
 
 def test_render_spdx_xml(monkeypatch, client):
     # Ensure expected_mime is 'text/xml' for '?ext=xml'
@@ -369,6 +372,7 @@ def test_render_spdx_xml(monkeypatch, client):
     cd = response.headers.get("Content-Disposition", "")
     assert "attachment" in cd and "filename=spdx_v2_3.xml" in cd
     assert response.data.decode("utf-8").lstrip().startswith("<")
+
 
 def test_render_openvex_json(client):
     response = client.get("/api/documents/OpenVex?ext=json")

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -127,6 +127,22 @@ def test_get_vulnerabilities_list(client):
     ]
 
 
+def test_get_vulnerabilities_compact_defers_modal_details(client):
+    response = client.get("/api/vulnerabilities?format=compact")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data) == 1
+
+    vuln = data[0]
+    assert vuln["id"] == "CVE-2020-35492"
+    assert vuln["details_loaded"] is False
+    assert "texts" not in vuln
+    assert "urls" not in vuln
+    assert vuln["severity"]["severity"] == "high"
+    for cvss in vuln["severity"]["cvss"]:
+        assert set(cvss) == {"version", "base_score", "attack_vector"}
+
+
 def test_get_vulnerabilities_dict(client):
     response = client.get("/api/vulnerabilities?format=dict")
     assert response.status_code == 200
@@ -144,6 +160,10 @@ def test_get_vulnerability_by_id(client):
     assert data["id"] == "CVE-2020-35492"
     assert data["severity"]["severity"] == "high"
     assert "cairo@1.16.0" in data["packages"]
+    assert "urls" in data
+    for cvss in data["severity"]["cvss"]:
+        assert "vector_string" in cvss
+        assert "author" in cvss
     assert data["texts"] == [
         {
             "title": "description",

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -192,6 +192,21 @@ def test_get_assessments_dict(client):
     assert data["da4d18f0-d89e-4d54-819d-86fc884cc737"]["impact_statement"] == "Yocto reported vulnerability as Patched"
 
 
+def test_get_assessments_compact(client):
+    response = client.get("/api/assessments?format=compact")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data) == 1
+    assessment = data[0]
+    assert assessment[0] == "da4d18f0-d89e-4d54-819d-86fc884cc737"
+    assert assessment[1] == "CVE-2020-35492"
+    assert assessment[2] == "cairo@1.16.0"
+    assert assessment[3] is None
+    assert isinstance(assessment[4], str)
+    assert assessment[5] == "fixed"
+    assert len(assessment) == 6
+
+
 def test_get_assessment_by_id(client):
     response = client.get("/api/assessments/da4d18f0-d89e-4d54-819d-86fc884cc737")
     assert response.status_code == 200

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -143,6 +143,32 @@ def test_get_vulnerabilities_compact_defers_modal_details(client):
         assert set(cvss) == {"version", "base_score", "attack_vector"}
 
 
+def test_search_vulnerability_descriptions(client):
+    response = client.post(
+        "/api/vulnerabilities/search-descriptions",
+        json={
+            "vulnerability_ids": ["CVE-2020-35492"],
+            "terms": ["IMAGE-COMPOSITOR", "yocto", "missing"],
+        },
+    )
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "matches": {
+            "image-compositor": ["CVE-2020-35492"],
+            "yocto": ["CVE-2020-35492"],
+            "missing": [],
+        }
+    }
+
+
+def test_search_vulnerability_descriptions_validates_payload(client):
+    response = client.post(
+        "/api/vulnerabilities/search-descriptions",
+        json={"vulnerability_ids": "CVE-2020-35492", "terms": ["cairo"]},
+    )
+    assert response.status_code == 400
+
+
 def test_get_vulnerabilities_dict(client):
     response = client.get("/api/vulnerabilities?format=dict")
     assert response.status_code == 200

--- a/tests/webapp_tests/test_project_variant_endpoints.py
+++ b/tests/webapp_tests/test_project_variant_endpoints.py
@@ -491,6 +491,8 @@ class TestPackagesFiltering:
         body = json.loads(response.data)
         cairo = next(p for p in body if p["name"] == "cairo")
         assert cairo["variants"] == ["VariantA"]
+        assert cairo["sources"] == []
+        assert cairo["sbom_documents"] == ["cdx"]
 
     # Compare-filtering tests:
     # VariantA has cairo@1.16.0, VariantB has no packages (via observations).

--- a/tests/webapp_tests/test_vulnerabilities_coverage.py
+++ b/tests/webapp_tests/test_vulnerabilities_coverage.py
@@ -973,8 +973,7 @@ def test_apply_variant_scoped_overrides_skips_missing_vuln():
 
 
 def test_populate_found_by_handles_non_string_doc_formats(monkeypatch):
-    """In the legacy fallback, non-string doc formats are skipped and tool
-    scan sources are mapped."""
+    """Fallback skips non-string document formats and maps scan sources."""
     from src.routes.vulnerabilities import _populate_found_by
 
     class _Record:
@@ -992,20 +991,19 @@ def test_populate_found_by_handles_non_string_doc_formats(monkeypatch):
         def all(self):
             return self._rows
 
-    # The function runs two queries: (1) provenance markers, (2) legacy
-    # fallback. Return no provenance markers so both vulns fall through to the
-    # fallback, then return fallback rows shaped (vuln_id, scan_source,
-    # doc_format).
+    # The function runs separate queries for provenance, fallback observations,
+    # and document formats to avoid multiplying observations by documents.
     fallback_rows = [
-        ("v1", "nvd", None),      # non-string doc format -> use scan_source
-        ("v2", None, 12345),      # both non-string -> nothing added
+        ("v1", "scan-1", "nvd"),
+        ("v2", "scan-2", None),
     ]
+    format_rows = [("scan-1", None), ("scan-2", 12345)]
     calls = {"n": 0}
 
     def _fake_execute(*args, **kwargs):
         calls["n"] += 1
-        # 1st call: provenance query (empty), 2nd call: fallback query
-        return _Result([] if calls["n"] == 1 else fallback_rows)
+        rows = {1: [], 2: fallback_rows, 3: format_rows}[calls["n"]]
+        return _Result(rows)
 
     monkeypatch.setattr(
         "src.routes.vulnerabilities.db.session.execute",


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

- Defers post-scan background tasks to prevent contention during initial Explorer loading.
- Optimizes package enrichment by splitting expensive database lookups.
- Introduces compact vulnerability responses with details loaded on demand.
- Reduces assessment payload size through compact serialization and compression.
- Preserves full vulnerability and assessment details when opening the vulnerability modal.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

- Load a huge `vulnscout.db` database with and without this pull request. Time to load the UI should be significantly reduced.
- Open or hover over a vulnerability and verify its description, links, and CVSS details appear.
- Verify assessment details remain available in the vulnerability modal.