### PR TITLE
fix(scans): serialize concurrent vulnerability scans

### DIFF
--- a/frontend/src/components/ScanProgressPanel.tsx
+++ b/frontend/src/components/ScanProgressPanel.tsx
@@ -32,8 +32,11 @@ type Props = {
 };
 
 export default function ScanProgressPanel({ entry, label, icon, colors, onDismiss }: Props) {
-    const { status, variantName, progress, logs, total, doneCount } = entry;
+    const { status, variantName, variantPosition, variantCount, progress, logs, total, doneCount } = entry;
     const pct = total > 0 ? Math.round((doneCount / total) * 100) : 0;
+    const variantProgress = variantPosition && variantCount && variantCount > 1
+        ? ` (variant ${variantPosition} of ${variantCount})`
+        : "";
 
     const logBoxRef = useRef<HTMLDivElement>(null);
     useEffect(() => {
@@ -53,7 +56,7 @@ export default function ScanProgressPanel({ entry, label, icon, colors, onDismis
             <div className={`px-4 py-2 flex items-center gap-3 ${colors.headerBg}`}>
                 <FontAwesomeIcon icon={icon} className={colors.iconText} />
                 <span className={`text-sm font-semibold ${colors.titleText}`}>
-                    {label} – {variantName} {statusText}
+                    {label} – {variantName} {statusText}{variantProgress}
                 </span>
                 <span className={`text-xs ${colors.subtitleText} ml-auto`}>
                     {progress ?? ""}

--- a/frontend/src/handlers/nvdScanState.ts
+++ b/frontend/src/handlers/nvdScanState.ts
@@ -13,6 +13,7 @@ const manager = new ScanStateManager(
     (vid, opts) => ScansHandler.triggerNvdScan(vid, opts.excludeKernel ?? true, opts.nvdMode ?? "local"),
     (vid) => ScansHandler.getNvdScanStatus(vid),
     "NVD",
+    true, // serial: scans can share engine and finding state
 );
 
 export const subscribe = manager.subscribe;

--- a/frontend/src/handlers/scanStateManager.ts
+++ b/frontend/src/handlers/scanStateManager.ts
@@ -15,6 +15,8 @@
 export type ScanEntryState = {
     variantId: string;
     variantName: string;
+    variantPosition?: number;
+    variantCount?: number;
     status: "idle" | "queued" | "running" | "done" | "error";
     error: string | null;
     progress: string | null;
@@ -187,6 +189,8 @@ export class ScanStateManager {
                 this.states.set(v.id, {
                     variantId: v.id,
                     variantName: v.name,
+                    variantPosition: i + 1,
+                    variantCount: variants.length,
                     status: i === 0 ? "running" : "queued",
                     error: null,
                     progress: i === 0 ? "starting" : "Queued",
@@ -219,10 +223,13 @@ export class ScanStateManager {
 
         // ---- parallel mode (default) ----
         // Create "running" entries
-        for (const v of variants) {
+        for (let i = 0; i < variants.length; i++) {
+            const v = variants[i];
             this.states.set(v.id, {
                 variantId: v.id,
                 variantName: v.name,
+                variantPosition: i + 1,
+                variantCount: variants.length,
                 status: "running",
                 error: null,
                 progress: "starting",

--- a/frontend/src/handlers/sccScanState.ts
+++ b/frontend/src/handlers/sccScanState.ts
@@ -13,6 +13,7 @@ const manager = new ScanStateManager(
     (vid, opts) => ScansHandler.triggerSbomCveCheckScan(vid, opts.excludeKernel ?? true),
     (vid) => ScansHandler.getSbomCveCheckScanStatus(vid),
     "sbom-cve-check",
+    true, // serial: scans share engine and finding state
 );
 
 export const subscribe = manager.subscribe;

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -1720,7 +1720,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                 ))
             }
             {nvdEntries
-                .filter(e => e.status === "running" || e.status === "done" || (e.status === "error" && e.logs.length > 0))
+                .filter(e => e.status === "queued" || e.status === "running" || e.status === "done" || (e.status === "error" && e.logs.length > 0))
                 .map(entry => (
                     <ScanProgressPanel key={`nvd-${entry.variantId}`} entry={entry} label="NVD Scan" icon={faShieldHalved} colors={nvdColors} onDismiss={() => nvdDismiss(entry.variantId)} />
                 ))
@@ -1732,7 +1732,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                 ))
             }
             {sccEntries
-                .filter(e => e.status === "running" || e.status === "done" || (e.status === "error" && e.logs.length > 0))
+                .filter(e => e.status === "queued" || e.status === "running" || e.status === "done" || (e.status === "error" && e.logs.length > 0))
                 .map(entry => (
                     <ScanProgressPanel key={`scc-${entry.variantId}`} entry={entry} label="sbom-cve-check Scan" icon={faCrosshairs} colors={sccColors} onDismiss={() => sccDismiss(entry.variantId)} />
                 ))

--- a/frontend/tests/unit_tests/test_scan_progress_panel.tsx
+++ b/frontend/tests/unit_tests/test_scan_progress_panel.tsx
@@ -44,6 +44,39 @@ describe('ScanProgressPanel', () => {
         expect(document.body.querySelector('.animate-pulse')).toBeInTheDocument();
     });
 
+    it('shows the position for a multi-variant scan', () => {
+        render(
+            <ScanProgressPanel
+                entry={makeEntry('running', {
+                    variantName: 'hyper-v',
+                    variantPosition: 2,
+                    variantCount: 3,
+                })}
+                label="sbom-cve-check Scan"
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText(/sbom-cve-check scan – hyper-v in progress \(variant 2 of 3\)/i)).toBeInTheDocument();
+    });
+
+    it('omits the position for a single-variant scan', () => {
+        render(
+            <ScanProgressPanel
+                entry={makeEntry('running', { variantPosition: 1, variantCount: 1 })}
+                label="NVD Scan"
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText(/nvd scan – variant 1 in progress/i)).toBeInTheDocument();
+        expect(screen.queryByText(/variant 1 of 1/i)).not.toBeInTheDocument();
+    });
+
     it('renders running and complete states with the expected log styling', async () => {
         const user = userEvent.setup();
         const onDismiss = jest.fn();

--- a/frontend/tests/unit_tests/test_scan_state_manager.ts
+++ b/frontend/tests/unit_tests/test_scan_state_manager.ts
@@ -318,6 +318,11 @@ describe('ScanStateManager.triggerScan (serial)', () => {
         expect(snap.find((s) => s.variantId === 'v1')?.status).toBe('running');
         expect(snap.find((s) => s.variantId === 'v2')?.status).toBe('queued');
         expect(snap.find((s) => s.variantId === 'v3')?.status).toBe('queued');
+        expect(snap.map((s) => [s.variantPosition, s.variantCount])).toEqual([
+            [1, 3],
+            [2, 3],
+            [3, 3],
+        ]);
         expect(triggerFn).toHaveBeenCalledTimes(1);
         expect(triggerFn).toHaveBeenCalledWith('v1', {});
     });

--- a/src/bin/cmd_vuln_scan.py
+++ b/src/bin/cmd_vuln_scan.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 """Vulnerability scanning commands: ``flask nvd-scan`` and ``flask osv-scan``."""
 
-from ..controllers.scc_engine import get_engine
+from ..controllers.scc_engine import get_engine, serialized_engine_operation
 from ..controllers.nvd_db import NVD_DB
 from ..controllers.nvd_persist import persist_nvd_cve
 from ..controllers.osv_client import OSVClient
@@ -103,6 +103,7 @@ def _persist_finding(pkg_id, vuln_id, scan_id, variant_uuid, origin: str,
 @click.option("--mode", "-m", default="local", type=click.Choice(["local", "api"]),
               help="NVD backend: 'local' (default, uses local NVD-FKIE DB) or 'api' (NVD REST API).")
 @with_appcontext
+@serialized_engine_operation
 def nvd_scan_command(project: str, variant: str | None, mode: str) -> None:
     """Run an NVD-based vulnerability scan for the given project/variant.
 
@@ -649,6 +650,7 @@ class _SccBulkWriter:
 @click.option("--variant", "-v", default=None,
               help=f"Variant name (defaults to '{DEFAULT_VARIANT_NAME}').")
 @with_appcontext
+@serialized_engine_operation
 def sbom_cve_check_scan_command(project: str, variant: str | None) -> None:
     """Run a local CVE-database scan (NVD-FKIE + CVEList V5) with version-range evaluation.
 

--- a/src/controllers/scc_engine.py
+++ b/src/controllers/scc_engine.py
@@ -132,9 +132,18 @@ def _serialized_engine_operation() -> Generator[None, None, None]:
         try:
             databases_dir.mkdir(parents=True, exist_ok=True)
             lock_path = databases_dir / ".vulnscout-engine.lock"
-        except OSError:
+        except OSError as exc:
             lock_path = pathlib.Path(tempfile.gettempdir()).joinpath(
                 f"vulnscout-engine-{os.getuid()}.lock"
+            )
+            _logger.warning(
+                "Could not create engine lock under %s (%s); falling back to "
+                "%s. Mutual exclusion is only guaranteed if every process "
+                "resolves to the same lock file, so concurrent scans may not "
+                "be serialized in this state.",
+                databases_dir,
+                exc,
+                lock_path,
             )
         with lock_path.open("a+") as lock_file:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
@@ -560,14 +569,18 @@ def get_cve_json(cve_id: str) -> "dict | None":
     Returns the raw NVD CVE JSON dict (same schema as NVD API v2) or ``None``
     if the CVE is not found or the database is not yet initialised.
     """
-    with _serialized_engine_operation():
-        with _ENGINE_LOCK:
-            engine = _ENGINE
-        if engine is None:
-            # Engine not yet built — the first build includes a fetch.
-            engine = _get_engine()
-        try:
-            return engine.get_nvd_cve_json(cve_id)
-        except Exception as exc:
-            _logger.warning("Failed to look up %s in local NVD database: %s", cve_id, exc)
-            return None
+    with _ENGINE_LOCK:
+        engine = _ENGINE
+    if engine is None:
+        # Engine not yet built — the first build includes a fetch and is
+        # serialized against concurrent scans via get_engine().  Read-only
+        # look-ups against an already-built engine deliberately skip that
+        # serialization so a running scan (which holds the exclusive engine
+        # lock for its full multi-minute duration) does not stall vuln-detail
+        # requests.
+        engine = get_engine()
+    try:
+        return engine.get_nvd_cve_json(cve_id)
+    except Exception as exc:
+        _logger.warning("Failed to look up %s in local NVD database: %s", cve_id, exc)
+        return None

--- a/src/controllers/scc_engine.py
+++ b/src/controllers/scc_engine.py
@@ -25,11 +25,14 @@ Configuration (environment variables):
 from __future__ import annotations
 
 import functools
+import fcntl
 import logging
 import os
 import pathlib
+import tempfile
 import threading
 from collections.abc import Generator
+from contextlib import contextmanager
 from typing import cast
 
 from sbom_cve_check.database.db_git import GitDatabase
@@ -46,6 +49,8 @@ from .scc_adapter import build_comp_build
 _logger = logging.getLogger(__name__)
 
 _ENGINE_LOCK = threading.Lock()
+_ENGINE_OPERATION_LOCK = threading.RLock()
+_ENGINE_OPERATION_STATE = threading.local()
 _ENGINE: "SccEngine | None" = None
 _PURE_CACHES_INSTALLED = False
 
@@ -108,6 +113,37 @@ def _databases_dir() -> pathlib.Path:
 
 def _truthy(value: str | None) -> bool:
     return (value or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+@contextmanager
+def _serialized_engine_operation() -> Generator[None, None, None]:
+    """Serialize local advisory-engine work across threads and processes."""
+    with _ENGINE_OPERATION_LOCK:
+        depth = getattr(_ENGINE_OPERATION_STATE, "depth", 0)
+        if depth:
+            _ENGINE_OPERATION_STATE.depth = depth + 1
+            try:
+                yield
+            finally:
+                _ENGINE_OPERATION_STATE.depth -= 1
+            return
+
+        databases_dir = _databases_dir()
+        try:
+            databases_dir.mkdir(parents=True, exist_ok=True)
+            lock_path = databases_dir / ".vulnscout-engine.lock"
+        except OSError:
+            lock_path = pathlib.Path(tempfile.gettempdir()).joinpath(
+                f"vulnscout-engine-{os.getuid()}.lock"
+            )
+        with lock_path.open("a+") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            _ENGINE_OPERATION_STATE.depth = 1
+            try:
+                yield
+            finally:
+                _ENGINE_OPERATION_STATE.depth = 0
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def _trust_git_directories(paths: list[pathlib.Path]) -> None:
@@ -463,16 +499,8 @@ class SccEngine:
         return None
 
 
-def get_engine() -> SccEngine:
-    """Return the process-wide indexed engine, building it on first use.
-
-    The engine is expensive to build and is cached for the lifetime of the
-    process.  Every call refreshes the advisory git clones before returning so
-    scans always run against up-to-date data.  Call this from full-scan paths.
-    For single-CVE look-ups that do not need an immediate git fetch, use
-    :func:`get_cve_json` instead (it reuses the cached engine without
-    triggering a refresh).
-    """
+def _get_engine() -> SccEngine:
+    """Build or reuse the process-wide engine and refresh its databases."""
     global _ENGINE
     with _ENGINE_LOCK:
         if _ENGINE is None:
@@ -488,6 +516,30 @@ def get_engine() -> SccEngine:
             )
     _ENGINE.refresh_databases()
     return _ENGINE
+
+
+def get_engine() -> SccEngine:
+    """Return the process-wide indexed engine, building it on first use.
+
+    The engine is expensive to build and is cached for the lifetime of the
+    process.  Every call refreshes the advisory git clones before returning so
+    scans always run against up-to-date data.  Call this from full-scan paths.
+    For single-CVE look-ups that do not need an immediate git fetch, use
+    :func:`get_cve_json` instead (it reuses the cached engine without
+    triggering a refresh).
+    """
+    with _serialized_engine_operation():
+        return _get_engine()
+
+
+def serialized_engine_operation(func):
+    """Serialize a decorated local advisory-engine operation end to end."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with _serialized_engine_operation():
+            return func(*args, **kwargs)
+
+    return wrapper
 
 
 def reset_engine() -> None:
@@ -508,13 +560,14 @@ def get_cve_json(cve_id: str) -> "dict | None":
     Returns the raw NVD CVE JSON dict (same schema as NVD API v2) or ``None``
     if the CVE is not found or the database is not yet initialised.
     """
-    with _ENGINE_LOCK:
-        engine = _ENGINE
-    if engine is None:
-        # Engine not yet built — the first build includes a fetch.
-        engine = get_engine()
-    try:
-        return engine.get_nvd_cve_json(cve_id)
-    except Exception as exc:
-        _logger.warning("Failed to look up %s in local NVD database: %s", cve_id, exc)
-        return None
+    with _serialized_engine_operation():
+        with _ENGINE_LOCK:
+            engine = _ENGINE
+        if engine is None:
+            # Engine not yet built — the first build includes a fetch.
+            engine = _get_engine()
+        try:
+            return engine.get_nvd_cve_json(cve_id)
+        except Exception as exc:
+            _logger.warning("Failed to look up %s in local NVD database: %s", cve_id, exc)
+            return None

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -404,7 +404,7 @@ def init_app(app: Flask) -> None:
         * **api** — queries the NVD REST API v2 using CPE identifiers from
           packages; honours NVD_API_KEY and rate limits.
         """
-        from ..controllers.scc_engine import get_engine
+        from ..controllers.scc_engine import get_engine, serialized_engine_operation
         from ..bin.cmd_vuln_scan import _SccBulkWriter
 
         variant_uuid, variant, err = validate_trigger(
@@ -423,6 +423,7 @@ def init_app(app: Flask) -> None:
             with app.app_context():
                 _do_nvd_scan(vid_str, variant_uuid)
 
+        @serialized_engine_operation
         def _do_nvd_scan(vid_str: str, variant_uuid: uuid.UUID) -> None:
             try:
                 _nvd_scans_in_progress[vid_str]["logs"].append(
@@ -855,6 +856,8 @@ def init_app(app: Flask) -> None:
         applies product-name aliasing and semantic version-range analysis, and
         records each engine VEX verdict.  Works once the databases are cloned.
         """
+        from ..controllers.scc_engine import serialized_engine_operation
+
         variant_uuid, variant, err = validate_trigger(
             variant_id, _sbom_cve_check_scans_in_progress, "sbom-cve-check scan")
         if err is not None:
@@ -1005,6 +1008,10 @@ def init_app(app: Flask) -> None:
             except Exception as e:
                 db.session.rollback()
                 set_error(_sbom_cve_check_scans_in_progress, vid_str, str(e)[:500])
+
+        _do_sbom_cve_check_scan = serialized_engine_operation(
+            _do_sbom_cve_check_scan
+        )
 
         thread = threading.Thread(
             target=_run_sbom_cve_check_scan,

--- a/tests/unit_tests/test_scc_engine_utils.py
+++ b/tests/unit_tests/test_scc_engine_utils.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import threading
 from unittest.mock import MagicMock, patch, call
 
 import pytest
@@ -67,6 +68,68 @@ class TestDatabasesDir:
         result = mod._databases_dir()
         assert "local_databases" in str(result)
 
+
+class TestSerializedEngineOperation:
+
+    def test_concurrent_operations_run_one_at_a_time(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", str(tmp_path))
+        from src.controllers.scc_engine import serialized_engine_operation
+
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        second_calling = threading.Event()
+        second_entered = threading.Event()
+        order: list[str] = []
+
+        @serialized_engine_operation
+        def operation(name: str) -> None:
+            order.append(f"enter-{name}")
+            if name == "first":
+                first_entered.set()
+                assert release_first.wait(timeout=2)
+            else:
+                second_entered.set()
+            order.append(f"exit-{name}")
+
+        first = threading.Thread(target=operation, args=("first",))
+
+        def run_second() -> None:
+            second_calling.set()
+            operation("second")
+
+        second = threading.Thread(target=run_second)
+        first.start()
+        assert first_entered.wait(timeout=2)
+        second.start()
+        assert second_calling.wait(timeout=2)
+        assert not second_entered.wait(timeout=0.05)
+
+        release_first.set()
+        first.join(timeout=2)
+        second.join(timeout=2)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert order == ["enter-first", "exit-first", "enter-second", "exit-second"]
+
+    def test_nested_operations_are_reentrant(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("SBOM_CVE_CHECK_DATABASES_DIR", str(tmp_path))
+        from src.controllers.scc_engine import serialized_engine_operation
+
+        calls: list[str] = []
+
+        @serialized_engine_operation
+        def inner() -> None:
+            calls.append("inner")
+
+        @serialized_engine_operation
+        def outer() -> None:
+            calls.append("outer")
+            inner()
+
+        outer()
+
+        assert calls == ["outer", "inner"]
 
 class TestTrustGitDirectories:
 


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

Queue NVD CPE and sbom-cve-check variant scans in the frontend, and serialize shared engine and finding operations across web and CLI processes. Add regression coverage for concurrent and reentrant engine access.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Run multiple NVD CPE and sbom-cve-check on many variants, both in the web dashboard and the CLI. You will notice that they get queued for process.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


