### PR TITLE
Feature/configurable upload limit

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -417,6 +417,10 @@ The following environment variables can be set via `vulnscout config` or exporte
 |`USER_GID`
 |GID used to write output files
 |current group
+
+|`VULNSCOUT_MAX_UPLOAD_MB`
+|Maximum upload/request body size accepted by the web API, in MB
+|`500`
 |===
 
 .Scan & enrichment

--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -410,6 +410,7 @@ Example:
 | `VITE_API_URL` | Backend API URL used by the dev frontend | `http://localhost:7275` |
 | `USER_UID` | UID used to write output files | current user |
 | `USER_GID` | GID used to write output files | current group |
+| `VULNSCOUT_MAX_UPLOAD_MB` | Maximum upload/request body size accepted by the web API, in MB | `500` |
 | `REFRESH_REMOTE_DELAY` | How often EPSS/NVD data is re-fetched (`never`, `always`, `48h`, `7d`, etc.) | `48h` |
 
 #### Scan & Enrichment

--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 from ..helpers.add_middleware import FlaskWithMiddleware as Flask
-from ..helpers.env_vars import get_bool_env
+from ..helpers.env_vars import get_bool_env, get_int_env
 from ..extensions import db, migrate, setup_write_serialization
 from ..routes import init_app
 from ..routes.documents import MAX_ASSET_UPLOAD_BYTES
@@ -22,7 +22,7 @@ from flask import request
 MAX_SCRIPT_STEPS = 8
 SCAN_FILE = "/scan/status.txt"
 DEFAULT_DB_URI = "sqlite:////cache/vulnscout/vulnscout.db"
-MAX_UPLOAD_REQUEST_BYTES = MAX_ASSET_UPLOAD_BYTES + 64 * 1024
+DEFAULT_MAX_UPLOAD_MB = 500  # overridable via VULNSCOUT_MAX_UPLOAD_MB
 DEFAULT_BACKGROUND_TASK_DELAY = 120.0
 
 
@@ -116,8 +116,10 @@ def create_app():
     app = Flask(__name__, static_folder="../static")
     app.config.from_prefixed_env()
     # Allow multipart headers while ensuring Werkzeug rejects oversized bodies
-    # before parsing and spooling uploaded files.
-    app.config["MAX_CONTENT_LENGTH"] = MAX_UPLOAD_REQUEST_BYTES
+    # before parsing and spooling uploaded files.  The cap is expressed in MB
+    # via VULNSCOUT_MAX_UPLOAD_MB and defaults to DEFAULT_MAX_UPLOAD_MB.
+    max_upload_mb = get_int_env("VULNSCOUT_MAX_UPLOAD_MB", DEFAULT_MAX_UPLOAD_MB)
+    app.config["MAX_CONTENT_LENGTH"] = max_upload_mb * 1024 * 1024
     app._INT_SCAN_FINISHED = False
     if "SCAN_FILE" not in app.config:
         app.config["SCAN_FILE"] = SCAN_FILE

--- a/src/helpers/env_vars.py
+++ b/src/helpers/env_vars.py
@@ -7,3 +7,14 @@ def get_bool_env(name: str, default: bool = False) -> bool:
     Any casing of 'true' or 1 is considered True.
     """
     return os.getenv(name, str(default)).lower() in ("true", "1")
+
+
+def get_int_env(name: str, default: int) -> int:
+    """
+    Get an integer from an environment variable.
+    Falls back to `default` when the variable is unset or not a valid integer.
+    """
+    try:
+        return int(os.getenv(name, default))
+    except (TypeError, ValueError):
+        return default


### PR DESCRIPTION
## Fixes #<issue> by @Emmmery

### Changes proposed in this pull request:

* Since v0.19, the web API upload size limit is hardcoded at ~5MB, which prevents
  larger uploads from going through.
* This PR makes the limit configurable via the new `VULNSCOUT_MAX_UPLOAD_MB`
  environment variable (value in MB, default `500`).
* Adds a small typed `get_int_env()` helper in `src/helpers/env_vars.py` to
  read integer environment variables safely.
* Documents the new variable in `README.adoc` and
  `doc/source/vulnscout-script.md`.

### Status

- [ ] READY
- [ ] HOLD
- [x] WIP (Work-In-Progress)

### How to verify this change

1. Set a small limit and restart in dev mode (so the local `src/` runs):
   ```bash
   ./vulnscout config VULNSCOUT_MAX_UPLOAD_MB 30
   ./vulnscout stop && ./vulnscout --dev --serve
   ```
2. Check the value reached the container:
   ```bash
   docker exec vulnscout printenv VULNSCOUT_MAX_UPLOAD_MB   # -> 30
   ```
3. Upload a file above the configured limit → the request is rejected with an
   HTTP 413 (Payload Too Large) error; below the limit → it succeeds.
4. Removing the variable (or setting `500`) restores the previous default.

### Additional notes

The default stays at 500 MB — maybe the default limit should be lower? 
### Related Issue

<!-- Link the related issue here, if any. -->

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers
