### PR TITLE
adding OpenAPI JSON API path and SwaggerUI interface

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -4,10 +4,10 @@ VulnScout exposes a REST API served by the Flask backend, available at `http://l
 All endpoints return JSON unless otherwise noted. Routes are registered directly on the Flask application without URL prefixes or blueprints.
 
 The backend also exposes a machine-readable OpenAPI document at `GET /api/openapi`.
-For compatibility, the same document is also available at `GET /api/openapi.json`.
+For compatibility, the same document is also available at `GET /api` and `GET /api/openapi.json`.
 An interactive Swagger UI is available at `GET /api/openapi/ui` and is preconfigured to load the canonical spec from `/api/openapi`.
 This JSON document is generated from the registered Flask routes and is intended to be the canonical API specification for external tooling.
-It is fully route-driven: the path inventory comes from currently registered Flask routes, and operation descriptions are inferred from route docstrings when available.
+It is fully route-driven: every registered `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` operation under `/api` is included, and operation descriptions and request metadata are inferred from route docstrings when available.
 
 ---
 
@@ -187,6 +187,57 @@ DELETE /api/variants/<variant_id>
 
 ---
 
+## Context
+
+### Get Merged Context
+
+```
+GET /api/context?project_id=<project_id>&variant_id=<variant_id>
+```
+
+Returns the merged project and variant context, including supplemental file metadata. Both UUID parameters are required,
+and the variant must belong to the selected project.
+
+### Get or Update Project Context
+
+```
+GET /api/projects/<project_id>/context
+PUT /api/projects/<project_id>/context
+```
+
+The `PUT` request accepts a JSON object with a `description` field.
+
+### Update Variant Context
+
+```
+PUT /api/variants/<variant_id>/context
+```
+
+Accepts a JSON object containing any of `variant_description`, `codebase_path`, `environment`, `threat_model`, `risks`,
+and `other_info`.
+
+### Import or Export Context
+
+```
+GET /api/context/export
+POST /api/context/import
+```
+
+Export accepts either a `project_id` and `variant_id` pair, a comma-separated `variant_ids` filter, or no filter to
+export all context. Import accepts an exported context JSON document and applies all valid entries atomically.
+
+### Manage Supplemental Context Files
+
+```
+POST /api/variants/<variant_id>/context/files
+DELETE /api/variants/<variant_id>/context/files/<file_id>
+```
+
+Upload uses `multipart/form-data` with a required `file`, an optional `description`, and a 10 MB size limit. These
+endpoints are retained for API compatibility but are not currently exposed by the frontend.
+
+---
+
 ## Packages
 
 ### List Packages
@@ -294,6 +345,39 @@ PATCH /api/vulnerabilities/batch
   "count": 2,
   "errors": [],
   "error_count": 0
+}
+```
+
+### Evaluate a Match Condition
+
+```
+POST /api/vulnerabilities/match-condition
+```
+
+Evaluates a condition expression against supplied objects and returns the matching IDs.
+
+**Request body:**
+```json
+{
+  "condition": "severity.cvss.base_score >= 7",
+  "items": [{ "id": "CVE-2026-0001", "data": { "severity": { "cvss": { "base_score": 8.1 } } } }]
+}
+```
+
+### Search Vulnerability Descriptions
+
+```
+POST /api/vulnerabilities/search-descriptions
+```
+
+Searches the supplied vulnerability IDs for each term. Optional `variant_id` or `project_id` query parameters scope
+observation descriptions to active scans.
+
+**Request body:**
+```json
+{
+  "vulnerability_ids": ["CVE-2026-0001"],
+  "terms": ["buffer overflow"]
 }
 ```
 

--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -3,6 +3,12 @@
 VulnScout exposes a REST API served by the Flask backend, available at `http://localhost:7275/api/` by default.
 All endpoints return JSON unless otherwise noted. Routes are registered directly on the Flask application without URL prefixes or blueprints.
 
+The backend also exposes a machine-readable OpenAPI document at `GET /api/openapi`.
+For compatibility, the same document is also available at `GET /api/openapi.json`.
+An interactive Swagger UI is available at `GET /api/openapi/ui` and is preconfigured to load the canonical spec from `/api/openapi`.
+This JSON document is generated from the registered Flask routes and is intended to be the canonical API specification for external tooling.
+It is fully route-driven: the path inventory comes from currently registered Flask routes, and operation descriptions are inferred from route docstrings when available.
+
 ---
 
 ## Version & Status

--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -17,6 +17,7 @@ import os
 import threading
 from datetime import datetime, timezone
 import signal
+from flask import request
 
 MAX_SCRIPT_STEPS = 8
 SCAN_FILE = "/scan/status.txt"
@@ -197,11 +198,24 @@ def create_app():
     # provide version info
     @app.route("/api/version")
     def version():
+        """Return the running VulnScout backend version.
+
+        OpenAPI:
+        response 200 JsonObject Backend version payload.
+        """
         return {"version": os.getenv("VULNSCOUT_VERSION", "unknown")}
 
     # bypass fail_scan middleware because it's before
     @app.route("/api/scan/status")
     def loading():
+        """Return initial import progress status for the web UI loader.
+
+        This endpoint remains available while other API routes are gated by the
+        scan-completion middleware.
+
+        OpenAPI:
+        response 200 JsonObject Scan bootstrap progress payload.
+        """
         with open(app.config["SCAN_FILE"], "r") as f:
             text = f.read()
             if "__END_OF_SCAN_SCRIPT__" in text:
@@ -222,6 +236,8 @@ def create_app():
 
     @app.middleware("/api")
     def fail_scan_not_finished(*args, **kw):
+        if request.path in {"/api", "/api/openapi", "/api/openapi.json", "/api/openapi/ui"}:
+            return None
         if not is_scan_finished():
             return {"error": "Scan not finished"}, 503
 

--- a/src/helpers/openapi.py
+++ b/src/helpers/openapi.py
@@ -16,9 +16,11 @@ _VISIBLE_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
 _DOC_OPENAPI_MARKER = "OpenAPI:"
 _COMPONENT_SCHEMAS = {"JsonObject", "Error"}
 _SCAN_EXEMPT_PATHS = {
+    "/api",
     "/api/openapi",
     "/api/openapi.json",
     "/api/openapi/ui",
+    "/api/scan/status",
     "/api/version",
 }
 
@@ -30,7 +32,7 @@ def build_openapi_spec(app: Flask) -> dict[str, Any]:
         key=lambda entry: (entry.rule, sorted(entry.methods or set())),
     )
     for rule in rules:
-        if not rule.rule.startswith("/api/"):
+        if rule.rule != "/api" and not rule.rule.startswith("/api/"):
             continue
         methods = sorted((rule.methods or set()) & _VISIBLE_METHODS)
         if not methods:
@@ -122,6 +124,8 @@ def _build_summary(path: str, method: str) -> str:
 
 
 def _build_tag(path: str) -> str:
+    if path == "/api":
+        return "system"
     suffix = path.removeprefix("/api/")
     system_paths = {"version", "openapi", "openapi.json", "openapi/ui", "scan/status"}
     if not suffix or suffix in system_paths:

--- a/src/helpers/openapi.py
+++ b/src/helpers/openapi.py
@@ -71,7 +71,7 @@ def _build_operation(app: Flask, rule: Rule, method: str) -> dict[str, Any]:
     summary, description, metadata = _parse_docstring(view_func)
     path = _normalize_rule_path(rule.rule)
     operation: dict[str, Any] = {
-        "operationId": f"{rule.endpoint}.{method.lower()}",
+        "operationId": _build_operation_id(path, method),
         "summary": summary or _build_summary(rule.rule, method),
         "tags": [_build_tag(rule.rule)],
         "responses": _build_responses(path, method, metadata),
@@ -91,6 +91,12 @@ def _build_operation(app: Flask, rule: Rule, method: str) -> dict[str, Any]:
             "content": _json_content(_schema_ref("JsonObject")),
         }
     return operation
+
+
+def _build_operation_id(path: str, method: str) -> str:
+    """Return a stable ID unique to one normalized path and HTTP method."""
+    path_id = re.sub(r"[^A-Za-z0-9]+", "_", path.strip("/")).strip("_") or "root"
+    return f"{path_id}.{method.lower()}"
 
 
 def _build_path_parameters(rule: Rule) -> list[dict[str, Any]]:

--- a/src/helpers/openapi.py
+++ b/src/helpers/openapi.py
@@ -1,0 +1,267 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Callable
+from typing import Any
+
+from flask import Flask
+from werkzeug.routing import Rule
+
+_PATH_PARAM_RE = re.compile(r"<(?:(?P<converter>[^:<>]+):)?(?P<name>[^<>]+)>")
+_VISIBLE_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+_DOC_OPENAPI_MARKER = "OpenAPI:"
+_COMPONENT_SCHEMAS = {"JsonObject", "Error"}
+_SCAN_EXEMPT_PATHS = {
+    "/api/openapi",
+    "/api/openapi.json",
+    "/api/openapi/ui",
+    "/api/version",
+}
+
+
+def build_openapi_spec(app: Flask) -> dict[str, Any]:
+    paths: dict[str, dict[str, Any]] = {}
+    rules = sorted(
+        app.url_map.iter_rules(),
+        key=lambda entry: (entry.rule, sorted(entry.methods or set())),
+    )
+    for rule in rules:
+        if not rule.rule.startswith("/api/"):
+            continue
+        methods = sorted((rule.methods or set()) & _VISIBLE_METHODS)
+        if not methods:
+            continue
+        path_item = paths.setdefault(_normalize_rule_path(rule.rule), {})
+        for method in methods:
+            path_item[method.lower()] = _build_operation(app, rule, method)
+
+    return {
+        "openapi": "3.0.3",
+        "info": {
+            "title": "VulnScout REST API",
+            "version": os.getenv("VULNSCOUT_VERSION", "unknown"),
+            "description": (
+                "OpenAPI export generated from currently registered Flask /api routes. "
+                "Operation descriptions are derived from route docstrings when present."
+            ),
+        },
+        "servers": [{"url": "/", "description": "Current VulnScout server"}],
+        "paths": paths,
+        "components": {
+            "schemas": {
+                "JsonObject": {"type": "object", "additionalProperties": True},
+                "Error": {
+                    "type": "object",
+                    "properties": {"error": {"type": "string"}},
+                    "required": ["error"],
+                },
+            },
+        },
+    }
+
+
+def _build_operation(app: Flask, rule: Rule, method: str) -> dict[str, Any]:
+    view_func = app.view_functions[rule.endpoint]
+    summary, description, metadata = _parse_docstring(view_func)
+    path = _normalize_rule_path(rule.rule)
+    operation: dict[str, Any] = {
+        "operationId": f"{rule.endpoint}.{method.lower()}",
+        "summary": summary or _build_summary(rule.rule, method),
+        "tags": [_build_tag(rule.rule)],
+        "responses": _build_responses(path, method, metadata),
+    }
+    if description:
+        operation["description"] = description
+
+    parameters = _build_path_parameters(rule) + metadata["parameters"]
+    if parameters:
+        operation["parameters"] = parameters
+
+    if metadata["requestBody"] is not None:
+        operation["requestBody"] = metadata["requestBody"]
+    elif method in {"POST", "PUT", "PATCH"}:
+        operation["requestBody"] = {
+            "required": False,
+            "content": _json_content(_schema_ref("JsonObject")),
+        }
+    return operation
+
+
+def _build_path_parameters(rule: Rule) -> list[dict[str, Any]]:
+    parameters: list[dict[str, Any]] = []
+    for match in _PATH_PARAM_RE.finditer(rule.rule):
+        name = match.group("name")
+        converter = match.group("converter") or "string"
+        parameters.append({
+            "name": name,
+            "in": "path",
+            "required": True,
+            "schema": _converter_to_schema(name, converter),
+        })
+    return parameters
+
+
+def _converter_to_schema(name: str, converter: str) -> dict[str, Any]:
+    if converter == "int":
+        return {"type": "integer"}
+    if converter == "float":
+        return {"type": "number", "format": "float"}
+    if converter == "uuid" or name.endswith("_id"):
+        return {"type": "string", "format": "uuid"}
+    return {"type": "string"}
+
+
+def _build_summary(path: str, method: str) -> str:
+    path_label = _normalize_rule_path(path).removeprefix("/api/")
+    path_label = path_label.replace("/", " ").replace("{", "").replace("}", "")
+    return f"{method.title()} {path_label}".strip()
+
+
+def _build_tag(path: str) -> str:
+    suffix = path.removeprefix("/api/")
+    system_paths = {"version", "openapi", "openapi.json", "openapi/ui", "scan/status"}
+    if not suffix or suffix in system_paths:
+        return "system"
+    return suffix.split("/", 1)[0]
+
+
+def _build_responses(path: str, method: str, metadata: dict[str, Any]) -> dict[str, Any]:
+    success_status = "201" if method == "POST" else "200"
+    responses = dict(metadata["responses"])
+    responses.setdefault(success_status, _build_success_response(path))
+    if path not in _SCAN_EXEMPT_PATHS:
+        responses.setdefault("503", {
+            "description": "Scan not finished",
+            "content": _json_content(_schema_ref("Error")),
+        })
+    return responses
+
+
+def _build_success_response(path: str) -> dict[str, Any]:
+    response: dict[str, Any] = {"description": "Successful response"}
+    if path == "/api/openapi/ui":
+        response["content"] = {"text/html": {"schema": {"type": "string"}}}
+    else:
+        response["content"] = _json_content(_schema_ref("JsonObject"))
+    return response
+
+
+def _json_content(schema: dict[str, Any]) -> dict[str, Any]:
+    return {"application/json": {"schema": schema}}
+
+
+def _schema_ref(name: str) -> dict[str, Any]:
+    return {"$ref": f"#/components/schemas/{name}"}
+
+
+def _schema_from_token(token: str) -> dict[str, Any]:
+    if token.endswith("[]"):
+        return {"type": "array", "items": _schema_from_token(token[:-2])}
+    primitive_schemas: dict[str, dict[str, Any]] = {
+        "string": {"type": "string"},
+        "integer": {"type": "integer"},
+        "number": {"type": "number"},
+        "boolean": {"type": "boolean"},
+        "object": {"type": "object", "additionalProperties": True},
+        "uuid": {"type": "string", "format": "uuid"},
+        "binary": {"type": "string", "format": "binary"},
+        "html": {"type": "string"},
+        "multipart": {"type": "object", "additionalProperties": True},
+    }
+    if token in primitive_schemas:
+        return primitive_schemas[token]
+    if token in _COMPONENT_SCHEMAS:
+        return _schema_ref(token)
+    return {"type": "object", "additionalProperties": True}
+
+
+def _media_type_for_token(token: str) -> str:
+    if token == "html":
+        return "text/html"
+    if token == "multipart":
+        return "multipart/form-data"
+    if token == "binary":
+        return "application/octet-stream"
+    return "application/json"
+
+
+def _parse_docstring(view_func: Callable[..., Any]) -> tuple[str, str, dict[str, Any]]:
+    doc = (view_func.__doc__ or "").strip()
+    metadata: dict[str, Any] = {
+        "parameters": [],
+        "requestBody": None,
+        "responses": {},
+    }
+    if not doc:
+        return "", "", metadata
+
+    raw_lines = [line.strip() for line in doc.splitlines()]
+    try:
+        marker_idx = raw_lines.index(_DOC_OPENAPI_MARKER)
+    except ValueError:
+        marker_idx = -1
+    prose_lines = raw_lines if marker_idx == -1 else raw_lines[:marker_idx]
+    annotation_lines = [] if marker_idx == -1 else raw_lines[marker_idx + 1:]
+    prose_lines = [line for line in prose_lines if line]
+    summary = prose_lines[0] if prose_lines else ""
+    description = "\n".join(prose_lines[1:]) if len(prose_lines) > 1 else ""
+
+    for line in annotation_lines:
+        if not line:
+            continue
+        parsed = _parse_openapi_annotation(line)
+        if parsed is None:
+            continue
+        kind, payload = parsed
+        if kind == "parameter":
+            metadata["parameters"].append(payload)
+        elif kind == "requestBody":
+            metadata["requestBody"] = payload
+        elif kind == "response":
+            metadata["responses"][payload["status"]] = payload["response"]
+    return summary, description, metadata
+
+
+def _parse_openapi_annotation(line: str) -> tuple[str, Any] | None:
+    parts = line.split()
+    if len(parts) < 4:
+        return None
+    annotation_type = parts[0].lower()
+    if annotation_type in {"query", "header", "cookie"}:
+        name, schema_token = parts[1], parts[2]
+        return "parameter", {
+            "name": name,
+            "in": annotation_type,
+            "required": _parse_required_token(parts[3]),
+            "schema": _schema_from_token(schema_token),
+            "description": " ".join(parts[4:]) if len(parts) > 4 else "",
+        }
+    if annotation_type == "body":
+        schema_token = parts[1]
+        media_type = _media_type_for_token(schema_token)
+        return "requestBody", {
+            "required": _parse_required_token(parts[2]),
+            "description": " ".join(parts[3:]) if len(parts) > 3 else "",
+            "content": {media_type: {"schema": _schema_from_token(schema_token)}},
+        }
+    if annotation_type == "response":
+        status, schema_token = parts[1], parts[2]
+        media_type = _media_type_for_token(schema_token)
+        response = {
+            "description": " ".join(parts[3:]) if len(parts) > 3 else "Successful response",
+            "content": {media_type: {"schema": _schema_from_token(schema_token)}},
+        }
+        return "response", {"status": status, "response": response}
+    return None
+
+
+def _parse_required_token(token: str) -> bool:
+    return token.lower() in {"required", "true", "yes"}
+
+
+def _normalize_rule_path(rule_path: str) -> str:
+    return _PATH_PARAM_RE.sub(lambda match: "{" + match.group("name") + "}", rule_path)

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -16,6 +16,7 @@ from .scans import init_app as init_scans_app
 from .scan_triggers import init_app as init_scan_triggers_app
 from .config import init_app as init_config_app
 from .settings import init_app as init_settings_app
+from .openapi import init_app as init_openapi_app
 from .frontpage import init_app as init_front_app
 from .context import init_app as init_context_app
 
@@ -37,6 +38,7 @@ def init_app(app):
     init_config_app(app)
     init_settings_app(app)
     init_context_app(app)
+    init_openapi_app(app)
     # keep front endpoint at the end
     init_front_app(app)
     return app

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -325,6 +325,17 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/assessments')
     def index_assess() -> ResponseReturnValue:
+        """List assessments with optional variant or project filtering.
+
+        By default returns every assessment; with ``format=dict`` the response
+        is keyed by assessment ID.
+
+        OpenAPI:
+        query variant_id uuid optional Filter by a single variant ID.
+        query project_id uuid optional Filter by a single project ID.
+        query format string optional Response format such as list or dict.
+        response 200 JsonObject Assessment collection.
+        """
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
         compact = request.args.get('format') == 'compact'
@@ -408,17 +419,37 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/assessments/review')
     def review_assessments() -> ResponseReturnValue:
-        """Return assessments not linked to any scan (handmade via the web UI)."""
+        """Return custom assessments awaiting review.
+
+        OpenAPI:
+        query variant_id uuid optional Restrict to a single variant.
+        query project_id uuid optional Restrict to every variant of a project.
+        response 200 JsonObject Custom assessment collection.
+        """
         return _review_assessments_by_origin("custom")
 
     @app.route('/api/assessments/review/ai')
     def review_ai_assessments() -> ResponseReturnValue:
-        """Return pending AI-generated assessments (``origin == 'ai'``)."""
+        """Return pending AI-generated assessments.
+
+        OpenAPI:
+        query variant_id uuid optional Restrict to a single variant.
+        query project_id uuid optional Restrict to every variant of a project.
+        response 200 JsonObject AI assessment collection.
+        """
         return _review_assessments_by_origin("ai")
 
     @app.route('/api/assessments/review/export')
     def export_review_openvex() -> ResponseReturnValue:
