### PR TITLE
feat(ui): unify search interactions

### DIFF
--- a/frontend/src/components/ExplicitSearchInput.tsx
+++ b/frontend/src/components/ExplicitSearchInput.tsx
@@ -1,0 +1,71 @@
+import { forwardRef } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+
+type Props = {
+    id: string;
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    onSearch: () => void | Promise<void>;
+    placeholder: string;
+    ariaLabel: string;
+    loading?: boolean;
+    ariaInvalid?: boolean;
+    labelClassName?: string;
+    inputClassName?: string;
+    inputType?: 'search' | 'text';
+};
+
+const ExplicitSearchInput = forwardRef<HTMLInputElement, Readonly<Props>>(function ExplicitSearchInput({
+    id,
+    label,
+    value,
+    onChange,
+    onSearch,
+    placeholder,
+    ariaLabel,
+    loading = false,
+    ariaInvalid = false,
+    labelClassName,
+    inputClassName = 'py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[250px] grow max-w-[800px]',
+    inputType = 'search',
+}, ref) {
+    const applySearch = () => void onSearch();
+
+    return <>
+        <label htmlFor={id} className={labelClassName}>{label}</label>
+        <input
+            id={id}
+            ref={ref}
+            value={value}
+            onChange={event => onChange(event.target.value)}
+            onKeyDown={event => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    applySearch();
+                }
+            }}
+            type={inputType}
+            aria-invalid={ariaInvalid}
+            className={inputClassName}
+            placeholder={placeholder}
+        />
+        <button
+            type="button"
+            aria-label={ariaLabel}
+            title={ariaLabel}
+            disabled={loading}
+            onClick={applySearch}
+            className="py-1 px-3 rounded bg-cyan-700 hover:bg-cyan-600 disabled:cursor-wait disabled:opacity-60"
+        >
+            <FontAwesomeIcon
+                icon={faMagnifyingGlass}
+                aria-hidden="true"
+                className={loading ? 'animate-pulse' : undefined}
+            />
+        </button>
+    </>;
+});
+
+export default ExplicitSearchInput;

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -7,7 +7,6 @@ import { asAssessment } from "../handlers/assessments";
 import type { Vulnerability } from "../handlers/vulnerabilities";
 import { asVulnerability } from "../handlers/vulnerabilities";
 import VulnModal from "../components/VulnModal";
-import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
 import ToggleSwitch from "../components/ToggleSwitch";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -23,6 +22,7 @@ import Packages from '../handlers/packages';
 import { useDocUrl } from '../helpers/useDocUrl';
 import { splitPkgId, extractSupplierName } from '../helpers/pkgId';
 import ReviewTransferModal from '../components/ReviewTransferModal';
+import ExplicitSearchInput from '../components/ExplicitSearchInput';
 
 type AssessmentMutation =
     | { type: 'delete'; vulnId: string; ids: string[] }
@@ -172,6 +172,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [search, setSearch] = useState<string>('');
+    const [draftSearch, setDraftSearch] = useState<string>('');
     const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
     const [selectedJustifications, setSelectedJustifications] = useState<string[]>([]);
     const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
@@ -336,12 +337,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             });
     }, [variantId, projectId]);
 
