### PR TITLE
Web dashboard: persist project variant selection

### DIFF
--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBox, faShieldHalved, faFileExport, faMoon, faSun, faClockRotateLeft, faClipboardCheck, faGear, faRightLeft, faRobot } from '@fortawesome/free-solid-svg-icons';
 import ProjectVariantSelector from './ProjectVariantSelector';
+import type { FrontendScope } from '../handlers/config';
 
 const greenTheme = true;
 const bgColor = greenTheme ? 'bg-cyan-800 text-neutral-50' : 'dark:bg-neutral-900 dark:text-neutral-50';
@@ -14,10 +15,11 @@ type Props = {
   setDarkMode: (mode: boolean) => void;
   defaultProject?: { id: string; name: string } | null;
   defaultVariant?: { id: string; name: string } | null;
+  defaultScope?: FrontendScope | null;
   onApply: (projectId: string, variantId: string, compareVariantId: string, operation: string, variantIds: string[], multiOperation: string) => void;
 };
 
-function NavigationBar({ tab, changeTab, darkMode, setDarkMode, defaultProject, defaultVariant, onApply }: Readonly<Props>) {
+function NavigationBar({ tab, changeTab, darkMode, setDarkMode, defaultProject, defaultVariant, defaultScope, onApply }: Readonly<Props>) {
   return (
   <nav aria-label="Main navigation">
     <ul className={["flex flex-row font-bold items-stretch", bgColor].join(' ')}>
@@ -145,6 +147,7 @@ function NavigationBar({ tab, changeTab, darkMode, setDarkMode, defaultProject, 
         <ProjectVariantSelector
           defaultProject={defaultProject}
           defaultVariant={defaultVariant}
+          defaultScope={defaultScope}
           onApply={onApply}
         />
       </li>

--- a/frontend/src/components/ProjectVariantSelector.tsx
+++ b/frontend/src/components/ProjectVariantSelector.tsx
@@ -6,6 +6,7 @@ import Projects from '../handlers/project';
 import type { Project } from '../handlers/project';
 import Variants from '../handlers/variant';
 import type { Variant } from '../handlers/variant';
+import type { FrontendScope } from '../handlers/config';
 
 const greenTheme = true;
 const bgHoverColor = greenTheme ? 'hover:bg-cyan-700' : 'dark:hover:bg-neutral-700';
@@ -27,10 +28,11 @@ type AppliedScope = {
 type Props = {
     defaultProject?: { id: string; name: string } | null;
     defaultVariant?: { id: string; name: string } | null;
+    defaultScope?: FrontendScope | null;
     onApply: (projectId: string, variantId: string, compareVariantId: string, operation: string, variantIds: string[], multiOperation: string) => void;
 };
 
-function ProjectVariantSelector({ defaultProject, onApply }: Readonly<Props>) {
+function ProjectVariantSelector({ defaultProject, defaultScope, onApply }: Readonly<Props>) {
     const [isOpen, setIsOpen] = useState(false);
     const buttonRef = useRef<HTMLButtonElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
@@ -77,20 +79,19 @@ function ProjectVariantSelector({ defaultProject, onApply }: Readonly<Props>) {
     useEffect(() => { variantsRef.current = variants; }, [variants]);
     useEffect(() => { selectedProjectIdRef.current = selectedProjectId; }, [selectedProjectId]);
 
-    // Sync display state when default config arrives from the server
+    // A persisted browser scope supersedes the server's default project.
     useEffect(() => {
-        if (defaultProject?.id) {
-            // All variants are selected by default on first load.
-            setSelectedProjectId(defaultProject.id);
-            setAppliedProject(defaultProject.name);
+        const initialProjectId = defaultScope?.project_id ?? defaultProject?.id;
+        if (initialProjectId) {
+            if (defaultScope?.mode === 'select') {
+                pendingRestoreRef.current = defaultScope.variant_ids;
+            }
+            const initialProject = projects.find(project => project.id === initialProjectId)
+                ?? (defaultProject?.id === initialProjectId ? defaultProject : null);
+            setSelectedProjectId(initialProjectId);
+            setAppliedProject(initialProject?.name ?? '');
         }
-    }, [defaultProject?.id, defaultProject?.name]);
-
-    useEffect(() => {
-        if (defaultProject?.id) {
-            setAppliedLabel('All variants');
-        }
-    }, [defaultProject?.id]);
+    }, [defaultProject, defaultScope, projects]);
 
     // Default the compare base / compare variant once variants are available
     useEffect(() => {
@@ -116,10 +117,12 @@ function ProjectVariantSelector({ defaultProject, onApply }: Readonly<Props>) {
 
     // Load variants when selected project changes
     useEffect(() => {
+        let cancelled = false;
         setVariants([]);
         if (!selectedProjectId) return;
         Variants.list(selectedProjectId)
             .then(vs => {
+                if (cancelled) return;
                 setVariants(vs);
                 const restore = pendingRestoreRef.current;
                 pendingRestoreRef.current = null;
@@ -133,25 +136,55 @@ function ProjectVariantSelector({ defaultProject, onApply }: Readonly<Props>) {
                     setSelectedVariantIds(vs.map(v => v.id));
                 }
             })
-            .catch(() => setVariants([]));
+            .catch(() => {
+                if (!cancelled) setVariants([]);
+            });
+        return () => { cancelled = true; };
     }, [selectedProjectId]);
 
     // Establish the initial applied scope from config once variants are known,
     // so the first reopen reflects the configured project/variant.
     useEffect(() => {
+        const initialProjectId = defaultScope?.project_id ?? defaultProject?.id;
         if (appliedScope || variants.length === 0 || !selectedProjectId) return;
-        if (defaultProject?.id !== selectedProjectId) return;
-        // All variants are selected by default.
-        const variantIds = variants.map(v => v.id);
-        applyScope({
+        if (initialProjectId !== selectedProjectId) return;
+        const validVariantIds = (defaultScope?.mode === 'select' && defaultScope.variant_ids.length > 0)
+            ? defaultScope.variant_ids.filter(id => variants.some(v => v.id === id))
+            : variants.map(v => v.id);
+        const initialScope: AppliedScope = defaultScope ? {
+            projectId: selectedProjectId,
+            mode: defaultScope.mode,
+            variantIds: validVariantIds,
+            compareBaseId: defaultScope.compare_base_id,
+            compareOp: defaultScope.compare_operation,
+            compareId: defaultScope.compare_variant_id,
+        } : {
             projectId: selectedProjectId,
             mode: 'select',
-            variantIds,
+            variantIds: validVariantIds,
             compareBaseId: variants[0]?.id ?? '',
             compareOp: 'difference',
             compareId: '',
-        });
-    }, [variants, selectedProjectId, appliedScope, defaultProject?.id]);
+        };
+        applyScope(initialScope);
+        setMode(initialScope.mode);
+        setSelectedVariantIds(initialScope.variantIds);
+        setCompareBaseVariantId(initialScope.compareBaseId);
+        setCompareOperation(initialScope.compareOp);
+        setSelectedCompareVariantId(initialScope.compareId);
+        if (initialScope.mode === 'compare') {
+            const base = variants.find(v => v.id === initialScope.compareBaseId);
+            const compare = variants.find(v => v.id === initialScope.compareId);
+            const symbol = initialScope.compareOp === 'difference' ? '∖' : '∩';
+            setAppliedLabel(`${base?.name ?? 'All'} ${symbol} ${compare?.name ?? ''}`);
+        } else if (initialScope.variantIds.length === variants.length) {
+            setAppliedLabel('All variants');
+        } else if (initialScope.variantIds.length === 1) {
+            setAppliedLabel(variants.find(v => v.id === initialScope.variantIds[0])?.name ?? '');
+        } else {
+            setAppliedLabel(`${initialScope.variantIds.length} variants (∪)`);
+        }
+    }, [variants, selectedProjectId, appliedScope, defaultProject?.id, defaultScope]);
 
     // Restore the panel controls from the applied scope each time it opens.
     useEffect(() => {

--- a/frontend/src/handlers/config.ts
+++ b/frontend/src/handlers/config.ts
@@ -1,3 +1,12 @@
+type FrontendScope = {
+    project_id: string;
+    mode: 'select' | 'compare';
+    variant_ids: string[];
+    compare_base_id: string;
+    compare_operation: 'difference' | 'intersection';
+    compare_variant_id: string;
+};
+
 type AppConfig = {
     project: { id: string; name: string } | null;
     variant: { id: string; name: string } | null;
@@ -8,10 +17,25 @@ type AppConfig = {
     grype_memlimit: string;
 };
 
-export type { AppConfig };
+export type { AppConfig, FrontendScope };
 
 class Config {
-     
+    private static readonly _frontendScopeStorageKey = 'vulnscout.frontendScope';
+
+    private static _normalizeFrontendScope(scope: unknown): FrontendScope | null {
+        return scope
+            && typeof scope === 'object'
+            && typeof (scope as FrontendScope).project_id === 'string'
+            && ((scope as FrontendScope).mode === 'select' || (scope as FrontendScope).mode === 'compare')
+            && Array.isArray((scope as FrontendScope).variant_ids)
+            && (scope as FrontendScope).variant_ids.every(id => typeof id === 'string')
+            && typeof (scope as FrontendScope).compare_base_id === 'string'
+            && ((scope as FrontendScope).compare_operation === 'difference' || (scope as FrontendScope).compare_operation === 'intersection')
+            && typeof (scope as FrontendScope).compare_variant_id === 'string'
+                ? scope as FrontendScope
+                : null;
+    }
+
     private static _normalizeConfig(data: any): AppConfig {
         return {
             project:
@@ -35,6 +59,31 @@ class Config {
             contact_email: typeof data?.contact_email === "string" ? data.contact_email : "",
             grype_memlimit: typeof data?.grype_memlimit === "string" ? data.grype_memlimit : "",
         };
+    }
+
+    static getFrontendScope(): FrontendScope | null {
+        try {
+            const value = window.localStorage.getItem(Config._frontendScopeStorageKey);
+            return value ? Config._normalizeFrontendScope(JSON.parse(value)) : null;
+        } catch {
+            return null;
+        }
+    }
+
+    static setFrontendScope(scope: FrontendScope): void {
+        window.localStorage.setItem(Config._frontendScopeStorageKey, JSON.stringify(scope));
+    }
+
+    static clearFrontendScope(): void {
+        window.localStorage.removeItem(Config._frontendScopeStorageKey);
+    }
+
+    static isFrontendScopeAvailable(scope: FrontendScope, projectIds: string[], variantIds: string[]): boolean {
+        if (!projectIds.includes(scope.project_id)) return false;
+        const referencedVariantIds = scope.mode === 'compare'
+            ? [scope.compare_base_id, scope.compare_variant_id]
+            : scope.variant_ids;
+        return referencedVariantIds.every(variantId => variantIds.includes(variantId));
     }
 
     static async get(): Promise<AppConfig> {

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -20,6 +20,9 @@ import AIContext from './AIContext';
 import Assessments, { removeDuplicateAssessments, STATUS_VEX_TO_GRAPH } from '../handlers/assessments';
 import Config from "../handlers/config";
 import type { AppConfig } from "../handlers/config";
+import type { FrontendScope } from "../handlers/config";
+import Projects from '../handlers/project';
+import Variants from '../handlers/variant';
 
 const tabLabels: Record<string, string> = {
         metrics: 'Metrics',
@@ -62,6 +65,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         contact_email: "",
         grype_memlimit: "",
     });
+    const [frontendScope, setFrontendScope] = useState<FrontendScope | null>(null);
     const [currentVariantId, setCurrentVariantId] = useState<string | undefined>(undefined);
     const [currentProjectId, setCurrentProjectId] = useState<string | undefined>(undefined);
     const [currentBaseVariantId, setCurrentBaseVariantId] = useState<string | undefined>(undefined);
@@ -122,16 +126,73 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
 
     // On mount: fetch default project/variant from config, then load data
     useEffect(() => {
+        let cancelled = false;
+
         Config.get()
-            .then(config => {
+            .then(async config => {
+                let scope = Config.getFrontendScope();
+                let discardedScope = false;
+                // Validate the saved scope against the live project/variant
+                // lists. A transient fetch failure here must not discard the
+                // successfully-loaded config: fall back to the server default
+                // scope while keeping the config and loading default data.
+                try {
+                    if (scope) {
+                        const projects = await Projects.list();
+                        const projectExists = projects.some(project => project.id === scope?.project_id);
+                        const canConfirmProjectAbsence = projects.length > 0 || !config.project;
+                        if (!projectExists && canConfirmProjectAbsence) {
+                            Config.clearFrontendScope();
+                            scope = null;
+                            discardedScope = true;
+                        } else if (projectExists) {
+                            const variants = await Variants.list(scope.project_id);
+                            if (!Config.isFrontendScopeAvailable(scope, projects.map(project => project.id), variants.map(variant => variant.id))) {
+                                Config.clearFrontendScope();
+                                scope = null;
+                                discardedScope = true;
+                            }
+                        }
+                    }
+                } catch {
+                    // Validation could not complete (e.g. network hiccup);
+                    // keep the loaded config and use the server default scope.
+                    scope = null;
+                }
+                if (cancelled) return;
                 setDefaultConfig(config);
-                const variantId = config.variant?.id || undefined;
-                const projectId = variantId ? undefined : (config.project?.id || undefined);
-                setCurrentVariantId(variantId);
-                setCurrentProjectId(config.project?.id || undefined);
-                loadData(variantId, projectId);
+                setFrontendScope(scope);
+                if (discardedScope) {
+                    triggerBanner("Saved selection is no longer available; using the default scope", "error");
+                }
+                const multiActive = scope?.mode === 'select' && scope.variant_ids.length >= 2;
+                const compareActive = scope?.mode === 'compare';
+                const variantId = compareActive
+                    ? scope?.compare_base_id
+                    : scope?.mode === 'select' && scope.variant_ids.length === 1
+                        ? scope.variant_ids[0]
+                        : config.variant?.id || undefined;
+                const projectId = scope?.project_id || config.project?.id || undefined;
+                const compareVariantId = compareActive ? scope?.compare_variant_id : undefined;
+                setCurrentVariantId(compareVariantId || variantId);
+                setCurrentProjectId(projectId);
+                setCurrentBaseVariantId(compareActive ? variantId : undefined);
+                setCurrentOperation(compareActive ? scope?.compare_operation : undefined);
+                setCurrentVariantIds(multiActive ? scope?.variant_ids : undefined);
+                setCurrentMultiOperation(multiActive ? 'union' : undefined);
+                loadData(
+                    multiActive ? undefined : variantId,
+                    (multiActive || !variantId) ? projectId : undefined,
+                    compareVariantId,
+                    compareActive ? scope?.compare_operation : undefined,
+                    multiActive ? scope?.variant_ids : undefined,
+                    multiActive ? 'union' : undefined,
+                );
             })
-            .catch(() => loadData(undefined));
+            .catch(() => {
+                if (!cancelled) loadData(undefined);
+            });
+        return () => { cancelled = true; };
     }, [loadData]);
 
     const handleApply = useCallback((projectId: string, variantId: string, compareVariantId: string, operation: string, variantIds: string[], multiOperation: string) => {
@@ -144,6 +205,20 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         setCurrentOperation((!multiActive && compareVariantId) ? (operation || undefined) : undefined);
         setCurrentVariantIds(multiActive ? variantIds : undefined);
         setCurrentMultiOperation(multiActive ? (multiOperation || undefined) : undefined);
+        const frontendScope: FrontendScope = {
+            project_id: projectId,
+            mode: compareVariantId ? 'compare' : 'select',
+            variant_ids: compareVariantId ? [] : (variantIds.length ? variantIds : (variantId ? [variantId] : [])),
+            compare_base_id: compareVariantId ? variantId : '',
+            compare_operation: operation === 'intersection' ? 'intersection' : 'difference',
+            compare_variant_id: compareVariantId,
+        };
+        try {
+            Config.setFrontendScope(frontendScope);
+            setFrontendScope(frontendScope);
+        } catch {
+            triggerBanner("Selection applied, but it could not be saved for restart", "error");
+        }
         loadData(
             multiActive ? undefined : (variantId || undefined),
             (multiActive || !variantId) ? (projectId || undefined) : undefined,
@@ -295,6 +370,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     setDarkMode={setDarkMode}
                     defaultProject={defaultConfig.project}
                     defaultVariant={defaultConfig.variant}
+                    defaultScope={frontendScope}
                     onApply={handleApply}
                 />
             </header>

--- a/frontend/tests/unit_tests/test_config_handler.ts
+++ b/frontend/tests/unit_tests/test_config_handler.ts
@@ -7,6 +7,7 @@ import Config from '../../src/handlers/config';
 describe('Config.get', () => {
     beforeEach(() => {
         fetchMock.resetMocks();
+        window.localStorage.clear();
     });
 
     test('maps report metadata fields', async () => {
@@ -47,6 +48,64 @@ describe('Config.get', () => {
         expect(result.author_name).toBe('vulnscout');
         expect(result.client_name).toBe('');
         expect(result.contact_email).toBe('');
+    });
+});
+
+
+describe('Config frontend scope storage', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+
+    test('stores and restores a valid frontend scope locally', () => {
+        const scope = {
+            project_id: 'p1',
+            mode: 'select' as const,
+            variant_ids: ['v1'],
+            compare_base_id: '',
+            compare_operation: 'difference' as const,
+            compare_variant_id: '',
+        };
+
+        Config.setFrontendScope(scope);
+
+        expect(Config.getFrontendScope()).toEqual(scope);
+    });
+
+    test('ignores malformed stored scope data', () => {
+        window.localStorage.setItem('vulnscout.frontendScope', '{"mode":"select"}');
+
+        expect(Config.getFrontendScope()).toBeNull();
+    });
+
+    test('clears a saved frontend scope', () => {
+        Config.setFrontendScope({
+            project_id: 'p1',
+            mode: 'select',
+            variant_ids: [],
+            compare_base_id: '',
+            compare_operation: 'difference',
+            compare_variant_id: '',
+        });
+
+        Config.clearFrontendScope();
+
+        expect(Config.getFrontendScope()).toBeNull();
+    });
+
+    test('detects unavailable projects and variants in saved scopes', () => {
+        const scope = {
+            project_id: 'p1',
+            mode: 'select' as const,
+            variant_ids: ['v1'],
+            compare_base_id: '',
+            compare_operation: 'difference' as const,
+            compare_variant_id: '',
+        };
+
+        expect(Config.isFrontendScopeAvailable(scope, ['p2'], ['v1'])).toBe(false);
+        expect(Config.isFrontendScopeAvailable(scope, ['p1'], ['v2'])).toBe(false);
+        expect(Config.isFrontendScopeAvailable(scope, ['p1'], ['v1'])).toBe(true);
     });
 });
 

--- a/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
+++ b/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
@@ -1,0 +1,190 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+// @ts-expect-error TS6133
+import React from 'react';
+
+import Explorer from '../../src/pages/Explorer';
+import Config from '../../src/handlers/config';
+import Projects from '../../src/handlers/project';
+import Variants from '../../src/handlers/variant';
+import Packages from '../../src/handlers/packages';
+import Vulnerabilities from '../../src/handlers/vulnerabilities';
+import Assessments from '../../src/handlers/assessments';
+
+jest.mock('../../src/handlers/config', () => ({
+    __esModule: true,
+    default: {
+        get: jest.fn(),
+        getFrontendScope: jest.fn(),
+        clearFrontendScope: jest.fn(),
+        setFrontendScope: jest.fn(),
+        isFrontendScopeAvailable: jest.fn((scope, projectIds, variantIds) =>
+            projectIds.includes(scope.project_id) && scope.variant_ids.every((variantId: string) => variantIds.includes(variantId)),
+        ),
+    },
+}));
+
+jest.mock('../../src/handlers/project', () => ({
+    __esModule: true,
+    default: { list: jest.fn() },
+}));
+
+jest.mock('../../src/handlers/variant', () => ({
+    __esModule: true,
+    default: { list: jest.fn() },
+}));
+
+jest.mock('../../src/handlers/packages', () => ({
+    __esModule: true,
+    default: {
+        list: jest.fn(),
+        enrich_with_vulns: jest.fn(() => []),
+    },
+}));
+
+jest.mock('../../src/handlers/vulnerabilities', () => ({
+    __esModule: true,
+    default: {
+        list: jest.fn(),
+        enrich_with_assessments: jest.fn(() => []),
+        calculate_cvss_from_vector: jest.fn(),
+        append_assessment: jest.fn(),
+        append_cvss: jest.fn(),
+    },
+}));
+
+jest.mock('../../src/handlers/assessments', () => ({
+    __esModule: true,
+    default: { list: jest.fn() },
+    removeDuplicateAssessments: jest.fn((lists: unknown[][]) => lists.flat()),
+    STATUS_VEX_TO_GRAPH: {},
+}));
+
+jest.mock('../../src/components/NavigationBar', () => ({
+    __esModule: true,
+    default: ({ defaultProject, defaultScope }: {
+        defaultProject?: { id: string } | null;
+        defaultScope?: { project_id: string } | null;
+    }) => (
+        <div>
+            <span data-testid="default-project">{defaultProject?.id ?? ''}</span>
+            <span data-testid="frontend-scope">{defaultScope?.project_id ?? ''}</span>
+        </div>
+    ),
+}));
+
+jest.mock('../../src/components/MessageBanner', () => ({
+    __esModule: true,
+    default: ({ message, isVisible }: { message: string; isVisible: boolean }) =>
+        isVisible ? <div role="alert">{message}</div> : null,
+}));
+
+jest.mock('../../src/components/VersionDisplay', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../src/pages/Metrics', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../src/pages/TablePackages', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../src/pages/TableVulnerabilities', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../src/pages/ScanHistory', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../src/pages/Review', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../src/pages/Settings', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../src/pages/Transfer', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../src/pages/Exports', () => ({ __esModule: true, default: () => null }));
+jest.mock('../../src/pages/AIContext', () => ({ __esModule: true, default: () => null }));
+
+const mockConfigGet = Config.get as jest.MockedFunction<typeof Config.get>;
+const mockGetFrontendScope = Config.getFrontendScope as jest.MockedFunction<typeof Config.getFrontendScope>;
+const mockClearFrontendScope = Config.clearFrontendScope as jest.MockedFunction<typeof Config.clearFrontendScope>;
+const mockProjectsList = Projects.list as jest.MockedFunction<typeof Projects.list>;
+const mockVariantsList = Variants.list as jest.MockedFunction<typeof Variants.list>;
+const mockPackagesList = Packages.list as jest.MockedFunction<typeof Packages.list>;
+const mockVulnerabilitiesList = Vulnerabilities.list as jest.MockedFunction<typeof Vulnerabilities.list>;
+const mockAssessmentsList = Assessments.list as jest.MockedFunction<typeof Assessments.list>;
+
+const SERVER_CONFIG = {
+    project: { id: 'default-project', name: 'Default Project' },
+    variant: { id: 'default-variant', name: 'Default Variant' },
+    product_name: '',
+    author_name: 'vulnscout',
+    client_name: '',
+    contact_email: '',
+    grype_memlimit: '',
+};
+
+const savedScope = (projectId: string, variantIds: string[]) => ({
+    project_id: projectId,
+    mode: 'select' as const,
+    variant_ids: variantIds,
+    compare_base_id: '',
+    compare_operation: 'difference' as const,
+    compare_variant_id: '',
+});
+
+describe('Explorer saved-scope validation', () => {
+    beforeEach(() => {
+        mockConfigGet.mockResolvedValue(SERVER_CONFIG);
+        mockPackagesList.mockResolvedValue([]);
+        mockVulnerabilitiesList.mockResolvedValue([]);
+        mockAssessmentsList.mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('clears a stale project scope and shows a fallback banner', async () => {
+        mockGetFrontendScope.mockReturnValue(savedScope('deleted-project', ['old-variant']));
+        mockProjectsList.mockResolvedValue([{ id: 'other-project', name: 'Other Project' }]);
+
+        render(<Explorer darkMode={false} setDarkMode={jest.fn()} />);
+
+        await waitFor(() => {
+            expect(mockClearFrontendScope).toHaveBeenCalledTimes(1);
+            expect(screen.getByTestId('default-project')).toHaveTextContent('default-project');
+            expect(screen.getByTestId('frontend-scope')).toBeEmptyDOMElement();
+            expect(screen.getByRole('alert')).toHaveTextContent('Saved selection is no longer available');
+        });
+    });
+
+    test('clears a scope whose saved variant is no longer available', async () => {
+        mockGetFrontendScope.mockReturnValue(savedScope('existing-project', ['deleted-variant']));
+        mockProjectsList.mockResolvedValue([{ id: 'existing-project', name: 'Existing Project' }]);
+        mockVariantsList.mockResolvedValue([{ id: 'current-variant', name: 'Current Variant', project_id: 'existing-project' }]);
+
+        render(<Explorer darkMode={false} setDarkMode={jest.fn()} />);
+
+        await waitFor(() => {
+            expect(mockClearFrontendScope).toHaveBeenCalledTimes(1);
+            expect(screen.getByTestId('frontend-scope')).toBeEmptyDOMElement();
+            expect(screen.getByRole('alert')).toHaveTextContent('Saved selection is no longer available');
+        });
+    });
+
+    test('keeps a saved scope when an empty projects response cannot confirm its absence', async () => {
+        const scope = savedScope('saved-project', ['saved-variant']);
+        mockGetFrontendScope.mockReturnValue(scope);
+        mockProjectsList.mockResolvedValue([]);
+
+        render(<Explorer darkMode={false} setDarkMode={jest.fn()} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('default-project')).toHaveTextContent('default-project');
+            expect(screen.getByTestId('frontend-scope')).toHaveTextContent('saved-project');
+        });
+        expect(mockClearFrontendScope).not.toHaveBeenCalled();
+        expect(mockVariantsList).not.toHaveBeenCalled();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    test('uses the server default when scope validation fails', async () => {
+        mockGetFrontendScope.mockReturnValue(savedScope('saved-project', ['saved-variant']));
+        mockProjectsList.mockRejectedValue(new Error('Temporary network failure'));
+
+        render(<Explorer darkMode={false} setDarkMode={jest.fn()} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('default-project')).toHaveTextContent('default-project');
+            expect(screen.getByTestId('frontend-scope')).toBeEmptyDOMElement();
+            expect(mockPackagesList).toHaveBeenCalledWith('default-variant', undefined, undefined, undefined, undefined, undefined);
+        });
+        expect(mockClearFrontendScope).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/tests/unit_tests/test_export_json.ts
+++ b/frontend/tests/unit_tests/test_export_json.ts
@@ -1,0 +1,67 @@
+import {
+    downloadBlob,
+    downloadJson,
+    formatTimestampForFilename,
+    sanitizeFilename,
+} from '../../src/helpers/exportJson';
+
+describe('exportJson helpers', () => {
+    const createObjectUrl = URL.createObjectURL;
+    const revokeObjectUrl = URL.revokeObjectURL;
+
+    beforeEach(() => {
+        Object.defineProperty(URL, 'createObjectURL', {
+            configurable: true,
+            value: () => 'blob:vulnscout-export',
+        });
+        Object.defineProperty(URL, 'revokeObjectURL', {
+            configurable: true,
+            value: () => undefined,
+        });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(URL, 'createObjectURL', {
+            configurable: true,
+            value: createObjectUrl,
+        });
+        Object.defineProperty(URL, 'revokeObjectURL', {
+            configurable: true,
+            value: revokeObjectUrl,
+        });
+    });
+
+    test('sanitizes filenames and formats a supplied timestamp', () => {
+        expect(sanitizeFilename(' Project: Alpha / report?.json ')).toBe('Project_Alpha_report.json');
+        expect(formatTimestampForFilename(new Date(2026, 6, 28, 9, 5, 3))).toBe('20260728_090503');
+    });
+
+    test('downloads a pre-encoded blob with the requested filename', () => {
+        let download = '';
+        const captureDownload = (event: MouseEvent) => {
+            event.preventDefault();
+            download = (event.target as HTMLAnchorElement).download;
+        };
+        document.addEventListener('click', captureDownload);
+
+        downloadBlob(new Blob(['export body'], { type: 'application/json' }), 'report.json');
+
+        document.removeEventListener('click', captureDownload);
+        expect(download).toBe('report.json');
+        expect(document.querySelector('a[download="report.json"]')).toBeNull();
+    });
+
+    test('serializes JSON before initiating a download', () => {
+        let download = '';
+        const captureDownload = (event: MouseEvent) => {
+            event.preventDefault();
+            download = (event.target as HTMLAnchorElement).download;
+        };
+        document.addEventListener('click', captureDownload);
+
+        downloadJson({ id: 'CVE-2026-0001' }, 'vulnerabilities.json');
+
+        document.removeEventListener('click', captureDownload);
+        expect(download).toBe('vulnerabilities.json');
+    });
+});

--- a/frontend/tests/unit_tests/test_project_variant_selector.tsx
+++ b/frontend/tests/unit_tests/test_project_variant_selector.tsx
@@ -41,6 +41,11 @@ const VARIANTS_PROJ1 = [
     { id: 'var-3', name: 'staging', project_id: 'proj-1' },
 ];
 
+const VARIANTS_PROJ2 = [
+    { id: 'var-4', name: 'production', project_id: 'proj-2' },
+    { id: 'var-5', name: 'candidate', project_id: 'proj-2' },
+];
+
 // -------------------------------------------------------------------------
 // Helpers
 // -------------------------------------------------------------------------
@@ -62,7 +67,9 @@ describe('ProjectVariantSelector', () => {
 
     beforeEach(() => {
         mockProjectsList.mockResolvedValue(PROJECTS);
-        mockVariantsList.mockResolvedValue(VARIANTS_PROJ1);
+        mockVariantsList.mockImplementation(projectId => Promise.resolve(
+            projectId === 'proj-2' ? VARIANTS_PROJ2 : VARIANTS_PROJ1,
+        ));
     });
 
     afterEach(() => {
@@ -524,6 +531,79 @@ describe('ProjectVariantSelector', () => {
         expect(screen.getByRole('checkbox', { name: 'staging' })).toBeChecked();
     });
 
+    test('restores a persisted single-variant scope', async () => {
+        render(
+            <ProjectVariantSelector
+                defaultProject={{ id: 'proj-1', name: 'ProjectAlpha' }}
+                defaultScope={{
+                    project_id: 'proj-1',
+                    mode: 'select',
+                    variant_ids: ['var-2'],
+                    compare_base_id: '',
+                    compare_operation: 'difference',
+                    compare_variant_id: '',
+                }}
+                onApply={jest.fn()}
+            />
+        );
+
+        await waitFor(() => expect(screen.getByText('release')).toBeInTheDocument());
+        await openPanel();
+        await waitFor(() => expect(screen.getByRole('checkbox', { name: 'release' })).toBeChecked());
+        expect(screen.getByRole('checkbox', { name: 'default' })).not.toBeChecked();
+        expect(screen.getByRole('checkbox', { name: 'staging' })).not.toBeChecked();
+    });
+
+    test('restores a persisted scope for a project different from the server default', async () => {
+        render(
+            <ProjectVariantSelector
+                defaultProject={{ id: 'proj-1', name: 'ProjectAlpha' }}
+                defaultScope={{
+                    project_id: 'proj-2',
+                    mode: 'select',
+                    variant_ids: ['var-4'],
+                    compare_base_id: '',
+                    compare_operation: 'difference',
+                    compare_variant_id: '',
+                }}
+                onApply={jest.fn()}
+            />
+        );
+
+        await waitFor(() => {
+            expect(mockVariantsList).toHaveBeenCalledWith('proj-2');
+            expect(screen.getByText('ProjectBeta')).toBeInTheDocument();
+            expect(screen.getByText('production')).toBeInTheDocument();
+        });
+        await openPanel();
+        await waitFor(() => expect(screen.getByRole('checkbox', { name: 'production' })).toBeChecked());
+        expect(screen.getByRole('checkbox', { name: 'candidate' })).not.toBeChecked();
+    });
+
+    test('restores a persisted compare scope', async () => {
+        render(
+            <ProjectVariantSelector
+                defaultProject={{ id: 'proj-1', name: 'ProjectAlpha' }}
+                defaultScope={{
+                    project_id: 'proj-1',
+                    mode: 'compare',
+                    variant_ids: [],
+                    compare_base_id: 'var-1',
+                    compare_operation: 'intersection',
+                    compare_variant_id: 'var-2',
+                }}
+                onApply={jest.fn()}
+            />
+        );
+
+        await waitFor(() => expect(screen.getByText('default ∩ release')).toBeInTheDocument());
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('radio', { name: /compare variants/i })).toBeChecked();
+        });
+        expect(screen.getByRole('radio', { name: /intersection/i })).toBeChecked();
+    });
+
     // -----------------------------------------------------------------------
     // Error handling
     // -----------------------------------------------------------------------
@@ -535,6 +615,23 @@ describe('ProjectVariantSelector', () => {
         await waitFor(() => {
             expect(screen.queryByRole('option', { name: 'ProjectAlpha' })).not.toBeInTheDocument();
         });
+    });
+
+    test('renders gracefully when Variants.list rejects after selecting a project', async () => {
+        mockVariantsList.mockRejectedValue(new Error('Network error'));
+        render(<ProjectVariantSelector onApply={jest.fn()} />);
+        await openPanel();
+        await waitFor(() => {
+            expect(screen.getByRole('option', { name: 'ProjectAlpha' })).toBeInTheDocument();
+        });
+
+        await selectProject('proj-1');
+
+        await waitFor(() => {
+            expect(mockVariantsList).toHaveBeenCalledWith('proj-1');
+            expect(screen.queryByRole('checkbox', { name: 'default' })).not.toBeInTheDocument();
+        });
+        expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
     });
 
     // -----------------------------------------------------------------------

--- a/frontend/tests/unit_tests/test_review_transfer_modal.tsx
+++ b/frontend/tests/unit_tests/test_review_transfer_modal.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReviewTransferModal from '../../src/components/ReviewTransferModal';
+
+const variants = [
+    { id: 'variant-1', name: 'Variant One', project_id: 'project-1' },
+    { id: 'variant-2', name: 'Variant Two', project_id: 'project-1' },
+];
+
+function renderModal(overrides = {}) {
+    const props = {
+        mode: 'import' as const,
+        variants,
+        selectedVariantIds: [] as string[],
+        transferFormat: 'custom' as const,
+        timestampPolicy: 'original' as const,
+        onSelectedVariantIdsChange: jest.fn(),
+        onTransferFormatChange: jest.fn(),
+        onTimestampPolicyChange: jest.fn(),
+        onConfirm: jest.fn(),
+        onCancel: jest.fn(),
+        ...overrides,
+    };
+    render(<ReviewTransferModal {...props} />);
+    return props;
+}
+
+describe('ReviewTransferModal', () => {
+    test('updates import format and timestamp preferences, then confirms', () => {
+        const props = renderModal();
+
+        fireEvent.click(screen.getByRole('radio', { name: /^OpenVEX/ }));
+        fireEvent.click(screen.getByRole('radio', { name: /^Use current system time/ }));
+        fireEvent.click(screen.getByRole('button', { name: 'Choose file' }));
+
+        expect(props.onTransferFormatChange).toHaveBeenCalledWith('openvex');
+        expect(props.onTimestampPolicyChange).toHaveBeenCalledWith('current');
+        expect(props.onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    test('selects the OpenVEX destination variant and invokes cancellation controls', () => {
+        const props = renderModal({
+            transferFormat: 'openvex' as const,
+            selectedVariantIds: ['variant-1'],
+        });
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Variant Two' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        fireEvent.keyDown(document, { key: 'Escape' });
+
+        expect(props.onSelectedVariantIdsChange).toHaveBeenCalledWith(['variant-2']);
+        expect(props.onCancel).toHaveBeenCalledTimes(2);
+    });
+
+    test('selects and clears all export variants', () => {
+        const props = renderModal({
+            mode: 'export' as const,
+            selectedVariantIds: [],
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
+
+        expect(props.onSelectedVariantIdsChange).toHaveBeenCalledWith(['variant-1', 'variant-2']);
+
+        const selectedProps = renderModal({
+            mode: 'export' as const,
+            selectedVariantIds: ['variant-1', 'variant-2'],
+        });
+        fireEvent.click(screen.getAllByRole('button', { name: 'Clear all' })[0]);
+
+        expect(selectedProps.onSelectedVariantIdsChange).toHaveBeenCalledWith([]);
+    });
+
+    test('toggles individual export variants and resets custom import settings', () => {
+        const exportProps = renderModal({
+            mode: 'export' as const,
+            selectedVariantIds: ['variant-1'],
+        });
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Variant One' }));
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Variant Two' }));
+
+        expect(exportProps.onSelectedVariantIdsChange).toHaveBeenNthCalledWith(1, []);
+        expect(exportProps.onSelectedVariantIdsChange).toHaveBeenNthCalledWith(2, ['variant-1', 'variant-2']);
+
+        cleanup();
+        const importProps = renderModal({
+            transferFormat: 'openvex' as const,
+            timestampPolicy: 'current' as const,
+        });
+        fireEvent.click(screen.getByRole('radio', { name: /^VulnScout JSON/ }));
+        fireEvent.click(screen.getByRole('radio', { name: /^Use original timestamps/ }));
+
+        expect(importProps.onTransferFormatChange).toHaveBeenCalledWith('custom');
+        expect(importProps.onTimestampPolicyChange).toHaveBeenCalledWith('original');
+    });
+});


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

Creates a base64 encoded config line for the current project / variant(s) so when you restart you are brought to the same context as before.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open the web dashboard, pick a project / variant through selector and restart, you should see the exact same project you left before.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