-        """Export review assessments for one variant as an OpenVEX JSON document."""
+        """Export custom assessments for one variant as an OpenVEX JSON document.
+
+        OpenAPI:
+        query variant_id uuid required Variant to export.
+        query author string optional Author name embedded in exported OpenVEX documents.
+        response 200 binary OpenVEX JSON download.
+        response 400 Error Exactly one variant was not supplied.
+        response 404 Error No review assessments available.
+        """
         from ..models.variant import Variant as DBVariant
 
         raw_variant_ids = request.args.getlist('variant_id')
@@ -448,8 +479,14 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/assessments/review/import', methods=['POST'])
     def import_review_openvex() -> ResponseReturnValue:
-        """Import a JSON OpenVEX document into exactly one selected variant."""
+        """Import an uploaded JSON OpenVEX document into one selected variant.
 
+        OpenAPI:
+        body multipart required Multipart request containing the JSON file and variant_id.
+        response 200 JsonObject Import summary.
+        response 400 Error Invalid uploaded OpenVEX payload.
+        response 404 Error Variant not found.
+        """
         if not (request.content_type and 'multipart/form-data' in request.content_type):
             return {"error": "Expected multipart/form-data with a file upload"}, 400
         uploaded = request.files.get('file')
@@ -500,6 +537,11 @@ def init_app(app: Flask) -> None:
         Each entry contains the vulnerability ID and its three-point estimate
         (optimistic / likely / pessimistic) as ISO 8601 durations plus the
         raw hour values.
+
+        OpenAPI:
+        query variant_id uuid optional Restrict to a single variant.
+        query project_id uuid optional Restrict to every variant of a project.
+        response 200 JsonObject Vulnerabilities with time estimates.
         """
         from ..models.time_estimate import TimeEstimate
         from ..models.iso8601_duration import Iso8601Duration
@@ -598,6 +640,11 @@ def init_app(app: Flask) -> None:
         """Return vulnerabilities that have custom CVSS scores.
 
         A custom CVSS score is identified by ``origin == 'custom'``.
+
+        OpenAPI:
+        query variant_id uuid optional Restrict to a single variant.
+        query project_id uuid optional Restrict to every variant of a project.
+        response 200 JsonObject Vulnerabilities with custom CVSS scores.
         """
         from ..models.metrics import Metrics
 
@@ -658,6 +705,12 @@ def init_app(app: Flask) -> None:
 
         * ``variant_id`` - restrict to selected variants; may be repeated.
         * ``project_id`` - restrict to all variants in a project.
+
+        OpenAPI:
+        query variant_id uuid optional Restrict export to selected variants; may be repeated.
+        query project_id uuid optional Restrict export to a single project.
+        response 200 binary Custom review data download.
+        response 404 Error No custom data available.
         """
         raw_variant_ids = request.args.getlist('variant_id')
         project_id = request.args.get('project_id')
@@ -719,6 +772,10 @@ def init_app(app: Flask) -> None:
           file.
         * ``application/json`` body with the custom-data payload directly.
 
+        OpenAPI:
+        body JsonObject optional JSON payload or uploaded custom-data file.
+        response 200 JsonObject Import summary.
+        response 400 Error Invalid import payload.
         """
         import json as _json
         if request.args.getlist('variant_id'):
@@ -760,6 +817,12 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/assessments/<assessment_id>')
     def assess_by_id(assessment_id: str) -> ResponseReturnValue:
+        """Return a single assessment by identifier.
+
+        OpenAPI:
+        response 200 JsonObject Assessment payload.
+        response 404 Error Assessment not found.
+        """
         item = DBAssessment.get_by_id(assessment_id)
         if item is None:
             return {"error": "Not found"}, 404
@@ -767,6 +830,12 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/vulnerabilities/<vuln_id>/assessments')
     def list_assess_by_vuln(vuln_id: str) -> ResponseReturnValue:
+        """List assessments linked to a vulnerability.
+
+        OpenAPI:
+        query format string optional Response format such as list or dict.
+        response 200 JsonObject Assessment collection for the vulnerability.
+        """
         # Get findings for this vulnerability then load their assessments
         findings = Finding.get_by_vulnerability(vuln_id)
         assessments = []
@@ -781,7 +850,11 @@ def init_app(app: Flask) -> None:
     @app.route('/api/vulnerabilities/<vuln_id>/variants', methods=['GET'])
     def list_variants_by_vuln(vuln_id: str) -> ResponseReturnValue:
         """Return all distinct variants that have a finding for this vulnerability
-        (via the Observation → Scan → Variant chain)."""
+        (via the Observation → Scan → Variant chain).
+
+        OpenAPI:
+        response 200 JsonObject Variants impacted by the vulnerability.
+        """
         from ..models.observation import Observation
         from ..models.scan import Scan
         from ..models.variant import Variant as DBVariant
@@ -812,6 +885,10 @@ def init_app(app: Flask) -> None:
 
         Lets the front-end classify deprecated (variant, package) pairs in a
         single request instead of one ``/api/packages`` call per variant.
+
+        OpenAPI:
+        query project_id uuid optional Restrict the result to one project.
+        response 200 JsonObject Active packages by variant.
         """
         from ..models.observation import Observation
         from ..models.scan import Scan
@@ -888,6 +965,14 @@ def init_app(app: Flask) -> None:
 
     @app.route("/api/vulnerabilities/<vuln_id>/assessments", methods=["POST"])
     def add_assessment(vuln_id: str) -> ResponseReturnValue:
+        """Create one or more custom assessments for a vulnerability.
+
+        OpenAPI:
+        body JsonObject optional Assessment creation payload.
+        response 200 JsonObject Created assessment payload.
+        response 400 Error Invalid assessment payload.
+        response 500 Error Database error while creating the assessment.
+        """
         payload_data = request.get_json()
         if not payload_data:
             return {"error": "Invalid request data"}, 400
@@ -975,6 +1060,13 @@ def init_app(app: Flask) -> None:
 
     @app.route("/api/assessments/batch", methods=["POST"])
     def add_assessments_batch() -> ResponseReturnValue:
+        """Create multiple custom assessments in a single request.
+
+        OpenAPI:
+        body JsonObject optional Batch assessment creation payload.
+        response 200 JsonObject Batch creation summary.
+        response 400 Error Invalid batch payload.
+        """
         payload_data = request.get_json()
         if not payload_data or "assessments" not in payload_data or not isinstance(payload_data["assessments"], list):
             return {"error": "Invalid request data. Expected: {assessments: [...]}"}, 400
@@ -1093,6 +1185,14 @@ def init_app(app: Flask) -> None:
 
     @app.route("/api/assessments/<assessment_id>", methods=["PUT", "PATCH"])
     def update_assessment(assessment_id: str) -> ResponseReturnValue:
+        """Update a custom assessment or override an automated one.
+
+        OpenAPI:
+        body JsonObject optional Assessment update payload.
+        response 200 JsonObject Updated assessment payload.
+        response 400 Error Invalid assessment update.
+        response 404 Error Assessment not found.
+        """
         payload_data = request.get_json()
         if not payload_data:
             return {"error": "Invalid request data"}, 400
@@ -1162,6 +1262,12 @@ def init_app(app: Flask) -> None:
 
     @app.route("/api/assessments/<assessment_id>", methods=["DELETE"])
     def delete_assessment(assessment_id: str) -> ResponseReturnValue:
+        """Delete an assessment.
+
+        OpenAPI:
+        response 200 JsonObject Deletion summary.
+        response 404 Error Assessment not found.
+        """
         existing = DBAssessment.get_by_id(assessment_id)
         if existing is None:
             return {"error": "Assessment not found"}, 404

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -91,6 +91,12 @@ def init_app(app: Flask) -> None:
         Returns 202 immediately and runs the refresh in a background thread.
         Returns 409 if a refresh is already in progress.
         Returns 400 if cve_ids is empty or contains no valid CVE identifiers.
+
+        OpenAPI:
+        body JsonObject optional JSON body containing cve_ids and mode.
+        response 202 JsonObject Refresh job accepted.
+        response 400 Error Invalid refresh request.
+        response 409 Error Refresh already running.
         """
         body = request.get_json(force=True, silent=True) or {}
         raw_ids = body.get("cve_ids", [])
@@ -199,6 +205,10 @@ def init_app(app: Flask) -> None:
 
         Returns 200 when the cancellation was accepted (refresh was running).
         Returns 409 when no bulk NVD refresh is currently in progress.
+
+        OpenAPI:
+        response 200 JsonObject Cancellation accepted.
+        response 409 Error No running NVD refresh.
         """
         if NVDProgressTracker.cancel():
             return jsonify({"status": "cancelling"}), 200
@@ -213,6 +223,12 @@ def init_app(app: Flask) -> None:
         Returns 202 immediately and runs the refresh in a background thread.
         Returns 409 if a refresh is already in progress.
         Returns 400 if cve_ids is empty or contains no valid CVE identifiers.
+
+        OpenAPI:
+        body JsonObject optional JSON body containing cve_ids.
+        response 202 JsonObject Refresh job accepted.
+        response 400 Error Invalid refresh request.
+        response 409 Error Refresh already running.
         """
         body = request.get_json(force=True, silent=True) or {}
         raw_ids = body.get("cve_ids", [])
@@ -300,6 +316,10 @@ def init_app(app: Flask) -> None:
 
         Returns 200 when the cancellation was accepted (refresh was running).
         Returns 409 when no bulk EPSS refresh is currently in progress.
+
+        OpenAPI:
+        response 200 JsonObject Cancellation accepted.
+        response 409 Error No running EPSS refresh.
         """
         if EPSSProgressTracker.cancel():
             return jsonify({"status": "cancelling"}), 200
@@ -315,6 +335,12 @@ def init_app(app: Flask) -> None:
         Returns 202 immediately and runs the refresh in a background thread.
         Returns 409 if a refresh is already in progress.
         Returns 400 if ghsa_ids is empty or contains no valid GHSA identifiers.
+
+        OpenAPI:
+        body JsonObject optional JSON body containing ghsa_ids.
+        response 202 JsonObject Refresh job accepted.
+        response 400 Error Invalid refresh request.
+        response 409 Error Refresh already running.
         """
         body = request.get_json(force=True, silent=True) or {}
         raw_ids = body.get("ghsa_ids", [])