-    const updateSearch = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
-        if (event.target.value.length < 2) {
-            if (search != '') setSearch('');
-        }
-        setSearch(event.target.value);
-    }, 550, { maxWait: 2500 });
+    const applySearch = () => setSearch(draftSearch.trim());
 
     useEffect(() => {
         const handleKeyPress = (event: KeyboardEvent) => {
@@ -482,6 +478,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
 
     const resetFilters = () => {
         setSearch('');
+        setDraftSearch('');
         setSelectedStatuses([]);
         setSelectedJustifications([]);
         setSelectedSuppliers([]);
@@ -1421,8 +1418,16 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     return (
         <div>
             <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2">
-                <div>Search</div>
-                <input ref={searchInputRef} onInput={updateSearch} type="search" className="py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[250px] grow max-w-[800px]" placeholder="Search by vulnerability, package, status, ..." />
+                <ExplicitSearchInput
+                    id="review-search"
+                    ref={searchInputRef}
+                    value={draftSearch}
+                    onChange={setDraftSearch}
+                    onSearch={applySearch}
+                    label="Search"
+                    placeholder="Search by vulnerability, package, status, ..."
+                    ariaLabel="Search reviews"
+                />
 
                 <div className="relative">
                     <button

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -2,7 +2,6 @@ import type { Package, VulnCounts } from "../handlers/packages";
 import { createColumnHelper, Row } from '@tanstack/react-table'
 import { useMemo, useState, useRef, useEffect, useCallback } from "react";
 import TableGeneric from "../components/TableGeneric";
-import debounce from 'lodash-es/debounce';
 import FilterOption from "../components/FilterOption";
 import ToggleSwitch from "../components/ToggleSwitch";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,6 +12,7 @@ import { formatSourceName, getOriginalSourceName } from '../helpers/sourceNames'
 import type { Vulnerability } from '../handlers/vulnerabilities';
 import Vulnerabilities from '../handlers/vulnerabilities';
 import MessageBanner from '../components/MessageBanner';
+import ExplicitSearchInput from '../components/ExplicitSearchInput';
 
 type Props = {
     packages: Package[];
@@ -42,6 +42,7 @@ const fuseKeys = ['id', 'name', 'version', 'cpe', 'purl']
 function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutdatedPackages, outdatedScopeKey }: Readonly<Props>) {
     const docUrl = useDocUrl("interactive-mode.html#sbom-table");
     const [search, setSearch] = useState<string>('');
+    const [draftSearch, setDraftSearch] = useState<string>('');
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
     const [selectedSbomDocs, setSelectedSbomDocs] = useState<string[]>([]);
     const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
@@ -82,12 +83,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
         { syntax: 'only:text', description: 'Show only packages whose name contains text (e.g. only:native)' },
     ];
 
-    const updateSearch = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
-        if (event.target.value.length < 2) {
-            if (search != '') setSearch('');
-        }
-        setSearch(event.target.value);
-    }, 550, { maxWait: 2500 });
+    const applySearch = () => setSearch(draftSearch.trim());
 
     useEffect(() => {
         const handleKeyPress = (event: KeyboardEvent) => {
@@ -267,6 +263,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
 
     const resetFilters = () => {
         setSearch('');
+        setDraftSearch('');
         setSelectedSources([]);
         setSelectedSbomDocs([]);
         setSelectedSuppliers([]);
@@ -537,8 +534,16 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
                     />
                 )}
         <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2">
-            <div>Search</div>
-            <input ref={searchInputRef} onInput={updateSearch} type="search" className="py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[250px] grow max-w-[800px]" placeholder="Search by package name, version, ..." />
+            <ExplicitSearchInput
+                id="package-search"
+                ref={searchInputRef}
+                value={draftSearch}
+                onChange={setDraftSearch}
+                onSearch={applySearch}
+                label="Search"
+                placeholder="Search by package name, version, ..."
+                ariaLabel="Search packages"
+            />
 
             <div className="relative">
                 <button
@@ -569,15 +574,18 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
                 )}
             </div>
 
-            <label htmlFor="sbom-match-condition" className="ml-2">Match condition</label>
-            <input
+            <ExplicitSearchInput
                 id="sbom-match-condition"
                 value={matchCondition}
-                onChange={event => setMatchCondition(event.target.value)}
-                onKeyDown={event => { if (event.key === 'Enter') void applyMatchCondition(); }}
-                className="py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[260px]"
+                onChange={setMatchCondition}
+                onSearch={applyMatchCondition}
+                label="Match condition"
+                labelClassName="ml-2"
+                inputClassName="py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[260px]"
+                inputType="text"
                 placeholder="cvss >= 7 and pending"
-                aria-invalid={matchConditionError ? 'true' : 'false'}
+                ariaLabel="Search match condition"
+                ariaInvalid={Boolean(matchConditionError)}
             />
             <div className="relative">
                 <button

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -73,6 +73,7 @@ function useRefreshProgressEffect(
 }
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
+import ExplicitSearchInput from '../components/ExplicitSearchInput';
 import RangeSlider from "../components/RangeSlider";
 
 type Props = {
@@ -1594,30 +1595,17 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
 
         <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2 flex-wrap">
             <div className="contents">
-                <label htmlFor="vulnerability-search">Search</label>
-                <input
+                <ExplicitSearchInput
                     id="vulnerability-search"
                     ref={searchInputRef}
                     value={draftSearch}
-                    onChange={event => setDraftSearch(event.target.value)}
-                    onKeyDown={event => {
-                        if (event.key === 'Enter') {
-                            event.preventDefault();
-                            void applySearch();
-                        }
-                    }}
-                    type="search"
-                    className="py-1 px-2 bg-sky-900 focus:bg-sky-950 min-w-[250px] grow max-w-[800px]"
+                    onChange={setDraftSearch}
+                    onSearch={applySearch}
+                    label="Search"
                     placeholder="Search by ID, packages, description, ..."
+                    ariaLabel="Search vulnerabilities"
+                    loading={descriptionSearchLoading}
                 />
-                <button
-                    type="button"
-                    disabled={descriptionSearchLoading}
-                    onClick={() => void applySearch()}
-                    className="py-1 px-3 rounded bg-cyan-700 hover:bg-cyan-600 disabled:cursor-wait disabled:opacity-60"
-                >
-                    {descriptionSearchLoading ? 'Searching…' : 'Apply'}
-                </button>
             </div>
             {descriptionSearchError && (
                 <span role="alert" className="text-sm text-red-200">

--- a/frontend/tests/unit_tests/test_explicit_search_input.tsx
+++ b/frontend/tests/unit_tests/test_explicit_search_input.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { describe, expect, jest, test } from '@jest/globals';
+
+import ExplicitSearchInput from '../../src/components/ExplicitSearchInput';
+
+
+describe('ExplicitSearchInput', () => {
+    test('applies the search from the button and Enter key', async () => {
+        const user = userEvent.setup();
+        const onChange = jest.fn<(value: string) => void>();
+        const onSearch = jest.fn<() => void>();
+        render(
+            <ExplicitSearchInput
+                id="test-search"
+                label="Search"
+                value="openssl"
+                onChange={onChange}
+                onSearch={onSearch}
+                placeholder="Search packages"
+                ariaLabel="Search packages"
+            />
+        );
+
+        const input = screen.getByRole('searchbox');
+        await user.type(input, '{enter}');
+        await user.click(screen.getByRole('button', {name: 'Search packages'}));
+
+        expect(onSearch).toHaveBeenCalledTimes(2);
+    });
+
+    test('reports changes and disables search while loading', async () => {
+        const user = userEvent.setup();
+        const onChange = jest.fn<(value: string) => void>();
+        const onSearch = jest.fn<() => void>();
+        render(
+            <ExplicitSearchInput
+                id="test-search"
+                label="Search"
+                value=""
+                onChange={onChange}
+                onSearch={onSearch}
+                placeholder="Search packages"
+                ariaLabel="Search packages"
+                loading={true}
+            />
+        );
+
+        await user.type(screen.getByRole('searchbox'), 'a');
+
+        expect(onChange).toHaveBeenCalledWith('a');
+        expect((screen.getByRole('button', {name: 'Search packages'}) as HTMLButtonElement).disabled).toBe(true);
+    });
+});

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -7,6 +7,7 @@ expect.extend(matchers);
 
 import type { Package } from "../../src/handlers/packages";
 import TablePackages from '../../src/pages/TablePackages';
+import Vulnerabilities from '../../src/handlers/vulnerabilities';
 
 
 const getDOMRect = (width: number, height: number) => ({
@@ -153,6 +154,45 @@ describe('Packages Table', () => {
         expect(version_col).toBeTruthy();
         expect(vuln_count_col).toBeTruthy();
         expect(source_col).toBeTruthy();
+    })
+
+    test('package search applies only with the button or Enter', async () => {
+        render(<TablePackages packages={packages} />);
+        const user = userEvent.setup();
+        const input = screen.getByPlaceholderText('Search by package name, version, ...');
+
+        await user.type(input, 'aaabbbccc');
+        expect(screen.getByText('xxxyyyzzz')).toBeTruthy();
+
+        await user.click(screen.getByRole('button', {name: 'Search packages'}));
+        await waitFor(() => expect(screen.queryByText('xxxyyyzzz')).toBeNull());
+
+        await user.clear(input);
+        await user.type(input, 'dddeeefff');
+        expect(screen.getByText('aaabbbccc')).toBeTruthy();
+
+        await user.keyboard('{Enter}');
+        await waitFor(() => expect(screen.queryByText('aaabbbccc')).toBeNull());
+        expect(screen.getByText('dddeeefff')).toBeTruthy();
+    })
+
+    test('match condition applies with the button or Enter', async () => {
+        const matchSpy = jest.spyOn(Vulnerabilities, 'matchCondition').mockResolvedValue([]);
+        render(<TablePackages packages={packages} />);
+        const user = userEvent.setup();
+        const input = screen.getByLabelText('Match condition');
+
+        await user.type(input, 'cvss >= 7');
+        expect(matchSpy).not.toHaveBeenCalled();
+
+        await user.click(screen.getByRole('button', {name: 'Search match condition'}));
+        await waitFor(() => expect(matchSpy).toHaveBeenCalledTimes(1));
+
+        await user.clear(input);
+        await user.type(input, 'pending');
+        await user.keyboard('{Enter}');
+        await waitFor(() => expect(matchSpy).toHaveBeenCalledTimes(2));
+        matchSpy.mockRestore();
     })
 
     test('does not render the obsolete severity toggle', () => {
@@ -303,6 +343,7 @@ describe('Packages Table', () => {
         const search_bar = await screen.getByRole('searchbox');
 
         await user.type(search_bar, 'yyy');
+        await user.keyboard('{Enter}');
 
         await waitFor(() => {
             const html = document.body.innerHTML;
@@ -319,12 +360,12 @@ describe('Packages Table', () => {
         const search_bar = await screen.getByRole('searchbox');
 
         await user.type(search_bar, '-aaabbbccc');
+        await user.keyboard('{Enter}');
 
         await waitFor(() => {
-            const html = document.body.innerHTML;
-            expect(html).not.toContain('aaabbbccc');
-            expect(html).toContain('xxxyyyzzz');
-            expect(html).toContain('dddeeefff');
+            expect(screen.queryByRole('cell', {name: 'aaabbbccc'})).toBeNull();
+            expect(screen.getByRole('cell', {name: 'xxxyyyzzz'})).toBeTruthy();
+            expect(screen.getByRole('cell', {name: 'dddeeefff'})).toBeTruthy();
         }, { timeout: 2000 });
     })
 
@@ -336,12 +377,12 @@ describe('Packages Table', () => {
         const search_bar = await screen.getByRole('searchbox');
 
         await user.type(search_bar, '-aaabbbccc xxxyyyzzz');
+        await user.keyboard('{Enter}');
 
         await waitFor(() => {
-            const html = document.body.innerHTML;
-            expect(html).not.toContain('aaabbbccc');
-            expect(html).not.toContain('dddeeefff');
-            expect(html).toContain('xxxyyyzzz');
+            expect(screen.queryByRole('cell', {name: 'aaabbbccc'})).toBeNull();
+            expect(screen.queryByRole('cell', {name: 'dddeeefff'})).toBeNull();
+            expect(screen.getByRole('cell', {name: 'xxxyyyzzz'})).toBeTruthy();
         }, { timeout: 2000 });
     })
 

--- a/frontend/tests/unit_tests/test_review.tsx
+++ b/frontend/tests/unit_tests/test_review.tsx
@@ -832,7 +832,8 @@ function mockNetworkWithDeferredVuln(
 
 const searchAssessments = (value: string) => {
     const input = screen.getByPlaceholderText(/Search by vulnerability/);
-    fireEvent.input(input, { target: { value } });
+    fireEvent.change(input, { target: { value } });
+    fireEvent.keyDown(input, { key: 'Enter' });
 };
 
 describe('Review — Assessments tab navigation', () => {
@@ -1269,19 +1270,26 @@ describe('Review — filters, search and keyboard', () => {
         await screen.findByText('CVE-2020-1111');
     });
 
-    test('typing in the search box updates the table search term', async () => {
+    test('search applies only with the button or Enter', async () => {
         mockNetwork([makeAssessment('a1', 'v1')]);
         render(<Review projectId="proj1" />);
         await screen.findByTitle('Edit assessment');
+        const user = userEvent.setup();
 
         const input = screen.getByPlaceholderText(/Search by vulnerability/);
-        fireEvent.input(input, { target: { value: 'pkg' } });
+        await user.type(input, 'pkg');
+        expect(screen.getByTestId('mock-table')).toHaveAttribute('data-search', '');
+
+        await user.click(screen.getByRole('button', {name: 'Search reviews'}));
         await waitFor(() => {
             expect(screen.getByTestId('mock-table')).toHaveAttribute('data-search', 'pkg');
         });
 
-        // Shrinking below 2 chars clears the search term first.
-        fireEvent.input(input, { target: { value: 'p' } });
+        await user.clear(input);
+        await user.type(input, 'p');
+        expect(screen.getByTestId('mock-table')).toHaveAttribute('data-search', 'pkg');
+
+        await user.keyboard('{Enter}');
         await waitFor(() => {
             expect(screen.getByTestId('mock-table')).toHaveAttribute('data-search', 'p');
         });

--- a/frontend/tests/unit_tests/test_sbom_match_condition.tsx
+++ b/frontend/tests/unit_tests/test_sbom_match_condition.tsx
@@ -83,12 +83,18 @@ describe('SBOM match condition', () => {
         render(<TablePackages packages={packages} vulnerabilities={vulnerabilities} />);
 
         const searchInput = screen.getByPlaceholderText('Search by package name, version, ...');
+        const searchButton = screen.getByRole('button', { name: 'Search packages' });
         const searchHelp = screen.getByRole('button', { name: 'search syntax helper' });
         const matchConditionInput = screen.getByLabelText('Match condition');
+        const matchConditionButton = screen.getByRole('button', { name: 'Search match condition' });
         const matchConditionHelp = screen.getByRole('button', { name: 'match condition help' });
 
-        expect(searchInput.nextElementSibling).toContainElement(searchHelp);
-        expect(matchConditionInput.nextElementSibling).toContainElement(matchConditionHelp);
+        expect(searchInput.nextElementSibling).toBe(searchButton);
+        expect(searchButton.nextElementSibling).toContainElement(searchHelp);
+        expect(matchConditionInput.nextElementSibling).toBe(matchConditionButton);
+        expect(matchConditionButton.nextElementSibling).toContainElement(matchConditionHelp);
+        expect(searchButton.querySelector('[data-icon="magnifying-glass"]')).toBeInTheDocument();
+        expect(matchConditionButton.querySelector('[data-icon="magnifying-glass"]')).toBeInTheDocument();
         expect(searchHelp.querySelector('[data-icon="circle-question"]')).toBeInTheDocument();
         expect(matchConditionHelp.querySelector('[data-icon="circle-info"]')).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'Apply' })).not.toBeInTheDocument();

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -525,7 +525,7 @@ describe('Vulnerability Table', () => {
         const search_bar = await screen.getByRole('searchbox');
 
         await user.type(search_bar, '2018-5678');
-        await user.click(screen.getByRole('button', { name: 'Apply' }));
+        await user.click(screen.getByRole('button', { name: 'Search vulnerabilities' }));
 
         // Allow the applied filter to render.
         await waitFor(() => {
@@ -544,7 +544,7 @@ describe('Vulnerability Table', () => {
         const search_bar = await screen.getByRole('searchbox');
 
         await user.type(search_bar, 'yyy');
-        await user.click(screen.getByRole('button', { name: 'Apply' }));
+        await user.click(screen.getByRole('button', { name: 'Search vulnerabilities' }));
 
         await waitFor(() => {
             expect(screen.queryByRole('cell', {name: /CVE-2010-1234/})).not.toBeInTheDocument();
@@ -562,7 +562,7 @@ describe('Vulnerability Table', () => {
         const search_bar = await screen.getByRole('searchbox');
 
         await user.type(search_bar, '-2010');
-        await user.click(screen.getByRole('button', { name: 'Apply' }));
+        await user.click(screen.getByRole('button', { name: 'Search vulnerabilities' }));
 
         await waitFor(() => {
             expect(screen.queryByRole('cell', {name: /CVE-2010-1234/})).not.toBeInTheDocument();
@@ -580,7 +580,7 @@ describe('Vulnerability Table', () => {
         const search_bar = await screen.getByRole('searchbox');
 
         await user.type(search_bar, '-2010 2024');
-        await user.click(screen.getByRole('button', { name: 'Apply' }));
+        await user.click(screen.getByRole('button', { name: 'Search vulnerabilities' }));
 
         // Better use waitFor for a combined check instead of using waitForElementToBeRemoved in sequence, because the items are filtered out after the user.type() is completed, which may lead to the success of the first check and failure of the rest.
         await waitFor(() => {
@@ -600,7 +600,7 @@ describe('Vulnerability Table', () => {
         const search_bar = await screen.getByRole('searchbox');
 
         await user.type(search_bar, 'authentification process');
-        await user.click(screen.getByRole('button', { name: 'Apply' }));
+        await user.click(screen.getByRole('button', { name: 'Search vulnerabilities' }));
 
         await waitFor(() => {
             expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).not.toBeInTheDocument();
@@ -1045,7 +1045,7 @@ describe('Vulnerability Table', () => {
         // Set search
         const search_bar = await screen.getByRole('searchbox');
         await user.type(search_bar, '2018-5678');
-        await user.click(screen.getByRole('button', { name: 'Apply' }));
+        await user.click(screen.getByRole('button', { name: 'Search vulnerabilities' }));
 
         // Wait for filters to take effect
         await waitFor(() => {


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Require explicit search application across the SBOM, vulnerabilities, and review tabs through Enter or accessible magnifying-glass buttons. Apply the same interaction to SBOM match conditions and add regression coverage.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Test search bar in SBOM, Vulnerabilities and Review tab

<img width="1186" height="68" alt="image" src="https://github.com/user-attachments/assets/edd82911-8aa4-4cee-bdf2-3578d2de2d78" />
