### PR TITLE
Fix: Classify outdated packages/variants correctly

### DIFF
--- a/doc/source/interactive-mode.md
+++ b/doc/source/interactive-mode.md
@@ -79,10 +79,6 @@ While a match condition is active, the **Show Vulnerabilities** button carries t
 
 See the [Match Conditions](ci_conditions.md) page for the full syntax and token reference.
 
-### Severity Toggle
-
-The **Severity** toggle switch in the toolbar adds a colour-coded severity tag next to each package's vulnerability count, showing the highest severity among the package's associated vulnerabilities. This gives an at-a-glance view of which packages carry the most critical exposure.
-
 ### Actions
 
 Each row has a **Show Vulnerabilities** button that navigates to the Vulnerability Table pre-filtered to show only the vulnerabilities associated with that specific package.

--- a/doc/source/interactive-mode.md
+++ b/doc/source/interactive-mode.md
@@ -70,6 +70,7 @@ The **Columns** dropdown lets you toggle which columns are displayed. The defaul
 ### Filters
 
 - **Source**: restrict the table to packages originating from a specific SBOM source (e.g. a particular SPDX or CycloneDX document).
+- **Outdated**: enable the toggle to show only historical package/variant combinations whose package version is no longer present in that variant's current SBOM. The toggle is off by default.
 
 ### Match Condition
 

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -28,6 +28,7 @@ type Props = {
     defaultSelectedPackages?: string[];
     variantPackageMap?: Record<string, string[]>;
     variantFindingsMap?: Record<string, Array<{ pkg: string; outdated: boolean }>>;
+    findingsLoading?: boolean;
 }
 
 function EditAssessment({
@@ -42,7 +43,8 @@ function EditAssessment({
     availablePackages,
     defaultSelectedPackages,
     variantPackageMap,
-    variantFindingsMap
+    variantFindingsMap,
+    findingsLoading = false
 }: Readonly<Props>) {
     const isImpactStatus = assessment.status === 'not_affected' || assessment.status === 'false_positive';
     const [status, setStatus] = useState(assessment.status || "under_investigation");
@@ -62,20 +64,27 @@ function EditAssessment({
     );
     const [includeOutdatedPackages, setIncludeOutdatedPackages] = useState(false);
     const outdatedPackages = useMemo(() => {
-        const findingStates = new Map<string, boolean>();
+        const packages = new Set<string>();
         for (const finding of Object.values(variantFindingsMap ?? {}).flat()) {
-            findingStates.set(finding.pkg, (findingStates.get(finding.pkg) ?? true) && finding.outdated);
+            if (finding.outdated) packages.add(finding.pkg);
         }
-        return new Set([...findingStates].filter(([, outdated]) => outdated).map(([pkg]) => pkg));
+        return packages;
     }, [variantFindingsMap]);
+    const packagesWithCurrentFindings = useMemo(() => new Set(
+        Object.values(variantFindingsMap ?? {}).flatMap(findings =>
+            findings.filter(finding => !finding.outdated).map(finding => finding.pkg)
+        )
+    ), [variantFindingsMap]);
     const packageOptions = useMemo(() => {
-        const options = new Set((availablePackages ?? []).filter(pkg => !outdatedPackages.has(pkg)));
+        const options = new Set((availablePackages ?? []).filter(pkg =>
+            !outdatedPackages.has(pkg) || packagesWithCurrentFindings.has(pkg)
+        ));
         for (const pkg of defaultSelectedPackages ?? []) options.add(pkg);
         if (includeOutdatedPackages) {
             for (const pkg of outdatedPackages) options.add(pkg);
         }
         return [...options];
-    }, [availablePackages, defaultSelectedPackages, includeOutdatedPackages, outdatedPackages]);
+    }, [availablePackages, defaultSelectedPackages, includeOutdatedPackages, outdatedPackages, packagesWithCurrentFindings]);
     const effectiveVariantPackageMap = useMemo(() => {
         if (!variantPackageMap) return undefined;
         const result: Record<string, string[]> = {};
@@ -325,25 +334,32 @@ function EditAssessment({
             </h3>
 
             {availableVariants && availableVariants.length > 0 && (
-                <div className="mt-2 mb-2 ml-1">
-                    <p className="text-sm font-medium text-gray-300 mb-1">Apply to variants:</p>
-                    <div className="flex flex-wrap gap-x-4 gap-y-1">
+                <div className="mt-3 rounded-lg border border-gray-600 bg-gray-800/40 p-3">
+                    <p className="mb-2 text-sm font-medium text-gray-200">Apply to variants:</p>
+                    <span className="float-right -mt-7 text-xs text-gray-400">{selectedVariantIds.length} selected</span>
+                    <div className="flex flex-wrap gap-2">
                         {availableVariants.map(v => {
                             const incompatible = allowedVariants !== null && !allowedVariants.has(v.id);
+                            const selected = selectedVariantIds.includes(v.id);
                             return (
                             <label
                                 key={v.id}
-                                className={['flex items-center gap-1.5 text-sm select-none', incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'].join(' ')}
-                                title={incompatible ? 'No selected package is present in this variant' : undefined}
+                                className={[
+                                    'inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium transition-colors select-none',
+                                    selected ? 'border-blue-400 bg-blue-500/20 text-blue-100' : 'border-gray-600 bg-gray-700/60 text-gray-300 hover:border-gray-500',
+                                    incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+                                ].join(' ')}
+                                title={incompatible ? 'Not every selected package version applies to this variant' : undefined}
                             >
                                 <input
                                     type="checkbox"
-                                    checked={selectedVariantIds.includes(v.id)}
+                                    checked={selected}
                                     disabled={incompatible}
                                     onChange={(e) => handleVariantToggle(v.id, e.target.checked)}
-                                    className="accent-blue-500"
+                                    className="sr-only"
                                 />
-                                <span className="text-gray-200">{v.name}</span>
+                                <span aria-hidden="true" className="mr-1.5 text-xs">{selected ? '✓' : '+'}</span>
+                                <span>{v.name}</span>
                             </label>
                             );
                         })}
@@ -351,38 +367,51 @@ function EditAssessment({
                 </div>
             )}
             {availablePackages && (packageOptions.length > 1 || outdatedPackages.size > 0) && (
-                <div className="mt-2 mb-2 ml-1">
-                    <p className="text-sm font-medium text-gray-300 mb-1">Apply to packages:</p>
-                    {outdatedPackages.size > 0 && (
-                        <label className="flex items-center gap-1.5 mb-1 text-sm text-amber-300 cursor-pointer select-none">
+                <div className="mt-3 rounded-lg border border-gray-600 bg-gray-800/40 p-3">
+                    <p className="mb-2 text-sm font-medium text-gray-200">Apply to packages:</p>
+                    <span className="float-right -mt-7 text-xs text-gray-400">{selectedPackages.length} selected</span>
+                    {findingsLoading && (
+                        <p className="mb-2 text-xs text-gray-400 animate-pulse">Checking for previous package versions…</p>
+                    )}
+                    {!findingsLoading && outdatedPackages.size > 0 && (
+                        <label className="mb-3 flex items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200 cursor-pointer select-none">
+                            <span>
+                                <span className="block font-medium">Include previous package versions</span>
+                                <span className="block text-xs text-amber-200/70">Show package versions from previous scans ({outdatedPackages.size})</span>
+                            </span>
                             <input
                                 type="checkbox"
+                                aria-label="Include previous package versions"
                                 checked={includeOutdatedPackages}
                                 onChange={event => handleIncludeOutdatedPackages(event.target.checked)}
-                                className="accent-amber-500"
+                                className="h-4 w-4 accent-amber-500"
                             />
-                            Include outdated package versions
                         </label>
                     )}
-                    <div className="flex flex-wrap gap-x-4 gap-y-1">
+                    <div className="flex flex-wrap gap-2">
                         {packageOptions.map(pkg => {
                             const isOutdated = outdatedPackages.has(pkg);
                             const incompatible = allowedPackages !== null && !allowedPackages.has(pkg);
+                            const selected = selectedPackages.includes(pkg);
                             return (
                             <label
                                 key={pkg}
-                                className={['flex items-center gap-1.5 text-sm select-none', incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'].join(' ')}
-                                title={incompatible ? 'Package has no finding in the selected variants' : (isOutdated ? 'Not in the current SBOM' : undefined)}
+                                className={[
+                                    'inline-flex items-center rounded-full border px-3 py-1.5 text-sm transition-colors select-none',
+                                    selected ? 'border-blue-400 bg-blue-500/20 text-blue-100' : 'border-gray-600 bg-gray-700/60 text-gray-300 hover:border-gray-500',
+                                    incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+                                ].join(' ')}
+                                title={incompatible ? 'This package version does not apply to every selected variant' : (isOutdated ? 'From a previous scan' : undefined)}
                             >
                                 <input
                                     type="checkbox"
-                                    checked={selectedPackages.includes(pkg)}
+                                    checked={selected}
                                     disabled={incompatible}
                                     onChange={(e) => handlePackageToggle(pkg, e.target.checked)}
-                                    className="accent-blue-400"
+                                    className="sr-only"
                                 />
-                                <span className={`font-mono ${incompatible ? 'text-gray-500' : 'text-gray-200'}`}>{formatPkgId(pkg)}</span>
-                                {isOutdated && <span className="text-xs font-semibold uppercase tracking-wide text-amber-300">Outdated</span>}
+                                <span aria-hidden="true" className="mr-1.5 text-xs">{selected ? '✓' : '+'}</span>
+                                <span className={`font-mono ${incompatible ? 'text-gray-500' : ''}`}>{formatPkgId(pkg)}</span>
                             </label>
                             );
                         })}

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -47,6 +47,15 @@ function EditAssessment({
     findingsLoading = false
 }: Readonly<Props>) {
     const isImpactStatus = assessment.status === 'not_affected' || assessment.status === 'false_positive';
+    const hasSelectedOutdatedFinding = useMemo(() => {
+        const selectedPackages = new Set(defaultSelectedPackages ?? []);
+        const variantIds = defaultSelectedVariantIds ?? Object.keys(variantFindingsMap ?? {});
+        return variantIds.some(variantId =>
+            (variantFindingsMap?.[variantId] ?? []).some(finding =>
+                finding.outdated && (selectedPackages.size === 0 || selectedPackages.has(finding.pkg))
+            )
+        );
+    }, [defaultSelectedPackages, defaultSelectedVariantIds, variantFindingsMap]);
     const [status, setStatus] = useState(assessment.status || "under_investigation");
     const [justification, setJustification] = useState(assessment.justification || "none");
     // For non-impact statuses (fixed, affected, …) Yocto stores its notes in impact_statement.
@@ -62,7 +71,7 @@ function EditAssessment({
     const [selectedPackages, setSelectedPackages] = useState<string[]>(
         defaultSelectedPackages ?? (availablePackages?.length === 1 ? [availablePackages[0]] : [])
     );
-    const [includeOutdatedPackages, setIncludeOutdatedPackages] = useState(false);
+    const [includeOutdatedPackages, setIncludeOutdatedPackages] = useState(hasSelectedOutdatedFinding);
     const outdatedPackages = useMemo(() => {
         const packages = new Set<string>();
         for (const finding of Object.values(variantFindingsMap ?? {}).flat()) {
@@ -100,51 +109,32 @@ function EditAssessment({
         return result;
     }, [variantPackageMap, variantFindingsMap, defaultSelectedPackages, includeOutdatedPackages]);
 
-    // Derived: which packages are reachable from the currently selected variants,
-    // and which variants are reachable from the currently selected packages.
+    // A saved assessment applies to the full package × variant product.
+    // Therefore each enabled package must exist in every selected variant, and
+    // each enabled variant must contain every selected package.
     const allowedPackages = useMemo<Set<string> | null>(() => {
-        if (!effectiveVariantPackageMap) return null;
+        if (!effectiveVariantPackageMap || selectedVariantIds.length === 0) return null;
 
-        let effectiveVariantIds: string[];
-        if (selectedVariantIds.length > 0) {
-            effectiveVariantIds = selectedVariantIds;
-        } else if (selectedPackages.length > 0) {
-            effectiveVariantIds = Object.entries(effectiveVariantPackageMap)
-                .filter(([, pkgs]) => selectedPackages.some(p => pkgs.includes(p)))
-                .map(([vid]) => vid);
-        } else {
-            return null;
+        const [firstVariantId, ...remainingVariantIds] = selectedVariantIds;
+        const intersection = new Set(effectiveVariantPackageMap[firstVariantId] ?? []);
+        for (const variantId of remainingVariantIds) {
+            const packages = new Set(effectiveVariantPackageMap[variantId] ?? []);
+            for (const pkg of intersection) {
+                if (!packages.has(pkg)) intersection.delete(pkg);
+            }
         }
-
-        const union = new Set<string>();
-        for (const vid of effectiveVariantIds) {
-            for (const pkg of effectiveVariantPackageMap[vid] ?? []) union.add(pkg);
-        }
-        return union.size > 0 ? union : null;
-    }, [effectiveVariantPackageMap, selectedVariantIds, selectedPackages]);
+        return intersection;
+    }, [effectiveVariantPackageMap, selectedVariantIds]);
 
     const allowedVariants = useMemo<Set<string> | null>(() => {
-        if (!effectiveVariantPackageMap) return null;
-
-        let effectivePackages: string[];
-        if (selectedPackages.length > 0) {
-            effectivePackages = selectedPackages;
-        } else if (selectedVariantIds.length > 0) {
-            const union = new Set<string>();
-            for (const vid of selectedVariantIds) {
-                for (const pkg of effectiveVariantPackageMap[vid] ?? []) union.add(pkg);
-            }
-            effectivePackages = [...union];
-        } else {
-            return null;
-        }
+        if (!effectiveVariantPackageMap || selectedPackages.length === 0) return null;
 
         const allowed = new Set<string>();
         for (const [vid, pkgs] of Object.entries(effectiveVariantPackageMap)) {
-            if (effectivePackages.some(p => pkgs.includes(p))) allowed.add(vid);
+            if (selectedPackages.every(pkg => pkgs.includes(pkg))) allowed.add(vid);
         }
-        return allowed.size > 0 ? allowed : null;
-    }, [effectiveVariantPackageMap, selectedPackages, selectedVariantIds]);
+        return allowed;
+    }, [effectiveVariantPackageMap, selectedPackages]);
 
     // When a variant is unchecked, drop packages that are no longer reachable.
     const handleVariantToggle = (variantId: string, checked: boolean) => {
@@ -176,7 +166,7 @@ function EditAssessment({
         if (effectiveVariantPackageMap && nextPackages.length > 0) {
             setSelectedVariantIds(prev =>
                 prev.filter(vid =>
-                    nextPackages.some(p => (effectiveVariantPackageMap[vid] ?? []).includes(p))
+                    nextPackages.every(p => (effectiveVariantPackageMap[vid] ?? []).includes(p))
                 )
             );
         }
@@ -184,12 +174,8 @@ function EditAssessment({
 
     const handleIncludeOutdatedPackages = (checked: boolean) => {
         setIncludeOutdatedPackages(checked);
-        if (!checked) {
-            const originalPackages = new Set(defaultSelectedPackages ?? []);
-            setSelectedPackages(prev => prev.filter(pkg =>
-                !outdatedPackages.has(pkg) || originalPackages.has(pkg)
-            ));
-        }
+        setSelectedVariantIds([]);
+        setSelectedPackages([]);
     };
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
@@ -204,6 +190,10 @@ function EditAssessment({
     const closeBanner = () => {
         setBannerVisible(false);
     };
+
+    useEffect(() => {
+        setIncludeOutdatedPackages(hasSelectedOutdatedFinding);
+    }, [hasSelectedOutdatedFinding]);
 
     // Check if fields have changes compared to original assessment
     useEffect(() => {
@@ -276,10 +266,10 @@ function EditAssessment({
         setStatusNotes(assessment.status_notes || (!isImpactStatus ? (assessment.impact_statement || "") : ""));
         setWorkaround(assessment.workaround || "");
         setImpact(isImpactStatus ? (assessment.impact_statement || "") : "");
-        setIncludeOutdatedPackages(false);
+        setIncludeOutdatedPackages(hasSelectedOutdatedFinding);
         setSelectedVariantIds(defaultSelectedVariantIds ?? (availableVariants?.length === 1 ? [availableVariants[0].id] : []));
         setSelectedPackages(defaultSelectedPackages ?? (availablePackages?.length === 1 ? [availablePackages[0]] : []));
-    }, [assessment, isImpactStatus, defaultSelectedVariantIds, defaultSelectedPackages, availableVariants, availablePackages]);
+    }, [assessment, isImpactStatus, defaultSelectedVariantIds, defaultSelectedPackages, availableVariants, availablePackages, hasSelectedOutdatedFinding]);
 
     useEffect(() => {
         if (shouldClearFields) {
@@ -333,6 +323,24 @@ function EditAssessment({
                 </>}
             </h3>
 
+            {findingsLoading && (
+                <p className="mt-3 text-xs text-gray-400 animate-pulse">Checking for previous package versions…</p>
+            )}
+            {!findingsLoading && outdatedPackages.size > 0 && (
+                <label className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200 cursor-pointer select-none">
+                    <span>
+                        <span className="block font-medium">Allow edit assessments on outdated packages/variant</span>
+                        <span className="block text-xs text-amber-200/70">Changing this option resets the selected variants and packages.</span>
+                    </span>
+                    <input
+                        type="checkbox"
+                        aria-label="Allow edit assessments on outdated packages/variant"
+                        checked={includeOutdatedPackages}
+                        onChange={event => handleIncludeOutdatedPackages(event.target.checked)}
+                        className="h-4 w-4 accent-amber-500"
+                    />
+                </label>
+            )}
             {availableVariants && availableVariants.length > 0 && (
                 <div className="mt-3 rounded-lg border border-gray-600 bg-gray-800/40 p-3">
                     <p className="mb-2 text-sm font-medium text-gray-200">Apply to variants:</p>
@@ -370,24 +378,6 @@ function EditAssessment({
                 <div className="mt-3 rounded-lg border border-gray-600 bg-gray-800/40 p-3">
                     <p className="mb-2 text-sm font-medium text-gray-200">Apply to packages:</p>
                     <span className="float-right -mt-7 text-xs text-gray-400">{selectedPackages.length} selected</span>
-                    {findingsLoading && (
-                        <p className="mb-2 text-xs text-gray-400 animate-pulse">Checking for previous package versions…</p>
-                    )}
-                    {!findingsLoading && outdatedPackages.size > 0 && (
-                        <label className="mb-3 flex items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200 cursor-pointer select-none">
-                            <span>
-                                <span className="block font-medium">Include previous package versions</span>
-                                <span className="block text-xs text-amber-200/70">Show package versions from previous scans ({outdatedPackages.size})</span>
-                            </span>
-                            <input
-                                type="checkbox"
-                                aria-label="Include previous package versions"
-                                checked={includeOutdatedPackages}
-                                onChange={event => handleIncludeOutdatedPackages(event.target.checked)}
-                                className="h-4 w-4 accent-amber-500"
-                            />
-                        </label>
-                    )}
                     <div className="flex flex-wrap gap-2">
                         {packageOptions.map(pkg => {
                             const isOutdated = outdatedPackages.has(pkg);

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -144,15 +144,11 @@ function EditAssessment({
         setSelectedVariantIds(nextVariants);
 
         if (!checked && effectiveVariantPackageMap) {
-            const stillAllowed = new Set<string>();
-            for (const vid of nextVariants) {
-                for (const pkg of effectiveVariantPackageMap[vid] ?? []) stillAllowed.add(pkg);
-            }
-            if (stillAllowed.size > 0) {
-                setSelectedPackages(prev => prev.filter(p => stillAllowed.has(p)));
-            } else {
-                setSelectedPackages([]);
-            }
+            setSelectedPackages(prev => prev.filter(pkg =>
+                nextVariants.length > 0 && nextVariants.every(vid =>
+                    (effectiveVariantPackageMap[vid] ?? []).includes(pkg)
+                )
+            ));
         }
     };
 

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -27,6 +27,7 @@ type Props = {
     availablePackages?: string[];
     defaultSelectedPackages?: string[];
     variantPackageMap?: Record<string, string[]>;
+    variantFindingsMap?: Record<string, Array<{ pkg: string; outdated: boolean }>>;
 }
 
 function EditAssessment({
@@ -40,7 +41,8 @@ function EditAssessment({
     defaultSelectedVariantIds,
     availablePackages,
     defaultSelectedPackages,
-    variantPackageMap
+    variantPackageMap,
+    variantFindingsMap
 }: Readonly<Props>) {
     const isImpactStatus = assessment.status === 'not_affected' || assessment.status === 'false_positive';
     const [status, setStatus] = useState(assessment.status || "under_investigation");
@@ -58,17 +60,47 @@ function EditAssessment({
     const [selectedPackages, setSelectedPackages] = useState<string[]>(
         defaultSelectedPackages ?? (availablePackages?.length === 1 ? [availablePackages[0]] : [])
     );
+    const [includeOutdatedPackages, setIncludeOutdatedPackages] = useState(false);
+    const outdatedPackages = useMemo(() => {
+        const findingStates = new Map<string, boolean>();
+        for (const finding of Object.values(variantFindingsMap ?? {}).flat()) {
+            findingStates.set(finding.pkg, (findingStates.get(finding.pkg) ?? true) && finding.outdated);
+        }
+        return new Set([...findingStates].filter(([, outdated]) => outdated).map(([pkg]) => pkg));
+    }, [variantFindingsMap]);
+    const packageOptions = useMemo(() => {
+        const options = new Set((availablePackages ?? []).filter(pkg => !outdatedPackages.has(pkg)));
+        for (const pkg of defaultSelectedPackages ?? []) options.add(pkg);
+        if (includeOutdatedPackages) {
+            for (const pkg of outdatedPackages) options.add(pkg);
+        }
+        return [...options];
+    }, [availablePackages, defaultSelectedPackages, includeOutdatedPackages, outdatedPackages]);
+    const effectiveVariantPackageMap = useMemo(() => {
+        if (!variantPackageMap) return undefined;
+        const result: Record<string, string[]> = {};
+        for (const [variantId, packages] of Object.entries(variantPackageMap)) {
+            const selectable = new Set(packages);
+            for (const finding of variantFindingsMap?.[variantId] ?? []) {
+                if (finding.outdated && (includeOutdatedPackages || defaultSelectedPackages?.includes(finding.pkg))) {
+                    selectable.add(finding.pkg);
+                }
+            }
+            result[variantId] = [...selectable];
+        }
+        return result;
+    }, [variantPackageMap, variantFindingsMap, defaultSelectedPackages, includeOutdatedPackages]);
 
     // Derived: which packages are reachable from the currently selected variants,
     // and which variants are reachable from the currently selected packages.
     const allowedPackages = useMemo<Set<string> | null>(() => {
-        if (!variantPackageMap) return null;
+        if (!effectiveVariantPackageMap) return null;
 
         let effectiveVariantIds: string[];
         if (selectedVariantIds.length > 0) {
             effectiveVariantIds = selectedVariantIds;
         } else if (selectedPackages.length > 0) {
-            effectiveVariantIds = Object.entries(variantPackageMap)
+            effectiveVariantIds = Object.entries(effectiveVariantPackageMap)
                 .filter(([, pkgs]) => selectedPackages.some(p => pkgs.includes(p)))
                 .map(([vid]) => vid);
         } else {
@@ -77,13 +109,13 @@ function EditAssessment({
 
         const union = new Set<string>();
         for (const vid of effectiveVariantIds) {
-            for (const pkg of variantPackageMap[vid] ?? []) union.add(pkg);
+            for (const pkg of effectiveVariantPackageMap[vid] ?? []) union.add(pkg);
         }
         return union.size > 0 ? union : null;
-    }, [variantPackageMap, selectedVariantIds, selectedPackages]);
+    }, [effectiveVariantPackageMap, selectedVariantIds, selectedPackages]);
 
     const allowedVariants = useMemo<Set<string> | null>(() => {
-        if (!variantPackageMap) return null;
+        if (!effectiveVariantPackageMap) return null;
 
         let effectivePackages: string[];
         if (selectedPackages.length > 0) {
@@ -91,7 +123,7 @@ function EditAssessment({
         } else if (selectedVariantIds.length > 0) {
             const union = new Set<string>();
             for (const vid of selectedVariantIds) {
-                for (const pkg of variantPackageMap[vid] ?? []) union.add(pkg);
+                for (const pkg of effectiveVariantPackageMap[vid] ?? []) union.add(pkg);
             }
             effectivePackages = [...union];
         } else {
@@ -99,11 +131,11 @@ function EditAssessment({
         }
 
         const allowed = new Set<string>();
-        for (const [vid, pkgs] of Object.entries(variantPackageMap)) {
+        for (const [vid, pkgs] of Object.entries(effectiveVariantPackageMap)) {
             if (effectivePackages.some(p => pkgs.includes(p))) allowed.add(vid);
         }
         return allowed.size > 0 ? allowed : null;
-    }, [variantPackageMap, selectedPackages, selectedVariantIds]);
+    }, [effectiveVariantPackageMap, selectedPackages, selectedVariantIds]);
 
     // When a variant is unchecked, drop packages that are no longer reachable.
     const handleVariantToggle = (variantId: string, checked: boolean) => {
@@ -112,10 +144,10 @@ function EditAssessment({
             : selectedVariantIds.filter(id => id !== variantId);
         setSelectedVariantIds(nextVariants);
 
-        if (!checked && variantPackageMap) {
+        if (!checked && effectiveVariantPackageMap) {
             const stillAllowed = new Set<string>();
             for (const vid of nextVariants) {
-                for (const pkg of variantPackageMap[vid] ?? []) stillAllowed.add(pkg);
+                for (const pkg of effectiveVariantPackageMap[vid] ?? []) stillAllowed.add(pkg);
             }
             if (stillAllowed.size > 0) {
                 setSelectedPackages(prev => prev.filter(p => stillAllowed.has(p)));
@@ -132,12 +164,22 @@ function EditAssessment({
             : selectedPackages.filter(p => p !== pkg);
         setSelectedPackages(nextPackages);
 
-        if (variantPackageMap && nextPackages.length > 0) {
+        if (effectiveVariantPackageMap && nextPackages.length > 0) {
             setSelectedVariantIds(prev =>
                 prev.filter(vid =>
-                    nextPackages.some(p => (variantPackageMap[vid] ?? []).includes(p))
+                    nextPackages.some(p => (effectiveVariantPackageMap[vid] ?? []).includes(p))
                 )
             );
+        }
+    };
+
+    const handleIncludeOutdatedPackages = (checked: boolean) => {
+        setIncludeOutdatedPackages(checked);
+        if (!checked) {
+            const originalPackages = new Set(defaultSelectedPackages ?? []);
+            setSelectedPackages(prev => prev.filter(pkg =>
+                !outdatedPackages.has(pkg) || originalPackages.has(pkg)
+            ));
         }
     };
     const [bannerMessage, setBannerMessage] = useState<string>('');
@@ -225,6 +267,7 @@ function EditAssessment({
         setStatusNotes(assessment.status_notes || (!isImpactStatus ? (assessment.impact_statement || "") : ""));
         setWorkaround(assessment.workaround || "");
         setImpact(isImpactStatus ? (assessment.impact_statement || "") : "");
+        setIncludeOutdatedPackages(false);
         setSelectedVariantIds(defaultSelectedVariantIds ?? (availableVariants?.length === 1 ? [availableVariants[0].id] : []));
         setSelectedPackages(defaultSelectedPackages ?? (availablePackages?.length === 1 ? [availablePackages[0]] : []));
     }, [assessment, isImpactStatus, defaultSelectedVariantIds, defaultSelectedPackages, availableVariants, availablePackages]);
@@ -307,17 +350,29 @@ function EditAssessment({
                     </div>
                 </div>
             )}
-            {availablePackages && availablePackages.length > 1 && (
+            {availablePackages && (packageOptions.length > 1 || outdatedPackages.size > 0) && (
                 <div className="mt-2 mb-2 ml-1">
                     <p className="text-sm font-medium text-gray-300 mb-1">Apply to packages:</p>
+                    {outdatedPackages.size > 0 && (
+                        <label className="flex items-center gap-1.5 mb-1 text-sm text-amber-300 cursor-pointer select-none">
+                            <input
+                                type="checkbox"
+                                checked={includeOutdatedPackages}
+                                onChange={event => handleIncludeOutdatedPackages(event.target.checked)}
+                                className="accent-amber-500"
+                            />
+                            Include outdated package versions
+                        </label>
+                    )}
                     <div className="flex flex-wrap gap-x-4 gap-y-1">
-                        {availablePackages.map(pkg => {
+                        {packageOptions.map(pkg => {
+                            const isOutdated = outdatedPackages.has(pkg);
                             const incompatible = allowedPackages !== null && !allowedPackages.has(pkg);
                             return (
                             <label
                                 key={pkg}
                                 className={['flex items-center gap-1.5 text-sm select-none', incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'].join(' ')}
-                                title={incompatible ? 'Package is not present in selected variants' : undefined}
+                                title={incompatible ? 'Package has no finding in the selected variants' : (isOutdated ? 'Not in the current SBOM' : undefined)}
                             >
                                 <input
                                     type="checkbox"
@@ -327,6 +382,7 @@ function EditAssessment({
                                     className="accent-blue-400"
                                 />
                                 <span className={`font-mono ${incompatible ? 'text-gray-500' : 'text-gray-200'}`}>{formatPkgId(pkg)}</span>
+                                {isOutdated && <span className="text-xs font-semibold uppercase tracking-wide text-amber-300">Outdated</span>}
                             </label>
                             );
                         })}

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -88,7 +88,11 @@ function EditAssessment({
         const options = new Set((availablePackages ?? []).filter(pkg =>
             !outdatedPackages.has(pkg) || packagesWithCurrentFindings.has(pkg)
         ));
-        for (const pkg of defaultSelectedPackages ?? []) options.add(pkg);
+        for (const pkg of defaultSelectedPackages ?? []) {
+            if (includeOutdatedPackages || !outdatedPackages.has(pkg) || packagesWithCurrentFindings.has(pkg)) {
+                options.add(pkg);
+            }
+        }
         if (includeOutdatedPackages) {
             for (const pkg of outdatedPackages) options.add(pkg);
         }
@@ -100,14 +104,14 @@ function EditAssessment({
         for (const [variantId, packages] of Object.entries(variantPackageMap)) {
             const selectable = new Set(packages);
             for (const finding of variantFindingsMap?.[variantId] ?? []) {
-                if (finding.outdated && (includeOutdatedPackages || defaultSelectedPackages?.includes(finding.pkg))) {
+                if (finding.outdated && includeOutdatedPackages) {
                     selectable.add(finding.pkg);
                 }
             }
             result[variantId] = [...selectable];
         }
         return result;
-    }, [variantPackageMap, variantFindingsMap, defaultSelectedPackages, includeOutdatedPackages]);
+    }, [variantPackageMap, variantFindingsMap, includeOutdatedPackages]);
 
     // A saved assessment applies to the full package × variant product.
     // Therefore each enabled package must exist in every selected variant, and

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -349,20 +349,21 @@ function EditAssessment({
                         {availableVariants.map(v => {
                             const incompatible = allowedVariants !== null && !allowedVariants.has(v.id);
                             const selected = selectedVariantIds.includes(v.id);
+                            const blocked = incompatible && !selected;
                             return (
                             <label
                                 key={v.id}
                                 className={[
                                     'inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium transition-colors select-none',
                                     selected ? 'border-blue-400 bg-blue-500/20 text-blue-100' : 'border-gray-600 bg-gray-700/60 text-gray-300 hover:border-gray-500',
-                                    incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+                                    blocked ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
                                 ].join(' ')}
-                                title={incompatible ? 'Not every selected package version applies to this variant' : undefined}
+                                title={blocked ? 'Not every selected package version applies to this variant' : undefined}
                             >
                                 <input
                                     type="checkbox"
                                     checked={selected}
-                                    disabled={incompatible}
+                                    disabled={blocked}
                                     onChange={(e) => handleVariantToggle(v.id, e.target.checked)}
                                     className="sr-only"
                                 />
@@ -383,25 +384,26 @@ function EditAssessment({
                             const isOutdated = outdatedPackages.has(pkg);
                             const incompatible = allowedPackages !== null && !allowedPackages.has(pkg);
                             const selected = selectedPackages.includes(pkg);
+                            const blocked = incompatible && !selected;
                             return (
                             <label
                                 key={pkg}
                                 className={[
                                     'inline-flex items-center rounded-full border px-3 py-1.5 text-sm transition-colors select-none',
                                     selected ? 'border-blue-400 bg-blue-500/20 text-blue-100' : 'border-gray-600 bg-gray-700/60 text-gray-300 hover:border-gray-500',
-                                    incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+                                    blocked ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
                                 ].join(' ')}
-                                title={incompatible ? 'This package version does not apply to every selected variant' : (isOutdated ? 'From a previous scan' : undefined)}
+                                title={blocked ? 'This package version does not apply to every selected variant' : (isOutdated ? 'From a previous scan' : undefined)}
                             >
                                 <input
                                     type="checkbox"
                                     checked={selected}
-                                    disabled={incompatible}
+                                    disabled={blocked}
                                     onChange={(e) => handlePackageToggle(pkg, e.target.checked)}
                                     className="sr-only"
                                 />
                                 <span aria-hidden="true" className="mr-1.5 text-xs">{selected ? '✓' : '+'}</span>
-                                <span className={`font-mono ${incompatible ? 'text-gray-500' : ''}`}>{formatPkgId(pkg)}</span>
+                                <span className={`font-mono ${blocked ? 'text-gray-500' : ''}`}>{formatPkgId(pkg)}</span>
                             </label>
                             );
                         })}

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -336,20 +336,21 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                     {variants.map(v => {
                         const incompatible = allowedVariants !== null && !allowedVariants.has(v.id);
                         const selected = selectedVariantIds.includes(v.id);
+                        const blocked = incompatible && !selected;
                         return (
                         <label
                             key={v.id}
                             className={[
                                 'inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium transition-colors select-none',
                                 selected ? 'border-blue-400 bg-blue-500/20 text-blue-100' : 'border-gray-600 bg-gray-700/60 text-gray-300 hover:border-gray-500',
-                                incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+                                blocked ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
                             ].join(' ')}
-                            title={incompatible ? 'Not every selected package version applies to this variant' : undefined}
+                            title={blocked ? 'Not every selected package version applies to this variant' : undefined}
                         >
                             <input
                                 type="checkbox"
                                 checked={selected}
-                                disabled={incompatible}
+                                disabled={blocked}
                                 onChange={(e) => handleVariantToggle(v.id, e.target.checked)}
                                 className="sr-only"
                             />
@@ -371,25 +372,26 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                         const isOutdated = outdatedPackages.has(pkg);
                         const incompatible = allowedPackages !== null && !allowedPackages.has(pkg);
                         const selected = selectedPackages.includes(pkg);
+                        const blocked = incompatible && !selected;
                         return (
                         <label
                             key={pkg}
                             className={[
                                 'inline-flex items-center rounded-full border px-3 py-1.5 text-sm transition-colors select-none',
                                 selected ? 'border-blue-400 bg-blue-500/20 text-blue-100' : 'border-gray-600 bg-gray-700/60 text-gray-300 hover:border-gray-500',
-                                incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+                                blocked ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
                             ].join(' ')}
-                            title={incompatible ? 'This package version does not apply to every selected variant' : (isOutdated ? 'From a previous scan' : undefined)}
+                            title={blocked ? 'This package version does not apply to every selected variant' : (isOutdated ? 'From a previous scan' : undefined)}
                         >
                             <input
                                 type="checkbox"
                                 checked={selected}
-                                disabled={incompatible}
+                                disabled={blocked}
                                 onChange={(e) => handlePackageToggle(pkg, e.target.checked)}
                                 className="sr-only"
                             />
                             <span aria-hidden="true" className="mr-1.5 text-xs">{selected ? '✓' : '+'}</span>
-                            <span className={`font-mono ${incompatible ? 'text-gray-500' : isActive ? '' : 'italic'}`}>{formatPkgId(pkg)}</span>
+                            <span className={`font-mono ${blocked ? 'text-gray-500' : isActive ? '' : 'italic'}`}>{formatPkgId(pkg)}</span>
                         </label>
                         );
                     })}

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -91,53 +91,32 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         return result;
     }, [variantPackageMap, variantFindingsMap, includeOutdatedPackages]);
 
-    // Derived: which packages are reachable from the currently selected variants,
-    // and which variants are reachable from the currently selected packages.
+    // A submitted assessment applies to the full package × variant product.
+    // Therefore each enabled package must exist in every selected variant, and
+    // each enabled variant must contain every selected package.
     const allowedPackages = useMemo<Set<string> | null>(() => {
-        if (!effectiveVariantPackageMap) return null;
+        if (!effectiveVariantPackageMap || selectedVariantIds.length === 0) return null;
 
-        // Use selected variant IDs if any are checked; otherwise derive from selected packages.
-        let effectiveVariantIds: string[];
-        if (selectedVariantIds.length > 0) {
-            effectiveVariantIds = selectedVariantIds;
-        } else if (selectedPackages.length > 0) {
-            effectiveVariantIds = Object.entries(effectiveVariantPackageMap)
-                .filter(([, pkgs]) => selectedPackages.some(p => pkgs.includes(p)))
-                .map(([vid]) => vid);
-        } else {
-            return null;
+        const [firstVariantId, ...remainingVariantIds] = selectedVariantIds;
+        const intersection = new Set(effectiveVariantPackageMap[firstVariantId] ?? []);
+        for (const variantId of remainingVariantIds) {
+            const packages = new Set(effectiveVariantPackageMap[variantId] ?? []);
+            for (const pkg of intersection) {
+                if (!packages.has(pkg)) intersection.delete(pkg);
+            }
         }
-
-        const union = new Set<string>();
-        for (const vid of effectiveVariantIds) {
-            for (const pkg of effectiveVariantPackageMap[vid] ?? []) union.add(pkg);
-        }
-        return union.size > 0 ? union : null;
-    }, [effectiveVariantPackageMap, selectedVariantIds, selectedPackages]);
+        return intersection;
+    }, [effectiveVariantPackageMap, selectedVariantIds]);
 
     const allowedVariants = useMemo<Set<string> | null>(() => {
-        if (!effectiveVariantPackageMap) return null;
-
-        // Use selected packages if any are checked; otherwise derive from selected variants.
-        let effectivePackages: string[];
-        if (selectedPackages.length > 0) {
-            effectivePackages = selectedPackages;
-        } else if (selectedVariantIds.length > 0) {
-            const union = new Set<string>();
-            for (const vid of selectedVariantIds) {
-                for (const pkg of effectiveVariantPackageMap[vid] ?? []) union.add(pkg);
-            }
-            effectivePackages = [...union];
-        } else {
-            return null;
-        }
+        if (!effectiveVariantPackageMap || selectedPackages.length === 0) return null;
 
         const allowed = new Set<string>();
         for (const [vid, pkgs] of Object.entries(effectiveVariantPackageMap)) {
-            if (effectivePackages.some(p => pkgs.includes(p))) allowed.add(vid);
+            if (selectedPackages.every(pkg => pkgs.includes(pkg))) allowed.add(vid);
         }
-        return allowed.size > 0 ? allowed : null;
-    }, [effectiveVariantPackageMap, selectedPackages, selectedVariantIds]);
+        return allowed;
+    }, [effectiveVariantPackageMap, selectedPackages]);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -194,7 +173,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         if (effectiveVariantPackageMap && nextPackages.length > 0) {
             setSelectedVariantIds(prev =>
                 prev.filter(vid =>
-                    nextPackages.some(p => (effectiveVariantPackageMap[vid] ?? []).includes(p))
+                    nextPackages.every(p => (effectiveVariantPackageMap[vid] ?? []).includes(p))
                 )
             );
         }
@@ -202,9 +181,8 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
 
     const handleIncludeOutdatedPackages = (checked: boolean) => {
         setIncludeOutdatedPackages(checked);
-        if (!checked) {
-            setSelectedPackages(prev => prev.filter(pkg => !outdatedPackages.has(pkg)));
-        }
+        setSelectedVariantIds([]);
+        setSelectedPackages([]);
     };
 
     // Update status when defaultStatus prop changes
@@ -332,6 +310,24 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                 </select>
             </>}
         </h3>
+        {findingsLoading && (
+            <p className="mt-3 text-xs text-gray-400 animate-pulse">Checking for previous package versions…</p>
+        )}
+        {!findingsLoading && outdatedPackages.size > 0 && (
+            <label className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200 cursor-pointer select-none">
+                <span>
+                    <span className="block font-medium">Allow new assessments on outdated packages/variant</span>
+                    <span className="block text-xs text-amber-200/70">Changing this option resets the selected variants and packages.</span>
+                </span>
+                <input
+                    type="checkbox"
+                    aria-label="Allow new assessments on outdated packages/variant"
+                    checked={includeOutdatedPackages}
+                    onChange={event => handleIncludeOutdatedPackages(event.target.checked)}
+                    className="h-4 w-4 accent-amber-500"
+                />
+            </label>
+        )}
         {variants && variants.length > 0 && (
             <div className="mt-3 rounded-lg border border-gray-600 bg-gray-800/40 p-3">
                 <p className="mb-2 text-sm font-medium text-gray-200">Apply to variants:</p>
@@ -369,24 +365,6 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             <div className="mt-3 rounded-lg border border-gray-600 bg-gray-800/40 p-3">
                 <p className="mb-2 text-sm font-medium text-gray-200">Apply to packages:</p>
                 <span className="float-right -mt-7 text-xs text-gray-400">{selectedPackages.length} selected</span>
-                {findingsLoading && (
-                    <p className="mb-2 text-xs text-gray-400 animate-pulse">Checking for previous package versions…</p>
-                )}
-                {!findingsLoading && outdatedPackages.size > 0 && (
-                    <label className="mb-3 flex items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200 cursor-pointer select-none">
-                        <span>
-                            <span className="block font-medium">Include previous package versions</span>
-                            <span className="block text-xs text-amber-200/70">Show package versions from previous scans ({outdatedPackages.size})</span>
-                        </span>
-                        <input
-                            type="checkbox"
-                            aria-label="Include previous package versions"
-                            checked={includeOutdatedPackages}
-                            onChange={event => handleIncludeOutdatedPackages(event.target.checked)}
-                            className="h-4 w-4 accent-amber-500"
-                        />
-                    </label>
-                )}
                 <div className="flex flex-wrap gap-2">
                     {packageOptions.map(pkg => {
                         const isActive = !defaultSelectedPackages || defaultSelectedPackages.length === 0 || defaultSelectedPackages.includes(pkg);

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -26,16 +26,29 @@ type Props = {
     defaultSelectedPackages?: string[];
     /** variant_id -> packages that exist for this CVE in that variant */
     variantPackageMap?: Record<string, string[]>;
+    /** variant_id -> historical findings that may be selected explicitly */
+    variantFindingsMap?: Record<string, Array<{ pkg: string; outdated: boolean }>>;
 }
 
-function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants, availablePackages, defaultSelectedPackages, variantPackageMap}: Readonly<Props>) {
+function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants, availablePackages, defaultSelectedPackages, variantPackageMap, variantFindingsMap}: Readonly<Props>) {
+    const outdatedPackages = useMemo(() => {
+        const findingStates = new Map<string, boolean>();
+        for (const finding of Object.values(variantFindingsMap ?? {}).flat()) {
+            findingStates.set(finding.pkg, (findingStates.get(finding.pkg) ?? true) && finding.outdated);
+        }
+        return new Set([...findingStates].filter(([, outdated]) => outdated).map(([pkg]) => pkg));
+    }, [variantFindingsMap]);
+    const currentPackages = useMemo(
+        () => (availablePackages ?? []).filter(pkg => !outdatedPackages.has(pkg)),
+        [availablePackages, outdatedPackages]
+    );
     // When multiple choices exist, start fully unchecked so the user makes an
     // explicit selection; when exactly one exists auto-select it.
     const initialPackages = useMemo(() => {
-        if (availablePackages && availablePackages.length === 1) return availablePackages;
+        if (currentPackages.length === 1) return currentPackages;
         if (defaultSelectedPackages && defaultSelectedPackages.length === 1) return defaultSelectedPackages;
         return [];
-    }, [defaultSelectedPackages, availablePackages]);
+    }, [defaultSelectedPackages, currentPackages]);
 
     const [status, setStatus] = useState(defaultStatus);
     const [justification, setJustification] = useState("none");
@@ -46,18 +59,41 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         variants?.length === 1 ? [variants[0].id] : []
     );
     const [selectedPackages, setSelectedPackages] = useState<string[]>(initialPackages);
+    const [includeOutdatedPackages, setIncludeOutdatedPackages] = useState(false);
+
+    const packageOptions = useMemo(() => {
+        const options = new Set(currentPackages);
+        if (includeOutdatedPackages) {
+            for (const pkg of outdatedPackages) options.add(pkg);
+        }
+        return [...options];
+    }, [currentPackages, includeOutdatedPackages, outdatedPackages]);
+    const effectiveVariantPackageMap = useMemo(() => {
+        if (!variantPackageMap) return undefined;
+        const result: Record<string, string[]> = {};
+        for (const [variantId, packages] of Object.entries(variantPackageMap)) {
+            const selectable = new Set(packages);
+            if (includeOutdatedPackages) {
+                for (const finding of variantFindingsMap?.[variantId] ?? []) {
+                    if (finding.outdated) selectable.add(finding.pkg);
+                }
+            }
+            result[variantId] = [...selectable];
+        }
+        return result;
+    }, [variantPackageMap, variantFindingsMap, includeOutdatedPackages]);
 
     // Derived: which packages are reachable from the currently selected variants,
     // and which variants are reachable from the currently selected packages.
     const allowedPackages = useMemo<Set<string> | null>(() => {
-        if (!variantPackageMap) return null;
+        if (!effectiveVariantPackageMap) return null;
 
         // Use selected variant IDs if any are checked; otherwise derive from selected packages.
         let effectiveVariantIds: string[];
         if (selectedVariantIds.length > 0) {
             effectiveVariantIds = selectedVariantIds;
         } else if (selectedPackages.length > 0) {
-            effectiveVariantIds = Object.entries(variantPackageMap)
+            effectiveVariantIds = Object.entries(effectiveVariantPackageMap)
                 .filter(([, pkgs]) => selectedPackages.some(p => pkgs.includes(p)))
                 .map(([vid]) => vid);
         } else {
@@ -66,13 +102,13 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
 
         const union = new Set<string>();
         for (const vid of effectiveVariantIds) {
-            for (const pkg of variantPackageMap[vid] ?? []) union.add(pkg);
+            for (const pkg of effectiveVariantPackageMap[vid] ?? []) union.add(pkg);
         }
         return union.size > 0 ? union : null;
-    }, [variantPackageMap, selectedVariantIds, selectedPackages]);
+    }, [effectiveVariantPackageMap, selectedVariantIds, selectedPackages]);
 
     const allowedVariants = useMemo<Set<string> | null>(() => {
-        if (!variantPackageMap) return null;
+        if (!effectiveVariantPackageMap) return null;
 
         // Use selected packages if any are checked; otherwise derive from selected variants.
         let effectivePackages: string[];
@@ -81,7 +117,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         } else if (selectedVariantIds.length > 0) {
             const union = new Set<string>();
             for (const vid of selectedVariantIds) {
-                for (const pkg of variantPackageMap[vid] ?? []) union.add(pkg);
+                for (const pkg of effectiveVariantPackageMap[vid] ?? []) union.add(pkg);
             }
             effectivePackages = [...union];
         } else {
@@ -89,11 +125,11 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         }
 
         const allowed = new Set<string>();
-        for (const [vid, pkgs] of Object.entries(variantPackageMap)) {
+        for (const [vid, pkgs] of Object.entries(effectiveVariantPackageMap)) {
             if (effectivePackages.some(p => pkgs.includes(p))) allowed.add(vid);
         }
         return allowed.size > 0 ? allowed : null;
-    }, [variantPackageMap, selectedPackages, selectedVariantIds]);
+    }, [effectiveVariantPackageMap, selectedPackages, selectedVariantIds]);
     const [bannerMessage, setBannerMessage] = useState<string>('');
     const [bannerType, setBannerType] = useState<'error' | 'success'>('success');
     const [bannerVisible, setBannerVisible] = useState<boolean>(false);
@@ -125,10 +161,10 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             : selectedVariantIds.filter(id => id !== variantId);
         setSelectedVariantIds(nextVariants);
 
-        if (!checked && variantPackageMap) {
+        if (!checked && effectiveVariantPackageMap) {
             const stillAllowed = new Set<string>();
             for (const vid of nextVariants) {
-                for (const pkg of variantPackageMap[vid] ?? []) stillAllowed.add(pkg);
+                for (const pkg of effectiveVariantPackageMap[vid] ?? []) stillAllowed.add(pkg);
             }
             if (stillAllowed.size > 0) {
                 setSelectedPackages(prev => prev.filter(p => stillAllowed.has(p)));
@@ -147,12 +183,19 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             : selectedPackages.filter(p => p !== pkg);
         setSelectedPackages(nextPackages);
 
-        if (variantPackageMap && nextPackages.length > 0) {
+        if (effectiveVariantPackageMap && nextPackages.length > 0) {
             setSelectedVariantIds(prev =>
                 prev.filter(vid =>
-                    nextPackages.some(p => (variantPackageMap[vid] ?? []).includes(p))
+                    nextPackages.some(p => (effectiveVariantPackageMap[vid] ?? []).includes(p))
                 )
             );
+        }
+    };
+
+    const handleIncludeOutdatedPackages = (checked: boolean) => {
+        setIncludeOutdatedPackages(checked);
+        if (!checked) {
+            setSelectedPackages(prev => prev.filter(pkg => !outdatedPackages.has(pkg)));
         }
     };
 
@@ -225,6 +268,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         setStatusNotes("");
         setWorkaround("");
         setImpact("");
+        setIncludeOutdatedPackages(false);
         setSelectedVariantIds(variants?.length === 1 ? [variants[0].id] : []);
         setSelectedPackages(
             (availablePackages?.length === 1 ? availablePackages :
@@ -306,18 +350,30 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                 </div>
             </div>
         )}
-        {availablePackages && availablePackages.length >= 1 && (
+        {availablePackages && (availablePackages.length >= 1 || outdatedPackages.size > 0) && (
             <div className="mt-2 mb-2 ml-1">
                 <p className="text-sm font-medium text-gray-300 mb-1">Apply to packages:</p>
+                {outdatedPackages.size > 0 && (
+                    <label className="flex items-center gap-1.5 mb-1 text-sm text-amber-300 cursor-pointer select-none">
+                        <input
+                            type="checkbox"
+                            checked={includeOutdatedPackages}
+                            onChange={event => handleIncludeOutdatedPackages(event.target.checked)}
+                            className="accent-amber-500"
+                        />
+                        Include outdated package versions
+                    </label>
+                )}
                 <div className="flex flex-wrap gap-x-4 gap-y-1">
-                    {availablePackages.map(pkg => {
+                    {packageOptions.map(pkg => {
                         const isActive = !defaultSelectedPackages || defaultSelectedPackages.length === 0 || defaultSelectedPackages.includes(pkg);
+                        const isOutdated = outdatedPackages.has(pkg);
                         const incompatible = allowedPackages !== null && !allowedPackages.has(pkg);
                         return (
                         <label
                             key={pkg}
                             className={['flex items-center gap-1.5 text-sm select-none', incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'].join(' ')}
-                            title={incompatible ? 'Package is not present in selected variants' : (isActive ? undefined : 'Not in active SBOM')}
+                            title={incompatible ? 'Package has no finding in the selected variants' : (isOutdated ? 'Not in the current SBOM' : undefined)}
                         >
                             <input
                                 type="checkbox"
@@ -327,6 +383,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                                 className="accent-blue-400"
                             />
                             <span className={`font-mono ${incompatible ? 'text-gray-500' : isActive ? 'text-gray-200' : 'text-gray-500 italic'}`}>{formatPkgId(pkg)}</span>
+                            {isOutdated && <span className="text-xs font-semibold uppercase tracking-wide text-amber-300">Outdated</span>}
                         </label>
                         );
                     })}

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -28,19 +28,27 @@ type Props = {
     variantPackageMap?: Record<string, string[]>;
     /** variant_id -> historical findings that may be selected explicitly */
     variantFindingsMap?: Record<string, Array<{ pkg: string; outdated: boolean }>>;
+    findingsLoading?: boolean;
 }
 
-function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants, availablePackages, defaultSelectedPackages, variantPackageMap, variantFindingsMap}: Readonly<Props>) {
+function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFields, onFieldsChange, triggerBanner, defaultStatus = "under_investigation", variants, availablePackages, defaultSelectedPackages, variantPackageMap, variantFindingsMap, findingsLoading = false}: Readonly<Props>) {
     const outdatedPackages = useMemo(() => {
-        const findingStates = new Map<string, boolean>();
+        const packages = new Set<string>();
         for (const finding of Object.values(variantFindingsMap ?? {}).flat()) {
-            findingStates.set(finding.pkg, (findingStates.get(finding.pkg) ?? true) && finding.outdated);
+            if (finding.outdated) packages.add(finding.pkg);
         }
-        return new Set([...findingStates].filter(([, outdated]) => outdated).map(([pkg]) => pkg));
+        return packages;
     }, [variantFindingsMap]);
+    const packagesWithCurrentFindings = useMemo(() => new Set(
+        Object.values(variantFindingsMap ?? {}).flatMap(findings =>
+            findings.filter(finding => !finding.outdated).map(finding => finding.pkg)
+        )
+    ), [variantFindingsMap]);
     const currentPackages = useMemo(
-        () => (availablePackages ?? []).filter(pkg => !outdatedPackages.has(pkg)),
-        [availablePackages, outdatedPackages]
+        () => (availablePackages ?? []).filter(pkg =>
+            !outdatedPackages.has(pkg) || packagesWithCurrentFindings.has(pkg)
+        ),
+        [availablePackages, outdatedPackages, packagesWithCurrentFindings]
     );
     // When multiple choices exist, start fully unchecked so the user makes an
     // explicit selection; when exactly one exists auto-select it.
@@ -325,25 +333,32 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             </>}
         </h3>
         {variants && variants.length > 0 && (
-            <div className="mt-2 mb-2 ml-1">
-                <p className="text-sm font-medium text-gray-300 mb-1">Apply to variants:</p>
-                <div className="flex flex-wrap gap-x-4 gap-y-1">
+            <div className="mt-3 rounded-lg border border-gray-600 bg-gray-800/40 p-3">
+                <p className="mb-2 text-sm font-medium text-gray-200">Apply to variants:</p>
+                <span className="float-right -mt-7 text-xs text-gray-400">{selectedVariantIds.length} selected</span>
+                <div className="flex flex-wrap gap-2">
                     {variants.map(v => {
                         const incompatible = allowedVariants !== null && !allowedVariants.has(v.id);
+                        const selected = selectedVariantIds.includes(v.id);
                         return (
                         <label
                             key={v.id}
-                            className={['flex items-center gap-1.5 text-sm select-none', incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'].join(' ')}
-                            title={incompatible ? 'No selected package is present in this variant' : undefined}
+                            className={[
+                                'inline-flex items-center rounded-full border px-3 py-1.5 text-sm font-medium transition-colors select-none',
+                                selected ? 'border-blue-400 bg-blue-500/20 text-blue-100' : 'border-gray-600 bg-gray-700/60 text-gray-300 hover:border-gray-500',
+                                incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+                            ].join(' ')}
+                            title={incompatible ? 'Not every selected package version applies to this variant' : undefined}
                         >
                             <input
                                 type="checkbox"
-                                checked={selectedVariantIds.includes(v.id)}
+                                checked={selected}
                                 disabled={incompatible}
                                 onChange={(e) => handleVariantToggle(v.id, e.target.checked)}
-                                className="accent-blue-500"
+                                className="sr-only"
                             />
-                            <span className="text-gray-200">{v.name}</span>
+                            <span aria-hidden="true" className="mr-1.5 text-xs">{selected ? '✓' : '+'}</span>
+                            <span>{v.name}</span>
                         </label>
                         );
                     })}
@@ -351,39 +366,52 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             </div>
         )}
         {availablePackages && (availablePackages.length >= 1 || outdatedPackages.size > 0) && (
-            <div className="mt-2 mb-2 ml-1">
-                <p className="text-sm font-medium text-gray-300 mb-1">Apply to packages:</p>
-                {outdatedPackages.size > 0 && (
-                    <label className="flex items-center gap-1.5 mb-1 text-sm text-amber-300 cursor-pointer select-none">
+            <div className="mt-3 rounded-lg border border-gray-600 bg-gray-800/40 p-3">
+                <p className="mb-2 text-sm font-medium text-gray-200">Apply to packages:</p>
+                <span className="float-right -mt-7 text-xs text-gray-400">{selectedPackages.length} selected</span>
+                {findingsLoading && (
+                    <p className="mb-2 text-xs text-gray-400 animate-pulse">Checking for previous package versions…</p>
+                )}
+                {!findingsLoading && outdatedPackages.size > 0 && (
+                    <label className="mb-3 flex items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200 cursor-pointer select-none">
+                        <span>
+                            <span className="block font-medium">Include previous package versions</span>
+                            <span className="block text-xs text-amber-200/70">Show package versions from previous scans ({outdatedPackages.size})</span>
+                        </span>
                         <input
                             type="checkbox"
+                            aria-label="Include previous package versions"
                             checked={includeOutdatedPackages}
                             onChange={event => handleIncludeOutdatedPackages(event.target.checked)}
-                            className="accent-amber-500"
+                            className="h-4 w-4 accent-amber-500"
                         />
-                        Include outdated package versions
                     </label>
                 )}
-                <div className="flex flex-wrap gap-x-4 gap-y-1">
+                <div className="flex flex-wrap gap-2">
                     {packageOptions.map(pkg => {
                         const isActive = !defaultSelectedPackages || defaultSelectedPackages.length === 0 || defaultSelectedPackages.includes(pkg);
                         const isOutdated = outdatedPackages.has(pkg);
                         const incompatible = allowedPackages !== null && !allowedPackages.has(pkg);
+                        const selected = selectedPackages.includes(pkg);
                         return (
                         <label
                             key={pkg}
-                            className={['flex items-center gap-1.5 text-sm select-none', incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'].join(' ')}
-                            title={incompatible ? 'Package has no finding in the selected variants' : (isOutdated ? 'Not in the current SBOM' : undefined)}
+                            className={[
+                                'inline-flex items-center rounded-full border px-3 py-1.5 text-sm transition-colors select-none',
+                                selected ? 'border-blue-400 bg-blue-500/20 text-blue-100' : 'border-gray-600 bg-gray-700/60 text-gray-300 hover:border-gray-500',
+                                incompatible ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+                            ].join(' ')}
+                            title={incompatible ? 'This package version does not apply to every selected variant' : (isOutdated ? 'From a previous scan' : undefined)}
                         >
                             <input
                                 type="checkbox"
-                                checked={selectedPackages.includes(pkg)}
+                                checked={selected}
                                 disabled={incompatible}
                                 onChange={(e) => handlePackageToggle(pkg, e.target.checked)}
-                                className="accent-blue-400"
+                                className="sr-only"
                             />
-                            <span className={`font-mono ${incompatible ? 'text-gray-500' : isActive ? 'text-gray-200' : 'text-gray-500 italic'}`}>{formatPkgId(pkg)}</span>
-                            {isOutdated && <span className="text-xs font-semibold uppercase tracking-wide text-amber-300">Outdated</span>}
+                            <span aria-hidden="true" className="mr-1.5 text-xs">{selected ? '✓' : '+'}</span>
+                            <span className={`font-mono ${incompatible ? 'text-gray-500' : isActive ? '' : 'italic'}`}>{formatPkgId(pkg)}</span>
                         </label>
                         );
                     })}

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -149,15 +149,11 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         setSelectedVariantIds(nextVariants);
 
         if (!checked && effectiveVariantPackageMap) {
-            const stillAllowed = new Set<string>();
-            for (const vid of nextVariants) {
-                for (const pkg of effectiveVariantPackageMap[vid] ?? []) stillAllowed.add(pkg);
-            }
-            if (stillAllowed.size > 0) {
-                setSelectedPackages(prev => prev.filter(p => stillAllowed.has(p)));
-            } else {
-                setSelectedPackages([]);
-            }
+            setSelectedPackages(prev => prev.filter(pkg =>
+                nextVariants.length > 0 && nextVariants.every(vid =>
+                    (effectiveVariantPackageMap[vid] ?? []).includes(pkg)
+                )
+            ));
         }
     };
 

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -1750,6 +1750,7 @@ type VariantScopedSnapshot = {
                                             availablePackages={projectPackages}
                                             defaultSelectedPackages={vuln.packages_current}
                                             variantPackageMap={Object.keys(variantPackageMap).length > 0 ? variantPackageMap : undefined}
+                                            variantFindingsMap={variantFindingsMap}
                                         />
                                     </li>
                                 )}
@@ -1935,6 +1936,8 @@ type VariantScopedSnapshot = {
                                                         )]}
                                                         availablePackages={projectPackages}
                                                         defaultSelectedPackages={group.packages}
+                                                        variantPackageMap={Object.keys(variantPackageMap).length > 0 ? variantPackageMap : undefined}
+                                                        variantFindingsMap={variantFindingsMap}
                                                     />
                                                 </div>
                                             )}

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -883,11 +883,10 @@ type VariantScopedSnapshot = {
         const groups: { [key: string]: Assessment[] } = {};
 
         assessments.forEach(assess => {
-            // Create a key based on timestamp (date only), status, and assessment content
-            const date = new Date(assess.timestamp);
-            const dateKey = date.toDateString(); // This gives us just the date part
+            // Rows created by one user action share the exact timestamp. Keep
+            // separate actions distinct even when their content is identical.
             const contentKey = `${assess.simplified_status}|${assess.justification || ''}|${assess.impact_statement || ''}|${assess.status_notes || ''}|${assess.workaround || ''}`;
-            const groupKey = `${dateKey}::${contentKey}`;
+            const groupKey = `${assess.timestamp}::${contentKey}`;
 
             if (!groups[groupKey]) {
                 groups[groupKey] = [];
@@ -1834,12 +1833,10 @@ type VariantScopedSnapshot = {
                                     const isNewlyAdded = group.assessments.some(assess => newAssessmentIds.has(assess.id));
                                     const isBeingEdited = editingAssessmentId === firstAssess.id;
                                     const groupOrigins = [...new Set(group.assessments.map(a => a.origin).filter(Boolean))];
-                                    const groupDateKey = new Date(group.timestamp).toDateString();
-                                    const groupFingerprint = `${firstAssess.simplified_status}|${firstAssess.justification || ''}|${firstAssess.impact_statement || ''}|${firstAssess.status_notes || ''}|${firstAssess.workaround || ''}`;
-                                    const matchingAssessmentsFromApi = allVulnAssessments.filter(a => {
-                                        const fingerprint = `${a.simplified_status}|${a.justification || ''}|${a.impact_statement || ''}|${a.status_notes || ''}|${a.workaround || ''}`;
-                                        return new Date(a.timestamp).toDateString() === groupDateKey && fingerprint === groupFingerprint;
-                                    });
+                                    const groupAssessmentIds = new Set(group.assessments.map(a => a.id));
+                                    const matchingAssessmentsFromApi = allVulnAssessments.filter(a =>
+                                        groupAssessmentIds.has(a.id)
+                                    );
                                     const matchingAssessments = matchingAssessmentsFromApi.length > 0
                                         ? matchingAssessmentsFromApi
                                         : group.assessments;

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -115,6 +115,12 @@ type AssessmentGroup = {
 
 type StatusSortKey = 'variant' | 'package' | 'status' | 'justification' | 'impact' | 'notes' | 'workaround';
 
+type VariantFinding = {
+    findingId: string;
+    pkg: string;
+    outdated: boolean;
+};
+
 type VariantScopedSnapshot = {
     variantId: string;
     variantName: string;
@@ -147,6 +153,7 @@ type VariantScopedSnapshot = {
     const [selectedTargetVariantIds, setSelectedTargetVariantIds] = useState<string[]>([]);
     const [variantSnapshots, setVariantSnapshots] = useState<VariantScopedSnapshot[]>([]);
     const [variantPackageMap, setVariantPackageMap] = useState<Record<string, string[]>>({});
+    const [variantFindingsMap, setVariantFindingsMap] = useState<Record<string, VariantFinding[]>>({});
     // True once the active-SBOM package list has been fetched for every variant,
     // so deprecated packages can reliably be split into their own table.
     const [variantPackageMapLoaded, setVariantPackageMapLoaded] = useState(false);
@@ -295,6 +302,7 @@ type VariantScopedSnapshot = {
         const controller = new AbortController();
         const signal = controller.signal;
         setVariantPackageMapLoaded(false);
+        setVariantFindingsMap({});
         if (availableVariants.length === 0) {
             // Only mark as loaded once we know variants have been resolved.
             // If variants are still loading (variantsLoadedForVulnId !== vuln.id),
@@ -322,20 +330,33 @@ type VariantScopedSnapshot = {
                 const response = await fetch(url.toString(), { mode: 'cors', signal });
                 const data = response.ok ? await response.json() : [];
                 const map: Record<string, string[]> = {};
+                const findingsMap: Record<string, VariantFinding[]> = {};
                 if (Array.isArray(data)) {
                     for (const entry of data) {
                         if (entry && typeof entry.variant_id === 'string' && Array.isArray(entry.active_packages)) {
                             map[entry.variant_id] = entry.active_packages.filter((p: unknown): p is string => typeof p === 'string');
+                            if (Array.isArray(entry.findings)) {
+                                findingsMap[entry.variant_id] = entry.findings.flatMap((finding: any): VariantFinding[] => {
+                                    if (typeof finding?.finding_id !== 'string' || typeof finding?.package !== 'string') return [];
+                                    return [{
+                                        findingId: finding.finding_id,
+                                        pkg: finding.package,
+                                        outdated: finding.outdated === true,
+                                    }];
+                                });
+                            }
                         }
                     }
                 }
                 if (!signal.aborted) {
                     setVariantPackageMap(map);
+                    setVariantFindingsMap(findingsMap);
                     setVariantPackageMapLoaded(true);
                 }
             } catch {
                 if (!signal.aborted) {
                     setVariantPackageMap({});
+                    setVariantFindingsMap({});
                     setVariantPackageMapLoaded(true);
                 }
             }
@@ -1703,13 +1724,13 @@ type VariantScopedSnapshot = {
                             <h3 className="font-bold mb-2">Assessments</h3>
                             {currentAssessmentRows.length > 0 && (
                                 <div className="mb-4 p-3 rounded-lg bg-gray-800/70 border border-gray-600">
-                                    <h4 className="font-semibold text-gray-200 mb-2">Assessments on current SBOMs packages</h4>
+                                    <h4 className="font-semibold text-gray-200 mb-2">Assessments on current SBOM packages and variants</h4>
                                     {renderStatusTable(sortStatusRows(currentAssessmentRows))}
                                 </div>
                             )}
                             {deprecatedAssessmentRows.length > 0 && (
                                 <div className="mb-4 p-3 rounded-lg bg-gray-800/70 border border-gray-600">
-                                    <h4 className="font-semibold text-gray-200 mb-2">Assessments on old packages (not present in current SBOMs)</h4>
+                                    <h4 className="font-semibold text-gray-200 mb-2">Assessments on old packages and variants (not present in current SBOMs)</h4>
                                     {renderStatusTable(sortStatusRows(deprecatedAssessmentRows))}
                                 </div>
                             )}
@@ -1772,11 +1793,21 @@ type VariantScopedSnapshot = {
                                                 {group.packages.map(pkg => {
                                                     const { nameVersion, supplier } = splitPkgId(pkg);
                                                     const supplierName = extractSupplierName(supplier);
+                                                    const variant = availableVariants.find(v => v.id === firstAssess.variant_id);
+                                                    const finding = firstAssess.variant_id
+                                                        ? variantFindingsMap[firstAssess.variant_id]?.find(item => item.pkg === pkg)
+                                                        : undefined;
                                                     return (
                                                         <span key={pkg} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300">
                                                             <FontAwesomeIcon icon={faBox} className="w-3 h-3 mr-1" />
                                                             {nameVersion}
                                                             {supplierName && <span className="ml-1 opacity-70 text-xs">({supplierName})</span>}
+                                                            {variant && <span className="ml-1.5 opacity-80">· {variant.name}</span>}
+                                                            {finding?.outdated && (
+                                                                <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-amber-200 text-amber-900 dark:bg-amber-700 dark:text-amber-100">
+                                                                    Outdated
+                                                                </span>
+                                                            )}
                                                         </span>
                                                     );
                                                 })}
@@ -1800,19 +1831,31 @@ type VariantScopedSnapshot = {
                                     const isNewlyAdded = group.assessments.some(assess => newAssessmentIds.has(assess.id));
                                     const isBeingEdited = editingAssessmentId === firstAssess.id;
                                     const groupOrigins = [...new Set(group.assessments.map(a => a.origin).filter(Boolean))];
-                                    // Per-package staleness: map each stale package reference to the
-                                    // version(s) that supersede it, so the "Outdated" pill can be shown
-                                    // next to the specific affected package rather than the whole group.
-                                    const supersededMap: Record<string, string[]> = {};
-                                    for (const a of group.assessments) {
-                                        if (a.outdated && a.superseded_map) {
-                                            for (const [ref, versions] of Object.entries(a.superseded_map)) {
-                                                // Union the replacement versions when several assessments
-                                                // in the group flag the same package reference.
-                                                supersededMap[ref] = [...new Set([...(supersededMap[ref] ?? []), ...versions])].sort();
-                                            }
-                                        }
-                                    }
+                                    const groupDateKey = new Date(group.timestamp).toDateString();
+                                    const groupFingerprint = `${firstAssess.simplified_status}|${firstAssess.justification || ''}|${firstAssess.impact_statement || ''}|${firstAssess.status_notes || ''}|${firstAssess.workaround || ''}`;
+                                    const matchingAssessmentsFromApi = allVulnAssessments.filter(a => {
+                                        const fingerprint = `${a.simplified_status}|${a.justification || ''}|${a.impact_statement || ''}|${a.status_notes || ''}|${a.workaround || ''}`;
+                                        return new Date(a.timestamp).toDateString() === groupDateKey && fingerprint === groupFingerprint;
+                                    });
+                                    const matchingAssessments = matchingAssessmentsFromApi.length > 0
+                                        ? matchingAssessmentsFromApi
+                                        : group.assessments;
+                                    const findingTags = [...new Map(
+                                        matchingAssessments.flatMap(assessment => assessment.packages.map(pkg => {
+                                            const variant = availableVariants.find(v => v.id === assessment.variant_id);
+                                            const finding = assessment.variant_id
+                                                ? variantFindingsMap[assessment.variant_id]?.find(item => item.pkg === pkg)
+                                                : undefined;
+                                            const outdated = finding?.outdated ?? (
+                                                variantPackageMapLoaded
+                                                && !!assessment.variant_id
+                                                && variantPackageMap[assessment.variant_id] !== undefined
+                                                && !variantPackageMap[assessment.variant_id].includes(pkg)
+                                            );
+                                            const key = `${assessment.variant_id ?? ''}::${pkg}`;
+                                            return [key, {key, pkg, variant, outdated}] as const;
+                                        }))
+                                    ).values()];
 
                                     return (
                                         <li key={encodeURIComponent(group.key)} className={`mb-10 ms-4 ${isNewlyAdded ? 'new-element-glow' : ''}`}>
@@ -1826,17 +1869,16 @@ type VariantScopedSnapshot = {
                                                 ))}
                                             </div>
                                             <div className="text-sm mb-2 flex flex-wrap gap-1">
-                                                {group.packages.map(pkg => {
+                                                {findingTags.map(({key, pkg, variant, outdated}) => {
                                                     const { nameVersion, supplier } = splitPkgId(pkg);
                                                     const supplierName = extractSupplierName(supplier);
-                                                    const supersededVersions = supersededMap[pkg];
-                                                    const pkgOutdated = Array.isArray(supersededVersions) && supersededVersions.length > 0;
                                                     return (
-                                                        <span key={pkg} className={`inline-flex items-center px-2.5 py-0.5 rounded-full font-medium ${pkgOutdated ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300' : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300'}`} title={pkgOutdated ? `Assessed against an older version — now present as ${supersededVersions.join(', ')}` : (supplierName ? `Supplier: ${supplierName}` : undefined)}>
+                                                        <span key={key} className={`inline-flex items-center px-2.5 py-0.5 rounded-full font-medium ${outdated ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300' : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300'}`} title={supplierName ? `Supplier: ${supplierName}` : undefined}>
                                                             <FontAwesomeIcon icon={faBox} className="w-3 h-3 mr-1" />
                                                             {nameVersion}
                                                             {supplierName && <span className="ml-1 opacity-70 text-xs">({supplierName})</span>}
-                                                            {pkgOutdated && (
+                                                            {variant && <span className="ml-1.5 opacity-80">· {variant.name}</span>}
+                                                            {outdated && (
                                                                 <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-amber-200 text-amber-900 dark:bg-amber-700 dark:text-amber-100">
                                                                     Outdated
                                                                 </span>
@@ -1845,35 +1887,6 @@ type VariantScopedSnapshot = {
                                                     );
                                                 })}
                                             </div>
-                                            {(() => {
-                                                // Build the same group key (date + content fingerprint) used by
-                                                // groupAssessments, then find ALL matching records in the
-                                                // unfiltered allVulnAssessments so we can show every variant tag
-                                                // even when the explorer is filtered to a single variant.
-                                                const groupDateKey = new Date(group.timestamp).toDateString();
-                                                const fp = `${firstAssess.simplified_status}|${firstAssess.justification || ''}|${firstAssess.impact_statement || ''}|${firstAssess.status_notes || ''}|${firstAssess.workaround || ''}`;
-                                                const allVariantIds = [...new Set(
-                                                    allVulnAssessments
-                                                        .filter(a => {
-                                                            const aDateKey = new Date(a.timestamp).toDateString();
-                                                            const afp = `${a.simplified_status}|${a.justification || ''}|${a.impact_statement || ''}|${a.status_notes || ''}|${a.workaround || ''}`;
-                                                            return aDateKey === groupDateKey && afp === fp && !!a.variant_id;
-                                                        })
-                                                        .map(a => a.variant_id as string)
-                                                )];
-                                                const variantTags = allVariantIds
-                                                    .map(vid => availableVariants.find(v => v.id === vid))
-                                                    .filter(Boolean) as Variant[];
-                                                return variantTags.length > 0 ? (
-                                                    <div className="text-sm mb-2 flex flex-wrap gap-1">
-                                                        {variantTags.map(v => (
-                                                            <span key={v.id} className="inline-flex items-center px-2.5 py-0.5 rounded-full font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
-                                                                {v.name}
-                                                            </span>
-                                                        ))}
-                                                    </div>
-                                                ) : null;
-                                            })()}
                                             <div className="flex items-start justify-between">
                                                 <div className="flex-1">
                                                     <h3 className="text-lg font-semibold text-white mb-2 flex items-center">

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -1109,7 +1109,7 @@ type VariantScopedSnapshot = {
             body: JSON.stringify({ assessments: items })
         });
         const data = await response.json();
-        if (data?.status === 'success') {
+        if (response.ok !== false && data?.status === 'success') {
             // Backend returns one record per (package, variant) pair.
             const rawList: unknown[] = Array.isArray(data?.assessments) ? data.assessments : [];
             for (const raw of rawList) {
@@ -1139,11 +1139,12 @@ type VariantScopedSnapshot = {
                     vuln.simplified_status = casted.simplified_status;
                 }
             }
-            if (Array.isArray(data?.errors) && data.errors.length > 0) {
-                showMessage(`Some assessments failed: ${escape(JSON.stringify(data.errors))}`, 'error');
-            }
         } else {
-            showMessage(`Failed to add assessment: HTTP code ${Number(response?.status)} | ${escape(JSON.stringify(data))}`, 'error');
+            const errors = Array.isArray(data?.errors)
+                ? data.errors.map((entry: {error?: unknown}) => String(entry?.error ?? '')).filter(Boolean).join('; ')
+                : '';
+            const detail = errors || String(data?.error ?? 'The selected package versions are not valid for every selected variant.');
+            showMessage(`Assessment not added: ${escape(detail)}`, 'error');
         }
 
         if (lastCasted) {
@@ -1751,6 +1752,7 @@ type VariantScopedSnapshot = {
                                             defaultSelectedPackages={vuln.packages_current}
                                             variantPackageMap={Object.keys(variantPackageMap).length > 0 ? variantPackageMap : undefined}
                                             variantFindingsMap={variantFindingsMap}
+                                            findingsLoading={!variantPackageMapLoaded}
                                         />
                                     </li>
                                 )}
@@ -1938,6 +1940,7 @@ type VariantScopedSnapshot = {
                                                         defaultSelectedPackages={group.packages}
                                                         variantPackageMap={Object.keys(variantPackageMap).length > 0 ? variantPackageMap : undefined}
                                                         variantFindingsMap={variantFindingsMap}
+                                                        findingsLoading={!variantPackageMapLoaded}
                                                     />
                                                 </div>
                                             )}

--- a/frontend/src/handlers/packages.ts
+++ b/frontend/src/handlers/packages.ts
@@ -12,11 +12,15 @@ type Package = {
     variants: string[];
     sbom_documents: string[];
     supplier: string;
+    outdated?: boolean;
+    findingIds?: string[];
+    findingVulnerabilityIds?: string[];
 };
 
 export type { Package, VulnCounts, Severities };
 import type { Vulnerability } from "./vulnerabilities";
 import { SEVERITY_ORDER, buildStatusSummary, getVulnerabilityStatusSummary } from "./vulnerabilities";
+import { asStringArray } from "./assessments";
 
 const asPackage = (data: any): Package | [] => {
     if (typeof data !== "object") return [];
@@ -34,6 +38,9 @@ const asPackage = (data: any): Package | [] => {
         variants: [],
         sbom_documents: [],
         supplier: "",
+        outdated: data?.outdated === true,
+        findingIds: asStringArray(data?.finding_ids),
+        findingVulnerabilityIds: asStringArray(data?.vulnerability_ids),
     };
     if (typeof data?.id === "string" && data?.id != "") pkg.id = data.id;
     if (Array.isArray(data?.cpe)) {
@@ -60,9 +67,13 @@ class Packages {
      * Fetch server API to list all packages
      * @returns {Promise<Package[]>} A promise that resolves to a list of packages
      */
-    static async list(variantId?: string, projectId?: string, compareVariantId?: string, operation?: string, variantIds?: string[], multiOperation?: string): Promise<Package[]> {
+    static async list(variantId?: string, projectId?: string, compareVariantId?: string, operation?: string, variantIds?: string[], multiOperation?: string, includeOutdated = false): Promise<Package[]> {
         const url = new URL(import.meta.env.VITE_API_URL + "/api/packages", window.location.href);
         url.searchParams.set('format', 'list');
+        if (includeOutdated) {
+            url.searchParams.set('include_outdated', 'true');
+            url.searchParams.set('outdated_only', 'true');
+        }
         if (variantId && compareVariantId) {
             url.searchParams.set('variant_id', variantId);
             url.searchParams.set('compare_variant_id', compareVariantId);
@@ -84,18 +95,27 @@ class Packages {
     }
 
     static enrich_with_vulns(pkgs: Package[], vulns: Vulnerability[]): Package[] {
-        const vulns_per_pkg = vulns.reduce((acc, vuln) => {
-            vuln.packages.forEach((pkg_id) => {
-                if (!acc[pkg_id]) {
-                    acc[pkg_id] = [];
-                }
-                acc[pkg_id].push(vuln);
-            });
-            return acc;
-        }, {} as {[key: string]: Vulnerability[]});
+        const needsPackageIndex = pkgs.some(pkg => !pkg.outdated);
+        const vulns_per_pkg = needsPackageIndex
+            ? vulns.reduce((acc, vuln) => {
+                vuln.packages.forEach((pkg_id) => {
+                    if (!acc[pkg_id]) {
+                        acc[pkg_id] = [];
+                    }
+                    acc[pkg_id].push(vuln);
+                });
+                return acc;
+            }, {} as {[key: string]: Vulnerability[]})
+            : {};
+        const vulnsById = new Map(vulns.map(vulnerability => [vulnerability.id, vulnerability]));
 
         return pkgs.map((pkg) => {
-            const vulnerabilities = vulns_per_pkg[pkg.id] || [];
+            const vulnerabilities = pkg.outdated
+                ? (pkg.findingVulnerabilityIds ?? []).flatMap(id => {
+                    const vulnerability = vulnsById.get(id);
+                    return vulnerability ? [vulnerability] : [];
+                })
+                : (vulns_per_pkg[pkg.id] || []);
             let severities: Severities = {};
             const counts: VulnCounts = vulnerabilities.reduce((acc, vuln) => {
                 const severity = {label: vuln.severity.severity, index: SEVERITY_ORDER.indexOf(vuln.severity.severity.toUpperCase())};
@@ -124,6 +144,10 @@ class Packages {
                 acc[status] = (acc[status] || 0) + 1;
                 return acc;
             }, {} as VulnCounts);
+            const knownVulnerabilityIds = new Set(vulnerabilities.map(vulnerability => vulnerability.id));
+            const missingFindingCount = (pkg.findingVulnerabilityIds ?? [])
+                .filter(vulnerabilityId => !knownVulnerabilityIds.has(vulnerabilityId)).length;
+            if (missingFindingCount > 0) counts.unknown = (counts.unknown ?? 0) + missingFindingCount;
             return {
                 ...pkg,
                 vulnerabilities: counts,

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -249,6 +249,17 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         );
         return Packages.enrich_with_vulns(loaded, vulnsRef.current);
     }, [currentBaseVariantId, currentVariantId, currentProjectId, currentOperation, currentVariantIds, currentMultiOperation]);
+    const outdatedPackagesScopeKey = [
+        currentProjectId ?? '',
+        currentBaseVariantId ?? '',
+        currentVariantId ?? '',
+        currentOperation,
+        currentMultiOperation,
+        ...(currentVariantIds ?? []),
+    ].join(':');
+    const hasOutdatedPackagesScope = Boolean(
+        currentProjectId || currentVariantId || (currentVariantIds?.length ?? 0) > 0
+    );
 
     function showVulnsForPackage(packageId: string, matchingVulnerabilityIds?: string[]) {
         setFilterVulnerabilityIds(matchingVulnerabilityIds);
@@ -319,7 +330,13 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     appendCVSS={appendCVSS}
                     projectId={currentProjectId}
                 />}
-                {tab === 'packages' && <TablePackages packages={pkgs} vulnerabilities={vulns} onShowVulns={showVulnsForPackage} onLoadOutdatedPackages={loadOutdatedPackages} />}
+                {tab === 'packages' && <TablePackages
+                    packages={pkgs}
+                    vulnerabilities={vulns}
+                    onShowVulns={showVulnsForPackage}
+                    onLoadOutdatedPackages={hasOutdatedPackagesScope ? loadOutdatedPackages : undefined}
+                    outdatedScopeKey={outdatedPackagesScopeKey}
+                />}
                 {tab === 'vulnerabilities' &&
                 <TableVulnerabilities
                     appendAssessment={appendAssessment}

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -235,6 +235,21 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
         setTab('vulnerabilities');
     }
 
+    const loadOutdatedPackages = useCallback(async () => {
+        const baseVariantId = currentBaseVariantId ?? currentVariantId;
+        const compareVariantId = currentBaseVariantId ? currentVariantId : undefined;
+        const loaded = await Packages.list(
+            baseVariantId,
+            baseVariantId ? undefined : currentProjectId,
+            compareVariantId,
+            currentOperation,
+            currentVariantIds,
+            currentMultiOperation,
+            true,
+        );
+        return Packages.enrich_with_vulns(loaded, vulnsRef.current);
+    }, [currentBaseVariantId, currentVariantId, currentProjectId, currentOperation, currentVariantIds, currentMultiOperation]);
+
     function showVulnsForPackage(packageId: string, matchingVulnerabilityIds?: string[]) {
         setFilterVulnerabilityIds(matchingVulnerabilityIds);
         goToVulnsTabWithFilter("Package", packageId);
@@ -304,7 +319,7 @@ function Explorer({ darkMode, setDarkMode }: Readonly<Props>) {
                     appendCVSS={appendCVSS}
                     projectId={currentProjectId}
                 />}
-                {tab === 'packages' && <TablePackages packages={pkgs} vulnerabilities={vulns} onShowVulns={showVulnsForPackage} />}
+                {tab === 'packages' && <TablePackages packages={pkgs} vulnerabilities={vulns} onShowVulns={showVulnsForPackage} onLoadOutdatedPackages={loadOutdatedPackages} />}
                 {tab === 'vulnerabilities' &&
                 <TableVulnerabilities
                     appendAssessment={appendAssessment}

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -886,9 +886,19 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     <div className="flex flex-wrap gap-1 items-center justify-center h-full">
                         {vids.map(vid => {
                             const name = variantNames[vid] ?? vid.slice(0, 8);
+                            const variantAssessments = (row._assessments ?? [row]).filter(a => a.variant_id === vid);
+                            const isOutdated = variantAssessments.length > 0 && variantAssessments.every(a =>
+                                a.outdated === true
+                                || (a.packages.length > 0 && a.packages.every(pkg => (a.superseded_map?.[pkg]?.length ?? 0) > 0))
+                            );
                             return (
-                                <span key={vid} className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                                <span
+                                    key={vid}
+                                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${isOutdated ? 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300' : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300'}`}
+                                    title={isOutdated ? 'Package version is not present in this variant’s current SBOM' : undefined}
+                                >
                                     {name}
+                                    {isOutdated && <span className="ml-1.5 text-[10px] font-semibold uppercase tracking-wide">Outdated</span>}
                                 </span>
                             );
                         })}
@@ -900,37 +910,9 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             header: () => <div className="flex items-center justify-center">Status</div>,
             size: 110,
             cell: info => {
-                const row = info.row.original as ReviewRow;
-                const rawAssessments = row._assessments ?? [row];
-                // Per-package staleness: union each stale package reference to the
-                // version(s) that supersede it, matching the detail shown in VulnModal.
-                const supersededMap: Record<string, string[]> = {};
-                for (const a of rawAssessments) {
-                    if (a.outdated && a.superseded_map) {
-                        for (const [ref, versions] of Object.entries(a.superseded_map)) {
-                            supersededMap[ref] = [...new Set([...(supersededMap[ref] ?? []), ...versions])].sort();
-                        }
-                    }
-                }
-                // The row is only flagged outdated once every package it covers is
-                // stale — a row spanning some current and some superseded packages
-                // is not fully outdated yet.
-                const isOutdated = row.packages.length > 0 && row.packages.every(p => p in supersededMap);
-                const supersededEntries = Object.entries(supersededMap);
-                const supersededTitle = supersededEntries.length > 0
-                    ? `Assessed against an older version — now present as ${supersededEntries.map(([ref, versions]) => `${ref} → ${versions.join(', ')}`).join('; ')}`
-                    : 'Assessed against an older version that is no longer in the active SBOM';
                 return (
-                    <div className="flex flex-col items-center justify-center gap-1 h-full">
+                    <div className="flex items-center justify-center h-full">
                         <code>{info.getValue()}</code>
-                        {isOutdated && (
-                            <span
-                                className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300"
-                                title={supersededTitle}
-                            >
-                                Outdated
-                            </span>
-                        )}
                     </div>
                 );
             },

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -501,7 +501,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
             }
             return true;
         });
-    }, [packages, packagesWithOutdated, onLoadOutdatedPackages, vulnerabilities, showOnlyOutdated, matchingVulnerabilityIds, selectedSources, selectedSbomDocs, selectedSuppliers, selectedVariants]);
+    }, [packages, packagesWithOutdated, vulnerabilities, showOnlyOutdated, matchingVulnerabilityIds, selectedSources, selectedSbomDocs, selectedSuppliers, selectedVariants]);
 
     return (<>
         {showOnlyOutdated && outdatedLoading && (

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -19,6 +19,7 @@ type Props = {
     vulnerabilities?: Vulnerability[];
     onShowVulns?: (packageId: string, matchingVulnerabilityIds?: string[]) => void;
     onLoadOutdatedPackages?: () => Promise<Package[]>;
+    outdatedScopeKey?: string;
 };
 
 const addVulnCounts = (counts: VulnCounts, ignore: string[]) => {
@@ -38,7 +39,7 @@ const sortVunerabilitiesFn = (rowA: Row<Package>, rowB: Row<Package>, ignore: st
 
 const fuseKeys = ['id', 'name', 'version', 'cpe', 'purl']
 
-function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutdatedPackages }: Readonly<Props>) {
+function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutdatedPackages, outdatedScopeKey }: Readonly<Props>) {
     const docUrl = useDocUrl("interactive-mode.html#sbom-table");
     const [search, setSearch] = useState<string>('');
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
@@ -223,6 +224,13 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
         setMatchConditionError('');
     }, [vulnerabilities]);
 
+    // Discard historical rows from the previous project/variant scope so an
+    // enabled outdated filter immediately fetches the new scope.
+    useEffect(() => {
+        setPackagesWithOutdated(null);
+        setOutdatedLoadError('');
+    }, [outdatedScopeKey]);
+
     useEffect(() => {
         if (!showOnlyOutdated || packagesWithOutdated !== null || !onLoadOutdatedPackages) return;
         let cancelled = false;
@@ -239,7 +247,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
                 if (!cancelled) setOutdatedLoading(false);
             });
         return () => { cancelled = true; };
-    }, [showOnlyOutdated, packagesWithOutdated, onLoadOutdatedPackages]);
+    }, [showOnlyOutdated, packagesWithOutdated, onLoadOutdatedPackages, outdatedScopeKey]);
 
     const applyMatchCondition = async () => {
         const condition = matchCondition.trim();

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -46,6 +46,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
     const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
     const [showOnlyOutdated, setShowOnlyOutdated] = useState(false);
     const [packagesWithOutdated, setPackagesWithOutdated] = useState<Package[] | null>(null);
+    const [outdatedLoading, setOutdatedLoading] = useState(false);
     const [outdatedLoadError, setOutdatedLoadError] = useState('');
     const [matchCondition, setMatchCondition] = useState('');
     const [matchingVulnerabilityIds, setMatchingVulnerabilityIds] = useState<string[] | null>(null);
@@ -225,10 +226,18 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
     useEffect(() => {
         if (!showOnlyOutdated || packagesWithOutdated !== null || !onLoadOutdatedPackages) return;
         let cancelled = false;
+        setOutdatedLoading(true);
         setOutdatedLoadError('');
         onLoadOutdatedPackages()
-            .then(loaded => { if (!cancelled) setPackagesWithOutdated(loaded); })
-            .catch(() => { if (!cancelled) setOutdatedLoadError('Unable to load outdated findings'); });
+            .then(loaded => {
+                if (!cancelled) setPackagesWithOutdated(loaded);
+            })
+            .catch(() => {
+                if (!cancelled) setOutdatedLoadError('Unable to load outdated findings');
+            })
+            .finally(() => {
+                if (!cancelled) setOutdatedLoading(false);
+            });
         return () => { cancelled = true; };
     }, [showOnlyOutdated, packagesWithOutdated, onLoadOutdatedPackages]);
 
@@ -495,6 +504,14 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
     }, [packages, packagesWithOutdated, onLoadOutdatedPackages, vulnerabilities, showOnlyOutdated, matchingVulnerabilityIds, selectedSources, selectedSbomDocs, selectedSuppliers, selectedVariants]);
 
     return (<>
+        {showOnlyOutdated && outdatedLoading && (
+            <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40" role="status" aria-live="polite">
+                <div className="flex flex-col items-center gap-3 text-white">
+                    <div className="w-10 h-10 border-4 border-white border-t-transparent rounded-full animate-spin" aria-hidden="true"></div>
+                    <span className="text-sm font-semibold">Loading outdated packages…</span>
+                </div>
+            </div>
+        )}
         {matchConditionError && (
             <MessageBanner
                 type="error"

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -1,11 +1,9 @@
-import type { Package, VulnCounts, Severities } from "../handlers/packages";
+import type { Package, VulnCounts } from "../handlers/packages";
 import { createColumnHelper, Row } from '@tanstack/react-table'
 import { useMemo, useState, useRef, useEffect, useCallback } from "react";
-import SeverityTag from "../components/SeverityTag";
 import TableGeneric from "../components/TableGeneric";
 import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
-import ToggleSwitch from "../components/ToggleSwitch";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faC, faCircleQuestion, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
 import { useDocUrl } from '../helpers/useDocUrl';
@@ -30,17 +28,6 @@ const addVulnCounts = (counts: VulnCounts, ignore: string[]) => {
     }, 0)
 }
 
-const highestSeverity = (severities: Severities, ignore: string[]) => {
-    return Object.keys(severities).reduce((acc, key) => {
-        if (!ignore.includes(key)) {
-            if (severities[key].index > acc.index) {
-                return severities[key]
-            }
-        }
-        return acc
-    }, {label: 'NONE', index: 0})
-}
-
 const sortVunerabilitiesFn = (rowA: Row<Package>, rowB: Row<Package>, ignore: string[]) => {
     const vulnsA = addVulnCounts(rowA.original.vulnerabilities, ignore)
     const vulnsB = addVulnCounts(rowB.original.vulnerabilities, ignore)
@@ -51,7 +38,6 @@ const fuseKeys = ['id', 'name', 'version', 'cpe', 'purl']
 
 function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly<Props>) {
     const docUrl = useDocUrl("interactive-mode.html#sbom-table");
-    const [showSeverity, setShowSeverity] = useState(false);
     const [search, setSearch] = useState<string>('');
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
     const [selectedSbomDocs, setSelectedSbomDocs] = useState<string[]>([]);
@@ -256,7 +242,6 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
         setMatchCondition('');
         setMatchingVulnerabilityIds(null);
         setMatchConditionError('');
-        setShowSeverity(false);
         setVisibleColumns(defaultVisibleColumns);
     }
 
@@ -343,7 +328,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
                 size: 200,
             }),
             columnHelper.accessor(
-            row => ({ counts: row.vulnerabilities, severity: row.maxSeverity }),
+            row => row.vulnerabilities,
             {
                 id: 'vulnerabilities',
                 header: () => <div className="flex items-center justify-center">Vulnerabilities</div>,
@@ -363,8 +348,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
                             </span>
                             {matchedCount ?? 0}
                         </span>
-                    ) : <span>{addVulnCounts(value.counts, [])}</span>}
-                    {showSeverity && <SeverityTag severity={highestSeverity(value.severity, []).label} />}
+                    ) : <span>{addVulnCounts(value, [])}</span>}
                     </div>
                 );
                 },
@@ -443,7 +427,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
                 size: 10
             })
         ]
-    }, [showSeverity, onShowVulns, matchingVulnerabilityIds, matchingVulnerabilityCounts]);
+    }, [onShowVulns, matchingVulnerabilityIds, matchingVulnerabilityCounts]);
 
     const columns = useMemo(() => {
         return allColumns.filter(col => {
@@ -609,14 +593,6 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
                     setSelected={setSelectedVariants}
                 />
             )}
-
-            <div className="ml-4">
-                <ToggleSwitch
-                    enabled={showSeverity}
-                    setEnabled={setShowSeverity}
-                    label="Severity"
-                />
-            </div>
 
             <div className="ml-auto flex items-center gap-2 relative">
                 <button

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState, useRef, useEffect, useCallback } from "react";
 import TableGeneric from "../components/TableGeneric";
 import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
+import ToggleSwitch from "../components/ToggleSwitch";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faC, faCircleQuestion, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
 import { useDocUrl } from '../helpers/useDocUrl';
@@ -17,6 +18,7 @@ type Props = {
     packages: Package[];
     vulnerabilities?: Vulnerability[];
     onShowVulns?: (packageId: string, matchingVulnerabilityIds?: string[]) => void;
+    onLoadOutdatedPackages?: () => Promise<Package[]>;
 };
 
 const addVulnCounts = (counts: VulnCounts, ignore: string[]) => {
@@ -36,12 +38,15 @@ const sortVunerabilitiesFn = (rowA: Row<Package>, rowB: Row<Package>, ignore: st
 
 const fuseKeys = ['id', 'name', 'version', 'cpe', 'purl']
 
-function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly<Props>) {
+function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutdatedPackages }: Readonly<Props>) {
     const docUrl = useDocUrl("interactive-mode.html#sbom-table");
     const [search, setSearch] = useState<string>('');
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
     const [selectedSbomDocs, setSelectedSbomDocs] = useState<string[]>([]);
     const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
+    const [showOnlyOutdated, setShowOnlyOutdated] = useState(false);
+    const [packagesWithOutdated, setPackagesWithOutdated] = useState<Package[] | null>(null);
+    const [outdatedLoadError, setOutdatedLoadError] = useState('');
     const [matchCondition, setMatchCondition] = useState('');
     const [matchingVulnerabilityIds, setMatchingVulnerabilityIds] = useState<string[] | null>(null);
     const [matchConditionError, setMatchConditionError] = useState('');
@@ -217,6 +222,16 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
         setMatchConditionError('');
     }, [vulnerabilities]);
 
+    useEffect(() => {
+        if (!showOnlyOutdated || packagesWithOutdated !== null || !onLoadOutdatedPackages) return;
+        let cancelled = false;
+        setOutdatedLoadError('');
+        onLoadOutdatedPackages()
+            .then(loaded => { if (!cancelled) setPackagesWithOutdated(loaded); })
+            .catch(() => { if (!cancelled) setOutdatedLoadError('Unable to load outdated findings'); });
+        return () => { cancelled = true; };
+    }, [showOnlyOutdated, packagesWithOutdated, onLoadOutdatedPackages]);
+
     const applyMatchCondition = async () => {
         const condition = matchCondition.trim();
         if (!condition) {
@@ -242,6 +257,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
         setMatchCondition('');
         setMatchingVulnerabilityIds(null);
         setMatchConditionError('');
+        setShowOnlyOutdated(false);
         setVisibleColumns(defaultVisibleColumns);
     }
 
@@ -263,7 +279,14 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
             columnHelper.accessor('name', {
                 id: 'name',
                 header: () => <div className="flex items-center justify-center">Name</div>,
-                cell: info => <div className="flex items-center justify-center h-full text-center">{info.getValue()}</div>,
+                cell: info => (
+                    <div className="flex items-center justify-center gap-2 h-full text-center">
+                        <span>{info.getValue()}</span>
+                        {info.row.original.outdated && (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-900 text-amber-200">Outdated</span>
+                        )}
+                    </div>
+                ),
                 footer: info => <div className="flex items-center justify-center h-full">{`Total: ${info.table.getRowCount()}`}</div>,
                 size: 300
             }),
@@ -410,9 +433,12 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
                         <button
                             className="bg-slate-800 hover:bg-slate-700 px-2 py-1 rounded-lg"
                             onClick={() => {
-                                const packageId = info.getValue().id;
+                                const packageRow = info.getValue();
+                                const packageId = packageRow.id;
                                 if (matchingVulnerabilityIds) {
                                     onShowVulns?.(packageId, matchingVulnerabilityIds);
+                                } else if (packageRow.findingVulnerabilityIds?.length) {
+                                    onShowVulns?.(packageId, packageRow.findingVulnerabilityIds);
                                 } else {
                                     onShowVulns?.(packageId);
                                 }
@@ -439,6 +465,9 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
     }, [allColumns, visibleColumns, columnDisplayNames]);
 
     const filteredPackages = useMemo(() => {
+        const availablePackages = showOnlyOutdated
+            ? (packagesWithOutdated ?? packages)
+            : packages;
         let matchedPackageIds: Set<string> | null = null;
         if (matchingVulnerabilityIds !== null) {
             const matchingIds = new Set(matchingVulnerabilityIds);
@@ -446,7 +475,8 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
                 .filter(vulnerability => matchingIds.has(vulnerability.id))
                 .flatMap(vulnerability => vulnerability.packages_current));
         }
-        return packages.filter((el) => {
+        return availablePackages.filter((el) => {
+            if (showOnlyOutdated ? !el.outdated : el.outdated) return false;
             if (matchedPackageIds && !matchedPackageIds.has(el.id)) return false;
             if (selectedSources.length && !selectedSources.some(src => el.source.includes(src))) {
                 return false;
@@ -462,7 +492,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
             }
             return true;
         });
-    }, [packages, vulnerabilities, matchingVulnerabilityIds, selectedSources, selectedSbomDocs, selectedSuppliers, selectedVariants]);
+    }, [packages, packagesWithOutdated, onLoadOutdatedPackages, vulnerabilities, showOnlyOutdated, matchingVulnerabilityIds, selectedSources, selectedSbomDocs, selectedSuppliers, selectedVariants]);
 
     return (<>
         {matchConditionError && (
@@ -473,6 +503,14 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
                 onClose={() => setMatchConditionError('')}
             />
         )}
+                {outdatedLoadError && (
+                    <MessageBanner
+                        type="error"
+                        message={outdatedLoadError}
+                        isVisible={true}
+                        onClose={() => setOutdatedLoadError('')}
+                    />
+                )}
         <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2">
             <div>Search</div>
             <input ref={searchInputRef} onInput={updateSearch} type="search" className="py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[250px] grow max-w-[800px]" placeholder="Search by package name, version, ..." />
@@ -593,6 +631,12 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns }: Readonly
                     setSelected={setSelectedVariants}
                 />
             )}
+
+            <ToggleSwitch
+                enabled={showOnlyOutdated}
+                setEnabled={setShowOnlyOutdated}
+                label="Outdated"
+            />
 
             <div className="ml-auto flex items-center gap-2 relative">
                 <button

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -847,4 +847,39 @@ describe('EditAssessment Component', () => {
             expect.objectContaining({ packages: expect.arrayContaining(['pkg1@1.0.0', 'pkg2@2.0.0']) })
         );
     });
+
+    test('allows adding an outdated package only after enabling the option', async () => {
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availableVariants={[{id: 'v1', name: 'default', project_id: 'p1'}]}
+                defaultSelectedVariantIds={['v1']}
+                availablePackages={['package@2.0.0']}
+                defaultSelectedPackages={['package@2.0.0']}
+                variantPackageMap={{v1: ['package@2.0.0']}}
+                variantFindingsMap={{v1: [
+                    {pkg: 'package@2.0.0', outdated: false},
+                    {pkg: 'package@1.0.0', outdated: true},
+                ]}}
+            />
+        );
+
+        expect(screen.queryByText('package@1.0.0')).not.toBeInTheDocument();
+        await user.click(screen.getByRole('checkbox', {name: 'Include outdated package versions'}));
+        const outdatedPackage = screen.getByText('package@1.0.0');
+        await user.click(outdatedPackage.closest('label')!.querySelector('input')!);
+        await user.click(screen.getByRole('checkbox', {name: 'Include outdated package versions'}));
+        await user.click(screen.getByRole('checkbox', {name: 'Include outdated package versions'}));
+        const restoredOutdatedPackage = screen.getByText('package@1.0.0').closest('label')!.querySelector('input')!;
+        expect(restoredOutdatedPackage).not.toBeChecked();
+        await user.click(restoredOutdatedPackage);
+        await user.click(screen.getByText('Save Changes'));
+
+        expect(mockOnSave).toHaveBeenCalledWith(expect.objectContaining({
+            packages: expect.arrayContaining(['package@2.0.0', 'package@1.0.0']),
+        }));
+    });
 });

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -908,6 +908,35 @@ describe('EditAssessment Component', () => {
         })).toBeChecked();
     });
 
+    test('hides an originally selected outdated package after opting out', async () => {
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availableVariants={[{id: 'v1', name: 'default', project_id: 'p1'}]}
+                defaultSelectedVariantIds={['v1']}
+                availablePackages={['package@2.0.0']}
+                defaultSelectedPackages={['package@1.0.0']}
+                variantPackageMap={{v1: ['package@2.0.0']}}
+                variantFindingsMap={{v1: [{pkg: 'package@1.0.0', outdated: true}]}}
+            />
+        );
+
+        const allowOutdated = screen.getByRole('checkbox', {
+            name: 'Allow edit assessments on outdated packages/variant',
+        });
+        expect(allowOutdated).toBeChecked();
+        expect(screen.getByText('package@1.0.0')).toBeInTheDocument();
+
+        await user.click(allowOutdated);
+
+        expect(allowOutdated).not.toBeChecked();
+        expect(screen.queryByText('package@1.0.0')).not.toBeInTheDocument();
+        expect(screen.getByText('package@2.0.0')).toBeInTheDocument();
+    });
+
     test('prunes selected packages by the intersection of remaining variants', async () => {
         const user = userEvent.setup();
         const variants = [

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -907,4 +907,52 @@ describe('EditAssessment Component', () => {
             name: 'Allow edit assessments on outdated packages/variant',
         })).toBeChecked();
     });
+
+    test('prunes selected packages by the intersection of remaining variants', async () => {
+        const user = userEvent.setup();
+        const variants = [
+            {id: 'v1', name: 'first', project_id: 'p1'},
+            {id: 'v2', name: 'second', project_id: 'p1'},
+            {id: 'v3', name: 'third', project_id: 'p1'},
+        ];
+        const selectedVariantIds = ['v1', 'v2', 'v3'];
+        const availablePackages = ['package@1.0.0', 'other@1.0.0'];
+        const selectedPackages = ['package@1.0.0'];
+        const view = render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availableVariants={variants}
+                defaultSelectedVariantIds={selectedVariantIds}
+                availablePackages={availablePackages}
+                defaultSelectedPackages={selectedPackages}
+                variantPackageMap={{
+                    v1: ['package@1.0.0'],
+                    v2: ['package@1.0.0'],
+                    v3: ['package@1.0.0'],
+                }}
+            />
+        );
+        view.rerender(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availableVariants={variants}
+                defaultSelectedVariantIds={selectedVariantIds}
+                availablePackages={availablePackages}
+                defaultSelectedPackages={selectedPackages}
+                variantPackageMap={{
+                    v1: ['package@1.0.0'],
+                    v2: ['package@1.0.0'],
+                    v3: [],
+                }}
+            />
+        );
+
+        await user.click(screen.getByText('first').closest('label')!.querySelector('input')!);
+
+        expect(screen.getByText('package@1.0.0').closest('label')!.querySelector('input')).not.toBeChecked();
+    });
 });

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -868,18 +868,43 @@ describe('EditAssessment Component', () => {
         );
 
         expect(screen.queryByText('package@1.0.0')).not.toBeInTheDocument();
-        await user.click(screen.getByRole('checkbox', {name: 'Include previous package versions'}));
+        const allowOutdated = screen.getByRole('checkbox', {name: 'Allow edit assessments on outdated packages/variant'});
+        await user.click(allowOutdated);
+        expect(screen.getByText('default').closest('label')!.querySelector('input')).not.toBeChecked();
+        expect(screen.getByText('package@2.0.0').closest('label')!.querySelector('input')).not.toBeChecked();
         const outdatedPackage = screen.getByText('package@1.0.0');
         await user.click(outdatedPackage.closest('label')!.querySelector('input')!);
-        await user.click(screen.getByRole('checkbox', {name: 'Include previous package versions'}));
-        await user.click(screen.getByRole('checkbox', {name: 'Include previous package versions'}));
+        await user.click(allowOutdated);
+        await user.click(allowOutdated);
         const restoredOutdatedPackage = screen.getByText('package@1.0.0').closest('label')!.querySelector('input')!;
         expect(restoredOutdatedPackage).not.toBeChecked();
+        await user.click(screen.getByText('default').closest('label')!.querySelector('input')!);
+        await user.click(screen.getByText('package@2.0.0').closest('label')!.querySelector('input')!);
         await user.click(restoredOutdatedPackage);
         await user.click(screen.getByText('Save Changes'));
 
         expect(mockOnSave).toHaveBeenCalledWith(expect.objectContaining({
             packages: expect.arrayContaining(['package@2.0.0', 'package@1.0.0']),
         }));
+    });
+
+    test('enables outdated package editing when an original finding is outdated', () => {
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availableVariants={[{id: 'v1', name: 'default', project_id: 'p1'}]}
+                defaultSelectedVariantIds={['v1']}
+                availablePackages={['package@1.0.0']}
+                defaultSelectedPackages={['package@1.0.0']}
+                variantPackageMap={{v1: []}}
+                variantFindingsMap={{v1: [{pkg: 'package@1.0.0', outdated: true}]}}
+            />
+        );
+
+        expect(screen.getByRole('checkbox', {
+            name: 'Allow edit assessments on outdated packages/variant',
+        })).toBeChecked();
     });
 });

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -868,11 +868,11 @@ describe('EditAssessment Component', () => {
         );
 
         expect(screen.queryByText('package@1.0.0')).not.toBeInTheDocument();
-        await user.click(screen.getByRole('checkbox', {name: 'Include outdated package versions'}));
+        await user.click(screen.getByRole('checkbox', {name: 'Include previous package versions'}));
         const outdatedPackage = screen.getByText('package@1.0.0');
         await user.click(outdatedPackage.closest('label')!.querySelector('input')!);
-        await user.click(screen.getByRole('checkbox', {name: 'Include outdated package versions'}));
-        await user.click(screen.getByRole('checkbox', {name: 'Include outdated package versions'}));
+        await user.click(screen.getByRole('checkbox', {name: 'Include previous package versions'}));
+        await user.click(screen.getByRole('checkbox', {name: 'Include previous package versions'}));
         const restoredOutdatedPackage = screen.getByText('package@1.0.0').closest('label')!.querySelector('input')!;
         expect(restoredOutdatedPackage).not.toBeChecked();
         await user.click(restoredOutdatedPackage);

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -174,7 +174,10 @@ describe('Packages Table', () => {
             findingIds: ['finding-old'],
             findingVulnerabilityIds: ['CVE-2026-0001'],
         };
-        const loadOutdatedPackages = jest.fn<() => Promise<Package[]>>().mockResolvedValue([...activePackages, outdatedPackage]);
+        let finishLoading: (packages: Package[]) => void = () => undefined;
+        const loadOutdatedPackages = jest.fn<() => Promise<Package[]>>().mockImplementation(() =>
+            new Promise(resolve => { finishLoading = resolve; })
+        );
         render(<TablePackages packages={activePackages} onLoadOutdatedPackages={loadOutdatedPackages} />);
 
         const user = userEvent.setup();
@@ -184,8 +187,12 @@ describe('Packages Table', () => {
 
         await user.click(outdatedToggle);
 
+        expect((await screen.findByRole('status')).textContent).toContain('Loading outdated packages…');
+        finishLoading([...activePackages, outdatedPackage]);
+
         await waitFor(() => {
             expect(loadOutdatedPackages).toHaveBeenCalledTimes(1);
+            expect(screen.queryByRole('status')).toBeNull();
             expect(screen.getByRole('cell', {name: /^0\.9\.0$/})).toBeTruthy();
             expect(screen.getAllByText('Outdated').length).toBeGreaterThanOrEqual(2);
             expect(screen.queryByRole('cell', {name: /^1\.0\.0$/})).toBeNull();

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import "@testing-library/jest-dom";
-import { describe, test, expect } from '@jest/globals';
+import { describe, test, expect, jest } from '@jest/globals';
 import matchers from '@testing-library/jest-dom/matchers';
 expect.extend(matchers);
 
@@ -159,6 +159,38 @@ describe('Packages Table', () => {
         render(<TablePackages packages={packages} />);
 
         expect(screen.queryByRole('button', {name: /severity/i})).toBeNull();
+    })
+
+    test('outdated toggle is off by default and loads historical finding rows', async () => {
+        const activePackages = packages.map(pkg => pkg.id === 'aaabbbccc@1.0.0'
+            ? {...pkg, variants: ['Variant A']}
+            : pkg);
+        const outdatedPackage: Package = {
+            ...packages[0],
+            id: 'aaabbbccc@0.9.0',
+            version: '0.9.0',
+            variants: ['Variant A'],
+            outdated: true,
+            findingIds: ['finding-old'],
+            findingVulnerabilityIds: ['CVE-2026-0001'],
+        };
+        const loadOutdatedPackages = jest.fn<() => Promise<Package[]>>().mockResolvedValue([...activePackages, outdatedPackage]);
+        render(<TablePackages packages={activePackages} onLoadOutdatedPackages={loadOutdatedPackages} />);
+
+        const user = userEvent.setup();
+        const outdatedToggle = screen.getByRole('button', {name: 'Show Outdated'});
+        expect(outdatedToggle.getAttribute('aria-pressed')).toBe('false');
+        expect(screen.queryByRole('cell', {name: /^0\.9\.0$/})).toBeNull();
+
+        await user.click(outdatedToggle);
+
+        await waitFor(() => {
+            expect(loadOutdatedPackages).toHaveBeenCalledTimes(1);
+            expect(screen.getByRole('cell', {name: /^0\.9\.0$/})).toBeTruthy();
+            expect(screen.getAllByText('Outdated').length).toBeGreaterThanOrEqual(2);
+            expect(screen.queryByRole('cell', {name: /^1\.0\.0$/})).toBeNull();
+            expect(screen.queryByRole('cell', {name: /^2\.0\.0$/})).toBeNull();
+        });
     })
 
     test('sorting by name', async () => {
@@ -366,6 +398,8 @@ describe('Packages Table', () => {
         const cveFinderCheckbox = await screen.getByRole('checkbox', { name: /cve-finder/i });
         await user.click(cveFinderCheckbox);
 
+        await user.click(screen.getByRole('button', { name: 'Show Outdated' }));
+
         // ACT: Click reset filters
         const resetBtn = await screen.getByRole('button', { name: /reset filters/i });
         await user.click(resetBtn);
@@ -373,6 +407,7 @@ describe('Packages Table', () => {
         // ASSERT: All packages should be visible again
         await waitFor(() => {
             expect(screen.getAllByRole('cell', { name: /aaabbbccc/ }).length).toBeGreaterThan(0);
+            expect(screen.getByRole('button', { name: 'Show Outdated' }).getAttribute('aria-pressed')).toBe('false');
         });
     })
 

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -200,6 +200,37 @@ describe('Packages Table', () => {
         });
     })
 
+    test('reloads outdated rows when the project or variant scope changes', async () => {
+        const user = userEvent.setup();
+        const firstOutdated = {...packages[0], id: 'old-a@1', name: 'old-a', outdated: true};
+        const secondOutdated = {...packages[0], id: 'old-b@1', name: 'old-b', outdated: true};
+        const firstLoader = jest.fn<() => Promise<Package[]>>().mockResolvedValue([firstOutdated]);
+        const secondLoader = jest.fn<() => Promise<Package[]>>().mockResolvedValue([secondOutdated]);
+        const view = render(
+            <TablePackages
+                packages={packages}
+                onLoadOutdatedPackages={firstLoader}
+                outdatedScopeKey="variant-a"
+            />
+        );
+
+        await user.click(screen.getByRole('button', {name: 'Show Outdated'}));
+        expect(await screen.findByText('old-a')).toBeTruthy();
+
+        view.rerender(
+            <TablePackages
+                packages={packages}
+                onLoadOutdatedPackages={secondLoader}
+                outdatedScopeKey="variant-b"
+            />
+        );
+
+        expect(await screen.findByText('old-b')).toBeTruthy();
+        await waitFor(() => expect(screen.queryByText('old-a')).toBeNull());
+        expect(firstLoader).toHaveBeenCalledTimes(1);
+        expect(secondLoader).toHaveBeenCalledTimes(1);
+    })
+
     test('sorting by name', async () => {
         // ARRANGE
         render(<TablePackages packages={packages} />);

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -155,24 +155,10 @@ describe('Packages Table', () => {
         expect(source_col).toBeTruthy();
     })
 
-    test('render severity when toggle activated', async () => {
-        // ARRANGE
+    test('does not render the obsolete severity toggle', () => {
         render(<TablePackages packages={packages} />);
 
-        // ACT
-        const user = userEvent.setup();
-        const severity_toggle = await screen.getByRole('button', {name: /show severity/i});
-
-        await user.click(severity_toggle); // switch to enabled mode
-
-        const btn_enabled = await screen.getByRole('button', {name: /hide severity/i});
-        const severity_high = await screen.getByText('high');
-        const severity_mediums = await screen.getAllByText('medium');
-
-        // ASSERT
-        expect(btn_enabled).toBeTruthy();
-        expect(severity_high).toBeTruthy();
-        expect(severity_mediums.length).toBeGreaterThan(0);
+        expect(screen.queryByRole('button', {name: /severity/i})).toBeNull();
     })
 
     test('sorting by name', async () => {
@@ -374,9 +360,6 @@ describe('Packages Table', () => {
         // Set some filters
         const search_bar = await screen.getByRole('searchbox');
         await user.type(search_bar, 'xyz');
-
-        const severity_toggle = await screen.getByRole('button', {name: /show severity/i});
-        await user.click(severity_toggle);
 
         const source_btn = await screen.getByRole('button', { name: /^source$/i });
         await user.click(source_btn);

--- a/frontend/tests/unit_tests/test_review.tsx
+++ b/frontend/tests/unit_tests/test_review.tsx
@@ -463,6 +463,23 @@ describe('Review — rendering columns and tabs', () => {
         expect(screen.getAllByText('—').length).toBeGreaterThan(0);
     });
 
+    test('shows outdated on the affected variant instead of the status', async () => {
+        mockNetwork([
+            {
+                ...makeAssessment('a1', 'v1'),
+                outdated: true,
+                superseded_map: {'pkgA@1.0.0': ['pkgA@2.0.0']},
+            },
+            makeAssessment('a2', 'v2'),
+        ]);
+        render(<Review projectId="proj1" />);
+
+        const outdated = await screen.findByText('Outdated');
+        expect(outdated.parentElement).toHaveTextContent(/Variant Alpha.*Outdated/);
+        expect(screen.getByText('Variant Beta').closest('span')).not.toHaveTextContent('Outdated');
+        expect(screen.getByText('Exploitable').closest('td')).not.toHaveTextContent('Outdated');
+    });
+
     test('shows the assessments empty state when there are none', async () => {
         mockNetwork([]);
         render(<Review projectId="proj1" />);

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -711,13 +711,38 @@ describe('StatusEditor', () => {
         );
 
         expect(screen.queryByText('pkg@1.0.0')).not.toBeInTheDocument();
-        const includeOutdated = screen.getByRole('checkbox', {name: 'Include outdated package versions'});
+        const includeOutdated = screen.getByRole('checkbox', {name: 'Include previous package versions'});
         await user.click(includeOutdated);
         const outdatedPackage = screen.getByText('pkg@1.0.0').closest('label')!.querySelector('input')!;
         await user.click(outdatedPackage);
-        expect(screen.getByText('Outdated')).toBeInTheDocument();
+        expect(screen.queryByText('Outdated')).not.toBeInTheDocument();
         await user.click(includeOutdated);
         await user.click(includeOutdated);
         expect(screen.getByText('pkg@1.0.0').closest('label')!.querySelector('input')).not.toBeChecked();
+    });
+
+    test('offers outdated findings when a package is current in another variant', () => {
+        render(
+            <StatusEditor
+                {...defaultProps}
+                variants={[
+                    {id: 'v1', name: 'current', project_id: 'p1'},
+                    {id: 'v2', name: 'historical', project_id: 'p1'},
+                ]}
+                availablePackages={['pkg@1.0.0']}
+                variantPackageMap={{v1: ['pkg@1.0.0'], v2: []}}
+                variantFindingsMap={{
+                    v1: [{pkg: 'pkg@1.0.0', outdated: false}],
+                    v2: [{pkg: 'pkg@1.0.0', outdated: true}],
+                }}
+            />
+        );
+
+        expect(screen.getByRole('checkbox', {name: 'Include previous package versions'})).toBeInTheDocument();
+    });
+
+    test('shows historical finding discovery while scope data loads', () => {
+        render(<StatusEditor {...defaultProps} availablePackages={['pkg@2.0.0']} findingsLoading={true} />);
+        expect(screen.getByText('Checking for previous package versions…')).toBeInTheDocument();
     });
 });

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -559,7 +559,7 @@ describe('StatusEditor', () => {
         expect(checkboxes[2].disabled).toBe(false);
     });
 
-    test('should deselect an incompatible variant when a conflicting package is checked', async () => {
+    test('should disable a package that is not available in every selected variant', async () => {
         const user = userEvent.setup();
         const variants = [
             { id: 'v1', name: 'default', project_id: 'p1' },
@@ -590,11 +590,9 @@ describe('StatusEditor', () => {
         expect(checkboxes[0].checked).toBe(true);
         expect(checkboxes[1].checked).toBe(true);
 
-        // Check pkgB, which only exists in v2.
-        await user.click(checkboxes[3]);
-
-        // v1 is no longer compatible with the selected package → auto-deselected
-        expect(checkboxes[0].checked).toBe(false);
+        // pkgB only exists in v2, so it cannot be applied while v1 is selected.
+        expect(checkboxes[3].disabled).toBe(true);
+        expect(checkboxes[0].checked).toBe(true);
         expect(checkboxes[1].checked).toBe(true);
     });
 
@@ -711,8 +709,10 @@ describe('StatusEditor', () => {
         );
 
         expect(screen.queryByText('pkg@1.0.0')).not.toBeInTheDocument();
-        const includeOutdated = screen.getByRole('checkbox', {name: 'Include previous package versions'});
+        const includeOutdated = screen.getByRole('checkbox', {name: 'Allow new assessments on outdated packages/variant'});
         await user.click(includeOutdated);
+        expect(screen.getByText('default').closest('label')!.querySelector('input')).not.toBeChecked();
+        expect(screen.getByText('pkg@2.0.0').closest('label')!.querySelector('input')).not.toBeChecked();
         const outdatedPackage = screen.getByText('pkg@1.0.0').closest('label')!.querySelector('input')!;
         await user.click(outdatedPackage);
         expect(screen.queryByText('Outdated')).not.toBeInTheDocument();
@@ -738,7 +738,51 @@ describe('StatusEditor', () => {
             />
         );
 
-        expect(screen.getByRole('checkbox', {name: 'Include previous package versions'})).toBeInTheDocument();
+        expect(screen.getByRole('checkbox', {name: 'Allow new assessments on outdated packages/variant'})).toBeInTheDocument();
+    });
+
+    test('requires every enabled variant to support every selected package', async () => {
+        const user = userEvent.setup();
+        render(
+            <StatusEditor
+                {...defaultProps}
+                variants={[
+                    {id: 'a', name: 'variant a', project_id: 'p'},
+                    {id: 'b', name: 'variant b', project_id: 'p'},
+                    {id: 'c', name: 'variant c', project_id: 'p'},
+                    {id: 'd', name: 'variant d', project_id: 'p'},
+                ]}
+                availablePackages={['p1@1.0.0', 'p2@1.0.0']}
+                variantPackageMap={{
+                    a: ['p2@1.0.0'],
+                    b: ['p1@1.0.0', 'p2@1.0.0'],
+                    c: ['p2@1.0.0'],
+                    d: ['p2@1.0.0'],
+                }}
+                variantFindingsMap={{
+                    a: [
+                        {pkg: 'p1@1.0.0', outdated: true},
+                        {pkg: 'p2@1.0.0', outdated: false},
+                    ],
+                    b: [
+                        {pkg: 'p1@1.0.0', outdated: false},
+                        {pkg: 'p2@1.0.0', outdated: false},
+                    ],
+                    c: [{pkg: 'p2@1.0.0', outdated: false}],
+                    d: [{pkg: 'p2@1.0.0', outdated: false}],
+                }}
+            />
+        );
+
+        await user.click(screen.getByRole('checkbox', {name: 'Allow new assessments on outdated packages/variant'}));
+        await user.click(screen.getByText('variant a').closest('label')!.querySelector('input')!);
+        await user.click(screen.getByText('p1@1.0.0').closest('label')!.querySelector('input')!);
+        await user.click(screen.getByText('p2@1.0.0').closest('label')!.querySelector('input')!);
+
+        expect(screen.getByText('variant a').closest('label')!.querySelector('input')).not.toBeDisabled();
+        expect(screen.getByText('variant b').closest('label')!.querySelector('input')).not.toBeDisabled();
+        expect(screen.getByText('variant c').closest('label')!.querySelector('input')).toBeDisabled();
+        expect(screen.getByText('variant d').closest('label')!.querySelector('input')).toBeDisabled();
     });
 
     test('shows historical finding discovery while scope data loads', () => {

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -693,4 +693,31 @@ describe('StatusEditor', () => {
         await user.click(checkboxes[1]);
         expect(checkboxes[1].checked).toBe(false);
     });
+
+    test('includes an outdated package only after enabling the option', async () => {
+        const user = userEvent.setup();
+        render(
+            <StatusEditor
+                {...defaultProps}
+                variants={[{id: 'v1', name: 'default', project_id: 'p1'}]}
+                availablePackages={['pkg@2.0.0']}
+                defaultSelectedPackages={['pkg@2.0.0']}
+                variantPackageMap={{v1: ['pkg@2.0.0']}}
+                variantFindingsMap={{v1: [
+                    {pkg: 'pkg@2.0.0', outdated: false},
+                    {pkg: 'pkg@1.0.0', outdated: true},
+                ]}}
+            />
+        );
+
+        expect(screen.queryByText('pkg@1.0.0')).not.toBeInTheDocument();
+        const includeOutdated = screen.getByRole('checkbox', {name: 'Include outdated package versions'});
+        await user.click(includeOutdated);
+        const outdatedPackage = screen.getByText('pkg@1.0.0').closest('label')!.querySelector('input')!;
+        await user.click(outdatedPackage);
+        expect(screen.getByText('Outdated')).toBeInTheDocument();
+        await user.click(includeOutdated);
+        await user.click(includeOutdated);
+        expect(screen.getByText('pkg@1.0.0').closest('label')!.querySelector('input')).not.toBeChecked();
+    });
 });

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -789,4 +789,44 @@ describe('StatusEditor', () => {
         render(<StatusEditor {...defaultProps} availablePackages={['pkg@2.0.0']} findingsLoading={true} />);
         expect(screen.getByText('Checking for previous package versions…')).toBeInTheDocument();
     });
+
+    test('prunes selected packages by the intersection after scope data changes', async () => {
+        const user = userEvent.setup();
+        const variants = [
+            {id: 'v1', name: 'first', project_id: 'p1'},
+            {id: 'v2', name: 'second', project_id: 'p1'},
+            {id: 'v3', name: 'third', project_id: 'p1'},
+        ];
+        const view = render(
+            <StatusEditor
+                {...defaultProps}
+                variants={variants}
+                availablePackages={['package@1.0.0']}
+                variantPackageMap={{
+                    v1: ['package@1.0.0'],
+                    v2: ['package@1.0.0'],
+                    v3: ['package@1.0.0'],
+                }}
+            />
+        );
+        for (const name of ['first', 'second', 'third']) {
+            await user.click(screen.getByText(name).closest('label')!.querySelector('input')!);
+        }
+
+        view.rerender(
+            <StatusEditor
+                {...defaultProps}
+                variants={variants}
+                availablePackages={['package@1.0.0']}
+                variantPackageMap={{
+                    v1: ['package@1.0.0'],
+                    v2: ['package@1.0.0'],
+                    v3: [],
+                }}
+            />
+        );
+        await user.click(screen.getByText('first').closest('label')!.querySelector('input')!);
+
+        expect(screen.getByText('package@1.0.0').closest('label')!.querySelector('input')).not.toBeChecked();
+    });
 });

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2170,35 +2170,57 @@ describe('Vulnerability Modal', () => {
             }
         ]));
         fetchMock.mockResponseOnce(JSON.stringify([])); // variant-snapshots
-        // Only pkgA is still active in the variant; pkgOld is deprecated.
+        // Finding rows carry their own package/variant outdated state.
         fetchMock.mockResponseOnce(JSON.stringify([
-            { variant_id: 'var-1', active_packages: ['pkgA@1.0.0'] }
+            {
+                variant_id: 'var-1',
+                active_packages: ['pkgA@1.0.0'],
+                findings: [
+                    {finding_id: 'finding-current', package: 'pkgA@1.0.0', outdated: false},
+                    {finding_id: 'finding-old', package: 'pkgOld@0.9.0', outdated: true},
+                ],
+            }
         ]));
 
         const multiPkgVuln: Vulnerability = {
             ...vulnerability,
             packages: ['pkgA@1.0.0'],
             packages_current: [],
-            assessments: [],
+            assessments: [
+                {
+                    id: 'assess-current', vuln_id: 'CVE-2010-1234', packages: ['pkgA@1.0.0'],
+                    status: 'affected', simplified_status: 'Exploitable', justification: '',
+                    impact_statement: '', status_notes: '', workaround: '',
+                    timestamp: '2025-06-01T00:00:00Z', origin: 'custom', responses: [], variant_id: 'var-1'
+                },
+                {
+                    id: 'assess-old', vuln_id: 'CVE-2010-1234', packages: ['pkgOld@0.9.0'],
+                    status: 'fixed', simplified_status: 'Fixed', justification: '',
+                    impact_statement: '', status_notes: '', workaround: '',
+                    timestamp: '2025-01-01T00:00:00Z', origin: 'custom', responses: [], variant_id: 'var-1'
+                },
+            ],
         };
 
         render(<VulnModal vuln={multiPkgVuln} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} projectId="proj1" />);
 
-        // Wait for the deprecated split to appear once variant-active-packages loads.
-        const deprecatedHeading = await screen.findByText('Assessments on old packages (not present in current SBOMs)');
+        const deprecatedHeading = await screen.findByText('Assessments on old packages and variants (not present in current SBOMs)');
         const deprecated = deprecatedHeading.parentElement as HTMLElement;
-        // The stale package version is broken out into the deprecated table.
         expect(within(deprecated).getByText('pkgOld@0.9.0')).toBeInTheDocument();
         expect(within(deprecated).getByText('Fixed')).toBeInTheDocument();
         expect(within(deprecated).queryByText('pkgA@1.0.0')).not.toBeInTheDocument();
 
-        // The active (variant, package) pair stays in the current table.
-        const current = screen.getByText('Assessments on current SBOMs packages').parentElement as HTMLElement;
+        const current = screen.getByText('Assessments on current SBOM packages and variants').parentElement as HTMLElement;
         expect(within(current).getByText('pkgA@1.0.0')).toBeInTheDocument();
         expect(within(current).getByText('Exploitable')).toBeInTheDocument();
         expect(within(current).queryByText('pkgOld@0.9.0')).not.toBeInTheDocument();
-        // Production appears as the variant tag in the current table.
-        expect(within(current).getByText('Production')).toBeInTheDocument();
+
+        const history = screen.getByText('Assessment history').nextElementSibling as HTMLElement;
+        const outdatedHistoryTag = within(history).getByText('pkgOld@0.9.0').closest('span');
+        expect(outdatedHistoryTag).toHaveTextContent(/pkgOld@0\.9\.0.*Production.*Outdated/);
+        const currentHistoryTag = within(history).getByText('pkgA@1.0.0').closest('span');
+        expect(currentHistoryTag).toHaveTextContent(/pkgA@1\.0\.0.*Production/);
+        expect(currentHistoryTag).not.toHaveTextContent('Outdated');
     });
 
     const pendingAiAssessment = {
@@ -2500,7 +2522,7 @@ describe('Vulnerability Modal', () => {
 
         render(<VulnModal vuln={{ ...vulnerability, assessments: [] }} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
-        const recapHeading = await screen.findByText('Assessments on current SBOMs packages');
+        const recapHeading = await screen.findByText('Assessments on current SBOM packages and variants');
         const recap = recapHeading.parentElement as HTMLElement;
         // Production reflects its most recent assessment (Not affected), not the older Exploitable
         expect(within(recap).getByText('Production')).toBeInTheDocument();
@@ -2535,7 +2557,7 @@ describe('Vulnerability Modal', () => {
 
         render(<VulnModal vuln={{ ...vulnerability, assessments: [] }} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
-        const recapHeading = await screen.findByText('Assessments on current SBOMs packages');
+        const recapHeading = await screen.findByText('Assessments on current SBOM packages and variants');
         const recap = recapHeading.parentElement as HTMLElement;
         // Staging has no assessment yet, so it is flagged as "No status"
         expect(within(recap).getByText('Staging')).toBeInTheDocument();

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -183,6 +183,45 @@ describe('Vulnerability Modal', () => {
         expect(screen.queryByText('Scc')).not.toBeInTheDocument();
     })
 
+    test('keeps independent same-day assessments with identical content separate', async () => {
+        const first = {
+            ...vulnerability.assessments[0],
+            id: 'same-day-first',
+            packages: ['first@1.0.0'],
+            timestamp: '2026-07-28T09:00:00Z',
+        };
+        const second = {
+            ...vulnerability.assessments[0],
+            id: 'same-day-second',
+            packages: ['second@1.0.0'],
+            timestamp: '2026-07-28T15:00:00Z',
+        };
+        fetchMock.resetMocks();
+        fetchMock.mockResponse((req) => {
+            if (req.url.includes(`/api/vulnerabilities/${encodeURIComponent(vulnerability.id)}/assessments`)) {
+                return Promise.resolve(JSON.stringify([first, second]));
+            }
+            return Promise.resolve(JSON.stringify([]));
+        });
+
+        render(
+            <VulnModal
+                vuln={{...vulnerability, assessments: [first, second]}}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
+            />
+        );
+
+        const history = screen.getByText('Assessment history').nextElementSibling as HTMLElement;
+        await waitFor(() => {
+            expect(within(history).getAllByRole('listitem')).toHaveLength(2);
+        });
+        expect(within(history).getAllByText('first@1.0.0')).toHaveLength(1);
+        expect(within(history).getAllByText('second@1.0.0')).toHaveLength(1);
+    });
+
 
     test('closing button', async () => {
         // ARRANGE

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -296,6 +296,32 @@ describe('Vulnerability Modal', () => {
         alertSpy.mockRestore();
     })
 
+    test('an invalid batch adds nothing and displays only the API error', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
+        fetchMock.mockResponseOnce(JSON.stringify({
+            status: 'error',
+            assessments: [],
+            count: 0,
+            errors: [{error: 'Invalid package version for vulnerability and variant: pkgB@1.0'}],
+        }), {status: 400});
+
+        const appendAssessment = jest.fn();
+        const patchVuln = jest.fn();
+        render(<VulnModal vuln={{ ...vulnerability, assessments: [] }} isEditing={true} onClose={() => {}} appendAssessment={appendAssessment} appendCVSS={() => null} patchVuln={patchVuln} />);
+        const user = userEvent.setup();
+        const selectStatus = screen.getAllByRole('combobox').find((el) =>
+            el.getAttribute('name')?.includes('new_assessment_status')) as HTMLElement;
+        await user.selectOptions(selectStatus, 'fixed');
+        await user.click(screen.getByText(/add assessment/i));
+
+        expect(await screen.findByText(/Assessment not added:.*pkgB@1\.0/i)).toBeInTheDocument();
+        expect(screen.queryByText(/Successfully added assessment/i)).not.toBeInTheDocument();
+        expect(appendAssessment).not.toHaveBeenCalled();
+        expect(patchVuln).not.toHaveBeenCalled();
+    });
+
     test('success message falls back to package-only when no variant touched', async () => {
         const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
         await submitAssessment({
@@ -721,7 +747,7 @@ describe('Vulnerability Modal', () => {
         expect(updateCb).not.toHaveBeenCalled();
         expect(patchVuln).not.toHaveBeenCalled();
 
-        const errorBanner = await screen.findByText(/failed to add assessment/i);
+        const errorBanner = await screen.findByText(/assessment not added/i);
         expect(errorBanner).toBeInTheDocument();
     });
 

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -68,6 +68,43 @@ def _resolve_package(pkg_string_id: str) -> "Package | None":
     return Package.get_by_string_id(pkg_string_id)
 
 
+def _find_valid_finding(package_id: UUID, vuln_id: str, variant_id: UUID) -> "Finding | None":
+    """Return the finding when it was actually observed for the variant.
+
+    Assessment writes may target active or historical package versions, but
+    they must never invent a package/vulnerability/variant relationship that
+    was not produced by a scan.
+    """
+    from ..models.observation import Observation
+    from ..models.scan import Scan
+
+    return db.session.execute(
+        db.select(Finding)
+        .join(Observation, Observation.finding_id == Finding.id)
+        .join(Scan, Scan.id == Observation.scan_id)
+        .where(
+            Finding.package_id == package_id,
+            Finding.vulnerability_id == vuln_id.upper(),
+            Scan.variant_id == variant_id,
+        )
+        .distinct()
+    ).scalar_one_or_none()
+
+
+def _validate_assessment_findings(
+    packages: list[Package], vuln_id: str, variant_id: UUID
+) -> "tuple[dict[UUID, Finding], list[str]]":
+    findings: dict[UUID, Finding] = {}
+    invalid: list[str] = []
+    for package in packages:
+        finding = _find_valid_finding(package.id, vuln_id, variant_id)
+        if finding is None:
+            invalid.append(package.string_id)
+        else:
+            findings[package.id] = finding
+    return findings, invalid
+
+
 def _create_assessment_record(
     assessment: "DBAssessment",
     finding_id: UUID,
@@ -902,13 +939,20 @@ def init_app(app: Flask) -> None:
                 + ". Assessments can only be written for existing packages."
             }, 400
 
+        valid_findings, invalid_findings = _validate_assessment_findings(
+            resolved_packages, vuln_id, variant_id
+        )
+        if invalid_findings:
+            return {
+                "error": "Invalid finding for vulnerability and variant: "
+                + ", ".join(invalid_findings)
+            }, 400
+
         created = []
         try:
             with batch_session():
                 for db_pkg in resolved_packages:
-                    # Ensure vulnerability record exists before creating Finding (FK constraint)
-                    DBVuln.get_or_create(vuln_id)
-                    finding = Finding.get_or_create(db_pkg.id, vuln_id)
+                    finding = valid_findings[db_pkg.id]
                     # Always create a new record — never merge with an existing one.
                     # from_vuln_assessment does a find-or-update which would overwrite
                     # previous user assessments on the same (finding, variant).
@@ -992,15 +1036,23 @@ def init_app(app: Flask) -> None:
                     })
                     continue
 
+                valid_findings, invalid_findings = _validate_assessment_findings(
+                    item_packages, vuln_id, variant_id
+                )
+                if invalid_findings:
+                    errors.append({
+                        "vuln_id": vuln_id,
+                        "error": "Invalid finding for vulnerability and variant: "
+                        + ", ".join(invalid_findings),
+                    })
+                    continue
+
                 for db_pkg in item_packages:
                     try:
-                        # Ensure vulnerability record exists before creating Finding (FK constraint)
-                        DBVuln.get_or_create(vuln_id)
-                        # Resolve finding from cache first, then DB
                         f_key = (db_pkg.id, vuln_id)
                         finding = finding_cache.get(f_key)
                         if finding is None:
-                            finding = Finding.get_or_create(db_pkg.id, vuln_id)
+                            finding = valid_findings[db_pkg.id]
                             finding_cache[f_key] = finding
                         # Always create a new record — never overwrite an existing assessment.
                         # Honour the per-item timestamp so rows added for the same action
@@ -1033,6 +1085,12 @@ def init_app(app: Flask) -> None:
         existing = DBAssessment.get_by_id(assessment_id)
         if existing is None:
             return {"error": "Assessment not found"}, 404
+        if existing.finding is None or existing.variant_id is None or _find_valid_finding(
+            existing.finding.package_id,
+            existing.finding.vulnerability_id,
+            existing.variant_id,
+        ) is None:
+            return {"error": "Assessment references a finding that is not valid for its variant"}, 400
 
         was_non_custom = (existing.origin or "") != "custom"
         # Editing a pending AI assessment directly must not silently approve

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import Any, Literal, overload
 from uuid import UUID
 
-from ..models import Assessment as DBAssessment, Package, Finding
+from ..models import Assessment as DBAssessment, Package, Finding, SBOMDocument, SBOMPackage
 from ..models.assessment import STATUS_TO_SIMPLIFIED
 from ..extensions import db, batch_session
 from ..models.vulnerability import Vulnerability as DBVuln
@@ -799,30 +799,52 @@ def init_app(app: Flask) -> None:
             if f.package_id and f.package:
                 pkg_string_by_id[f.package_id] = f.package.string_id
 
-        # Distinct variants with a finding for this vuln (Observation -> Scan -> Variant)
+        # Distinct variants and findings for this vuln
+        # (Finding -> Observation -> Scan -> Variant).
         seen_variant_ids: set[UUID] = set()
         variant_ids: list[UUID] = []
+        finding_ids_by_variant: dict[UUID, set[UUID]] = {}
         for finding in findings:
             for obs in Observation.get_by_finding(finding.id):
                 scan = db.session.get(Scan, obs.scan_id)
-                if scan is None or scan.variant_id in seen_variant_ids:
+                if scan is None:
                     continue
-                seen_variant_ids.add(scan.variant_id)
                 if project_uuid is not None:
                     variant = db.session.get(DBVariant, scan.variant_id)
                     if variant is None or variant.project_id != project_uuid:
                         continue
-                variant_ids.append(scan.variant_id)
+                finding_ids_by_variant.setdefault(scan.variant_id, set()).add(finding.id)
+                if scan.variant_id not in seen_variant_ids:
+                    seen_variant_ids.add(scan.variant_id)
+                    variant_ids.append(scan.variant_id)
 
         result = []
         vuln_pkg_ids = set(pkg_string_by_id.keys())
         for vid in variant_ids:
-            active_ids = active_package_ids_for_scans(
-                active_sbom_scan_ids_for_variant(vid),
-                restrict_to_package_ids=vuln_pkg_ids,
-            )
+            active_scan_ids = active_sbom_scan_ids_for_variant(vid)
+            active_ids = active_package_ids_for_scans(active_scan_ids, restrict_to_package_ids=vuln_pkg_ids)
             active_packages = [sid for pid, sid in pkg_string_by_id.items() if pid in active_ids]
-            result.append({"variant_id": str(vid), "active_packages": active_packages})
+            active_identities = set(db.session.execute(
+                db.select(Package.name, Package.version)
+                .join(SBOMPackage, Package.id == SBOMPackage.package_id)
+                .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+                .where(SBOMDocument.scan_id.in_(active_scan_ids))
+                .distinct()
+            ).all()) if active_scan_ids else set()
+            variant_findings = []
+            for finding in findings:
+                if finding.id not in finding_ids_by_variant.get(vid, set()) or finding.package is None:
+                    continue
+                variant_findings.append({
+                    "finding_id": str(finding.id),
+                    "package": finding.package.string_id,
+                    "outdated": (finding.package.name, finding.package.version) not in active_identities,
+                })
+            result.append({
+                "variant_id": str(vid),
+                "active_packages": active_packages,
+                "findings": sorted(variant_findings, key=lambda item: (item["package"], item["finding_id"])),
+            })
         return result, 200
 
     @app.route("/api/vulnerabilities/<vuln_id>/assessments", methods=["POST"])

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -944,7 +944,7 @@ def init_app(app: Flask) -> None:
         )
         if invalid_findings:
             return {
-                "error": "Invalid finding for vulnerability and variant: "
+                "error": "Invalid package version for vulnerability and variant: "
                 + ", ".join(invalid_findings)
             }, 400
 
@@ -975,94 +975,105 @@ def init_app(app: Flask) -> None:
         if not payload_data or "assessments" not in payload_data or not isinstance(payload_data["assessments"], list):
             return {"error": "Invalid request data. Expected: {assessments: [...]}"}, 400
 
-        results = []
-        errors = []
-        # Cache resolved packages across the batch to avoid repeated SELECTs
-        pkg_cache: dict = {}
-        finding_cache: dict = {}
+        errors: list[dict[str, Any]] = []
+        prepared: list[tuple[DBAssessment, UUID, list[Package], dict[UUID, Finding]]] = []
+        pkg_cache: dict[str, Package] = {}
 
-        with batch_session():
-            for item in payload_data["assessments"]:
-                if not isinstance(item, dict) or "vuln_id" not in item:
-                    errors.append({"error": "Invalid assessment data", "item": item})
-                    continue
+        # Validate the complete request before opening the write transaction.
+        # A batch represents one user action, so one invalid package/variant
+        # relationship must cancel every assessment in that action.
+        for item in payload_data["assessments"]:
+            if not isinstance(item, dict) or "vuln_id" not in item:
+                errors.append({"error": "Invalid assessment data", "item": item})
+                continue
 
-                assessment, status = payload_to_assessment(item)
-                if status != 200:
-                    if not isinstance(assessment, dict):
-                        errors.append({"vuln_id": item.get("vuln_id"), "error": "Internal error"})
-                        continue
-                    errors.append({"vuln_id": item.get("vuln_id"), "error": assessment.get("error", "Unknown error")})
-                    continue
-                if not isinstance(assessment, DBAssessment):
-                    errors.append({"vuln_id": item.get("vuln_id"), "error": "Internal error"})
-                    continue
+            assessment, status = payload_to_assessment(item)
+            if status != 200:
+                error = assessment.get("error", "Unknown error") if isinstance(assessment, dict) else "Internal error"
+                errors.append({"vuln_id": item.get("vuln_id"), "error": error})
+                continue
+            if not isinstance(assessment, DBAssessment):
+                errors.append({"vuln_id": item.get("vuln_id"), "error": "Internal error"})
+                continue
 
-                vuln_id = assessment.vuln_id
-                # variant_id is required for every batch item
-                variant_id_raw = item.get('variant_id') or None
-                if not variant_id_raw:
-                    errors.append({"vuln_id": vuln_id, "error": "variant_id is required"})
-                    continue
-                variant_id, err = parse_uuid_or_400(variant_id_raw, "variant_id")
-                if err:
-                    errors.append({"vuln_id": vuln_id, "error": "Invalid variant_id"})
-                    continue
-                pkg_list = assessment.packages or []
-                if not pkg_list:
-                    errors.append({"vuln_id": vuln_id, "error": "No valid package found"})
-                    continue
+            vuln_id = assessment.vuln_id
+            variant_id_raw = item.get("variant_id") or None
+            if not variant_id_raw:
+                errors.append({"vuln_id": vuln_id, "error": "variant_id is required"})
+                continue
+            variant_id, err = parse_uuid_or_400(variant_id_raw, "variant_id")
+            if err:
+                errors.append({"vuln_id": vuln_id, "error": "Invalid variant_id"})
+                continue
 
-                # Assessments must never create a package. Resolve every package
-                # for this item up front; if any is missing, reject the whole
-                # item (other items in the batch are unaffected).
-                item_packages: list[Package] = []
-                item_missing: list[str] = []
-                for pkg_string_id in pkg_list:
-                    db_pkg = pkg_cache.get(pkg_string_id)
-                    if db_pkg is None:
-                        db_pkg = _resolve_package(pkg_string_id)
-                        if db_pkg is not None:
-                            pkg_cache[pkg_string_id] = db_pkg
-                    if db_pkg is None:
-                        item_missing.append(pkg_string_id)
-                    else:
-                        item_packages.append(db_pkg)
-                if item_missing:
-                    errors.append({
-                        "vuln_id": vuln_id,
-                        "error": "Package not found: " + ", ".join(item_missing)
-                        + ". Assessments can only be written for existing packages.",
-                    })
-                    continue
+            pkg_list = assessment.packages or []
+            if not pkg_list:
+                errors.append({"vuln_id": vuln_id, "variant_id": str(variant_id), "error": "No valid package found"})
+                continue
 
-                valid_findings, invalid_findings = _validate_assessment_findings(
-                    item_packages, vuln_id, variant_id
-                )
-                if invalid_findings:
-                    errors.append({
-                        "vuln_id": vuln_id,
-                        "error": "Invalid finding for vulnerability and variant: "
-                        + ", ".join(invalid_findings),
-                    })
-                    continue
+            item_packages: list[Package] = []
+            item_missing: list[str] = []
+            for pkg_string_id in pkg_list:
+                db_pkg = pkg_cache.get(pkg_string_id)
+                if db_pkg is None:
+                    db_pkg = _resolve_package(pkg_string_id)
+                    if db_pkg is not None:
+                        pkg_cache[pkg_string_id] = db_pkg
+                if db_pkg is None:
+                    item_missing.append(pkg_string_id)
+                else:
+                    item_packages.append(db_pkg)
+            if item_missing:
+                errors.append({
+                    "vuln_id": vuln_id,
+                    "variant_id": str(variant_id),
+                    "error": "Package not found: " + ", ".join(item_missing)
+                    + ". Assessments can only be written for existing packages.",
+                })
+                continue
 
-                for db_pkg in item_packages:
-                    try:
-                        f_key = (db_pkg.id, vuln_id)
-                        finding = finding_cache.get(f_key)
-                        if finding is None:
-                            finding = valid_findings[db_pkg.id]
-                            finding_cache[f_key] = finding
-                        # Always create a new record — never overwrite an existing assessment.
-                        # Honour the per-item timestamp so rows added for the same action
-                        # (e.g. one assessment across several variants) share a value.
+            valid_findings, invalid_findings = _validate_assessment_findings(
+                item_packages, vuln_id, variant_id
+            )
+            if invalid_findings:
+                errors.append({
+                    "vuln_id": vuln_id,
+                    "variant_id": str(variant_id),
+                    "error": "Invalid package version for vulnerability and variant: "
+                    + ", ".join(invalid_findings),
+                })
+                continue
+            prepared.append((assessment, variant_id, item_packages, valid_findings))
+
+        if errors:
+            return {
+                "status": "error",
+                "assessments": [],
+                "count": 0,
+                "vuln_count": 0,
+                "errors": errors,
+                "error_count": len(errors),
+            }, 400
+
+        results: list[AssessmentDict] = []
+        try:
+            with batch_session():
+                for assessment, variant_id, item_packages, valid_findings in prepared:
+                    for db_pkg in item_packages:
                         db_a = _create_assessment_record(
-                            assessment, finding.id, variant_id,
-                            timestamp=getattr(assessment, 'timestamp', None))
+                            assessment, valid_findings[db_pkg.id].id, variant_id,
+                            timestamp=getattr(assessment, "timestamp", None),
+                        )
                         results.append(db_a.to_dict())
-                    except Exception as e:
-                        errors.append({"vuln_id": vuln_id, "error": str(e)})
+        except Exception as e:
+            return {
+                "status": "error",
+                "assessments": [],
+                "count": 0,
+                "vuln_count": 0,
+                "errors": [{"error": f"DB error: {e}"}],
+                "error_count": 1,
+            }, 500
 
         distinct_vulns = len({r.get("vuln_id") for r in results if r.get("vuln_id")})
         response = {
@@ -1071,9 +1082,6 @@ def init_app(app: Flask) -> None:
             "count": len(results),
             "vuln_count": distinct_vulns
         }
-        if errors:
-            response["errors"] = errors
-            response["error_count"] = len(errors)
         return response, 200 if results else 400
 
     @app.route("/api/assessments/<assessment_id>", methods=["PUT", "PATCH"])
@@ -1090,7 +1098,7 @@ def init_app(app: Flask) -> None:
             existing.finding.vulnerability_id,
             existing.variant_id,
         ) is None:
-            return {"error": "Assessment references a finding that is not valid for its variant"}, 400
+            return {"error": "Assessment references a package version that is not valid for its variant"}, 400
 
         was_non_custom = (existing.origin or "") != "custom"
         # Editing a pending AI assessment directly must not silently approve

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -11,7 +11,6 @@ from uuid import UUID
 from ..models import Assessment as DBAssessment, Package, Finding, SBOMDocument, SBOMPackage
 from ..models.assessment import STATUS_TO_SIMPLIFIED
 from ..extensions import db, batch_session
-from ..models.vulnerability import Vulnerability as DBVuln
 from ..models.variant import Variant as DBVariant
 from ._scan_helpers import parse_uuid_or_400
 from ._scan_queries import VulnerabilityText, fetch_vulnerabilities_texts
@@ -855,7 +854,7 @@ def init_app(app: Flask) -> None:
                     seen_variant_ids.add(scan.variant_id)
                     variant_ids.append(scan.variant_id)
 
-        result = []
+        result: list[dict[str, Any]] = []
         vuln_pkg_ids = set(pkg_string_by_id.keys())
         for vid in variant_ids:
             active_scan_ids = active_sbom_scan_ids_for_variant(vid)
@@ -868,7 +867,7 @@ def init_app(app: Flask) -> None:
                 .where(SBOMDocument.scan_id.in_(active_scan_ids))
                 .distinct()
             ).all()) if active_scan_ids else set()
-            variant_findings = []
+            variant_findings: list[dict[str, str | bool]] = []
             for finding in findings:
                 if finding.id not in finding_ids_by_variant.get(vid, set()) or finding.package is None:
                     continue
@@ -880,7 +879,10 @@ def init_app(app: Flask) -> None:
             result.append({
                 "variant_id": str(vid),
                 "active_packages": active_packages,
-                "findings": sorted(variant_findings, key=lambda item: (item["package"], item["finding_id"])),
+                "findings": sorted(
+                    variant_findings,
+                    key=lambda item: (str(item.get("package", "")), str(item.get("finding_id", ""))),
+                ),
             })
         return result, 200
 
@@ -910,6 +912,8 @@ def init_app(app: Flask) -> None:
         variant_id, err = parse_uuid_or_400(variant_id_raw, "variant_id")
         if err:
             return err
+        if variant_id is None:
+            return {"error": "Invalid variant_id"}, 400
 
         ai_generated = bool(payload_data.get("ai_generated"))
         target_origin = "ai" if ai_generated else "custom"
@@ -1003,6 +1007,9 @@ def init_app(app: Flask) -> None:
                 continue
             variant_id, err = parse_uuid_or_400(variant_id_raw, "variant_id")
             if err:
+                errors.append({"vuln_id": vuln_id, "error": "Invalid variant_id"})
+                continue
+            if variant_id is None:
                 errors.append({"vuln_id": vuln_id, "error": "Invalid variant_id"})
                 continue
 

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -7,6 +7,8 @@ from flask import Flask
 from flask.typing import ResponseReturnValue
 
 from ..models.package import Package
+from ..models.finding import Finding
+from ..models.observation import Observation
 from ..models.scan import Scan
 from ..models.variant import Variant
 from ..models.sbom_document import SBOMDocument
@@ -29,6 +31,10 @@ def init_app(app: Flask) -> None:
         project_id = request.args.get('project_id')
         compare_variant_id = request.args.get('compare_variant_id')
         variant_ids = request.args.get('variant_ids')
+        include_outdated = request.args.get('include_outdated', '').lower() in ('1', 'true', 'yes')
+        outdated_only = request.args.get('outdated_only', '').lower() in ('1', 'true', 'yes')
+        include_outdated = include_outdated or outdated_only
+        scope_variant_ids: list[uuid.UUID] = []
         if variant_id and compare_variant_id:
             base_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
             if err:
@@ -40,6 +46,7 @@ def init_app(app: Flask) -> None:
                 return err
             if compare_uuid is None:
                 return {"error": "Internal error"}, 500
+            scope_variant_ids = [compare_uuid]
             operation = request.args.get('operation', 'difference')
 
             def _pkg_ids_for_variant(variant_uuid: uuid.UUID) -> set[uuid.UUID]:
@@ -54,7 +61,9 @@ def init_app(app: Flask) -> None:
                     .distinct()
                 ).scalars().all())
 
-            if operation == 'intersection':
+            if outdated_only:
+                pkgs = []
+            elif operation == 'intersection':
                 base_ids = _pkg_ids_for_variant(base_uuid)
                 compare_ids = _pkg_ids_for_variant(compare_uuid)
                 result_ids = list(base_ids & compare_ids)
@@ -96,6 +105,7 @@ def init_app(app: Flask) -> None:
                 if parsed is None:
                     return {"error": "Internal error"}, 500
                 parsed_uuids.append(parsed)
+            scope_variant_ids = parsed_uuids
             operation = request.args.get('operation', 'union')
 
             def _multi_pkg_ids_for_variant(variant_uuid: uuid.UUID) -> set[uuid.UUID]:
@@ -110,18 +120,21 @@ def init_app(app: Flask) -> None:
                     .distinct()
                 ).scalars().all())
 
-            id_sets = [_multi_pkg_ids_for_variant(u) for u in parsed_uuids]
-            if not id_sets:
-                multi_result_ids: list[uuid.UUID] = []
-            elif operation == 'intersection':
-                multi_result_ids = list(set.intersection(*id_sets))
-            else:  # union (default)
-                multi_result_ids = list(set.union(*id_sets))
-            pkgs = list(db.session.execute(
-                db.select(Package)
-                .where(Package.id.in_(multi_result_ids))
-                .order_by(Package.name)
-            ).scalars().all()) if multi_result_ids else []
+            if outdated_only:
+                pkgs = []
+            else:
+                id_sets = [_multi_pkg_ids_for_variant(u) for u in parsed_uuids]
+                if not id_sets:
+                    multi_result_ids: list[uuid.UUID] = []
+                elif operation == 'intersection':
+                    multi_result_ids = list(set.intersection(*id_sets))
+                else:  # union (default)
+                    multi_result_ids = list(set.union(*id_sets))
+                pkgs = list(db.session.execute(
+                    db.select(Package)
+                    .where(Package.id.in_(multi_result_ids))
+                    .order_by(Package.name)
+                ).scalars().all()) if multi_result_ids else []
             # Restrict enrichment to the active SBOM scans of the selected variants
             active_scan_ids = [
                 sid
@@ -134,8 +147,9 @@ def init_app(app: Flask) -> None:
                 return err
             if variant_uuid is None:
                 return {"error": "Internal error"}, 500
+            scope_variant_ids = [variant_uuid]
             sbom_ids = active_sbom_scan_ids_for_variant(variant_uuid)
-            if not sbom_ids:
+            if outdated_only or not sbom_ids:
                 pkgs = []
             else:
                 pkg_sets = _packages_by_scan_ids(sbom_ids)
@@ -149,8 +163,9 @@ def init_app(app: Flask) -> None:
                 return err
             if project_uuid is None:
                 return {"error": "Internal error"}, 500
+            scope_variant_ids = [variant.id for variant in Variant.get_by_project(project_uuid)]
             sbom_ids = active_sbom_scan_ids_for_project(project_uuid)
-            if not sbom_ids:
+            if outdated_only or not sbom_ids:
                 pkgs = []
             else:
                 pkg_sets = _packages_by_scan_ids(sbom_ids)
@@ -159,8 +174,9 @@ def init_app(app: Flask) -> None:
                 pkgs = sorted(pkg_lookup.values(), key=lambda p: p.name)
             active_scan_ids = sbom_ids
         else:
-            pkgs = Package.get_all()
+            pkgs = [] if outdated_only else Package.get_all()
             active_scan_ids = []
+            scope_variant_ids = [variant.id for variant in Variant.get_all()]
         result = [pkg.to_dict() for pkg in pkgs]
 
         for p in result:
@@ -238,6 +254,70 @@ def init_app(app: Flask) -> None:
                 p["variants"] = sorted(info.get("variants", set()))
                 p["sources"] = sorted(info.get("sources", set()))
                 p["sbom_documents"] = sorted(info.get("sbom_documents", set()))
+
+        if include_outdated and scope_variant_ids:
+            # A finding is outdated for a variant when the package name/version
+            # it observed historically is absent from that variant's active
+            # SBOM.  Match by name/version rather than package UUID so scanner
+            # findings without supplier metadata still match supplier-qualified
+            # packages from the SBOM.
+            active_identities_by_variant: dict[uuid.UUID, set[tuple[str, str]]] = {}
+            for scope_variant_id in scope_variant_ids:
+                scan_ids = active_sbom_scan_ids_for_variant(scope_variant_id)
+                if not scan_ids:
+                    active_identities_by_variant[scope_variant_id] = set()
+                    continue
+                active_identities_by_variant[scope_variant_id] = set(db.session.execute(
+                    db.select(Package.name, Package.version)
+                    .join(SBOMPackage, Package.id == SBOMPackage.package_id)
+                    .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+                    .where(SBOMDocument.scan_id.in_(scan_ids))
+                    .distinct()
+                ).all())
+
+            historical_rows = db.session.execute(
+                db.select(Finding, Package, Variant, Scan.scan_source)
+                .join(Package, Finding.package_id == Package.id)
+                .join(Observation, Observation.finding_id == Finding.id)
+                .join(Scan, Observation.scan_id == Scan.id)
+                .join(Variant, Scan.variant_id == Variant.id)
+                .where(Variant.id.in_(scope_variant_ids))
+                .distinct()
+            ).all()
+
+            outdated_rows: dict[tuple[uuid.UUID, uuid.UUID], dict] = {}
+            for finding, package, variant, scan_source in historical_rows:
+                if (package.name, package.version) in active_identities_by_variant.get(variant.id, set()):
+                    continue
+                key = (package.id, variant.id)
+                if key not in outdated_rows:
+                    item = package.to_dict()
+                    item.update({
+                        "variants": [variant.name],
+                        "sources": [],
+                        "sbom_documents": [],
+                        "outdated": True,
+                        "finding_ids": [],
+                        "vulnerability_ids": [],
+                    })
+                    outdated_rows[key] = item
+                item = outdated_rows[key]
+                finding_id = str(finding.id)
+                if finding_id not in item["finding_ids"]:
+                    item["finding_ids"].append(finding_id)
+                if finding.vulnerability_id not in item["vulnerability_ids"]:
+                    item["vulnerability_ids"].append(finding.vulnerability_id)
+                if scan_source and scan_source not in item["sources"]:
+                    item["sources"].append(scan_source)
+
+            for item in outdated_rows.values():
+                item["finding_ids"].sort()
+                item["vulnerability_ids"].sort()
+                item["sources"].sort()
+            result.extend(sorted(
+                outdated_rows.values(),
+                key=lambda item: (item["name"], item["version"], item["variants"]),
+            ))
 
         if request.args.get('format', 'list') == "dict":
             return {p["name"] + "@" + p["version"]: p for p in result}

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -267,13 +267,16 @@ def init_app(app: Flask) -> None:
                 if not scan_ids:
                     active_identities_by_variant[scope_variant_id] = set()
                     continue
-                active_identities_by_variant[scope_variant_id] = set(db.session.execute(
-                    db.select(Package.name, Package.version)
-                    .join(SBOMPackage, Package.id == SBOMPackage.package_id)
-                    .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
-                    .where(SBOMDocument.scan_id.in_(scan_ids))
-                    .distinct()
-                ).all())
+                active_identities_by_variant[scope_variant_id] = {
+                    (name, version)
+                    for name, version in db.session.execute(
+                        db.select(Package.name, Package.version)
+                        .join(SBOMPackage, Package.id == SBOMPackage.package_id)
+                        .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+                        .where(SBOMDocument.scan_id.in_(scan_ids))
+                        .distinct()
+                    )
+                }
 
             historical_rows = db.session.execute(
                 db.select(Finding, Package, Variant, Scan.scan_source)
@@ -289,8 +292,8 @@ def init_app(app: Flask) -> None:
             for finding, package, variant, scan_source in historical_rows:
                 if (package.name, package.version) in active_identities_by_variant.get(variant.id, set()):
                     continue
-                key = (package.id, variant.id)
-                if key not in outdated_rows:
+                outdated_key = (package.id, variant.id)
+                if outdated_key not in outdated_rows:
                     item = package.to_dict()
                     item.update({
                         "variants": [variant.name],
@@ -300,8 +303,8 @@ def init_app(app: Flask) -> None:
                         "finding_ids": [],
                         "vulnerability_ids": [],
                     })
-                    outdated_rows[key] = item
-                item = outdated_rows[key]
+                    outdated_rows[outdated_key] = item
+                item = outdated_rows[outdated_key]
                 finding_id = str(finding.id)
                 if finding_id not in item["finding_ids"]:
                     item["finding_ids"].append(finding_id)

--- a/src/routes/packages.py
+++ b/src/routes/packages.py
@@ -34,6 +34,8 @@ def init_app(app: Flask) -> None:
         include_outdated = request.args.get('include_outdated', '').lower() in ('1', 'true', 'yes')
         outdated_only = request.args.get('outdated_only', '').lower() in ('1', 'true', 'yes')
         include_outdated = include_outdated or outdated_only
+        if include_outdated and not any((variant_id, project_id, variant_ids)):
+            return {"error": "A variant or project scope is required for outdated packages"}, 400
         scope_variant_ids: list[uuid.UUID] = []
         if variant_id and compare_variant_id:
             base_uuid, err = parse_uuid_or_400(variant_id, "variant_id")
@@ -183,6 +185,7 @@ def init_app(app: Flask) -> None:
             p.setdefault("variants", [])
             p.setdefault("sources", [])
             p.setdefault("sbom_documents", [])
+            p["outdated"] = False
 
         # Enrich each package with its variants and sources derived from the
         # SBOMPackage → SBOMDocument → Scan → Variant chain so that the
@@ -297,6 +300,7 @@ def init_app(app: Flask) -> None:
                     item = package.to_dict()
                     item.update({
                         "variants": [variant.name],
+                        "variant_id": str(variant.id),
                         "sources": [],
                         "sbom_documents": [],
                         "outdated": True,
@@ -323,5 +327,11 @@ def init_app(app: Flask) -> None:
             ))
 
         if request.args.get('format', 'list') == "dict":
-            return {p["name"] + "@" + p["version"]: p for p in result}
+            dict_result = {}
+            for package in result:
+                key = package["name"] + "@" + package["version"]
+                if package["outdated"]:
+                    key += "@" + package["variant_id"]
+                dict_result[key] = package
+            return dict_result
         return result

--- a/tests/webapp_tests/test_ai_assessments.py
+++ b/tests/webapp_tests/test_ai_assessments.py
@@ -49,6 +49,16 @@ def app(init_files):
             "NVD_DB_PATH": "webapp_tests/mini_nvd.db",
         })
         setup_demo_db(application, extra_packages=["abc@1.2.3"])
+        with application.app_context():
+            from src.models.finding import Finding
+            from src.models.observation import Observation
+            from src.models.package import Package
+
+            package = Package.get_by_string_id(PKG2)
+            assert package is not None
+            finding = Finding.get_or_create(package.id, VULN_ID)
+            Observation.create(finding.id, SCAN_UUID, commit=False)
+            db.session.commit()
         yield application
     finally:
         os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
@@ -94,15 +104,7 @@ def test_ai_post_second_variant_allowed(client, app):
     assert first.status_code == 200
 
     other_variant = "22222222-2222-2222-2222-222222222223"
-    with app.app_context():
-        db.session.add(
-            Variant(
-                id=uuid.UUID(other_variant),
-                project_id=PROJECT_UUID,
-                name="variant-b",
-            )
-        )
-        db.session.commit()
+    _add_variant(app, other_variant)
 
     second = _post_ai(client, variant_id=other_variant)
     assert second.status_code == 200
@@ -197,9 +199,19 @@ def test_approve_non_ai_returns_400(client):
 
 def _add_variant(app, variant_id):
     with app.app_context():
+        from src.models.finding import Finding
+        from src.models.observation import Observation
+        from src.models.scan import Scan
+
+        variant_uuid = uuid.UUID(variant_id)
         db.session.add(
-            Variant(id=uuid.UUID(variant_id), project_id=PROJECT_UUID, name="variant-b")
+            Variant(id=variant_uuid, project_id=PROJECT_UUID, name="variant-b")
         )
+        scan = Scan(id=uuid.uuid4(), variant_id=variant_uuid)
+        db.session.add(scan)
+        db.session.flush()
+        for finding in Finding.get_by_vulnerability(VULN_ID):
+            Observation.create(finding.id, scan.id, commit=False)
         db.session.commit()
 
 

--- a/tests/webapp_tests/test_assessments_coverage.py
+++ b/tests/webapp_tests/test_assessments_coverage.py
@@ -36,6 +36,21 @@ def app(init_files):
             "NVD_DB_PATH": "webapp_tests/mini_nvd.db"
         })
         setup_demo_db(application, extra_packages=["test@1.0.0", "pkg@1.0.0", "pkg1@1.0.0", "pkg2@2.0.0", "pkg3@3.0.0"])
+        with application.app_context():
+            from src.extensions import db
+            from src.models.finding import Finding
+            from src.models.observation import Observation
+            from src.models.package import Package
+            from src.models.vulnerability import Vulnerability
+
+            for vuln_id in ("CVE-2021-99999", "CVE-2021-11111", "CVE-2021-22222"):
+                Vulnerability.get_or_create(vuln_id)
+                for package_id in ("test@1.0.0", "pkg@1.0.0", "pkg1@1.0.0", "pkg2@2.0.0", "pkg3@3.0.0"):
+                    package = Package.get_by_string_id(package_id)
+                    assert package is not None
+                    finding = Finding.get_or_create(package.id, vuln_id)
+                    Observation.create(finding.id, "33333333-3333-3333-3333-333333333333", commit=False)
+            db.session.commit()
         yield application
     finally:
         os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)

--- a/tests/webapp_tests/test_assessments_coverage.py
+++ b/tests/webapp_tests/test_assessments_coverage.py
@@ -208,7 +208,7 @@ def test_post_assessments_batch_all_valid(client):
 
 # Test POST assessment batch - mixed valid and invalid
 def test_post_assessments_batch_mixed_validity(client):
-    """Test batch creation with mix of valid and invalid assessments"""
+    """A mix of valid and invalid assessments cancels the whole batch."""
     response = client.post("/api/assessments/batch", json={
         'assessments': [
             {
@@ -228,10 +228,11 @@ def test_post_assessments_batch_mixed_validity(client):
             }
         ]
     })
-    assert response.status_code == 200
+    assert response.status_code == 400
     data = json.loads(response.data)
-    assert data["count"] == 1
-    assert data["vuln_count"] == 1
+    assert data["count"] == 0
+    assert data["vuln_count"] == 0
+    assert data["assessments"] == []
     assert data["error_count"] == 2
     assert len(data["errors"]) == 2
 
@@ -285,7 +286,7 @@ def test_post_assessments_batch_not_a_list(client):
 
 # Test POST assessment batch - invalid item structure
 def test_post_assessments_batch_invalid_item_structure(client):
-    """Test batch creation with invalid item structure"""
+    """An invalid item structure cancels valid entries in the same batch."""
     response = client.post("/api/assessments/batch", json={
         'assessments': [
             'not_a_dict',
@@ -293,9 +294,10 @@ def test_post_assessments_batch_invalid_item_structure(client):
              'variant_id': DEMO_VARIANT_ID}
         ]
     })
-    assert response.status_code == 200
+    assert response.status_code == 400
     data = json.loads(response.data)
-    assert data["count"] == 1
+    assert data["count"] == 0
+    assert data["assessments"] == []
     assert data["error_count"] == 1
 
 
@@ -631,6 +633,40 @@ def test_post_assessments_batch_invalid_variant_id(client):
     assert data["error_count"] >= 1
     assert any("variant_id" in str(e).lower() or "invalid" in str(e).lower()
                for e in data["errors"])
+
+
+def test_post_assessments_batch_is_atomic_when_one_variant_is_invalid(client, app):
+    """One invalid package/variant pair cancels every item in the batch."""
+    from src.models.assessment import Assessment
+
+    with app.app_context():
+        before = len(Assessment.get_by_vulnerability("CVE-2021-11111"))
+
+    response = client.post("/api/assessments/batch", json={
+        "assessments": [
+            {
+                "vuln_id": "CVE-2021-11111",
+                "packages": ["pkg1@1.0.0"],
+                "status": "affected",
+                "variant_id": DEMO_VARIANT_ID,
+            },
+            {
+                "vuln_id": "CVE-2021-11111",
+                "packages": ["pkg1@1.0.0"],
+                "status": "affected",
+                "variant_id": "22222222-2222-2222-2222-222222222223",
+            },
+        ]
+    })
+
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert data["status"] == "error"
+    assert data["count"] == 0
+    assert data["assessments"] == []
+    assert data["error_count"] == 1
+    with app.app_context():
+        assert len(Assessment.get_by_vulnerability("CVE-2021-11111")) == before
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webapp_tests/test_post_endpoints.py
+++ b/tests/webapp_tests/test_post_endpoints.py
@@ -241,13 +241,16 @@ def test_post_assessment_rejects_unobserved_finding(client):
         'variant_id': '22222222-2222-2222-2222-222222222222',
     })
     assert response.status_code == 400
-    assert "Invalid finding" in response.get_data(as_text=True)
+    assert "Invalid package version" in response.get_data(as_text=True)
 
 
-def test_batch_missing_package_skips_item_only(client):
-    # In a batch, an item referencing a missing package is rejected with a
-    # per-item error while valid items still succeed.
+def test_batch_missing_package_cancels_whole_batch(client):
+    # A missing package cancels the complete user action, including valid items.
+    from src.models.assessment import Assessment
     from src.models.package import Package
+
+    with client.application.app_context():
+        before = len(Assessment.get_by_vulnerability("CVE-1999-12345"))
 
     response = client.post("/api/assessments/batch", json={
         'assessments': [
@@ -265,14 +268,16 @@ def test_batch_missing_package_skips_item_only(client):
             },
         ]
     })
-    assert response.status_code == 200
+    assert response.status_code == 400
     data = json.loads(response.data)
-    assert data["count"] == 1
+    assert data["count"] == 0
+    assert data["assessments"] == []
     assert data.get("error_count") == 1
     assert any("ghost@0.0.1" in e.get("error", "") for e in data["errors"])
 
     with client.application.app_context():
         assert Package.get_by_string_id("ghost@0.0.1") is None
+        assert len(Assessment.get_by_vulnerability("CVE-1999-12345")) == before
 
 
 def test_patch_vulnerability_empty(client):

--- a/tests/webapp_tests/test_post_endpoints.py
+++ b/tests/webapp_tests/test_post_endpoints.py
@@ -36,6 +36,19 @@ def app(init_files):
             "NVD_DB_PATH": "webapp_tests/mini_nvd.db"
         })
         setup_demo_db(application)
+        with application.app_context():
+            from src.extensions import db
+            from src.models.finding import Finding
+            from src.models.observation import Observation
+            from src.models.package import Package
+            from src.models.vulnerability import Vulnerability
+
+            package = Package.get_by_string_id("cairo@1.16.0")
+            assert package is not None
+            Vulnerability.get_or_create("CVE-1999-12345")
+            finding = Finding.get_or_create(package.id, "CVE-1999-12345")
+            Observation.create(finding.id, "33333333-3333-3333-3333-333333333333", commit=False)
+            db.session.commit()
         yield application
     finally:
         os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
@@ -191,6 +204,44 @@ def test_post_assessment_any_missing_package_blocks_all(client):
         assert Package.get_by_string_id("missing@1.0.0") is None
     after = client.get("/api/assessments?format=list")
     assert len(json.loads(after.data)) == before_count
+
+
+def test_post_assessment_accepts_outdated_observed_finding(client):
+    from src.extensions import db
+    from src.models.finding import Finding
+    from src.models.observation import Observation
+    from src.models.package import Package
+
+    with client.application.app_context():
+        old_package = Package.find_or_create("cairo", "1.15.0")
+        old_finding = Finding.get_or_create(old_package.id, "CVE-1999-12345")
+        Observation.create(old_finding.id, "33333333-3333-3333-3333-333333333333", commit=False)
+        db.session.commit()
+
+    response = client.post("/api/vulnerabilities/CVE-1999-12345/assessments", json={
+        'packages': ['cairo@1.15.0'],
+        'status': 'exploitable',
+        'variant_id': '22222222-2222-2222-2222-222222222222',
+    })
+    assert response.status_code == 200
+    assert json.loads(response.data)["assessment"]["packages"] == ["cairo@1.15.0"]
+
+
+def test_post_assessment_rejects_unobserved_finding(client):
+    from src.models.package import Package
+
+    with client.application.app_context():
+        Package.find_or_create("cairo", "1.14.0")
+        from src.extensions import db
+        db.session.commit()
+
+    response = client.post("/api/vulnerabilities/CVE-1999-12345/assessments", json={
+        'packages': ['cairo@1.14.0'],
+        'status': 'exploitable',
+        'variant_id': '22222222-2222-2222-2222-222222222222',
+    })
+    assert response.status_code == 400
+    assert "Invalid finding" in response.get_data(as_text=True)
 
 
 def test_batch_missing_package_skips_item_only(client):

--- a/tests/webapp_tests/test_project_variant_endpoints.py
+++ b/tests/webapp_tests/test_project_variant_endpoints.py
@@ -410,6 +410,14 @@ class TestConfigEndpoint:
 
 class TestPackagesFiltering:
 
+    def test_packages_outdated_requires_scope(self, client):
+        response = client.get("/api/packages?format=list&outdated_only=true")
+
+        assert response.status_code == 400
+        assert json.loads(response.data) == {
+            "error": "A variant or project scope is required for outdated packages"
+        }
+
     def test_packages_include_outdated_finding_variant_rows(self, client_and_data, app_with_data):
         client, data = client_and_data
         application, _ = app_with_data
@@ -440,6 +448,37 @@ class TestPackagesFiltering:
         assert old_row["variants"] == ["VariantA"]
         assert old_row["vulnerability_ids"] == ["CVE-2099-OLD1"]
         assert all(item["outdated"] is True for item in body)
+
+    def test_packages_dict_keeps_active_and_outdated_variant_rows(self, client_and_data, app_with_data):
+        client, data = client_and_data
+        application, _ = app_with_data
+        from src.extensions import db
+        from src.models.finding import Finding
+        from src.models.observation import Observation
+        from src.models.package import Package
+        from src.models.scan import Scan
+
+        with application.app_context():
+            cairo = Package.get_by_string_id("cairo@1.16.0")
+            assert cairo is not None
+            finding = Finding.get_or_create(cairo.id, "CVE-2020-35492")
+            variant_b_scan_id = db.session.execute(
+                db.select(Scan.id).where(Scan.variant_id == uuid.UUID(data["variant_b_id"]))
+            ).scalar_one()
+            Observation.create(finding.id, variant_b_scan_id)
+            db.session.commit()
+
+        response = client.get(
+            f"/api/packages?format=dict&include_outdated=true"
+            f"&variant_ids={data['variant_a_id']},{data['variant_b_id']}"
+        )
+
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        assert body["cairo@1.16.0"]["outdated"] is False
+        outdated_key = f"cairo@1.16.0@{data['variant_b_id']}"
+        assert body[outdated_key]["outdated"] is True
+        assert body[outdated_key]["variant_id"] == data["variant_b_id"]
 
     def test_packages_no_filter_returns_all(self, client_and_data):
         client, _ = client_and_data

--- a/tests/webapp_tests/test_project_variant_endpoints.py
+++ b/tests/webapp_tests/test_project_variant_endpoints.py
@@ -410,6 +410,37 @@ class TestConfigEndpoint:
 
 class TestPackagesFiltering:
 
+    def test_packages_include_outdated_finding_variant_rows(self, client_and_data, app_with_data):
+        client, data = client_and_data
+        application, _ = app_with_data
+        from src.extensions import db
+        from src.models.package import Package
+        from src.models.vulnerability import Vulnerability
+        from src.models.finding import Finding
+        from src.models.observation import Observation
+        from src.models.scan import Scan
+
+        with application.app_context():
+            old_package = Package.find_or_create("cairo", "1.15.0")
+            Vulnerability.create_record("CVE-2099-OLD1")
+            old_finding = Finding.get_or_create(old_package.id, "CVE-2099-OLD1")
+            scan_id = db.session.execute(
+                db.select(Scan.id).where(Scan.variant_id == uuid.UUID(data["variant_a_id"]))
+            ).scalar_one()
+            Observation.create(old_finding.id, scan_id)
+            db.session.commit()
+
+        response = client.get(
+            f"/api/packages?variant_id={data['variant_a_id']}&format=list&outdated_only=true"
+        )
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        old_row = next(item for item in body if item["id"] == "cairo@1.15.0")
+        assert old_row["outdated"] is True
+        assert old_row["variants"] == ["VariantA"]
+        assert old_row["vulnerability_ids"] == ["CVE-2099-OLD1"]
+        assert all(item["outdated"] is True for item in body)
+
     def test_packages_no_filter_returns_all(self, client_and_data):
         client, _ = client_and_data
         response = client.get("/api/packages?format=list")

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -329,8 +329,10 @@ def test_review_ai_list_after_create(client):
 def test_review_ai_does_not_leak_into_custom_review(client):
     """AI-origin assessments must not appear in the custom /review list, and
     custom assessments must not appear in the AI review list."""
-    _create_ai_assessment(client)
-    _create_handmade_assessment(client, vuln_id="CVE-2020-35492", packages=["abc@1.2.3"])
+    ai_create_resp = _create_ai_assessment(client)
+    custom_create_resp = _create_handmade_assessment(client)
+    assert ai_create_resp.status_code == 200
+    assert custom_create_resp.status_code == 200
 
     custom_resp = client.get("/api/assessments/review")
     ai_resp = client.get("/api/assessments/review/ai")

--- a/tests/webapp_tests/test_vuln_assess_coverage.py
+++ b/tests/webapp_tests/test_vuln_assess_coverage.py
@@ -123,6 +123,11 @@ class TestVariantActivePackages:
             assert isinstance(entry["variant_id"], str)
             assert isinstance(entry["active_packages"], list)
             assert all(isinstance(p, str) for p in entry["active_packages"])
+            assert isinstance(entry["findings"], list)
+            for finding in entry["findings"]:
+                assert isinstance(finding["finding_id"], str)
+                assert isinstance(finding["package"], str)
+                assert isinstance(finding["outdated"], bool)
 
     def test_project_id_filter(self, client):
         """project_id filters variants without error."""


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

-Marks package findings as outdated per package/variant combination.
-Exposes historical package findings and their associated variants through the API.
-Displays Outdated badges in vulnerability details and review views.
-Adds authoritative backend validation so assessments cannot target findings that do not belong to the requested package/variant scope

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

Load a project with a variant which have two SBOM entries with outdated elements

SBOM tab: 

<img width="1902" height="488" alt="image" src="https://github.com/user-attachments/assets/ce597932-291f-47fb-aeab-0f1473236959" />

VulnModal:

<img width="1806" height="348" alt="image" src="https://github.com/user-attachments/assets/30681ab8-6285-46b9-a1fd-672f830adb72" />

<img width="1788" height="474" alt="image" src="https://github.com/user-attachments/assets/9afb8970-2655-4931-b476-9282bf70d7a5" />

(Same vulnerability) 

<img width="1792" height="551" alt="image" src="https://github.com/user-attachments/assets/706b4aed-b7a9-4631-b5ba-d4d16840e539" />

Review tab:

<img width="1892" height="510" alt="image" src="https://github.com/user-attachments/assets/07035d67-5dd9-495e-9f72-41d3d844d409" />