@@ -409,6 +435,10 @@ def init_app(app: Flask) -> None:
 
         Returns 200 when the cancellation was accepted (refresh was running).
         Returns 409 when no bulk GHSA refresh is currently in progress.
+
+        OpenAPI:
+        response 200 JsonObject Cancellation accepted.
+        response 409 Error No running GHSA refresh.
         """
         if GHSAProgressTracker.cancel():
             return jsonify({"status": "cancelling"}), 200
@@ -428,6 +458,12 @@ def init_app(app: Flask) -> None:
         Returns 202 immediately and runs the enrichment in a background thread.
         Returns 409 if an enrichment is already in progress.
         Returns 400 if cve_ids is empty or contains no valid CVE identifiers.
+
+        OpenAPI:
+        body JsonObject optional JSON body containing cve_ids.
+        response 202 JsonObject Refresh job accepted.
+        response 400 Error Invalid refresh request.
+        response 409 Error Refresh already running.
         """
         body = request.get_json(force=True, silent=True) or {}
         raw_ids = body.get("cve_ids", [])
@@ -511,6 +547,10 @@ def init_app(app: Flask) -> None:
 
         Returns 200 when the cancellation was accepted (refresh was running).
         Returns 409 when no bulk EUVD refresh is currently in progress.
+
+        OpenAPI:
+        response 200 JsonObject Cancellation accepted.
+        response 409 Error No running EUVD refresh.
         """
         if EUVDProgressTracker.cancel():
             return jsonify({"status": "cancelling"}), 200

--- a/src/routes/config.py
+++ b/src/routes/config.py
@@ -68,6 +68,11 @@ def init_app(app):
 
     @app.route('/api/config', methods=['GET'])
     def get_config():
+        """Return active UI and scanning configuration values.
+
+        OpenAPI:
+        response 200 JsonObject Active configuration payload.
+        """
         project_name = os.environ.get('PROJECT_NAME', '')
         variant_name = os.environ.get('VARIANT_NAME', 'default')
         author_name = os.environ.get('AUTHOR_NAME', 'vulnscout')
@@ -103,6 +108,13 @@ def init_app(app):
 
     @app.route('/api/config', methods=['PATCH'])
     def patch_config():
+        """Update mutable configuration keys and persist them to config.env.
+
+        OpenAPI:
+        body JsonObject optional JSON object containing mutable config keys.
+        response 200 JsonObject Updated configuration payload.
+        response 400 Error Invalid request payload.
+        """
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
             return jsonify({"error": "Expected a JSON object body."}), 400
@@ -175,6 +187,11 @@ def init_app(app):
 
     @app.route('/api/config/nvd-api-key', methods=['GET'])
     def get_nvd_api_key():
+        """Return NVD API key presence and masked representation.
+
+        OpenAPI:
+        response 200 JsonObject Masked NVD API key status.
+        """
         key = os.environ.get('NVD_API_KEY', '')
         if not key:
             return jsonify({"has_key": False, "masked_key": ""})
@@ -182,6 +199,14 @@ def init_app(app):
 
     @app.route('/api/config/nvd-api-key', methods=['PUT'])
     def set_nvd_api_key():
+        """Validate and store a new NVD API key.
+
+        OpenAPI:
+        body JsonObject optional JSON body containing api_key.
+        response 200 JsonObject Stored NVD API key status.
+        response 400 Error Invalid NVD API key payload.
+        response 503 Error NVD API unavailable for validation.
+        """
         data = request.get_json(silent=True)
         if data is None or "api_key" not in data:
             return {"error": "Missing 'api_key' field"}, 400

--- a/src/routes/context.py
+++ b/src/routes/context.py
@@ -33,6 +33,15 @@ def init_app(app):
 
     @app.route('/api/context', methods=['GET'])
     def get_merged_context():
+        """Return merged project and variant context.
+
+        OpenAPI:
+        query project_id uuid required Project UUID.
+        query variant_id uuid required Variant UUID belonging to the project.
+        response 200 JsonObject Merged project and variant context.
+        response 400 Error Invalid identifiers or mismatched project and variant.
+        response 404 Error Project or variant not found.
+        """
         project_id_str = request.args.get('project_id', '')
         variant_id_str = request.args.get('variant_id', '')
 
@@ -73,6 +82,13 @@ def init_app(app):
 
     @app.route('/api/projects/<project_id>/context', methods=['GET'])
     def get_project_context(project_id):
+        """Return context for a project.
+
+        OpenAPI:
+        response 200 JsonObject Project context.
+        response 400 Error Invalid project identifier.
+        response 404 Error Project not found.
+        """
         project_uuid, err = parse_uuid_or_400(project_id, 'project_id')
         if err:
             return err
@@ -89,6 +105,14 @@ def init_app(app):
 
     @app.route('/api/projects/<project_id>/context', methods=['PUT'])
     def put_project_context(project_id):
+        """Create or update context for a project.
+
+        OpenAPI:
+        body JsonObject required Project context fields.
+        response 200 JsonObject Updated project context.
+        response 400 Error Invalid project identifier.
+        response 404 Error Project not found.
+        """
         project_uuid, err = parse_uuid_or_400(project_id, 'project_id')
         if err:
             return err
@@ -104,6 +128,14 @@ def init_app(app):
 
     @app.route('/api/variants/<variant_id>/context', methods=['PUT'])
     def put_variant_context(variant_id):
+        """Create or update context for a variant.
+
+        OpenAPI:
+        body JsonObject required Variant context fields.
+        response 200 JsonObject Updated variant context.
+        response 400 Error Invalid variant identifier.
+        response 404 Error Variant not found.
+        """
         variant_uuid, err = parse_uuid_or_400(variant_id, 'variant_id')
         if err:
             return err
@@ -125,6 +157,20 @@ def init_app(app):
 
     @app.route('/api/context/export', methods=['GET'])
     def export_context():
+        """Export project and variant context.
+
+        With no filters, exports all context. A single-variant export requires
+        both ``project_id`` and ``variant_id``. ``variant_ids`` selects a
+        comma-separated set of variants.
+
+        OpenAPI:
+        query project_id uuid optional Project UUID for a single-variant export.
+        query variant_id uuid optional Variant UUID for a single-variant export.
+        query variant_ids string optional Comma-separated variant UUIDs.
+        response 200 JsonObject Exported context document.
+        response 400 Error Invalid or inconsistent filters.
+        response 404 Error Requested project or variant not found.
+        """
         project_id_str = request.args.get('project_id')
         variant_id_str = request.args.get('variant_id')
         variant_ids_str = request.args.get('variant_ids')
@@ -164,6 +210,14 @@ def init_app(app):
 
     @app.route('/api/context/import', methods=['POST'])
     def import_context():
+        """Import project and variant context atomically.
+
+        OpenAPI:
+        body JsonObject required Context export document to import.
+        response 200 JsonObject Import result.
+        response 400 Error Invalid context document.
+        response 500 Error Context could not be persisted.
+        """
         body = request.get_json(silent=True)
         try:
             entries = extract_entries(body)
@@ -195,6 +249,18 @@ def init_app(app):
     # the context_files table.
     @app.route('/api/variants/<variant_id>/context/files', methods=['POST'])
     def post_context_file(variant_id):
+        """Upload a supplemental context file for a variant.
+
+        Files are limited to 10 MB. The multipart payload accepts a required
+        ``file`` field and an optional ``description`` field.
+
+        OpenAPI:
+        body multipart required Supplemental file and optional description.
+        response 201 JsonObject Uploaded context-file metadata.
+        response 400 Error Invalid identifier, missing file, or oversized file.
+        response 404 Error Variant not found.
+        response 500 Error File could not be stored.
+        """
         variant_uuid, err = parse_uuid_or_400(variant_id, 'variant_id')
         if err:
             return err
@@ -243,6 +309,13 @@ def init_app(app):
 
     @app.route('/api/variants/<variant_id>/context/files/<file_id>', methods=['DELETE'])
     def delete_context_file(variant_id, file_id):
+        """Delete a supplemental context file.
+
+        OpenAPI:
+        response 204 string Context file deleted.
+        response 400 Error Invalid variant or file identifier.
+        response 404 Error Variant or context file not found.
+        """
         variant_uuid, err = parse_uuid_or_400(variant_id, 'variant_id')
         if err:
             return err

--- a/src/routes/documents.py
+++ b/src/routes/documents.py
@@ -189,6 +189,12 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/documents', methods=['GET'])
     def index_docs() -> ResponseReturnValue:
+        """List available report templates and SBOM export formats.
+
+        OpenAPI:
+        response 200 JsonObject Available document descriptors.
+        response 500 Error Document discovery failed.
+        """
         controllers = ControllersCache()
         controllers.vulnerabilities = None  # type: ignore
         # to avoid pre-loading cache, TODO change that, maybe by moving list_documents somewhere else
@@ -230,6 +236,12 @@ def init_app(app: Flask) -> None:
         Expects a ``multipart/form-data`` request with a single ``file`` field.
         The template is saved under the first writable templates directory so it
         becomes available as a "custom" report.
+
+        OpenAPI:
+        body multipart optional Multipart request containing a template file.
+        response 201 JsonObject Imported template descriptor.
+        response 400 Error Invalid upload request.
+        response 500 Error Template storage failed.
         """
         if not (request.content_type and 'multipart/form-data' in request.content_type):
             return {"error": "Expected multipart/form-data with a file upload."}, 400
@@ -309,6 +321,21 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/documents/<doc_name>', methods=['GET'])
     def doc_by_name(doc_name: str) -> ResponseReturnValue:
+        """Render or export a document template or SBOM format.
+
+        OpenAPI:
+        query ext string optional Output extension or conversion target.
+        query author string optional Author metadata injected into the document.
+        query client_name string optional Client metadata injected into the document.
+        query export_date string optional Export date override.
+        query ignore_before string optional Lower bound for historical data inclusion.
+        query only_epss_greater number optional Minimum EPSS threshold to include.
+        query variant_id uuid optional Restrict export to a single variant.
+        query project_id uuid optional Restrict export to a single project.
+        response 200 JsonObject Exported document payload or download response.
+        response 400 Error Invalid export request.
+        response 503 Error Required conversion tool not available.
+        """
         try:
             base_mime = guess_mime_type(doc_name)
             if base_mime is None:

--- a/src/routes/epss_progress.py
+++ b/src/routes/epss_progress.py
@@ -26,6 +26,9 @@ def init_app(app):
                 "last_update": str,
                 "started_at": str
             }
+
+        OpenAPI:
+        response 200 JsonObject EPSS refresh progress payload.
         """
         tracker = EPSSProgressTracker
         progress = tracker.get_progress()

--- a/src/routes/euvd_progress.py
+++ b/src/routes/euvd_progress.py
@@ -24,6 +24,9 @@ def init_app(app):
                 "last_update": str,
                 "started_at": str
             }
+
+        OpenAPI:
+        response 200 JsonObject EUVD refresh progress payload.
         """
         progress = EUVDProgressTracker.get_progress()
         return jsonify(progress), 200

--- a/src/routes/ghsa_progress.py
+++ b/src/routes/ghsa_progress.py
@@ -24,6 +24,9 @@ def init_app(app):
                 "last_update": str,
                 "started_at": str
             }
+
+        OpenAPI:
+        response 200 JsonObject GHSA refresh progress payload.
         """
         progress = GHSAProgressTracker.get_progress()
         return jsonify(progress), 200

--- a/src/routes/nvd_progress.py
+++ b/src/routes/nvd_progress.py
@@ -26,6 +26,9 @@ def init_app(app):
                 "last_update": str,      # ISO timestamp of last update
                 "started_at": str        # ISO timestamp when update started
             }
+
+        OpenAPI:
+        response 200 JsonObject NVD refresh progress payload.
         """
         tracker = NVDProgressTracker
         progress = tracker.get_progress()

--- a/src/routes/openapi.py
+++ b/src/routes/openapi.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+from flask import Flask, Response
+
+from ..helpers.openapi import build_openapi_spec
+
+
+_SWAGGER_UI_HTML = """<!doctype html>
+<html lang=\"en\">
+    <head>
+        <meta charset=\"utf-8\" />
+        <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+        <title>VulnScout OpenAPI UI</title>
+        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css\" />
+        <style>
+            html, body { margin: 0; padding: 0; }
+            #swagger-ui { min-height: 100vh; }
+        </style>
+    </head>
+    <body>
+        <div id=\"swagger-ui\"></div>
+        <script src=\"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js\"></script>
+        <script src=\"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js\"></script>
+        <script>
+            window.ui = SwaggerUIBundle({
+                url: '/api/openapi',
+                dom_id: '#swagger-ui',
+                deepLinking: true,
+                presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+                layout: 'StandaloneLayout',
+            });
+        </script>
+    </body>
+</html>
+"""
+
+
+def init_app(app: Flask) -> None:
+    def openapi_spec() -> dict:
+        """Return the OpenAPI document for the Flask REST API.
+
+        OpenAPI:
+        response 200 JsonObject Generated OpenAPI specification document.
+        """
+        return build_openapi_spec(app)
+
+    def openapi_ui() -> Response:
+        """Return Swagger UI bound to the canonical OpenAPI endpoint.
+
+        OpenAPI:
+        response 200 html Interactive Swagger UI page.
+        """
+        return Response(_SWAGGER_UI_HTML, mimetype="text/html")
+
+    app.add_url_rule("/api", endpoint="openapi_spec", view_func=openapi_spec, methods=["GET"])
+    app.add_url_rule("/api/openapi", endpoint="openapi_spec", view_func=openapi_spec, methods=["GET"])
+    app.add_url_rule("/api/openapi.json", endpoint="openapi_spec", view_func=openapi_spec, methods=["GET"])
+    app.add_url_rule("/api/openapi/ui", endpoint="openapi_ui", view_func=openapi_ui, methods=["GET"])

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -26,6 +26,20 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/packages')
     def index_pkg() -> ResponseReturnValue:
+        """List packages with optional project/variant comparison filters.
+
+        Supports single-variant, project-wide, and multi-variant modes,
+        including union/intersection/difference operations.
+
+        OpenAPI:
+        query variant_id uuid optional Filter by a single variant ID.
+        query project_id uuid optional Filter by a single project ID.
+        query compare_variant_id uuid optional Compare against a second variant ID.
+        query variant_ids string optional Comma-separated list of variant IDs.
+        query operation string optional Comparison mode such as difference, intersection, or union.
+        query format string optional Response format such as list or dict.
+        response 200 JsonObject Filtered package collection.
+        """
         from flask import request
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')

--- a/src/routes/project.py
+++ b/src/routes/project.py
@@ -10,5 +10,10 @@ def init_app(app):
 
     @app.route('/api/projects')
     def list_projects():
+        """List all projects currently stored in the database.
+
+        OpenAPI:
+        response 200 JsonObject Project collection.
+        """
         projects = ProjectController.get_all()
         return jsonify(ProjectController.serialize_list(projects))

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -130,6 +130,11 @@ def init_app(app: Flask) -> None:
 
         Exports the variant's packages as CycloneDX, runs ``grype`` on the
         export, and merges the results back into the DB as a tool scan.
+
+        OpenAPI:
+        query exclude_kernel string optional Disable kernel package exclusion by passing false.
+        response 202 JsonObject Scan job accepted.
+        response 503 Error Grype binary not available.
         """
         import subprocess
         import tempfile
@@ -384,7 +389,11 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/variants/<variant_id>/grype-scan/status')
     def grype_scan_status(variant_id: str) -> ResponseReturnValue:
-        """Check the status of a running Grype scan for the given variant."""
+        """Check the status of a running Grype scan for the given variant.
+
+        OpenAPI:
+        response 200 JsonObject Grype scan progress payload.
+        """
         return scan_status_response(variant_id, _grype_scans_in_progress)
 
     # ------------------------------------------------------------------
@@ -403,6 +412,11 @@ def init_app(app: Flask) -> None:
           sbom-cve-check engine; no network, no rate limits.
         * **api** — queries the NVD REST API v2 using CPE identifiers from
           packages; honours NVD_API_KEY and rate limits.
+
+                OpenAPI:
+                query exclude_kernel string optional Disable kernel package exclusion by passing false.
+                query mode string optional Select local or api mode.
+                response 202 JsonObject Scan job accepted.
         """
         from ..controllers.scc_engine import get_engine, serialized_engine_operation
         from ..bin.cmd_vuln_scan import _SccBulkWriter
@@ -637,7 +651,11 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/variants/<variant_id>/nvd-scan/status')
     def nvd_scan_status(variant_id: str) -> ResponseReturnValue:
-        """Check the status of a running NVD scan for the given variant."""
+        """Check the status of a running NVD scan for the given variant.
+
+        OpenAPI:
+        response 200 JsonObject NVD scan progress payload.
+        """
         return scan_status_response(variant_id, _nvd_scans_in_progress)
 
     # ------------------------------------------------------------------
@@ -653,6 +671,10 @@ def init_app(app: Flask) -> None:
         For every active package that has PURL identifiers, query the OSV API
         and create findings/observations for any vulnerabilities returned.
         The result is stored as a tool scan.
+
+        OpenAPI:
+        query exclude_kernel string optional Disable kernel package exclusion by passing false.
+        response 202 JsonObject Scan job accepted.
         """
         variant_uuid, variant, err = validate_trigger(
             variant_id, _osv_scans_in_progress, "OSV scan")
@@ -839,7 +861,11 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/variants/<variant_id>/osv-scan/status')
     def osv_scan_status(variant_id: str) -> ResponseReturnValue:
-        """Check the status of a running OSV scan for the given variant."""
+        """Check the status of a running OSV scan for the given variant.
+
+        OpenAPI:
+        response 200 JsonObject OSV scan progress payload.
+        """
         return scan_status_response(variant_id, _osv_scans_in_progress)
 
     # ------------------------------------------------------------------
@@ -855,6 +881,10 @@ def init_app(app: Flask) -> None:
         Matches every active package against locally-cloned advisory databases,
         applies product-name aliasing and semantic version-range analysis, and
         records each engine VEX verdict.  Works once the databases are cloned.
+
+        OpenAPI:
+        query exclude_kernel string optional Disable kernel package exclusion by passing false.
+        response 202 JsonObject Scan job accepted.
         """
         from ..controllers.scc_engine import serialized_engine_operation
 
@@ -1024,7 +1054,11 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/variants/<variant_id>/sbom-cve-check-scan/status')
     def sbom_cve_check_scan_status(variant_id: str) -> ResponseReturnValue:
-        """Check the status of a running sbom-cve-check scan for the given variant."""
+        """Check the status of a running sbom-cve-check scan for the given variant.
+
+        OpenAPI:
+        response 200 JsonObject sbom-cve-check progress payload.
+        """
         return scan_status_response(variant_id, _sbom_cve_check_scans_in_progress)
 
     # ------------------------------------------------------------------
@@ -1038,6 +1072,9 @@ def init_app(app: Flask) -> None:
         Lets the frontend restore in-progress scan panels after a page
         refresh with a single request instead of polling each variant's
         per-type ``/status`` endpoint individually.
+
+        OpenAPI:
+        response 200 JsonObject Running scan groups.
         """
         groups = {
             "grype": _grype_scans_in_progress,

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -286,12 +286,23 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/scans')
     def list_all_scans() -> ResponseReturnValue:
+        """List every scan currently stored in the database.
+
+        OpenAPI:
+        response 200 JsonObject Scan collection.
+        """
         scans = ScanController.get_all()
         result = serialize_list_with_diff_cached("all", scans)
         return jsonify(result)
 
     @app.route('/api/projects/<project_id>/scans')
     def list_scans_by_project(project_id: str) -> ResponseReturnValue:
+        """List scans belonging to a specific project.
+
+        OpenAPI:
+        response 200 JsonObject Scan collection for the selected project.
+        response 404 Error Project not found.
+        """
         project = ProjectController.get(project_id)
         if project is None:
             return jsonify({"error": "Project not found"}), 404
@@ -301,6 +312,12 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/variants/<variant_id>/scans')
     def list_scans_by_variant(variant_id: str) -> ResponseReturnValue:
+        """List scans belonging to a specific variant.
+
+        OpenAPI:
+        response 200 JsonObject Scan collection for the selected variant.
+        response 404 Error Variant not found.
+        """
         variant = VariantController.get(variant_id)
         if variant is None:
             return jsonify({"error": "Variant not found"}), 404
@@ -310,6 +327,14 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/scans/<scan_id>', methods=['PATCH'])
     def update_scan(scan_id: str) -> ResponseReturnValue:
+        """Update the editable description of a scan.
+
+        OpenAPI:
+        body JsonObject optional JSON object containing a description field.
+        response 200 JsonObject Updated scan payload.
+        response 400 Error Invalid scan identifier or payload.
+        response 404 Error Scan not found.
+        """
         from flask import request as req
         try:
             scan_uuid = uuid_module.UUID(scan_id)
@@ -334,6 +359,11 @@ def init_app(app: Flask) -> None:
         Findings that are no longer referenced by any observation are
         also removed (cascade cleaned).  The response includes the
         number of orphaned findings that were deleted.
+
+        OpenAPI:
+        response 200 JsonObject Deletion summary.
+        response 400 Error Invalid scan identifier.
+        response 404 Error Scan not found.
         """
         try:
             scan_uuid = uuid_module.UUID(scan_id)
