### PR TITLE
Review: add timestamp policies to imports

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -306,11 +306,14 @@ The `--export-custom-vulnscout-data` flag exports custom assessments, CVSS score
 ./vulnscout --project demo --variant x86 --export-custom-vulnscout-data
 ----
 
-The `--import-custom-vulnscout-data` command restores entries according to the variant metadata in the file.
+The `--import-custom-vulnscout-data` command restores entries according to the variant metadata in the file. Imported assessments use the current system time by default. Add `--use-original-timestamps` to preserve assessment timestamps from the file.
+`--use-current-timestamps` is also accepted to select the default explicitly.
 
 [source,shell]
 ----
 ./vulnscout --project demo --import-custom-vulnscout-data /path/to/custom_vulnscout_data_all.json
+
+./vulnscout --project demo --import-custom-vulnscout-data /path/to/custom_vulnscout_data_all.json --use-original-timestamps
 ----
 
 ==== OpenVEX
@@ -324,7 +327,12 @@ The OpenVEX custom-assessment commands operate on one JSON document and require 
 
 # Import into a variant
 ./vulnscout --project demo --variant x86 --import-custom-openvex-assessments /path/to/custom_openvex_x86.json
+
+# Ignore OpenVEX statement timestamps and use the current system time
+./vulnscout --project demo --variant x86 --import-custom-openvex-assessments /path/to/custom_openvex_x86.json --use-current-timestamps
 ----
+
+OpenVEX imports preserve statement timestamps by default. Add `--use-current-timestamps` to use the current system time, or use `--use-original-timestamps` to select the default explicitly.
 
 Both commands can be combined with other flags:
 

--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -62,8 +62,10 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 | `--export-openvex` | Export project as OpenVEX document to `/scan/outputs/` |
 | `--export-custom-vulnscout-data` | Export custom VulnScout JSON data for all project variants, or the selected `--variant`, to `/scan/outputs/` |
 | `--import-custom-vulnscout-data <path>` | Import custom VulnScout JSON data using the variant metadata in the file |
+| `--use-original-timestamps` | With either custom import, preserve file timestamps |
 | `--export-custom-openvex-assessments` | Export custom assessments for the selected `--variant` as an OpenVEX `.json` file |
 | `--import-custom-openvex-assessments <path>` | Import an OpenVEX `.json` file into the selected `--variant` |
+| `--use-current-timestamps` | With either custom import, use the current system time |
 | `--match-condition <expr>` | Exit with code 2 if expression matches any vulnerability. Incompatible with `--serve` |
 | `--delete-scan <id>` | Delete a past scan by its ID |
 

--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -330,10 +330,16 @@ Export one variant:
 ./vulnscout --project demo --variant x86 --export-custom-vulnscout-data
 ```
 
-The `--import-custom-vulnscout-data` command restores entries according to the variant metadata stored in the file:
+The `--import-custom-vulnscout-data` command restores entries according to the
+variant metadata stored in the file. Imported assessments use the current
+system time by default. Add `--use-original-timestamps` to preserve assessment
+timestamps from the file. `--use-current-timestamps` is also accepted to select
+the default explicitly.
 
 ```bash
 ./vulnscout --project demo --import-custom-vulnscout-data /path/to/custom_vulnscout_data_all.json
+
+./vulnscout --project demo --import-custom-vulnscout-data /path/to/custom_vulnscout_data_all.json --use-original-timestamps
 ```
 
 ### OpenVEX
@@ -346,7 +352,14 @@ OpenVEX custom-assessment transfers operate on one JSON document and require `--
 
 # Import into a variant
 ./vulnscout --project demo --variant x86 --import-custom-openvex-assessments /path/to/custom_openvex_x86.json
