### PR TITLE
Save tables user options into local storage

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -14,3 +14,7 @@ global.fetch = jest.fn(() =>
 jest.mock('./src/helpers/useDocUrl', () => ({
   useDocUrl: (path: string) => `https://vulnscout.readthedocs.io/en/test/${path}`,
 }));
+
+beforeEach(() => {
+  window.localStorage.clear();
+});

--- a/frontend/src/components/TableGeneric.tsx
+++ b/frontend/src/components/TableGeneric.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowUpShortWide, faArrowDownWideShort, faSort, faCircleQuestion } from "@fortawesome/free-solid-svg-icons";
 import { ReactNode, useMemo, useRef, useState, useEffect, useCallback } from "react";
 import Fuse from 'fuse.js';
+import { useLocalStorageState } from '../handlers/localStorage';
 
 declare module '@tanstack/react-table' {
     interface ColumnDefBase<TData extends RowData, TValue = unknown> {
@@ -30,6 +31,7 @@ type Props<DataType> = {
     onFilteredDataChange?: (filteredData: DataType[]) => void;
     onFocusedRowChange?: (rowIndex: number | null) => void;
     onHoverData?: (item: DataType) => Promise<DataType | null | undefined>;
+    persistenceKey?: string;
     /**
      * Values checked by the `only:<term>` search operator. When provided, a row
      * is kept only if EVERY string returned here satisfies the (optionally
@@ -63,12 +65,19 @@ function TableGeneric<DataType> ({
     onFilteredDataChange,
     onFocusedRowChange,
     onHoverData,
-    forAllValues
+    forAllValues,
+    persistenceKey
 }: Readonly<Props<DataType>>) {
-    const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 50 })
+    const [pagination, setPagination] = useLocalStorageState<PaginationState>(
+        persistenceKey ? `${persistenceKey}.pagination` : null,
+        { pageIndex: 0, pageSize: 50 }
+    )
     const pageIndex = pagination.pageIndex
     const itemsPerPage = pagination.pageSize
-    const [sorting, setSorting] = useState<SortingState>([])
+    const [sorting, setSorting] = useLocalStorageState<SortingState>(
+        persistenceKey ? `${persistenceKey}.sorting` : null,
+        []
+    )
     const [focusedRowIndex, setFocusedRowIndex] = useState<number | null>(null)
     const [hintColumnId, setHintColumnId] = useState<string | null>(null)
     const rowRefs = useRef<Map<number, HTMLTableRowElement>>(new Map())

--- a/frontend/src/handlers/localStorage.ts
+++ b/frontend/src/handlers/localStorage.ts
@@ -1,0 +1,27 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+
+function readStoredValue<T>(key: string | null, initialValue: T): T {
+    if (key === null) return initialValue;
+    try {
+        const storedValue = window.localStorage.getItem(key);
+        return storedValue === null ? initialValue : JSON.parse(storedValue) as T;
+    } catch {
+        return initialValue;
+    }
+}
+
+
+export function useLocalStorageState<T>(key: string | null, initialValue: T): [T, Dispatch<SetStateAction<T>>] {
+    const [value, setValue] = useState<T>(() => readStoredValue(key, initialValue));
+
+    useEffect(() => {
+        if (key === null) return;
+        try {
+            window.localStorage.setItem(key, JSON.stringify(value));
+        } catch {
+            // Storage can be unavailable or full; keep the in-memory state usable.
+        }
+    }, [key, value]);
+
+    return [value, setValue];
+}

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -236,6 +236,9 @@ function Explorer() {
     const handleApply = useCallback((projectId: string, variantId: string, compareVariantId: string, operation: string, variantIds: string[], multiOperation: string) => {
         const multiActive = !!(variantIds && variantIds.length >= 2);
         const effectiveVariantId = multiActive ? undefined : (compareVariantId || variantId || undefined);
+        setFilterLabel(undefined);
+        setFilterValue(undefined);
+        setFilterVulnerabilityIds(undefined);
         setCurrentVariantId(effectiveVariantId);
         setCurrentProjectId(projectId || undefined);
         // Track origin variant and operation separately for MultiEditBar intersection logic
@@ -362,7 +365,7 @@ function Explorer() {
         );
         return Packages.enrich_with_vulns(loaded, vulnsRef.current);
     }, [currentBaseVariantId, currentVariantId, currentProjectId, currentOperation, currentVariantIds, currentMultiOperation]);
-    const outdatedPackagesScopeKey = [
+    const tablePreferenceScopeKey = [
         currentProjectId ?? '',
         currentBaseVariantId ?? '',
         currentVariantId ?? '',
@@ -370,6 +373,7 @@ function Explorer() {
         currentMultiOperation,
         ...(currentVariantIds ?? []),
     ].join(':');
+    const outdatedPackagesScopeKey = tablePreferenceScopeKey;
     const hasOutdatedPackagesScope = Boolean(
         currentProjectId || currentVariantId || (currentVariantIds?.length ?? 0) > 0
     );
@@ -448,18 +452,22 @@ function Explorer() {
                     projectId={currentProjectId}
                 />}
                 {tab === 'packages' && <TablePackages
+                    key={tablePreferenceScopeKey}
                     packages={pkgs}
                     vulnerabilities={vulns}
+                    preferenceScopeKey={tablePreferenceScopeKey}
                     onShowVulns={showVulnsForPackage}
                     onLoadOutdatedPackages={hasOutdatedPackagesScope ? loadOutdatedPackages : undefined}
                     outdatedScopeKey={outdatedPackagesScopeKey}
                 />}
                 {tab === 'vulnerabilities' &&
                 <TableVulnerabilities
+                    key={tablePreferenceScopeKey}
                     appendAssessment={appendAssessment}
                     appendCVSS={appendCVSS}
                     patchVuln={patchVuln}
                     vulnerabilities={vulns}
+                    preferenceScopeKey={tablePreferenceScopeKey}
                     filterLabel={filterLabel}
                     filterValue={filterValue}
                     filterVulnerabilityIds={filterVulnerabilityIds}

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -21,6 +21,7 @@ type Props = {
     onShowVulns?: (packageId: string, matchingVulnerabilityIds?: string[]) => void;
     onLoadOutdatedPackages?: () => Promise<Package[]>;
     outdatedScopeKey?: string;
+    preferenceScopeKey?: string;
 };
 
 const addVulnCounts = (counts: VulnCounts, ignore: string[]) => {
@@ -41,9 +42,9 @@ const sortVunerabilitiesFn = (rowA: Row<Package>, rowB: Row<Package>, ignore: st
 const fuseKeys = ['id', 'name', 'version', 'cpe', 'purl']
 const emptyVulnerabilities: Vulnerability[] = [];
 
-function TablePackages({ packages, vulnerabilities = emptyVulnerabilities, onShowVulns, onLoadOutdatedPackages, outdatedScopeKey }: Readonly<Props>) {
+function TablePackages({ packages, vulnerabilities = emptyVulnerabilities, onShowVulns, onLoadOutdatedPackages, outdatedScopeKey, preferenceScopeKey = 'unscoped' }: Readonly<Props>) {
     const docUrl = useDocUrl("interactive-mode.html#sbom-table");
-    const preferenceKey = 'vulnscout.tables.packages';
+    const preferenceKey = `vulnscout.tables.packages.${encodeURIComponent(preferenceScopeKey)}`;
     const [search, setSearch] = useLocalStorageState(`${preferenceKey}.search`, '');
     const [draftSearch, setDraftSearch] = useLocalStorageState(`${preferenceKey}.draftSearch`, '');
     const [selectedSources, setSelectedSources] = useLocalStorageState<string[]>(`${preferenceKey}.sources`, []);

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -13,6 +13,7 @@ import type { Vulnerability } from '../handlers/vulnerabilities';
 import Vulnerabilities from '../handlers/vulnerabilities';
 import MessageBanner from '../components/MessageBanner';
 import ExplicitSearchInput from '../components/ExplicitSearchInput';
+import { useLocalStorageState } from '../handlers/localStorage';
 
 type Props = {
     packages: Package[];
@@ -38,19 +39,22 @@ const sortVunerabilitiesFn = (rowA: Row<Package>, rowB: Row<Package>, ignore: st
 }
 
 const fuseKeys = ['id', 'name', 'version', 'cpe', 'purl']
+const emptyVulnerabilities: Vulnerability[] = [];
 
-function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutdatedPackages, outdatedScopeKey }: Readonly<Props>) {
+function TablePackages({ packages, vulnerabilities = emptyVulnerabilities, onShowVulns, onLoadOutdatedPackages, outdatedScopeKey }: Readonly<Props>) {
     const docUrl = useDocUrl("interactive-mode.html#sbom-table");
-    const [search, setSearch] = useState<string>('');
-    const [draftSearch, setDraftSearch] = useState<string>('');
-    const [selectedSources, setSelectedSources] = useState<string[]>([]);
-    const [selectedSbomDocs, setSelectedSbomDocs] = useState<string[]>([]);
-    const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
-    const [showOnlyOutdated, setShowOnlyOutdated] = useState(false);
+    const preferenceKey = 'vulnscout.tables.packages';
+    const [search, setSearch] = useLocalStorageState(`${preferenceKey}.search`, '');
+    const [draftSearch, setDraftSearch] = useLocalStorageState(`${preferenceKey}.draftSearch`, '');
+    const [selectedSources, setSelectedSources] = useLocalStorageState<string[]>(`${preferenceKey}.sources`, []);
+    const [selectedSbomDocs, setSelectedSbomDocs] = useLocalStorageState<string[]>(`${preferenceKey}.sbomDocuments`, []);
+    const [selectedSuppliers, setSelectedSuppliers] = useLocalStorageState<string[]>(`${preferenceKey}.suppliers`, []);
+    const [showOnlyOutdated, setShowOnlyOutdated] = useLocalStorageState(`${preferenceKey}.outdatedOnly`, false);
     const [packagesWithOutdated, setPackagesWithOutdated] = useState<Package[] | null>(null);
     const [outdatedLoading, setOutdatedLoading] = useState(false);
     const [outdatedLoadError, setOutdatedLoadError] = useState('');
-    const [matchCondition, setMatchCondition] = useState('');
+    const [matchCondition, setMatchCondition] = useLocalStorageState(`${preferenceKey}.matchCondition`, '');
+    const [appliedMatchCondition, setAppliedMatchCondition] = useLocalStorageState(`${preferenceKey}.appliedMatchCondition`, '');
     const [matchingVulnerabilityIds, setMatchingVulnerabilityIds] = useState<string[] | null>(null);
     const [matchConditionError, setMatchConditionError] = useState('');
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
@@ -158,7 +162,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
         return cols;
     }, [hasSupplierInfo]);
 
-    const [visibleColumns, setVisibleColumns] = useState<string[]>(defaultVisibleColumns);
+    const [visibleColumns, setVisibleColumns] = useLocalStorageState<string[]>(`${preferenceKey}.visibleColumns`, defaultVisibleColumns);
 
     const matchingVulnerabilityCounts = useMemo(() => {
         const counts = new Map<string, number>();
@@ -193,9 +197,21 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
     // Matched IDs are a snapshot of a server-side evaluation; drop them whenever
     // the vulnerability data changes so the filter never shows stale results.
     useEffect(() => {
-        setMatchingVulnerabilityIds(null);
+        let cancelled = false;
         setMatchConditionError('');
-    }, [vulnerabilities]);
+        if (!appliedMatchCondition) {
+            setMatchingVulnerabilityIds(null);
+            return;
+        }
+        Vulnerabilities.matchCondition(appliedMatchCondition, vulnerabilities)
+            .then(ids => { if (!cancelled) setMatchingVulnerabilityIds(ids); })
+            .catch(error => {
+                if (cancelled) return;
+                setMatchingVulnerabilityIds(null);
+                setMatchConditionError(error instanceof Error ? error.message : 'Unable to evaluate match condition');
+            });
+        return () => { cancelled = true; };
+    }, [appliedMatchCondition, vulnerabilities]);
 
     // Discard historical rows from the previous project/variant scope so an
     // enabled outdated filter immediately fetches the new scope.
@@ -222,20 +238,10 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
         return () => { cancelled = true; };
     }, [showOnlyOutdated, packagesWithOutdated, onLoadOutdatedPackages, outdatedScopeKey]);
 
-    const applyMatchCondition = async () => {
+    const applyMatchCondition = () => {
         const condition = matchCondition.trim();
-        if (!condition) {
-            setMatchingVulnerabilityIds(null);
-            setMatchConditionError('');
-            return;
-        }
         setMatchConditionError('');
-        try {
-            setMatchingVulnerabilityIds(await Vulnerabilities.matchCondition(condition, vulnerabilities));
-        } catch (error) {
-            setMatchingVulnerabilityIds(null);
-            setMatchConditionError(error instanceof Error ? error.message : 'Unable to evaluate match condition');
-        }
+        setAppliedMatchCondition(condition);
     };
 
     const resetFilters = () => {
@@ -245,6 +251,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
         setSelectedSbomDocs([]);
         setSelectedSuppliers([]);
         setMatchCondition('');
+        setAppliedMatchCondition('');
         setMatchingVulnerabilityIds(null);
         setMatchConditionError('');
         setShowOnlyOutdated(false);
@@ -683,7 +690,7 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
         </div>
 
         <div ref={tableRef}>
-            <TableGeneric fuseKeys={fuseKeys} forAllValues={(pkg) => [pkg.name]} search={search} columns={columns} data={filteredPackages} estimateRowHeight={57} />
+            <TableGeneric persistenceKey={preferenceKey} fuseKeys={fuseKeys} forAllValues={(pkg) => [pkg.name]} search={search} columns={columns} data={filteredPackages} estimateRowHeight={57} />
         </div>
     </>);
 }

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -75,6 +75,7 @@ function useRefreshProgressEffect(
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFilter, faCaretDown, faCircleQuestion, faSync, faCircleInfo, faBook } from '@fortawesome/free-solid-svg-icons';
 import ExplicitSearchInput from '../components/ExplicitSearchInput';
+import { useLocalStorageState } from '../handlers/localStorage';
 import RangeSlider from "../components/RangeSlider";
 
 type Props = {
@@ -368,6 +369,7 @@ const SEVERITY_RANGE_MIN = 0;
 const SEVERITY_RANGE_MAX = 10;
 
 function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filterVulnerabilityIds, appendAssessment, appendCVSS, patchVuln, variantId, projectId, baseVariantId, compareOperation, variantIds, multiOperation, onRefreshComplete, missingEuvdDataBannerDismissed, onMissingEuvdDataBannerDismissedChange, missingPublishedDateDataBannerDismissed, onMissingPublishedDateDataBannerDismissedChange }: Readonly<Props>) {
+    const preferenceKey = 'vulnscout.tables.vulnerabilities';
 
     const docUrl = useDocUrl("interactive-mode.html#vulnerability-table");
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);
@@ -437,20 +439,20 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         return () => controller.abort();
     }, [modalVuln, variantId, projectId]);
     const [isEditing, setIsEditing] = useState<boolean>(false);
-    const [search, setSearch] = useState<string>('');
-    const [draftSearch, setDraftSearch] = useState<string>('');
+    const [search, setSearch] = useLocalStorageState(`${preferenceKey}.search`, '');
+    const [draftSearch, setDraftSearch] = useLocalStorageState(`${preferenceKey}.draftSearch`, '');
     const [descriptionMatches, setDescriptionMatches] = useState<Record<string, Set<string>>>({});
     const [descriptionSearchLoading, setDescriptionSearchLoading] = useState(false);
     const [descriptionSearchError, setDescriptionSearchError] = useState(false);
-    const [selectedSeverities, setSelectedSeverities] = useState<string[]>([]);
-    const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
-    const [selectedSources, setSelectedSources] = useState<string[]>([]);
-    const [selectedPackages, setSelectedPackages] = useState<string[]>([]);
-    const [publishedDateFilterType, setPublishedDateFilterType] = useState<string>('');
-    const [publishedDateValue, setPublishedDateValue] = useState<string>('');
-    const [publishedDaysValue, setPublishedDaysValue] = useState<string>('');
-    const [publishedDateFrom, setPublishedDateFrom] = useState<string>('');
-    const [publishedDateTo, setPublishedDateTo] = useState<string>('');
+    const [selectedSeverities, setSelectedSeverities] = useLocalStorageState<string[]>(`${preferenceKey}.severities`, []);
+    const [selectedStatuses, setSelectedStatuses] = useLocalStorageState<string[]>(`${preferenceKey}.statuses`, []);
+    const [selectedSources, setSelectedSources] = useLocalStorageState<string[]>(`${preferenceKey}.sources`, []);
+    const [selectedPackages, setSelectedPackages] = useLocalStorageState<string[]>(`${preferenceKey}.packages`, []);
+    const [publishedDateFilterType, setPublishedDateFilterType] = useLocalStorageState(`${preferenceKey}.publishedDate.type`, '');
+    const [publishedDateValue, setPublishedDateValue] = useLocalStorageState(`${preferenceKey}.publishedDate.value`, '');
+    const [publishedDaysValue, setPublishedDaysValue] = useLocalStorageState(`${preferenceKey}.publishedDate.days`, '');
+    const [publishedDateFrom, setPublishedDateFrom] = useLocalStorageState(`${preferenceKey}.publishedDate.from`, '');
+    const [publishedDateTo, setPublishedDateTo] = useLocalStorageState(`${preferenceKey}.publishedDate.to`, '');
     const [nvdProgress, setNvdProgress] = useState<NVDProgress | null>(null);
     const [epssProgress, setEpssProgress] = useState<EPSSProgress | null>(null);
     const [ghsaProgress, setGhsaProgress] = useState<GHSAProgress | null>(null);
@@ -464,24 +466,25 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
     const [localMissingEuvdDataBannerDismissed, setLocalMissingEuvdDataBannerDismissed] = useState(false);
     const [localMissingPublishedDateDataBannerDismissed, setLocalMissingPublishedDateDataBannerDismissed] = useState(false);
     const [searchFilteredData, setSearchFilteredData] = useState<Vulnerability[]>([]);
-    const [visibleColumns, setVisibleColumns] = useState<string[]>([
+    const [visibleColumns, setVisibleColumns] = useLocalStorageState<string[]>(`${preferenceKey}.visibleColumns`, [
         'ID', 'Severity', 'EU KEV', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Assessed'
     ]);
     const [focusedRowIndex, setFocusedRowIndex] = useState<number | null>(null);
 
-    const [showCustomSeverityFilter, setShowCustomSeverityFilter] = useState<boolean>(false);
-    const [severityRange, setSeverityRange] = useState<{ min: number; max: number }>({ min: SEVERITY_RANGE_MIN, max: SEVERITY_RANGE_MAX });
-    const [showCustomEpssFilter, setShowCustomEpssFilter] = useState<boolean>(false);
-    const [epssRange, setEpssRange] = useState<{ min: number; max: number }>({ min: 0, max: 100 });
-    const [selectedAttackVectors, setSelectedAttackVectors] = useState<string[]>([]);
-    const [selectedFirstScanDates, setSelectedFirstScanDates] = useState<string[]>([]);
+    const [showCustomSeverityFilter, setShowCustomSeverityFilter] = useLocalStorageState(`${preferenceKey}.customSeverity.enabled`, false);
+    const [severityRange, setSeverityRange] = useLocalStorageState(`${preferenceKey}.customSeverity.range`, { min: SEVERITY_RANGE_MIN, max: SEVERITY_RANGE_MAX });
+    const [showCustomEpssFilter, setShowCustomEpssFilter] = useLocalStorageState(`${preferenceKey}.customEpss.enabled`, false);
+    const [epssRange, setEpssRange] = useLocalStorageState(`${preferenceKey}.customEpss.range`, { min: 0, max: 100 });
+    const [selectedAttackVectors, setSelectedAttackVectors] = useLocalStorageState<string[]>(`${preferenceKey}.attackVectors`, []);
+    const [selectedFirstScanDates, setSelectedFirstScanDates] = useLocalStorageState<string[]>(`${preferenceKey}.firstScanDates`, []);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
     const [showMoreFilters, setShowMoreFilters] = useState(false);
-    const [aiSuggestionFilter, setAiSuggestionFilter] = useState<'any' | 'has' | 'no'>('any');
+    const [aiSuggestionFilter, setAiSuggestionFilter] = useLocalStorageState<'any' | 'has' | 'no'>(`${preferenceKey}.aiSuggestion`, 'any');
     const [aiSuggestionVulnIds, setAiSuggestionVulnIds] = useState<Set<string>>(new Set());
 
     const searchInputRef = useRef<HTMLInputElement>(null);
+    const hasRestoredSearch = useRef(false);
     const descriptionSearchController = useRef<AbortController | null>(null);
     const shortcutButtonRef = useRef<HTMLButtonElement>(null);
     const shortcutDropdownRef = useRef<HTMLDivElement>(null);
@@ -601,7 +604,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         if (filterLabel === "Severity") setSelectedSeverities([filterValue]);
         if (filterLabel === "Status") setSelectedStatuses([filterValue]);
         if (filterLabel === "Package") setSelectedPackages([filterValue]);
-    }, [filterLabel, filterValue]);
+    }, [filterLabel, filterValue, setSelectedPackages, setSelectedSeverities, setSelectedSources, setSelectedStatuses]);
 
     // Fetch pending AI suggestions (origin == 'ai') for the current scope. These are
     // excluded from the vulnerabilities' assessments array by the backend, so they must
@@ -1416,7 +1419,13 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         } finally {
             if (!controller.signal.aborted) setDescriptionSearchLoading(false);
         }
-    }, [draftSearch, vulnerabilities, variantId, projectId]);
+    }, [draftSearch, vulnerabilities, variantId, projectId, setSearch]);
+
+    useEffect(() => {
+        if (hasRestoredSearch.current) return;
+        hasRestoredSearch.current = true;
+        if (draftSearch.trim()) void applySearch();
+    }, [applySearch, draftSearch]);
 
     useEffect(() => () => descriptionSearchController.current?.abort(), []);
 
@@ -1921,6 +1930,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         />
 
         <TableGeneric
+            persistenceKey={preferenceKey}
             fuseKeys={fuseKeys}
             forAllValues={(vuln) => (vuln.packages_current?.length ? vuln.packages_current : vuln.packages)}
             hoverField="texts"

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -86,6 +86,7 @@ type Props = {
     filterLabel?: "Source" | "Severity" | "Status" | "Package";
     filterValue?: string;
     filterVulnerabilityIds?: string[];
+    preferenceScopeKey?: string;
     variantId?: string;
     projectId?: string;
     /** Origin variant when compare mode is active */
@@ -368,8 +369,8 @@ function PublishedDateFilter({
 const SEVERITY_RANGE_MIN = 0;
 const SEVERITY_RANGE_MAX = 10;
 
-function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filterVulnerabilityIds, appendAssessment, appendCVSS, patchVuln, variantId, projectId, baseVariantId, compareOperation, variantIds, multiOperation, onRefreshComplete, missingEuvdDataBannerDismissed, onMissingEuvdDataBannerDismissedChange, missingPublishedDateDataBannerDismissed, onMissingPublishedDateDataBannerDismissedChange }: Readonly<Props>) {
-    const preferenceKey = 'vulnscout.tables.vulnerabilities';
+function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filterVulnerabilityIds, preferenceScopeKey = 'unscoped', appendAssessment, appendCVSS, patchVuln, variantId, projectId, baseVariantId, compareOperation, variantIds, multiOperation, onRefreshComplete, missingEuvdDataBannerDismissed, onMissingEuvdDataBannerDismissedChange, missingPublishedDateDataBannerDismissed, onMissingPublishedDateDataBannerDismissedChange }: Readonly<Props>) {
+    const preferenceKey = `vulnscout.tables.vulnerabilities.${encodeURIComponent(preferenceScopeKey)}`;
 
     const docUrl = useDocUrl("interactive-mode.html#vulnerability-table");
     const [modalVuln, setModalVuln] = useState<Vulnerability|undefined>(undefined);

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -485,7 +485,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
     const [aiSuggestionVulnIds, setAiSuggestionVulnIds] = useState<Set<string>>(new Set());
 
     const searchInputRef = useRef<HTMLInputElement>(null);
-    const hasRestoredSearch = useRef(false);
     const descriptionSearchController = useRef<AbortController | null>(null);
     const shortcutButtonRef = useRef<HTMLButtonElement>(null);
     const shortcutDropdownRef = useRef<HTMLDivElement>(null);
@@ -1422,11 +1421,22 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         }
     }, [draftSearch, vulnerabilities, variantId, projectId, setSearch]);
 