@@ -375,6 +405,13 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/scans/<scan_id>/diff')
     def get_scan_diff(scan_id: str) -> ResponseReturnValue:
+        """Return the computed diff between a scan and its predecessor.
+
+        OpenAPI:
+        response 200 JsonObject Scan diff payload.
+        response 400 Error Invalid scan identifier.
+        response 404 Error Scan not found.
+        """
         try:
             scan_uuid = uuid_module.UUID(scan_id)
         except ValueError:
@@ -444,6 +481,11 @@ def init_app(app: Flask) -> None:
 
         Uses the shared ``_global_result_full`` helper so that the counts
         are consistent with the list view's *Scan Result* badges.
+
+        OpenAPI:
+        response 200 JsonObject Aggregated scan result.
+        response 400 Error Invalid scan identifier.
+        response 404 Error Scan not found.
         """
         try:
             scan_uuid = uuid_module.UUID(scan_id)
@@ -719,7 +761,13 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/scans/<scan_id>/export-diff')
     def export_scan_diff(scan_id: str) -> ResponseReturnValue:
-        """Export a single scan's diff as a cleaned JSON download."""
+        """Export a single scan's diff as a cleaned JSON download.
+
+        OpenAPI:
+        response 200 JsonObject JSON download containing the scan diff.
+        response 400 Error Invalid scan identifier.
+        response 404 Error Scan not found.
+        """
         try:
             scan_uuid = uuid_module.UUID(scan_id)
         except ValueError:
@@ -746,7 +794,13 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/scans/<scan_id>/export-result')
     def export_scan_result(scan_id: str) -> ResponseReturnValue:
-        """Export a single scan's global result as a cleaned JSON download."""
+        """Export a single scan's global result as a cleaned JSON download.
+
+        OpenAPI:
+        response 200 JsonObject JSON download containing the global scan result.
+        response 400 Error Invalid scan identifier.
+        response 404 Error Scan not found.
+        """
         try:
             scan_uuid = uuid_module.UUID(scan_id)
         except ValueError:
@@ -782,6 +836,14 @@ def init_app(app: Flask) -> None:
           - type: 'diff' or 'total' (default: 'diff')
         Returns a JSON array of export objects grouped per variant, with
         Content-Disposition for download.
+
+                OpenAPI:
+                query variant_id uuid optional Restrict export to a single variant.
+                query project_id uuid optional Restrict export to a single project.
+                query type string optional Export type: diff or total.
+                response 200 JsonObject JSON export payload.
+                response 400 Error Invalid filter or export type.
+                response 404 Error Project not found.
         """
         export_type = flask_request.args.get("type", "diff")
         if export_type not in ("diff", "total"):

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -267,6 +267,14 @@ def init_app(app: Flask) -> None:
     # ------------------------------------------------------------------
     @app.route('/api/projects/<project_id>/rename', methods=['PATCH'])
     def rename_project(project_id: str) -> ResponseReturnValue:
+        """Rename a project.
+
+        OpenAPI:
+        body JsonObject optional JSON object containing the new name.
+        response 200 JsonObject Updated project payload.
+        response 404 Error Project not found.
+        response 409 Error Project name already exists.
+        """
         new_name, err = _validate_name_from_request("Project")
         if err:
             return err
@@ -300,6 +308,14 @@ def init_app(app: Flask) -> None:
     # ------------------------------------------------------------------
     @app.route('/api/variants/<variant_id>/rename', methods=['PATCH'])
     def rename_variant(variant_id: str) -> ResponseReturnValue:
+        """Rename a variant.
+
+        OpenAPI:
+        body JsonObject optional JSON object containing the new name.
+        response 200 JsonObject Updated variant payload.
+        response 404 Error Variant not found.
+        response 409 Error Variant name already exists in the project.
+        """
         new_name, err = _validate_name_from_request("Variant")
         if err:
             return err
@@ -333,6 +349,13 @@ def init_app(app: Flask) -> None:
     # ------------------------------------------------------------------
     @app.route('/api/projects', methods=['POST'])
     def create_project() -> ResponseReturnValue:
+        """Create a new project.
+
+        OpenAPI:
+        body JsonObject optional JSON object containing the project name.
+        response 201 JsonObject Created project payload.
+        response 409 Error Project name already exists.
+        """
         new_name, err = _validate_name_from_request("Project")
         if err:
             return err
@@ -353,6 +376,14 @@ def init_app(app: Flask) -> None:
     # ------------------------------------------------------------------
     @app.route('/api/projects/<project_id>/variants', methods=['POST'])
     def create_variant(project_id: str) -> ResponseReturnValue:
+        """Create a new variant inside a project.
+
+        OpenAPI:
+        body JsonObject optional JSON object containing the variant name.
+        response 201 JsonObject Created variant payload.
+        response 404 Error Project not found.
+        response 409 Error Variant name already exists in the project.
+        """
         _, err = parse_uuid_or_400(project_id, "project ID")
         if err:
             return err
@@ -694,6 +725,14 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/variants/copy-assessments/preview', methods=['POST'])
     def preview_copy_variant_assessments() -> ResponseReturnValue:
+        """Preview assessment copy operations between two variants.
+
+        OpenAPI:
+        body JsonObject optional Preview payload describing source, target, and copy mode.
+        response 200 JsonObject Assessment copy preview.
+        response 400 Error Invalid preview payload.
+        response 404 Error Variant not found.
+        """
         payload = request.get_json(silent=True) or {}
         source_id = payload.get("source_variant_id")
         target_id = payload.get("target_variant_id")
@@ -805,6 +844,14 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/variants/copy-assessments', methods=['POST'])
     def copy_variant_assessments() -> ResponseReturnValue:
+        """Copy custom assessments from one variant to another.
+
+        OpenAPI:
+        body JsonObject optional Copy payload describing source, target, mode, and selections.
+        response 200 JsonObject Assessment copy summary.
+        response 400 Error Invalid copy payload.
+        response 404 Error Variant not found.
+        """
         from ..models.assessment import Assessment as DBAssessment
         from ..models.finding import Finding
 
@@ -1004,6 +1051,12 @@ def init_app(app: Flask) -> None:
     # ------------------------------------------------------------------
     @app.route('/api/projects/<project_id>', methods=['DELETE'])
     def delete_project(project_id: str) -> ResponseReturnValue:
+        """Delete a project and its related data.
+
+        OpenAPI:
+        response 200 JsonObject Deletion summary.
+        response 404 Error Project not found.
+        """
         return _delete_entity(project_id, ProjectController, "project ID", "Project")
 
     # ------------------------------------------------------------------
@@ -1011,6 +1064,12 @@ def init_app(app: Flask) -> None:
     # ------------------------------------------------------------------
     @app.route('/api/variants/<variant_id>', methods=['DELETE'])
     def delete_variant(variant_id: str) -> ResponseReturnValue:
+        """Delete a variant and its related scans.
+
+        OpenAPI:
+        response 200 JsonObject Deletion summary.
+        response 404 Error Variant not found.
+        """
         return _delete_entity(variant_id, VariantController, "variant ID", "Variant")
 
     # ------------------------------------------------------------------
@@ -1027,6 +1086,12 @@ def init_app(app: Flask) -> None:
         - files: one or more SBOM files (.json)  (field name ``files``)
         - project_id: UUID of the target project
         - variant_id: UUID of the target variant
+
+        OpenAPI:
+        body multipart optional Multipart request containing files, project_id, variant_id, and optional format.
+        response 202 JsonObject Accepted upload summary.
+        response 400 Error Invalid upload request.
+        response 404 Error Project or variant not found.
         """
         if not (request.content_type and 'multipart/form-data' in request.content_type):
             return jsonify({"error": "Expected multipart/form-data with a file upload."}), 400
@@ -1156,6 +1221,12 @@ def init_app(app: Flask) -> None:
     # ------------------------------------------------------------------
     @app.route('/api/sbom/upload/<upload_id>/status')
     def upload_sbom_status(upload_id: str) -> ResponseReturnValue:
+        """Return the processing status of an asynchronous SBOM upload.
+
+        OpenAPI:
+        response 200 JsonObject Upload progress payload.
+        response 404 Error Unknown upload identifier.
+        """
         status = _upload_status.get(upload_id)
         if status is None:
             return jsonify({"error": "Unknown upload ID."}), 404

--- a/src/routes/variant.py
+++ b/src/routes/variant.py
@@ -11,6 +11,11 @@ def init_app(app):
 
     @app.route('/api/variants')
     def list_all_variants():
+        """List all variants across every project.
+
+        OpenAPI:
+        response 200 JsonObject Variant collection.
+        """
         projects = ProjectController.get_all()
         all_variants = []
         for project in projects:
@@ -21,6 +26,12 @@ def init_app(app):
 
     @app.route('/api/projects/<project_id>/variants')
     def list_variants_by_project(project_id):
