### PR TITLE
feat(assessments): preserve timestamps when editing

### DIFF
--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -13,6 +13,7 @@ type EditAssessmentData = {
     workaround?: string;
     variant_ids?: string[];
     packages?: string[];
+    update_timestamp?: boolean;
 }
 
 type Props = {
@@ -72,6 +73,7 @@ function EditAssessment({
         defaultSelectedPackages ?? (availablePackages?.length === 1 ? [availablePackages[0]] : [])
     );
     const [includeOutdatedPackages, setIncludeOutdatedPackages] = useState(hasSelectedOutdatedFinding);
+    const [keepCurrentTimestamp, setKeepCurrentTimestamp] = useState(true);
     const outdatedPackages = useMemo(() => {
         const packages = new Set<string>();
         for (const finding of Object.values(variantFindingsMap ?? {}).flat()) {
@@ -203,10 +205,11 @@ function EditAssessment({
             justification !== (assessment.justification || "none") ||
             statusNotes !== initialStatusNotes ||
             workaround !== (assessment.workaround || "") ||
-            impact !== (isImpactStatus ? (assessment.impact_statement || "") : "")
+            impact !== (isImpactStatus ? (assessment.impact_statement || "") : "") ||
+            !keepCurrentTimestamp
         );
         onFieldsChange?.(hasChanges);
-    }, [status, justification, statusNotes, workaround, impact, onFieldsChange, assessment, isImpactStatus]);
+    }, [status, justification, statusNotes, workaround, impact, keepCurrentTimestamp, onFieldsChange, assessment, isImpactStatus]);
 
     // Auto-select single variant when availableVariants load asynchronously (e.g. Edit from Actions column)
     useEffect(() => {
@@ -256,7 +259,8 @@ function EditAssessment({
             // For non-impact statuses the value was folded into status_notes; clear impact_statement.
             impact_statement: includeImpact ? impact : "",
             variant_ids: selectedVariantIds.length > 0 ? selectedVariantIds : undefined,
-            packages: selectedPackages.length > 0 ? selectedPackages : (availablePackages ?? [])
+            packages: selectedPackages.length > 0 ? selectedPackages : (availablePackages ?? []),
+            update_timestamp: !keepCurrentTimestamp,
         });
     }
 
@@ -267,6 +271,7 @@ function EditAssessment({
         setWorkaround(assessment.workaround || "");
         setImpact(isImpactStatus ? (assessment.impact_statement || "") : "");
         setIncludeOutdatedPackages(hasSelectedOutdatedFinding);
+        setKeepCurrentTimestamp(true);
         setSelectedVariantIds(defaultSelectedVariantIds ?? (availableVariants?.length === 1 ? [availableVariants[0].id] : []));
         setSelectedPackages(defaultSelectedPackages ?? (availablePackages?.length === 1 ? [availablePackages[0]] : []));
     }, [assessment, isImpactStatus, defaultSelectedVariantIds, defaultSelectedPackages, availableVariants, availablePackages, hasSelectedOutdatedFinding]);
@@ -410,6 +415,32 @@ function EditAssessment({
                     </div>
                 </div>
             )}
+
+            <div className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-gray-600 bg-gray-800/40 px-3 py-2">
+                <span>
+                    <span className="block text-sm font-medium text-gray-200">Keep the current timestamp</span>
+                    <span className="block text-xs text-gray-400">
+                        Turn off to place the edited assessment at the top of the history with the current timestamp.
+                    </span>
+                </span>
+                <button
+                    type="button"
+                    role="switch"
+                    aria-label="Keep the current timestamp"
+                    aria-checked={keepCurrentTimestamp}
+                    onClick={() => setKeepCurrentTimestamp(value => !value)}
+                    className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors duration-300 ${
+                        keepCurrentTimestamp ? 'bg-green-500' : 'bg-gray-400'
+                    }`}
+                >
+                    <span
+                        aria-hidden="true"
+                        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-300 ${
+                            keepCurrentTimestamp ? 'translate-x-6' : 'translate-x-1'
+                        }`}
+                    />
+                </button>
+            </div>
 
             {(status === 'not_affected' || status === 'false_positive') && (
                 <><textarea

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -672,8 +672,12 @@ type VariantScopedSnapshot = {
         if (!editingGroup) return;
         setSubmittingMessage('Editing assessment...');
 
-        // Share a single timestamp across all created rows in this edit action
-        const editSharedTimestamp = new Date().toISOString();
+        // Keep every row affected by this edit in one history group. Depending
+        // on the user's choice, reuse the group's timestamp or move the whole
+        // group to the top with one shared current timestamp.
+        const editSharedTimestamp = data.update_timestamp === false
+            ? editingGroup.timestamp
+            : new Date().toISOString();
 
         // Build target (package × variantId) combos from form selection
         const targetVariantIds: Array<string | undefined> =
@@ -727,7 +731,9 @@ type VariantScopedSnapshot = {
                             justification: data.justification,
                             impact_statement: data.impact_statement,
                             status_notes: data.status_notes,
-                            workaround: data.workaround
+                            workaround: data.workaround,
+                            update_timestamp: data.update_timestamp !== false,
+                            timestamp: editSharedTimestamp,
                         })
                     });
                     if (res.ok) {

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -80,6 +80,58 @@ describe('EditAssessment Component', () => {
         expect(mockOnSave).toHaveBeenCalled();
     });
 
+    test('keeps the current assessment timestamp by default', async () => {
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+            />
+        );
+
+        expect(screen.getByRole('switch', {name: 'Keep the current timestamp'})).toHaveAttribute(
+            'aria-checked', 'true'
+        );
+        await user.click(screen.getByText('Save Changes'));
+
+        expect(mockOnSave).toHaveBeenCalledWith(expect.objectContaining({update_timestamp: false}));
+    });
+
+    test('can move the edited assessment to the top with a new timestamp', async () => {
+        const user = userEvent.setup();
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+            />
+        );
+
+        const timestampSwitch = screen.getByRole('switch', {name: 'Keep the current timestamp'});
+        await user.click(timestampSwitch);
+        await user.click(screen.getByText('Save Changes'));
+
+        expect(timestampSwitch).toHaveAttribute('aria-checked', 'false');
+        expect(mockOnSave).toHaveBeenCalledWith(expect.objectContaining({update_timestamp: true}));
+    });
+
+    test('shows the timestamp choice below package selection', () => {
+        render(
+            <EditAssessment
+                assessment={mockAssessment}
+                onSaveAssessment={mockOnSave}
+                onCancel={mockOnCancel}
+                availablePackages={['first@1.0.0', 'second@1.0.0']}
+                defaultSelectedPackages={['first@1.0.0']}
+            />
+        );
+
+        const packagesHeading = screen.getByText('Apply to packages:');
+        const timestampLabel = screen.getByText('Keep the current timestamp');
+        expect(packagesHeading.compareDocumentPosition(timestampLabel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
     test('shows internal banner when validation fails', async () => {
         const minimalAssessment: Assessment = {
             ...mockAssessment,
@@ -258,7 +310,8 @@ describe('EditAssessment Component', () => {
             // not wiped, since the impact textarea is shown and editable for it.
             impact_statement: 'test impact',
             packages: [],
-            variant_ids: undefined
+            variant_ids: undefined,
+            update_timestamp: false,
         });
     });
 
@@ -491,7 +544,8 @@ describe('EditAssessment Component', () => {
             workaround: 'test workaround',
             impact_statement: 'test impact',
             packages: [],
-            variant_ids: undefined
+            variant_ids: undefined,
+            update_timestamp: false,
         });
     });
 

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -1577,7 +1577,8 @@ describe('Vulnerability Modal', () => {
 
         await user.click(editBtn);
 
-        // Should show EditAssessment component, simulate save
+        // The default keeps the current history position and timestamp.
+        expect(screen.getByRole('switch', {name: 'Keep the current timestamp'})).toBeChecked();
         const saveBtn = screen.getByText(/save changes/i);
         await user.click(saveBtn);
 
@@ -1585,6 +1586,12 @@ describe('Vulnerability Modal', () => {
             expect.stringContaining('/api/assessments/assessment-1'),
             expect.objectContaining({ method: 'PUT' })
         );
+        const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT');
+        const putBody = JSON.parse(String(putCall?.[1]?.body));
+        expect(putBody).toEqual(expect.objectContaining({
+            update_timestamp: false,
+            timestamp: '2021-01-01T00:00:00Z',
+        }));
         expect(patchVuln).toHaveBeenCalled();
 
         // Check for success banner

--- a/src/models/assessment.py
+++ b/src/models/assessment.py
@@ -743,6 +743,8 @@ class Assessment(Base):
         impact_statement: Optional[str] = None,
         workaround: Optional[str] = None,
         responses: Optional[list[str]] = None,
+        timestamp: Optional[datetime] = None,
+        update_timestamp: bool = True,
     ) -> "Assessment":
         """Update fields in place, persist the change and return ``self``."""
         if status is not None:
@@ -763,7 +765,8 @@ class Assessment(Base):
             self.workaround = workaround
         if responses is not None:
             self.responses = responses
-        self.timestamp = datetime.now(timezone.utc)
+        if update_timestamp:
+            self.timestamp = timestamp or datetime.now(timezone.utc)
         db.session.commit()
         return self
 

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -1289,6 +1289,18 @@ def init_app(app: Flask) -> None:
         if "workaround" in payload_data and isinstance(payload_data["workaround"], str):
             mem_assess.set_workaround(payload_data["workaround"])
 
+        update_timestamp = payload_data.get("update_timestamp", True)
+        if not isinstance(update_timestamp, bool):
+            return {"error": "update_timestamp must be a boolean"}, 400
+        edit_timestamp = None
+        if update_timestamp and "timestamp" in payload_data:
+            if not isinstance(payload_data["timestamp"], str):
+                return {"error": "timestamp must be an ISO 8601 string"}, 400
+            try:
+                edit_timestamp = datetime.fromisoformat(payload_data["timestamp"].replace("Z", "+00:00"))
+            except ValueError:
+                return {"error": "Invalid timestamp"}, 400
+
         existing.update(
             status=mem_assess.status,
             origin=new_origin,
@@ -1297,6 +1309,8 @@ def init_app(app: Flask) -> None:
             impact_statement=mem_assess.impact_statement,
             workaround=getattr(mem_assess, "workaround", None),
             responses=list(mem_assess.responses or []),
+            timestamp=edit_timestamp,
+            update_timestamp=update_timestamp,
         )
         # Editing an automated assessment removes it from the scan-history
         # counts (it becomes custom-origin), so refresh the cached list view.

--- a/tests/webapp_tests/test_assessments_coverage.py
+++ b/tests/webapp_tests/test_assessments_coverage.py
@@ -385,6 +385,43 @@ def test_update_assessment_status_only(client):
     assert data["assessment"]["status_notes"] == 'Initial notes'  # Should remain unchanged
 
 
+def test_update_assessment_can_preserve_timestamp(client):
+    response = client.post("/api/vulnerabilities/CVE-2021-99999/assessments", json={
+        'packages': ['test@1.0.0'],
+        'status': 'under_investigation',
+        'variant_id': DEMO_VARIANT_ID,
+        'timestamp': '2024-01-15T12:00:00Z',
+    })
+    assessment = json.loads(response.data)["assessment"]
+
+    response = client.put(f"/api/assessments/{assessment['id']}", json={
+        'status': 'affected',
+        'update_timestamp': False,
+    })
+
+    assert response.status_code == 200
+    updated = json.loads(response.data)["assessment"]
+    assert updated["timestamp"] == assessment["timestamp"]
+
+
+def test_update_assessment_accepts_shared_timestamp(client):
+    response = client.post("/api/vulnerabilities/CVE-2021-99999/assessments", json={
+        'packages': ['test@1.0.0'],
+        'status': 'under_investigation',
+        'variant_id': DEMO_VARIANT_ID,
+    })
+    assessment_id = json.loads(response.data)["assessment"]["id"]
+
+    response = client.put(f"/api/assessments/{assessment_id}", json={
+        'status': 'affected',
+        'update_timestamp': True,
+        'timestamp': '2026-07-28T12:34:56Z',
+    })
+
+    assert response.status_code == 200
+    assert json.loads(response.data)["assessment"]["timestamp"] == '2026-07-28T12:34:56+00:00'
+
+
 # Test PUT assessment - update status_notes
 def test_update_assessment_status_notes(client):
     """Test updating status notes"""


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Add an edit option, enabled by default, that keeps an assessment's current timestamp and history position. Allow opting out to assign the current timestamp and move the edited assessment to the top of the history.

Persist explicit timestamps through the assessment update endpoint and cover both frontend and backend behaviors.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Edit an assessment and play with "Keep the current timestamp"


<img width="1755" height="608" alt="image" src="https://github.com/user-attachments/assets/06df804d-effe-487c-b312-3b9826846848" />