+    const applySearchRef = useRef(applySearch);
+    applySearchRef.current = applySearch;
+
+    // Re-run the persisted/restored search whenever the scoped vulnerability
+    // data changes. Explorer loads vulnerabilities asynchronously and may
+    // initially render the previous scope's rows, so restoring only once on
+    // mount would evaluate the search against stale or empty IDs and leave an
+    // incorrectly filtered table. Re-running on data changes keeps
+    // descriptionMatches consistent with the current scope; applySearch aborts
+    // any in-flight description request before starting a new one. Depending on
+    // `vulnerabilities` (not `draftSearch`) avoids firing a description search
+    // on every keystroke.
     useEffect(() => {
-        if (hasRestoredSearch.current) return;
-        hasRestoredSearch.current = true;
-        if (draftSearch.trim()) void applySearch();
-    }, [applySearch, draftSearch]);
+        if (draftSearch.trim()) void applySearchRef.current();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [vulnerabilities]);
 
     useEffect(() => () => descriptionSearchController.current?.abort(), []);
 

--- a/frontend/tests/unit_tests/test_local_storage_handler.tsx
+++ b/frontend/tests/unit_tests/test_local_storage_handler.tsx
@@ -1,0 +1,32 @@
+import { act, renderHook } from '@testing-library/react';
+import { useLocalStorageState } from '../../src/handlers/localStorage';
+
+describe('useLocalStorageState', () => {
+    beforeEach(() => window.localStorage.clear());
+
+    it('restores a stored value', () => {
+        window.localStorage.setItem('test.preference', JSON.stringify(['saved']));
+
+        const { result } = renderHook(() => useLocalStorageState('test.preference', [] as string[]));
+
+        expect(result.current[0]).toEqual(['saved']);
+    });
+
+    it('persists direct and functional updates', () => {
+        const { result } = renderHook(() => useLocalStorageState('test.preference', 1));
+
+        act(() => result.current[1](2));
+        expect(window.localStorage.getItem('test.preference')).toBe('2');
+
+        act(() => result.current[1](value => value + 1));
+        expect(window.localStorage.getItem('test.preference')).toBe('3');
+    });
+
+    it('uses the default when stored JSON is invalid', () => {
+        window.localStorage.setItem('test.preference', '{invalid');
+
+        const { result } = renderHook(() => useLocalStorageState('test.preference', 'default'));
+
+        expect(result.current[0]).toBe('default');
+    });
+});

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -157,14 +157,33 @@ describe('Packages Table', () => {
     })
 
     test('restores the applied search from local storage', async () => {
-        window.localStorage.setItem('vulnscout.tables.packages.search', JSON.stringify('xxxyyyzzz'));
-        window.localStorage.setItem('vulnscout.tables.packages.draftSearch', JSON.stringify('xxxyyyzzz'));
+        window.localStorage.setItem('vulnscout.tables.packages.unscoped.search', JSON.stringify('xxxyyyzzz'));
+        window.localStorage.setItem('vulnscout.tables.packages.unscoped.draftSearch', JSON.stringify('xxxyyyzzz'));
 
         render(<TablePackages packages={packages} />);
 
         expect(await screen.findByText('xxxyyyzzz')).toBeTruthy();
         expect(screen.queryByText('aaabbbccc')).toBeNull();
         expect((screen.getByLabelText('Search') as HTMLInputElement).value).toBe('xxxyyyzzz');
+    });
+
+    test('keeps search preferences separate for each variant scope', async () => {
+        window.localStorage.setItem('vulnscout.tables.packages.variant-a.search', JSON.stringify('xxxyyyzzz'));
+        window.localStorage.setItem('vulnscout.tables.packages.variant-a.draftSearch', JSON.stringify('xxxyyyzzz'));
+
+        const variantA = render(<TablePackages key="variant-a" preferenceScopeKey="variant-a" packages={packages} />);
+        expect(await screen.findByText('xxxyyyzzz')).toBeTruthy();
+        expect(screen.queryByText('aaabbbccc')).toBeNull();
+        variantA.unmount();
+
+        const variantB = render(<TablePackages key="variant-b" preferenceScopeKey="variant-b" packages={packages} />);
+        expect(await screen.findByText('aaabbbccc')).toBeTruthy();
+        expect((screen.getByLabelText('Search') as HTMLInputElement).value).toBe('');
+        variantB.unmount();
+
+        render(<TablePackages key="variant-a" preferenceScopeKey="variant-a" packages={packages} />);
+        expect(await screen.findByText('xxxyyyzzz')).toBeTruthy();
+        expect(screen.queryByText('aaabbbccc')).toBeNull();
     });
 
     test('package search applies only with the button or Enter', async () => {

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -156,6 +156,17 @@ describe('Packages Table', () => {
         expect(source_col).toBeTruthy();
     })
 
+    test('restores the applied search from local storage', async () => {
+        window.localStorage.setItem('vulnscout.tables.packages.search', JSON.stringify('xxxyyyzzz'));
+        window.localStorage.setItem('vulnscout.tables.packages.draftSearch', JSON.stringify('xxxyyyzzz'));
+
+        render(<TablePackages packages={packages} />);
+
+        expect(await screen.findByText('xxxyyyzzz')).toBeTruthy();
+        expect(screen.queryByText('aaabbbccc')).toBeNull();
+        expect((screen.getByLabelText('Search') as HTMLInputElement).value).toBe('xxxyyyzzz');
+    });
+
     test('package search applies only with the button or Enter', async () => {
         render(<TablePackages packages={packages} />);
         const user = userEvent.setup();

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -665,6 +665,61 @@ describe('Vulnerability Table', () => {
         });
     })
 
+    test('re-runs a restored description search when scoped vulnerabilities load', async () => {
+        // A persisted search containing a description term must be evaluated
+        // against the current scope's vulnerabilities. Explorer loads data
+        // asynchronously and can initially render the previous scope's rows, so
+        // the restored search has to re-run once the correct vulnerabilities
+        // arrive instead of staying stuck on the stale evaluation.
+        const scopeKey = 'restore-regression';
+        window.localStorage.setItem(
+            `vulnscout.tables.vulnerabilities.${scopeKey}.draftSearch`,
+            JSON.stringify('authentification'),
+        );
+        window.localStorage.setItem(
+            `vulnscout.tables.vulnerabilities.${scopeKey}.search`,
+            JSON.stringify('authentification'),
+        );
+
+        const staleVulnerabilities = [{
+            ...vulnerabilities[0],
+            id: 'CVE-1999-0001',
+            texts: [],
+            details_loaded: false,
+        }] as Vulnerability[];
+        const scopedVulnerabilities = vulnerabilities.map(vuln => ({
+            ...vuln,
+            texts: [],
+            details_loaded: false,
+        }));
+
+        // Any description search resolves to a match on CVE-2010-1234 only.
+        fetchMock.mockResponse(JSON.stringify({ matches: { authentification: ['CVE-2010-1234'] } }));
+
+        // Initial render uses the stale scope, so the first restore evaluates the
+        // search against IDs that do not belong to the current scope.
+        const view = render(<TableVulnerabilities key={scopeKey} preferenceScopeKey={scopeKey} vulnerabilities={staleVulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+        // The current scope's data arrives, replacing the stale rows in place.
+        view.rerender(<TableVulnerabilities key={scopeKey} preferenceScopeKey={scopeKey} vulnerabilities={scopedVulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        // The restored search re-runs against the freshly loaded vulnerabilities.
+        await waitFor(() => {
+            const calls = fetchMock.mock.calls;
+            const lastBody = JSON.parse(calls[calls.length - 1][1]?.body as string);
+            expect(lastBody.vulnerability_ids).toContain('CVE-2010-1234');
+        });
+
+        // And the table ends up filtered to the matching vulnerability only.
+        await waitFor(() => {
+            expect(screen.queryByRole('cell', {name: /CVE-2018-5678/})).not.toBeInTheDocument();
+        });
+        expect(screen.getByRole('cell', {name: /CVE-2010-1234/})).toBeInTheDocument();
+
+        window.localStorage.clear();
+    })
+
     test('filter by source', async () => {
         // ARRANGE
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -336,10 +336,27 @@ describe('Vulnerability Table', () => {
     })
 
     test('restores visible columns from local storage', async () => {
-        window.localStorage.setItem('vulnscout.tables.vulnerabilities.visibleColumns', JSON.stringify(['ID']));
+        window.localStorage.setItem('vulnscout.tables.vulnerabilities.unscoped.visibleColumns', JSON.stringify(['ID']));
 
         render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
+        expect(await screen.findByRole('columnheader', {name: /id/i})).toBeTruthy();
+        expect(screen.queryByRole('columnheader', {name: /severity/i})).toBeNull();
+    });
+
+    test('keeps column preferences separate for each variant scope', async () => {
+        window.localStorage.setItem('vulnscout.tables.vulnerabilities.variant-a.visibleColumns', JSON.stringify(['ID']));
+
+        const variantA = render(<TableVulnerabilities key="variant-a" preferenceScopeKey="variant-a" vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        expect(await screen.findByRole('columnheader', {name: /id/i})).toBeTruthy();
+        expect(screen.queryByRole('columnheader', {name: /severity/i})).toBeNull();
+        variantA.unmount();
+
+        const variantB = render(<TableVulnerabilities key="variant-b" preferenceScopeKey="variant-b" vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        expect(await screen.findByRole('columnheader', {name: /severity/i})).toBeTruthy();
+        variantB.unmount();
+
+        render(<TableVulnerabilities key="variant-a" preferenceScopeKey="variant-a" vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         expect(await screen.findByRole('columnheader', {name: /id/i})).toBeTruthy();
         expect(screen.queryByRole('columnheader', {name: /severity/i})).toBeNull();
     });

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -335,6 +335,15 @@ describe('Vulnerability Table', () => {
         expect(source_header).toBeInTheDocument();
     })
 
+    test('restores visible columns from local storage', async () => {
+        window.localStorage.setItem('vulnscout.tables.vulnerabilities.visibleColumns', JSON.stringify(['ID']));
+
+        render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        expect(await screen.findByRole('columnheader', {name: /id/i})).toBeTruthy();
+        expect(screen.queryByRole('columnheader', {name: /severity/i})).toBeNull();
+    });
+
     test('render with vulnerabilities', async () => {
         // ARRANGE
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

Save tables user options into local storage:
This means each time the user does a filter, sort, match condition, it gets saved in browser local storage so that they can find the same context when they come back later.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Pick a project / variant. go to the vulns or SBOM tables then do any number of filters / sorting / match condition, then either refresh the webpage or switch project / variant and come back to the one you desire to work on.
Observe that the actions are saved then restored.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