+
+# Ignore OpenVEX statement timestamps and use the current system time
+./vulnscout --project demo --variant x86 --import-custom-openvex-assessments /path/to/custom_openvex_x86.json --use-current-timestamps
 ```
+
+OpenVEX imports preserve statement timestamps by default. Add
+`--use-current-timestamps` to use the current system time, or use
+`--use-original-timestamps` to select the default explicitly.
 
 ---
 

--- a/frontend/src/components/ReviewTransferModal.tsx
+++ b/frontend/src/components/ReviewTransferModal.tsx
@@ -8,8 +8,10 @@ type Props = {
     variants: Variant[];
     selectedVariantIds: string[];
     transferFormat: 'custom' | 'openvex';
+    timestampPolicy: 'original' | 'current';
     onSelectedVariantIdsChange: (ids: string[]) => void;
     onTransferFormatChange: (format: 'custom' | 'openvex') => void;
+    onTimestampPolicyChange: (policy: 'original' | 'current') => void;
     onConfirm: () => void;
     onCancel: () => void;
 };
@@ -19,8 +21,10 @@ function ReviewTransferModal({
     variants,
     selectedVariantIds,
     transferFormat,
+    timestampPolicy,
     onSelectedVariantIdsChange,
     onTransferFormatChange,
+    onTimestampPolicyChange,
     onConfirm,
     onCancel,
 }: Readonly<Props>) {
@@ -59,16 +63,32 @@ function ReviewTransferModal({
                     <fieldset>
                         <legend className="mb-2 text-sm font-semibold text-gray-200">Format</legend>
                         <div className="grid grid-cols-2 gap-3">
-                            <label className="flex cursor-pointer items-start gap-2 rounded border border-gray-600 p-3 text-gray-100">
-                                <input type="radio" name="review-transfer-format" checked={transferFormat === 'custom'} onChange={() => onTransferFormatChange('custom')} />
-                                <span><span className="block font-medium">VulnScout JSON</span><span className="text-xs text-gray-400">{mode === 'export' ? 'Assessments, CVSS, and time estimates' : 'Uses the variants recorded in the file'}</span></span>
+                            <label className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${transferFormat === 'custom' ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
+                                <input type="radio" name="review-transfer-format" checked={transferFormat === 'custom'} onChange={() => onTransferFormatChange('custom')} className="mt-0.5 accent-cyan-500" />
+                                <span className="flex flex-col"><span className="text-sm font-medium">VulnScout JSON</span><span className="text-xs text-zinc-400">{mode === 'export' ? 'Assessments, CVSS, and time estimates' : 'Uses the variants recorded in the file'}</span></span>
                             </label>
-                            <label className="flex cursor-pointer items-start gap-2 rounded border border-gray-600 p-3 text-gray-100">
-                                <input type="radio" name="review-transfer-format" checked={isOpenVex} onChange={() => onTransferFormatChange('openvex')} />
-                                <span><span className="block font-medium">OpenVEX</span><span className="text-xs text-gray-400">One variant in a JSON document</span></span>
+                            <label className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${isOpenVex ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
+                                <input type="radio" name="review-transfer-format" checked={isOpenVex} onChange={() => onTransferFormatChange('openvex')} className="mt-0.5 accent-cyan-500" />
+                                <span className="flex flex-col"><span className="text-sm font-medium">OpenVEX</span><span className="text-xs text-zinc-400">One variant in a JSON document</span></span>
                             </label>
                         </div>
                     </fieldset>
+
+                    {mode === 'import' && (
+                        <fieldset>
+                            <legend className="mb-2 text-sm font-semibold text-gray-200">Assessment timestamps</legend>
+                            <div className="space-y-2">
+                                <label className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${timestampPolicy === 'original' ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
+                                    <input type="radio" name="review-import-timestamp" checked={timestampPolicy === 'original'} onChange={() => onTimestampPolicyChange('original')} className="mt-0.5 accent-cyan-500" />
+                                    <span className="flex flex-col"><span className="text-sm font-medium">Use original timestamps from file</span><span className="text-xs text-zinc-400">Preserve when each assessment was originally recorded</span></span>
+                                </label>
+                                <label className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${timestampPolicy === 'current' ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
+                                    <input type="radio" name="review-import-timestamp" checked={timestampPolicy === 'current'} onChange={() => onTimestampPolicyChange('current')} className="mt-0.5 accent-cyan-500" />
+                                    <span className="flex flex-col"><span className="text-sm font-medium">Use current system time</span><span className="text-xs text-zinc-400">Ignore timestamps stored in the file</span></span>
+                                </label>
+                            </div>
+                        </fieldset>
+                    )}
 
                     {needsVariantSelection && (
                         <fieldset>
@@ -80,13 +100,16 @@ function ReviewTransferModal({
                                     </button>
                                 </div>
                             )}
-                            <div className="clear-both max-h-64 space-y-1 overflow-y-auto rounded border border-gray-600 p-2">
-                                {variants.map(variant => (
-                                    <label key={variant.id} className="flex cursor-pointer items-center gap-3 rounded px-2 py-2 text-sm text-gray-100 hover:bg-gray-700">
-                                        <input type={supportsMultipleVariants ? 'checkbox' : 'radio'} name="review-openvex-variant" checked={supportsMultipleVariants ? selectedVariantIds.includes(variant.id) : selectedVariantIds[0] === variant.id} onChange={() => supportsMultipleVariants ? toggleVariant(variant.id) : onSelectedVariantIdsChange([variant.id])} />
-                                        {variant.name}
-                                    </label>
-                                ))}
+                            <div className="clear-both max-h-64 space-y-2 overflow-y-auto">
+                                {variants.map(variant => {
+                                    const selected = supportsMultipleVariants ? selectedVariantIds.includes(variant.id) : selectedVariantIds[0] === variant.id;
+                                    return (
+                                        <label key={variant.id} className={`flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2 text-sm transition-colors ${selected ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
+                                            <input type={supportsMultipleVariants ? 'checkbox' : 'radio'} name="review-openvex-variant" checked={selected} onChange={() => supportsMultipleVariants ? toggleVariant(variant.id) : onSelectedVariantIdsChange([variant.id])} className={supportsMultipleVariants ? 'rounded border-slate-500 bg-slate-900 text-cyan-500 focus:ring-cyan-500' : 'accent-cyan-500'} />
+                                            {variant.name}
+                                        </label>
+                                    );
+                                })}
                             </div>
                         </fieldset>
                     )}

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -145,6 +145,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     const [transferMode, setTransferMode] = useState<'import' | 'export' | null>(null);
     const [transferVariantIds, setTransferVariantIds] = useState<string[]>([]);
     const [transferFormat, setTransferFormat] = useState<'custom' | 'openvex'>('custom');
+    const [importTimestampPolicy, setImportTimestampPolicy] = useState<'original' | 'current'>('original');
 
     const showMessage = useCallback((message: string, type: "error" | "success") => {
         setBannerMessage(message);
@@ -438,6 +439,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
 
     const openTransfer = useCallback((mode: 'import' | 'export') => {
         setTransferFormat('custom');
+        setImportTimestampPolicy('original');
         setTransferVariantIds(mode === 'export'
             ? variantId ? [variantId] : transferVariants.map(variant => variant.id)
             : []);
@@ -513,6 +515,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             const formData = new FormData();
             formData.append('file', file);
             formData.append('variant_id', transferVariantIds[0]);
+            formData.append('timestamp_policy', importTimestampPolicy);
             fetch(new URL(import.meta.env.VITE_API_URL + "/api/assessments/review/import", window.location.href).toString(), {
                 method: 'POST',
                 body: formData,
@@ -558,7 +561,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     method: 'POST',
                     mode: 'cors',
                     headers: { 'Content-Type': 'application/json' },
-                    body: text,
+                    body: JSON.stringify({ ...parsed, timestamp_policy: importTimestampPolicy }),
                 });
                 const data = await result.json() as ImportResult;
 
@@ -591,7 +594,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             }
         };
         reader.readAsText(file);
-    }, [variantId, projectId, showMessage, transferFormat, transferVariantIds]);
+    }, [variantId, projectId, showMessage, transferFormat, transferVariantIds, importTimestampPolicy]);
 
     const handleDeleteRow = useCallback(async () => {
         if (!rowToDelete) return;
@@ -1423,8 +1426,10 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     variants={transferVariants}
                     selectedVariantIds={transferVariantIds}
                     transferFormat={transferFormat}
+                    timestampPolicy={importTimestampPolicy}
                     onSelectedVariantIdsChange={setTransferVariantIds}
                     onTransferFormatChange={changeTransferFormat}
+                    onTimestampPolicyChange={setImportTimestampPolicy}
                     onConfirm={transferMode === 'export' ? handleExportReview : handleImportReview}
                     onCancel={() => setTransferMode(null)}
                 />

--- a/frontend/tests/unit_tests/test_review.tsx
+++ b/frontend/tests/unit_tests/test_review.tsx
@@ -1397,6 +1397,8 @@ describe('Review — import and export', () => {
         await user.click(screen.getByText('Import'));
         const dialog = screen.getByRole('dialog');
         expect(within(dialog).queryByText('Variant')).not.toBeInTheDocument();
+        expect(within(dialog).getByRole('radio', { name: /Use original timestamps from file/ })).toBeChecked();
+        await user.click(within(dialog).getByRole('radio', { name: /Use current system time/ }));
         await user.click(within(dialog).getByRole('button', { name: 'Choose file' }));
 
         const file = new File(
@@ -1407,6 +1409,8 @@ describe('Review — import and export', () => {
         fireEvent.change(fileInput(), { target: { files: [file] } });
 
         await screen.findByText(/Imported:/);
+        const importCall = postCalls().find(call => String(call[0]).includes('/api/assessments/review/import-custom-data'));
+        expect(JSON.parse(String((importCall?.[1] as RequestInit).body)).timestamp_policy).toBe('current');
     });
 
     test('imports OpenVEX into one selected variant without using the filename', async () => {
@@ -1433,6 +1437,7 @@ describe('Review — import and export', () => {
         expect(importCalls).toHaveLength(1);
         const targetedVariantIds = importCalls.map(call => ((call[1] as RequestInit).body as FormData).get('variant_id'));
         expect(targetedVariantIds).toEqual(['v2']);
+        expect(((importCalls[0][1] as RequestInit).body as FormData).get('timestamp_policy')).toBe('original');
     });
 
     test('file selection accepts JSON only', async () => {

--- a/src/bin/cmd_assessments.py
+++ b/src/bin/cmd_assessments.py
@@ -91,8 +91,17 @@ def export_custom_vulnscout_data_command(output_dir: str, project: str, variant:
 @click.command("import-custom-vulnscout-data")
 @click.argument("file_path")
 @click.option("--project", "-p", required=True, help="Project name.")
+@click.option(
+    "--use-original-timestamps/--use-current-timestamps",
+    default=False,
+    help="Choose whether to preserve assessment timestamps from the file.",
+)
 @with_appcontext
-def import_custom_vulnscout_data_command(file_path: str, project: str) -> None:
+def import_custom_vulnscout_data_command(
+    file_path: str,
+    project: str,
+    use_original_timestamps: bool,
+) -> None:
     """Import custom VulnScout JSON data using its embedded variant metadata."""
     project_obj = resolve_project(project)
     data = _load_json_file(file_path)
@@ -100,7 +109,11 @@ def import_custom_vulnscout_data_command(file_path: str, project: str) -> None:
         raise click.ClickException("Not a valid VulnScout JSON data file.")
 
     variant_by_name = build_variant_by_name_map(project_obj.id)
-    _print_custom_data_import_result(import_custom_data(data, variant_by_name))
+    _print_custom_data_import_result(import_custom_data(
+        data,
+        variant_by_name,
+        use_original_timestamps=use_original_timestamps,
+    ))
 
 
 @click.command("export-custom-openvex-assessments")
@@ -132,8 +145,18 @@ def export_custom_openvex_assessments_command(output_dir: str, project: str, var
 @click.argument("file_path")
 @click.option("--project", "-p", required=True, help="Project name.")
 @click.option("--variant", "-v", required=True, help="Variant name to import into.")
+@click.option(
+    "--use-original-timestamps/--use-current-timestamps",
+    default=True,
+    help="Choose whether to preserve assessment timestamps from the file.",
+)
 @with_appcontext
-def import_custom_openvex_assessments_command(file_path: str, project: str, variant: str) -> None:
+def import_custom_openvex_assessments_command(
+    file_path: str,
+    project: str,
+    variant: str,
+    use_original_timestamps: bool,
+) -> None:
     """Import one OpenVEX JSON document into the specified variant."""
     _, variant_obj = resolve_project_variant(project, variant, create=False)
     data = _load_json_file(file_path)
@@ -141,7 +164,9 @@ def import_custom_openvex_assessments_command(file_path: str, project: str, vari
         raise click.ClickException("Not a valid OpenVEX document.")
 
     total_created, total_errors, total_skipped = import_statements(
-        data["statements"], variant_obj.id
+        data["statements"],
+        variant_obj.id,
+        use_original_timestamps=use_original_timestamps,
     )
     for error in total_errors:
         click.echo(f"  Warning: {error}", err=True)

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -121,7 +121,9 @@ Scan & output commands:
   --export-cdx              Export project as CycloneDX 1.6 SBOM to /scan/outputs/
   --export-openvex          Export project as OpenVEX document to /scan/outputs/
     --export-custom-vulnscout-data  Export custom VulnScout JSON data to /scan/outputs/
-    --import-custom-vulnscout-data <path>  Import custom VulnScout JSON data
+        --import-custom-vulnscout-data <path>  Import custom VulnScout JSON data
+            --use-original-timestamps    Preserve file timestamps instead of using system time
+            --use-current-timestamps     Use current system time instead of file timestamps
     --export-custom-openvex-assessments  Export custom OpenVEX assessments for --variant
     --import-custom-openvex-assessments <path>  Import custom OpenVEX assessments into --variant
     --export-context          Export AI assessment context (project/variant description, threat model, etc.) to /scan/outputs/context-export.json
@@ -549,6 +551,9 @@ cmd_import_custom_vulnscout_data() {
     local file="$1"
 
     import_args=(--project "$PROJECT_NAME")
+    if [[ "${IMPORT_CUSTOM_TIMESTAMP_POLICY:-current}" == "original" ]]; then
+        import_args+=(--use-original-timestamps)
+    fi
 
     cd "$BASE_DIR"
     local raw_basename dest_name dest_file
@@ -600,8 +605,12 @@ cmd_import_custom_openvex_assessments() {
     fi
 
     flask --app src.bin.webapp db upgrade
-    flask --app src.bin.webapp import-custom-openvex-assessments \
-        --project "$PROJECT_NAME" --variant "$VARIANT_NAME" "$file"
+    local -a import_args=(--project "$PROJECT_NAME" --variant "$VARIANT_NAME")
+    if [[ "${IMPORT_CUSTOM_TIMESTAMP_POLICY:-original}" == "current" ]]; then
+        import_args+=(--use-current-timestamps)
+    fi
+    import_args+=("$file")
+    flask --app src.bin.webapp import-custom-openvex-assessments "${import_args[@]}"
     setup_user
 }
 
@@ -756,6 +765,7 @@ EXPORT_FORMATS=()
 SCAN_REQUIRED=false
 JSON_OUTPUT=false
 DATA_REQUESTED=""
+IMPORT_CUSTOM_TIMESTAMP_POLICY=""
 
 if [[ $# -eq 0 ]]; then
     cmd_daemon
@@ -832,6 +842,10 @@ while [[ $# -gt 0 ]]; do
             EXPORT_CONTEXT=true; shift ;;
         --import-context)
             IMPORT_CONTEXT_FILE="$2"; shift 2 ;;
+        --use-original-timestamps)
+            IMPORT_CUSTOM_TIMESTAMP_POLICY=original; shift ;;
+        --use-current-timestamps)
+            IMPORT_CUSTOM_TIMESTAMP_POLICY=current; shift ;;
         --list-projects|--list-scans)
             cmd_get_data "$1"; shift ;;
         --config)
@@ -844,6 +858,11 @@ while [[ $# -gt 0 ]]; do
             echo "Unknown command: $1"; echo "Run --help for usage."; exit 1 ;;
     esac
 done
+
+if [[ -n "${IMPORT_CUSTOM_TIMESTAMP_POLICY:-}" && -z "${IMPORT_CUSTOM_VULNSCOUT_DATA_FILE:-}" && -z "${IMPORT_CUSTOM_OPENVEX_ASSESSMENTS_FILE:-}" ]]; then
+    echo "Error: timestamp options require a custom VulnScout or OpenVEX import." >&2
+    exit 1
+fi
 
 # Step 1: Scan the new inputs/match condition if any
 match_exit=0

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -164,9 +164,59 @@ def is_openvex_doc(doc: object) -> bool:
     return "openvex" in str(ctx) and isinstance(doc.get("statements"), list)
 
 
+def parse_imported_timestamp(raw_ts: object, use_original_timestamps: bool) -> "_dt | None":
+    """Return the timestamp to persist for an imported assessment.
+
+    Returns ``None`` when *use_original_timestamps* is false or when *raw_ts*
+    is missing/unparseable, in which case the caller lets the model apply the
+    current time.  Parsed values are always converted to UTC: SQLite drops the
+    offset when storing, so a non-UTC timestamp would otherwise be read back as
+    if its local wall-clock time had been UTC.
+    """
+    if not use_original_timestamps or not isinstance(raw_ts, str) or not raw_ts:
+        return None
+    try:
+        parsed = _dt.fromisoformat(raw_ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=_tz.utc)
+    return parsed.astimezone(_tz.utc)
+
+
+def duplicate_assessment_query(
+    finding_id: "_uuid.UUID",
+    variant_id: "_uuid.UUID | None",
+    status: str,
+    origin: str,
+    timestamp: "_dt | None" = None,
+) -> Any:
+    """Build the SELECT used to detect an already-imported assessment.
+
+    When *timestamp* is given (i.e. the caller preserves the timestamps stored
+    in the file) it is part of the identity: an assessment recorded at another
+    date is a distinct entry in the vulnerability's history and must be
+    imported instead of being silently dropped as a duplicate.  Without it,
+    re-importing the same file stays idempotent.
+    """
+    from ..extensions import db
+    from ..models.assessment import Assessment as DBAssessment
+
+    query = db.select(DBAssessment).where(
+        DBAssessment.finding_id == finding_id,
+        DBAssessment.variant_id == variant_id,
+        DBAssessment.status == status,
+        DBAssessment.origin == origin,
+    )
+    if timestamp is not None:
+        query = query.where(DBAssessment.timestamp == timestamp)
+    return query
+
+
 def import_statements(
     statements: list[dict[str, Any]],
     variant_id: "_uuid.UUID",
+    use_original_timestamps: bool = True,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], int]:
     """Persist a list of OpenVEX statement dicts as DB assessments.
 
@@ -177,6 +227,9 @@ def import_statements(
         OpenVEX JSON document).
     variant_id:
         UUID of the target variant to attach the assessments to.
+    use_original_timestamps:
+        Preserve valid statement timestamps when true.  When false, newly
+        created assessments use the database server's current time.
 
     Returns
     -------
@@ -237,13 +290,9 @@ def import_statements(
         # Preserve the original assessment date so exports remain ordered by
         # the date of the custom assessment and stay reproducible when two
         # developers import each other's assessments.
-        imported_ts: "_dt | None" = None
-        raw_ts = stmt.get("timestamp")
-        if isinstance(raw_ts, str) and raw_ts:
-            try:
-                imported_ts = _dt.fromisoformat(raw_ts)
-            except (ValueError, TypeError):
-                imported_ts = None
+        imported_ts = parse_imported_timestamp(
+            stmt.get("timestamp"), use_original_timestamps
+        )
 
         for pkg_string_id in pkg_ids:
             try:
@@ -256,11 +305,12 @@ def import_statements(
                 finding = Finding.get_or_create(db_pkg.id, vuln_name)
 
                 existing = db.session.execute(
-                    db.select(DBAssessment).where(
-                        DBAssessment.finding_id == finding.id,
-                        DBAssessment.variant_id == variant_id,
-                        DBAssessment.status == status,
-                        DBAssessment.origin == "custom",
+                    duplicate_assessment_query(
+                        finding_id=finding.id,
+                        variant_id=variant_id,
+                        status=status,
+                        origin="custom",
+                        timestamp=imported_ts,
                     )
                 ).scalars().first()
                 if existing is not None:
@@ -366,6 +416,7 @@ def build_custom_data_export(
                 "impact_statement": assessment_dict.get("impact_statement") or None,
                 "status_notes": assessment_dict.get("status_notes") or None,
                 "workaround": assessment_dict.get("workaround") or None,
+                "timestamp": assessment_dict["timestamp"],
                 "packages": assessment_dict["packages"],
                 "variant_id": assessment_dict.get("variant_id"),
             })
@@ -491,6 +542,7 @@ def import_custom_data(
     data: dict[str, Any],
     variant_by_name: "dict[str, _Variant]",
     variant_id: "_uuid.UUID | None" = None,
+    use_original_timestamps: bool = False,
 ) -> dict[str, Any]:
     """Import a custom-data JSON document containing assessments, CVSS and
     time estimates.
@@ -506,6 +558,9 @@ def import_custom_data(
     variant_id:
         When provided, all assessments are attached to this variant.
         When *None*, each assessment's ``variant_id`` field is used.
+    use_original_timestamps:
+        Preserve valid assessment timestamps when true.  When false, newly
+        created assessments use the database server's current time.
 
     Returns
     -------
@@ -600,6 +655,9 @@ def import_custom_data(
             impact_statement = a.get("impact_statement", "")
             status_notes = a.get("status_notes", "")
             workaround = a.get("workaround", "")
+            imported_ts = parse_imported_timestamp(
+                a.get("timestamp"), use_original_timestamps
+            )
 
             for pkg_string_id in pkg_ids:
                 try:
@@ -616,11 +674,12 @@ def import_custom_data(
                     finding = Finding.get_or_create(db_pkg.id, vuln_name)
 
                     existing = db.session.execute(
-                        db.select(DBAssessment).where(
-                            DBAssessment.finding_id == finding.id,
-                            DBAssessment.variant_id == target_variant_id,
-                            DBAssessment.status == status,
-                            DBAssessment.origin == origin,
+                        duplicate_assessment_query(
+                            finding_id=finding.id,
+                            variant_id=target_variant_id,
+                            status=status,
+                            origin=origin,
+                            timestamp=imported_ts,
                         )
                     ).scalars().first()
                     if existing is not None:
@@ -640,6 +699,7 @@ def import_custom_data(
                         impact_statement=impact_statement,
                         workaround=workaround,
                         responses=[],
+                        timestamp=imported_ts,
                         commit=True,
                     )
                     result[imported_key] += 1

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -433,6 +433,10 @@ def init_app(app: Flask) -> None:
         if DBVariant.get_by_id(target_variant_id) is None:
             return {"error": "Variant not found"}, 404
 
+        timestamp_policy = request.form.get('timestamp_policy', 'original')
+        if timestamp_policy not in {'original', 'current'}:
+            return {"error": "timestamp_policy must be 'original' or 'current'"}, 400
+
         import json
         try:
             data = json.load(uploaded.stream)
@@ -446,7 +450,11 @@ def init_app(app: Flask) -> None:
                          "or 'statements' array)"
             }, 400
 
-        created, errors, skipped = _import_openvex_statements(data["statements"], target_variant_id)
+        created, errors, skipped = _import_openvex_statements(
+            data["statements"],
+            target_variant_id,
+            use_original_timestamps=timestamp_policy == 'original',
+        )
         return {"status": "success", "imported": len(created), "skipped": skipped, "errors": errors}, 200
 
     @app.route('/api/assessments/review/time-estimates')
@@ -700,8 +708,16 @@ def init_app(app: Flask) -> None:
         if not isinstance(data, dict) or "version" not in data:
             return {"error": "Invalid custom-data format. Expected {version, assessments, ...}"}, 400
 
+        timestamp_policy = data.get('timestamp_policy', 'current')
+        if timestamp_policy not in {'original', 'current'}:
+            return {"error": "timestamp_policy must be 'original' or 'current'"}, 400
+
         variant_by_name = build_variant_by_name_map()
-        result = import_custom_data(data, variant_by_name)
+        result = import_custom_data(
+            data,
+            variant_by_name,
+            use_original_timestamps=timestamp_policy == 'original',
+        )
 
         status_code = 200 if result["status"] == "success" else 400
         return result, status_code

--- a/tests/cli_tests/test_cmd_assessments.py
+++ b/tests/cli_tests/test_cmd_assessments.py
@@ -4,6 +4,7 @@
 
 import json
 import pytest
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from src.bin.webapp import create_app
@@ -98,3 +99,165 @@ class TestExportCustomVulnScoutData:
         assert exported["assessments"] == []
         assert len(exported["ai_assessments"]) == 1
         assert exported["ai_assessments"][0]["vuln_id"] == "CVE-2099-5678"
+
+
+class TestImportTimestampOptions:
+    def test_vulnscout_import_can_preserve_original_timestamps(self, app, tmp_path):
+        from src.helpers.datetime_utils import ensure_utc_iso
+        from src.models.assessment import Assessment
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        original_timestamp = "2001-02-03T04:05:06+00:00"
+        with app.app_context():
+            project = Project.create("TimestampProject")
+            variant = Variant.create("vulnscout", project.id)
+            project_name = project.name
+            variant_id = variant.id
+
+        import_file = tmp_path / "custom-vulnscout.json"
+        import_file.write_text(json.dumps({
+            "version": 1,
+            "assessments": [{
+                "vuln_id": "CVE-2099-10001",
+                "status": "affected",
+                "packages": ["vulnscout-timestamp@1.0"],
+                "variant_id": str(variant_id),
+                "timestamp": original_timestamp,
+            }],
+        }))
+
+        result = app.test_cli_runner().invoke(args=[
+            "import-custom-vulnscout-data",
+            "--project", project_name,
+            "--use-original-timestamps",
+            str(import_file),
+        ])
+
+        assert result.exit_code == 0, result.output
+        with app.app_context():
+            imported = Assessment.get_by_origin([variant_id], origin="custom")
+            assert len(imported) == 1
+            assert ensure_utc_iso(imported[0].timestamp) == original_timestamp
+
+    def test_vulnscout_import_can_use_current_timestamps(self, app, tmp_path):
+        from src.models.assessment import Assessment
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        with app.app_context():
+            project = Project.create("TimestampProject")
+            variant = Variant.create("vulnscout-current", project.id)
+            project_name = project.name
+            variant_id = variant.id
+
+        import_file = tmp_path / "custom-vulnscout-current.json"
+        import_file.write_text(json.dumps({
+            "version": 1,
+            "assessments": [{
+                "vuln_id": "CVE-2099-10003",
+                "status": "affected",
+                "packages": ["vulnscout-current@1.0"],
+                "variant_id": str(variant_id),
+                "timestamp": "2001-02-03T04:05:06+00:00",
+            }],
+        }))
+        before_import = datetime.now(timezone.utc)
+
+        result = app.test_cli_runner().invoke(args=[
+            "import-custom-vulnscout-data",
+            "--project", project_name,
+            "--use-current-timestamps",
+            str(import_file),
+        ])
+        after_import = datetime.now(timezone.utc)
+
+        assert result.exit_code == 0, result.output
+        with app.app_context():
+            imported = Assessment.get_by_origin([variant_id], origin="custom")
+            assert len(imported) == 1
+            stored_timestamp = imported[0].timestamp
+            if stored_timestamp.tzinfo is None:
+                stored_timestamp = stored_timestamp.replace(tzinfo=timezone.utc)
+            assert before_import <= stored_timestamp <= after_import
+
+    def test_openvex_import_can_use_current_timestamps(self, app, tmp_path):
+        from src.models.assessment import Assessment
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        with app.app_context():
+            project = Project.create("TimestampProject")
+            variant = Variant.create("openvex", project.id)
+            project_name = project.name
+            variant_name = variant.name
+            variant_id = variant.id
+
+        import_file = tmp_path / "custom-openvex.json"
+        import_file.write_text(json.dumps({
+            "@context": "https://openvex.dev/ns/v0.2.0",
+            "statements": [{
+                "vulnerability": {"name": "CVE-2099-10002"},
+                "status": "affected",
+                "products": [{"@id": "openvex-timestamp@1.0"}],
+                "timestamp": "2001-02-03T04:05:06+00:00",
+            }],
+        }))
+        before_import = datetime.now(timezone.utc)
+
+        result = app.test_cli_runner().invoke(args=[
+            "import-custom-openvex-assessments",
+            "--project", project_name,
+            "--variant", variant_name,
+            "--use-current-timestamps",
+            str(import_file),
+        ])
+        after_import = datetime.now(timezone.utc)
+
+        assert result.exit_code == 0, result.output
+        with app.app_context():
+            imported = Assessment.get_by_origin([variant_id], origin="custom")
+            assert len(imported) == 1
+            stored_timestamp = imported[0].timestamp
+            if stored_timestamp.tzinfo is None:
+                stored_timestamp = stored_timestamp.replace(tzinfo=timezone.utc)
+            assert before_import <= stored_timestamp <= after_import
+
+    def test_openvex_import_can_preserve_original_timestamps(self, app, tmp_path):
+        from src.helpers.datetime_utils import ensure_utc_iso
+        from src.models.assessment import Assessment
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        original_timestamp = "2001-02-03T04:05:06+00:00"
+        with app.app_context():
+            project = Project.create("TimestampProject")
+            variant = Variant.create("openvex-original", project.id)
+            project_name = project.name
+            variant_name = variant.name
+            variant_id = variant.id
+
+        import_file = tmp_path / "custom-openvex-original.json"
+        import_file.write_text(json.dumps({
+            "@context": "https://openvex.dev/ns/v0.2.0",
+            "statements": [{
+                "vulnerability": {"name": "CVE-2099-10004"},
+                "status": "affected",
+                "products": [{"@id": "openvex-original@1.0"}],
+                "timestamp": original_timestamp,
+            }],
+        }))
+
+        result = app.test_cli_runner().invoke(args=[
+            "import-custom-openvex-assessments",
+            "--project", project_name,
+            "--variant", variant_name,
+            "--use-original-timestamps",
+            str(import_file),
+        ])
+
+        assert result.exit_code == 0, result.output
+        with app.app_context():
+            imported = Assessment.get_by_origin([variant_id], origin="custom")
+            assert len(imported) == 1
+            assert ensure_utc_iso(imported[0].timestamp) == original_timestamp

--- a/tests/unit_tests/test_assessment_io_coverage.py
+++ b/tests/unit_tests/test_assessment_io_coverage.py
@@ -161,6 +161,7 @@ class TestBuildCustomDataExport:
             "impact_statement": None,
             "status_notes": None,
             "workaround": None,
+            "timestamp": result["ai_assessments"][0]["timestamp"],
             "packages": ["ai-pkg@1.0.0"],
             "variant_id": str(var.id),
             "variant": "io-cov-var",

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -12,6 +12,7 @@
 import io
 import json
 import uuid
+from datetime import datetime, timezone
 
 import pytest
 
@@ -626,6 +627,59 @@ def test_import_duplicate_skipped(client):
     assert r2["imported"] == 0
 
 
+def _import_openvex_with_timestamp(client, vuln_id, package, timestamp):
+    statements = [{
+        "vulnerability": {"name": vuln_id},
+        "products": [{"@id": package}],
+        "status": "affected",
+        "timestamp": timestamp,
+    }]
+    data = _make_openvex_json("default", statements)
+    return client.post(
+        "/api/assessments/review/import",
+        data={
+            "file": (io.BytesIO(data), "default.json"),
+            "variant_id": str(VARIANT_UUID),
+            "timestamp_policy": "original",
+        },
+        content_type="multipart/form-data",
+    )
+
+
+def test_import_openvex_original_timestamp_keeps_distinct_entries(client):
+    """A later statement timestamp is imported instead of skipped as duplicate."""
+    vuln_id, package = "CVE-2020-35492", "openvex-history@1.0"
+
+    first = _import_openvex_with_timestamp(
+        client, vuln_id, package, "2026-07-07T10:00:00+00:00")
+    second = _import_openvex_with_timestamp(
+        client, vuln_id, package, "2026-07-20T10:00:00+00:00")
+
+    assert json.loads(first.data)["imported"] == 1
+    assert json.loads(second.data)["imported"] == 1
+
+    listed = json.loads(client.get("/api/assessments/review").data)
+    timestamps = sorted(
+        a["timestamp"] for a in listed
+        if a["vuln_id"] == vuln_id and package in a["packages"]
+    )
+    assert timestamps == ["2026-07-07T10:00:00+00:00", "2026-07-20T10:00:00+00:00"]
+
+
+def test_import_openvex_original_timestamp_is_idempotent(client):
+    """Re-importing an identical OpenVEX document stays a no-op."""
+    vuln_id, package = "CVE-2020-35492", "openvex-idempotent@1.0"
+
+    first = _import_openvex_with_timestamp(
+        client, vuln_id, package, "2026-07-20T10:00:00+00:00")
+    second = _import_openvex_with_timestamp(
+        client, vuln_id, package, "2026-07-20T10:00:00+00:00")
+
+    assert json.loads(first.data)["imported"] == 1
+    assert json.loads(second.data)["imported"] == 0
+    assert json.loads(second.data)["skipped"] == 1
+
+
 def test_import_statement_missing_vuln(client):
     """Statement without vulnerability name → error."""
     statements = [{
@@ -1110,6 +1164,141 @@ def test_import_custom_data_assessments(client):
     result = json.loads(resp.data)
     assert result["status"] == "success"
     assert result["assessments_imported"] >= 1
+
+
+def test_import_custom_data_uses_original_timestamp(app, client):
+    original_timestamp = "2001-02-03T04:05:06+00:00"
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2099-91001",
+        "status": "affected",
+        "packages": ["timestamp-original@1.0"],
+        "variant_id": str(VARIANT_UUID),
+        "timestamp": original_timestamp,
+    }])
+    payload["timestamp_policy"] = "original"
+
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload,
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    with app.app_context():
+        from src.helpers.datetime_utils import ensure_utc_iso
+        from src.models.assessment import Assessment
+
+        imported = next(
+            assessment for assessment in Assessment.get_by_origin([VARIANT_UUID], origin="custom")
+            if assessment.vuln_id == "CVE-2099-91001"
+        )
+        assert ensure_utc_iso(imported.timestamp) == original_timestamp
+
+
+def test_import_custom_data_uses_current_system_time(app, client):
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2099-91002",
+        "status": "affected",
+        "packages": ["timestamp-current@1.0"],
+        "variant_id": str(VARIANT_UUID),
+        "timestamp": "2001-02-03T04:05:06+00:00",
+    }])
+    payload["timestamp_policy"] = "current"
+    before_import = datetime.now(timezone.utc)
+
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload,
+        content_type="application/json",
+    )
+    after_import = datetime.now(timezone.utc)
+
+    assert resp.status_code == 200
+    with app.app_context():
+        from src.models.assessment import Assessment
+
+        imported = next(
+            assessment for assessment in Assessment.get_by_origin([VARIANT_UUID], origin="custom")
+            if assessment.vuln_id == "CVE-2099-91002"
+        )
+        stored_timestamp = imported.timestamp
+        if stored_timestamp.tzinfo is None:
+            stored_timestamp = stored_timestamp.replace(tzinfo=timezone.utc)
+        assert before_import <= stored_timestamp <= after_import
+
+
+def test_import_custom_data_rejects_invalid_timestamp_policy(client):
+    payload = _custom_data_payload()
+    payload["timestamp_policy"] = "invalid"
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload,
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 400
+    assert "timestamp_policy" in json.loads(resp.data)["error"]
+
+
+def _import_custom_data_with_timestamp(client, vuln_id, package, timestamp, **extra):
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": vuln_id,
+        "status": "affected",
+        "packages": [package],
+        "variant_id": str(VARIANT_UUID),
+        "timestamp": timestamp,
+        **extra,
+    }])
+    payload["timestamp_policy"] = "original"
+    return client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload,
+        content_type="application/json",
+    )
+
+
+def test_import_custom_data_original_timestamp_keeps_distinct_entries(client):
+    """A later timestamp is a new history entry, not a duplicate to discard."""
+    vuln_id, package = "CVE-2099-91003", "timestamp-history@1.0"
+
+    first = _import_custom_data_with_timestamp(
+        client, vuln_id, package, "2026-07-07T10:00:00+00:00")
+    second = _import_custom_data_with_timestamp(
+        client, vuln_id, package, "2026-07-20T10:00:00+00:00")
+
+    assert json.loads(first.data)["assessments_imported"] == 1
+    assert json.loads(second.data)["assessments_imported"] == 1
+
+    listed = json.loads(client.get("/api/assessments/review").data)
+    timestamps = sorted(a["timestamp"] for a in listed if a["vuln_id"] == vuln_id)
+    assert timestamps == ["2026-07-07T10:00:00+00:00", "2026-07-20T10:00:00+00:00"]
+
+
+def test_import_custom_data_original_timestamp_is_idempotent(client):
+    """Re-importing the same file does not duplicate its assessments."""
+    vuln_id, package = "CVE-2099-91004", "timestamp-idempotent@1.0"
+
+    first = _import_custom_data_with_timestamp(
+        client, vuln_id, package, "2026-07-20T10:00:00+00:00")
+    second = _import_custom_data_with_timestamp(
+        client, vuln_id, package, "2026-07-20T10:00:00+00:00")
+
+    assert json.loads(first.data)["assessments_imported"] == 1
+    assert json.loads(second.data)["assessments_imported"] == 0
+    assert json.loads(second.data)["assessments_skipped"] == 1
+
+
+def test_import_custom_data_original_timestamp_normalised_to_utc(client):
+    """A non-UTC offset is converted rather than stored as wall-clock time."""
+    vuln_id, package = "CVE-2099-91005", "timestamp-offset@1.0"
+
+    resp = _import_custom_data_with_timestamp(
+        client, vuln_id, package, "2026-07-20T12:00:00+02:00")
+
+    assert json.loads(resp.data)["assessments_imported"] == 1
+    listed = json.loads(client.get("/api/assessments/review").data)
+    imported = next(a for a in listed if a["vuln_id"] == vuln_id)
+    assert imported["timestamp"] == "2026-07-20T10:00:00+00:00"
 
 
 def test_import_custom_data_assessments_without_variant_field(client):

--- a/vulnscout
+++ b/vulnscout
@@ -79,7 +79,9 @@ Scan & output commands:
   --export-cdx                    Export project as CycloneDX 1.6 SBOM
   --export-openvex                Export project as OpenVEX document
     --export-custom-vulnscout-data  Export custom VulnScout JSON data
-    --import-custom-vulnscout-data <path>  Import custom VulnScout JSON data
+        --import-custom-vulnscout-data <path>  Import custom VulnScout JSON data
+            --use-original-timestamps    Preserve file timestamps instead of using system time
+            --use-current-timestamps     Use current system time instead of file timestamps
     --export-custom-openvex-assessments  Export custom OpenVEX assessments for --variant
     --import-custom-openvex-assessments <path>  Import custom OpenVEX assessments into --variant
     --export-context                 Export AI assessment context to /scan/outputs/context-export.json
@@ -372,6 +374,10 @@ parse_and_run() {
                 call_container_engine cp "$import_ctx_file" "$CONTAINER_NAME:$import_ctx_staged"
                 EXPORT_ARGS+=(--import-context "$import_ctx_staged")
                 shift 2 ;;
+            --use-original-timestamps)
+                EXPORT_ARGS+=(--use-original-timestamps); shift ;;
+            --use-current-timestamps)
+                EXPORT_ARGS+=(--use-current-timestamps); shift ;;
             delete-scan|--delete-scan)
                 ensure_running
                 exec_container --delete-scan "$2"


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Allow user to pick between original or current timestamps when importing data in the Review tab

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open the web dashboard, initiate an import then test the different timestamp options.
For the CLI, refer to the new documentation for testing the extra timestamp args.

### Related Issue

#474 

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