+        """List variants belonging to a specific project.
+
+        OpenAPI:
+        response 200 JsonObject Variant collection for the selected project.
+        response 404 Error Project not found.
+        """
         project = ProjectController.get(project_id)
         if project is None:
             return jsonify({"error": "Project not found"}), 404

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -327,6 +327,13 @@ def init_app(app: Flask) -> None:
 
     @app.post('/api/vulnerabilities/match-condition')
     def match_condition() -> ResponseReturnValue:
+        """Evaluate a condition against supplied data objects.
+
+        OpenAPI:
+        body JsonObject required Condition string and items containing id and data fields.
+        response 200 JsonObject IDs of items matching the condition.
+        response 400 Error Invalid request or condition.
+        """
         payload = request.get_json(silent=True)
         if not isinstance(payload, dict):
             return {"error": "Request body must be a JSON object"}, 400
@@ -856,7 +863,15 @@ def init_app(app: Flask) -> None:
 
     @app.post('/api/vulnerabilities/search-descriptions')
     def search_vulnerability_descriptions() -> ResponseReturnValue:
-        """Return vulnerability IDs whose scoped descriptions contain each term."""
+        """Return vulnerability IDs whose scoped descriptions contain each term.
+
+        OpenAPI:
+        query variant_id uuid optional Restrict descriptions to a variant's active scans.
+        query project_id uuid optional Restrict descriptions to a project's active scans.
+        body JsonObject required Vulnerability ID and search-term arrays.
+        response 200 JsonObject Matching vulnerability IDs grouped by normalized term.
+        response 400 Error Invalid identifiers, arrays, or size limits.
+        """
         payload = request.get_json(silent=True)
         if not isinstance(payload, dict):
             return {"error": "Expected a JSON object"}, 400

--- a/src/routes/vulnerabilities.py
+++ b/src/routes/vulnerabilities.py
@@ -361,6 +361,20 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/vulnerabilities')
     def index_vulns() -> ResponseReturnValue:
+        """List vulnerabilities with optional variant and project filters.
+
+        Supports single-variant, project-wide, pairwise comparison, and
+        multi-variant union or intersection modes.
+
+        OpenAPI:
+        query variant_id uuid optional Restrict to a single variant.
+        query project_id uuid optional Restrict to a single project.
+        query compare_variant_id uuid optional Compare against a second variant.
+        query variant_ids string optional Comma-separated list of variant IDs.
+        query operation string optional Comparison mode such as difference, intersection, or union.
+        query format string optional Response format such as list or dict.
+        response 200 JsonObject Vulnerability collection.
+        """
         response_format = request.args.get('format', 'list')
         variant_id = request.args.get('variant_id')
         project_id = request.args.get('project_id')
@@ -921,6 +935,13 @@ def init_app(app: Flask) -> None:
 
     @app.get('/api/vulnerabilities/<id>')
     def get_vuln(id: str) -> ResponseReturnValue:
+        """Return a single vulnerability.
+
+        OpenAPI:
+        query variant_id uuid optional Apply variant-scoped CVSS and effort overrides.
+        response 200 JsonObject Vulnerability payload.
+        response 404 Error Vulnerability not found.
+        """
         record = Vulnerability.get_by_id(id)
         if not record:
             return "Not found", 404
@@ -978,6 +999,11 @@ def init_app(app: Flask) -> None:
         observes this vulnerability, in a single response.
 
         Replaces the previous per-variant N+1 fetch performed by the modal.
+
+        OpenAPI:
+        query project_id uuid optional Restrict snapshots to variants from one project.
+        response 200 JsonObject Variant-scoped vulnerability snapshots.
+        response 404 Error Vulnerability not found.
         """
         record = Vulnerability.get_by_id(id)
         if not record:
@@ -1017,6 +1043,14 @@ def init_app(app: Flask) -> None:
 
     @app.patch('/api/vulnerabilities/<id>')
     def patch_vuln(id: str) -> ResponseReturnValue:
+        """Update variant-scoped effort or custom CVSS data for a vulnerability.
+
+        OpenAPI:
+        body JsonObject optional Vulnerability update payload.
+        response 200 JsonObject Updated vulnerability payload.
+        response 400 Error Invalid update payload.
+        response 404 Error Vulnerability not found.
+        """
         record = Vulnerability.get_by_id(id)
         if not record:
             return "Not found", 404
@@ -1097,6 +1131,13 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/vulnerabilities/batch', methods=['PATCH'])
     def update_vulns_batch() -> ResponseReturnValue:
+        """Update multiple vulnerabilities in a single request.
+
+        OpenAPI:
+        body JsonObject optional Batch vulnerability update payload.
+        response 200 JsonObject Batch update summary.
+        response 400 Error Invalid batch payload.
+        """
         payload_data = request.get_json()
         if (not payload_data
                 or "vulnerabilities" not in payload_data
@@ -1210,6 +1251,15 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/vulnerabilities/<cve_id>/nvd-refresh', methods=['POST'])
     def refresh_single_cve(cve_id: str) -> ResponseReturnValue:
+        """Refresh NVD data for a single CVE.
+
+        OpenAPI:
+        body JsonObject optional Request body containing mode: local or api.
+        response 200 JsonObject Refreshed vulnerability payload.
+        response 404 Error CVE not found.
+        response 429 Error NVD API rate limit exceeded.
+        response 503 Error NVD data source unavailable.
+        """
         cve_id_upper = cve_id.upper()
         rec = db.session.get(Vulnerability, cve_id_upper)
         if rec is None:
@@ -1316,6 +1366,13 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/vulnerabilities/<cve_id>/epss-refresh', methods=['POST'])
     def refresh_single_cve_epss(cve_id: str) -> ResponseReturnValue:
+        """Refresh EPSS data for a single CVE.
+
+        OpenAPI:
+        response 200 JsonObject Refreshed vulnerability payload.
+        response 404 Error CVE not found.
+        response 503 Error EPSS data source unavailable.
+        """
         cve_id_upper = cve_id.upper()
         rec = db.session.get(Vulnerability, cve_id_upper)
         if rec is None:
@@ -1351,6 +1408,15 @@ def init_app(app: Flask) -> None:
 
     @app.route('/api/vulnerabilities/<ghsa_id>/ghsa-refresh', methods=['POST'])
     def refresh_single_ghsa(ghsa_id: str) -> ResponseReturnValue:
+        """Refresh GitHub advisory metadata for a single GHSA identifier.
+
+        OpenAPI:
+        response 200 JsonObject Refreshed vulnerability payload.
+        response 400 Error Invalid GHSA identifier.
+        response 404 Error GHSA advisory not found.
+        response 502 Error Upstream GitHub advisory error.
+        response 503 Error GitHub advisory data source unavailable.
+        """
         ghsa_id_upper = ghsa_id.upper()
         if not _GHSA_RE.match(ghsa_id_upper):
             return jsonify({"error": "Only valid GHSA identifiers (GHSA-xxxx-xxxx-xxxx) are supported"}), 400

--- a/tests/webapp_tests/test_openapi_spec.py
+++ b/tests/webapp_tests/test_openapi_spec.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+import json
+
+import pytest
+
+from src.bin.webapp import create_app
+
+
+@pytest.fixture()
+def init_status_file(tmp_path):
+    status_path = tmp_path / "status.txt"
+    status_path.write_text("4 merging something")
+    return status_path
+
+
+@pytest.fixture()
+def app(init_status_file):
+    application = create_app()
+    application.config.update({
+        "TESTING": True,
+        "SCAN_FILE": init_status_file,
+    })
+    yield application
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_openapi_spec_is_available_before_scan_completion(client):
+    response = client.get("/api/openapi")
+    assert response.status_code == 200
+    assert response.content_type == "application/json"
+
+    data = json.loads(response.data)
+    assert data["openapi"] == "3.0.3"
+    assert data["info"]["title"] == "VulnScout REST API"
+    assert "components" in data
+    assert "schemas" in data["components"]
+    assert "JsonObject" in data["components"]["schemas"]
+    assert "Error" in data["components"]["schemas"]
+
+
+def test_openapi_json_alias_returns_same_document(client):
+    canonical = client.get("/api/openapi")
+    root_alias = client.get("/api")
+    alias = client.get("/api/openapi.json")
+    assert canonical.status_code == 200
+    assert root_alias.status_code == 200
+    assert alias.status_code == 200
+    assert json.loads(canonical.data) == json.loads(root_alias.data)
+    assert json.loads(canonical.data) == json.loads(alias.data)
+
+
+def test_openapi_swagger_ui_is_available_before_scan_completion(client):
+    response = client.get("/api/openapi/ui")
+    assert response.status_code == 200
+    assert response.content_type.startswith("text/html")
+
+    content = response.data.decode("utf-8")
+    assert "SwaggerUIBundle" in content
+    assert "url: '/api/openapi'" in content
+
+
+def test_openapi_spec_lists_registered_api_paths(client):
+    response = client.get("/api/openapi")
+    data = json.loads(response.data)
+
+    assert "/api/openapi" in data["paths"]
+    assert "/api/openapi.json" in data["paths"]
+    assert "/api/openapi/ui" in data["paths"]
+    assert "/api/version" in data["paths"]
+    assert "/api/assessments" in data["paths"]
+    assert "/api/vulnerabilities/{vuln_id}/assessments" in data["paths"]
+
+    assessment_ops = data["paths"]["/api/assessments/{assessment_id}"]
+    assert sorted(assessment_ops) == ["delete", "get", "patch", "put"]
+
+
+def test_openapi_spec_marks_scan_blocked_routes(client):
+    response = client.get("/api/openapi")
+    data = json.loads(response.data)
+
+    package_get = data["paths"]["/api/packages"]["get"]
+    assert "503" in package_get["responses"]
+
+    version_get = data["paths"]["/api/version"]["get"]
+    assert "503" not in version_get["responses"]
+
+
+def test_openapi_spec_exposes_typed_schemas_for_core_routes(client):
+    response = client.get("/api/openapi")
+    data = json.loads(response.data)
+
+    config_patch = data["paths"]["/api/config"]["patch"]
+    assert config_patch["requestBody"]["content"]["application/json"]["schema"]["$ref"] == "#/components/schemas/JsonObject"
+
+    projects_post = data["paths"]["/api/projects"]["post"]
+    assert projects_post["requestBody"]["content"]["application/json"]["schema"]["$ref"] == "#/components/schemas/JsonObject"
+
+    packages_get = data["paths"]["/api/packages"]["get"]
+    assert packages_get["responses"]["200"]["content"]["application/json"]["schema"]["$ref"] == "#/components/schemas/JsonObject"
+
+
+def test_openapi_spec_reads_parameter_annotations_from_docstrings(client):
+    response = client.get("/api/openapi")
+    data = json.loads(response.data)
+
+    package_parameters = data["paths"]["/api/packages"]["get"]["parameters"]
+    package_parameter_names = {item["name"] for item in package_parameters if item["in"] == "query"}
+    assert {"variant_id", "project_id", "compare_variant_id", "variant_ids", "operation", "format"} <= package_parameter_names
+
+    config_patch = data["paths"]["/api/config"]["patch"]
+    assert config_patch["responses"]["400"]["content"]["application/json"]["schema"]["$ref"] == "#/components/schemas/Error"
+
+
+def test_openapi_spec_exposes_multipart_upload_routes(client):
+    response = client.get("/api/openapi")
+    data = json.loads(response.data)
+
+    sbom_upload = data["paths"]["/api/sbom/upload"]["post"]
+    assert "multipart/form-data" in sbom_upload["requestBody"]["content"]
+
+    openvex_import = data["paths"]["/api/assessments/review/import"]["post"]
+    assert "multipart/form-data" in openvex_import["requestBody"]["content"]

--- a/tests/webapp_tests/test_openapi_spec.py
+++ b/tests/webapp_tests/test_openapi_spec.py
@@ -102,6 +102,20 @@ def test_openapi_spec_includes_every_registered_api_operation(app, client):
     assert documented == registered
 
 
+def test_openapi_operation_ids_are_unique(client):
+    data = json.loads(client.get("/api/openapi").data)
+    operation_ids = [
+        operation["operationId"]
+        for path_item in data["paths"].values()
+        for operation in path_item.values()
+    ]
+
+    assert len(operation_ids) == len(set(operation_ids))
+    assert data["paths"]["/api"]["get"]["operationId"] == "api.get"
+    assert data["paths"]["/api/openapi"]["get"]["operationId"] == "api_openapi.get"
+    assert data["paths"]["/api/openapi.json"]["get"]["operationId"] == "api_openapi_json.get"
+
+
 def test_openapi_spec_marks_scan_blocked_routes(client):
     response = client.get("/api/openapi")
     data = json.loads(response.data)

--- a/tests/webapp_tests/test_openapi_spec.py
+++ b/tests/webapp_tests/test_openapi_spec.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import json
+import re
 
 import pytest
 
@@ -72,6 +73,7 @@ def test_openapi_spec_lists_registered_api_paths(client):
     data = json.loads(response.data)
 
     assert "/api/openapi" in data["paths"]
+    assert "/api" in data["paths"]
     assert "/api/openapi.json" in data["paths"]
     assert "/api/openapi/ui" in data["paths"]
     assert "/api/version" in data["paths"]
@@ -80,6 +82,24 @@ def test_openapi_spec_lists_registered_api_paths(client):
 
     assessment_ops = data["paths"]["/api/assessments/{assessment_id}"]
     assert sorted(assessment_ops) == ["delete", "get", "patch", "put"]
+
+
+def test_openapi_spec_includes_every_registered_api_operation(app, client):
+    data = json.loads(client.get("/api/openapi").data)
+    documented = {
+        (path, method.upper())
+        for path, path_item in data["paths"].items()
+        for method in path_item
+    }
+    visible_methods = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+    registered = {
+        (re.sub(r"<(?:(?:[^:<>]+):)?([^<>]+)>", r"{\1}", rule.rule), method)
+        for rule in app.url_map.iter_rules()
+        if rule.rule == "/api" or rule.rule.startswith("/api/")
+        for method in (rule.methods or set()) & visible_methods
+    }
+
+    assert documented == registered
 
 
 def test_openapi_spec_marks_scan_blocked_routes(client):
@@ -92,19 +112,25 @@ def test_openapi_spec_marks_scan_blocked_routes(client):
     version_get = data["paths"]["/api/version"]["get"]
     assert "503" not in version_get["responses"]
 
+    scan_status_get = data["paths"]["/api/scan/status"]["get"]
+    assert "503" not in scan_status_get["responses"]
+
 
 def test_openapi_spec_exposes_typed_schemas_for_core_routes(client):
     response = client.get("/api/openapi")
     data = json.loads(response.data)
 
     config_patch = data["paths"]["/api/config"]["patch"]
-    assert config_patch["requestBody"]["content"]["application/json"]["schema"]["$ref"] == "#/components/schemas/JsonObject"
+    config_schema = config_patch["requestBody"]["content"]["application/json"]["schema"]
+    assert config_schema["$ref"] == "#/components/schemas/JsonObject"
 
     projects_post = data["paths"]["/api/projects"]["post"]
-    assert projects_post["requestBody"]["content"]["application/json"]["schema"]["$ref"] == "#/components/schemas/JsonObject"
+    project_schema = projects_post["requestBody"]["content"]["application/json"]["schema"]
+    assert project_schema["$ref"] == "#/components/schemas/JsonObject"
 
     packages_get = data["paths"]["/api/packages"]["get"]
-    assert packages_get["responses"]["200"]["content"]["application/json"]["schema"]["$ref"] == "#/components/schemas/JsonObject"
+    package_schema = packages_get["responses"]["200"]["content"]["application/json"]["schema"]
+    assert package_schema["$ref"] == "#/components/schemas/JsonObject"
 
 
 def test_openapi_spec_reads_parameter_annotations_from_docstrings(client):
@@ -113,10 +139,14 @@ def test_openapi_spec_reads_parameter_annotations_from_docstrings(client):
 
     package_parameters = data["paths"]["/api/packages"]["get"]["parameters"]
     package_parameter_names = {item["name"] for item in package_parameters if item["in"] == "query"}
-    assert {"variant_id", "project_id", "compare_variant_id", "variant_ids", "operation", "format"} <= package_parameter_names
+    expected_parameters = {
+        "variant_id", "project_id", "compare_variant_id", "variant_ids", "operation", "format",
+    }
+    assert expected_parameters <= package_parameter_names
 
     config_patch = data["paths"]["/api/config"]["patch"]
-    assert config_patch["responses"]["400"]["content"]["application/json"]["schema"]["$ref"] == "#/components/schemas/Error"
+    error_schema = config_patch["responses"]["400"]["content"]["application/json"]["schema"]
+    assert error_schema["$ref"] == "#/components/schemas/Error"
 
 
 def test_openapi_spec_exposes_multipart_upload_routes(client):
@@ -128,3 +158,26 @@ def test_openapi_spec_exposes_multipart_upload_routes(client):
 
     openvex_import = data["paths"]["/api/assessments/review/import"]["post"]
     assert "multipart/form-data" in openvex_import["requestBody"]["content"]
+
+    context_file_upload = data["paths"]["/api/variants/{variant_id}/context/files"]["post"]
+    assert "multipart/form-data" in context_file_upload["requestBody"]["content"]
+
+
+def test_openapi_spec_documents_context_and_vulnerability_helpers(client):
+    data = json.loads(client.get("/api/openapi").data)
+
+    context_get = data["paths"]["/api/context"]["get"]
+    context_parameters = {parameter["name"]: parameter for parameter in context_get["parameters"]}
+    assert context_parameters["project_id"]["required"] is True
+    assert context_parameters["variant_id"]["required"] is True
+
+    context_import = data["paths"]["/api/context/import"]["post"]
+    assert context_import["requestBody"]["required"] is True
+
+    match_condition = data["paths"]["/api/vulnerabilities/match-condition"]["post"]
+    assert match_condition["requestBody"]["required"] is True
+    assert "400" in match_condition["responses"]
+
+    description_search = data["paths"]["/api/vulnerabilities/search-descriptions"]["post"]
+    parameter_names = {parameter["name"] for parameter in description_search["parameters"]}
+    assert parameter_names == {"project_id", "variant_id"}


### PR DESCRIPTION
### Changes proposed in this pull request:

* Adding a JSON OpenAPI path providing a fully understandable Swagger file.
* Adding Swagger UI where developer can play with every API endpoints and test integration with any third party tool. :) 

OpenAPI JSON view :   
<img width="923" height="289" alt="Screenshot from 2026-07-24 16-12-43" src="https://github.com/user-attachments/assets/d5d30815-94ff-45e6-baa6-8c3f77cf25df" />

Swagger UI :  
<img width="1851" height="1035" alt="Screenshot from 2026-07-24 16-13-43" src="https://github.com/user-attachments/assets/59f3f56c-5d18-4009-8309-931d315e09d2" />


### Status

- [X] READY

### How to verify this change

Please, review the docstring part, because this feature rely mainly on docstring description in every API path. This change the way developer add feature because every new API path/route and feature should add documentation as comments if we want the Swagger UI to be up to date.

I was a bit helped by a Copilot on the feature, but I verified most of the code, I'm not fully sure about those elements :   
https://github.com/savoirfairelinux/vulnscout/blob/0376cb3dde5c9fc5428a555bc6d3fe0c36720f2f/src/bin/webapp.py#L208 -> the exception made here seem important for middleware, but I'm not sure if it is useful  
  
On the OpenAPI part, swagger UI use third party JS libs, should we want to add them on statics files ? https://github.com/savoirfairelinux/vulnscout/blob/0376cb3dde5c9fc5428a555bc6d3fe0c36720f2f/src/routes/openapi.py 

Here : https://github.com/savoirfairelinux/vulnscout/blob/0376cb3dde5c9fc5428a555bc6d3fe0c36720f2f/src/routes/openapi.py#L59 I'm not sure about the path name, there is something better that `/api/openapi/ui` ?


### Additional notes

VulnScout provide an API with a HTML documentation here : https://vulnscout.readthedocs.io/en/v0.18/api.html  
  
Usually, developers would use Postman/Insomnia or others API manager to do automation and tests.  
MCP use also often API and need API Schema to be efficient.   
  
Adding an OpenAPI JSON file help a lot when we work on those context, and developers like Swagger UI to do quick tests :) 

### Related Issue

No related issue is associated.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Added necessary reviewers


