### PR TITLE
fix(import): reject foreign variant_id then fall back to variant name

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -630,7 +630,9 @@ Accepts either:
 - `multipart/form-data` with a `file` field containing a `.json` file.
 - `application/json` body with the custom-data payload directly.
 
-The records keep the variant identifiers embedded in the file.
+The JSON body must include the destination `project_id` UUID. Variant IDs in
+the file are resolved only within that project; a foreign ID falls back to its
+variant name in the selected project.
 
 **Response:**
 ```json

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -565,8 +565,8 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             return;
         }
 
-        // VulnScout JSON carries its own variant IDs, so no target selection
-        // or override is sent with the request.
+        // VulnScout JSON carries its own variant IDs, while the active project
+        // constrains name-based fallback for exports from other instances.
         const reader = new FileReader();
         reader.onload = async () => {
             try {
@@ -585,7 +585,11 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     method: 'POST',
                     mode: 'cors',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ ...parsed, timestamp_policy: importTimestampPolicy }),
+                    body: JSON.stringify({
+                        ...parsed,
+                        project_id: projectId,
+                        timestamp_policy: importTimestampPolicy,
+                    }),
                 });
                 const data = await result.json() as ImportResult;
 

--- a/frontend/tests/unit_tests/test_review.tsx
+++ b/frontend/tests/unit_tests/test_review.tsx
@@ -1570,7 +1570,9 @@ describe('Review — import and export', () => {
 
         await screen.findByText(/Imported:/);
         const importCall = postCalls().find(call => String(call[0]).includes('/api/assessments/review/import-custom-data'));
-        expect(JSON.parse(String((importCall?.[1] as RequestInit).body)).timestamp_policy).toBe('current');
+        const importPayload = JSON.parse(String((importCall?.[1] as RequestInit).body));
+        expect(importPayload.timestamp_policy).toBe('current');
+        expect(importPayload.project_id).toBe('proj1');
     });
 
     test('imports OpenVEX into one selected variant without using the filename', async () => {

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -601,6 +601,8 @@ def import_custom_data(
         ).all()
         return [variant_id for (variant_id,) in rows]
 
+    known_variant_ids = {v.id for v in variant_by_name.values()}
+
     def _resolve_variant(raw_item: dict) -> "_uuid.UUID | None":
         if variant_id is not None:
             return variant_id
@@ -613,12 +615,25 @@ def import_custom_data(
             return None
 
         try:
-            return _uuid.UUID(str(variant_token))
+            parsed = _uuid.UUID(str(variant_token))
         except (ValueError, TypeError):
-            mapped_variant = variant_by_name.get(str(variant_token))
-            if mapped_variant is None:
-                return None
-            return mapped_variant.id
+            parsed = None
+
+        # A variant_id copied from another VulnScout instance's export never
+        # matches a variant in this database (each instance generates its own
+        # UUIDs), so it must not be trusted as-is: doing so silently attaches
+        # the record to a variant_id that no local query will ever match.
+        # Fall back to the human-readable name in that case.
+        if parsed is not None and parsed in known_variant_ids:
+            return parsed
+
+        name_token = raw_item.get("variant")
+        if name_token in (None, ""):
+            name_token = variant_token
+        mapped_variant = variant_by_name.get(str(name_token))
+        if mapped_variant is None:
+            return None
+        return mapped_variant.id
 
     def _import_assessments(
         key: str,
@@ -650,6 +665,16 @@ def import_custom_data(
 
             # Determine which variant to attach to
             target_variant_id = _resolve_variant(a)
+
+            variant_token = a.get("variant_id")
+            if variant_token in (None, ""):
+                variant_token = a.get("variant")
+            if target_variant_id is None and variant_token not in (None, ""):
+                result["errors"].append({
+                    "vuln_id": vuln_name,
+                    "error": f"Variant '{variant_token}' not found",
+                })
+                continue
 
             justification = a.get("justification", "")
             impact_statement = a.get("impact_statement", "")

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -815,7 +815,7 @@ def init_app(app: Flask) -> None:
         Accepts either:
 
         * ``multipart/form-data`` with a ``file`` field containing a ``.json``
-          file.
+                    file and a destination ``project_id`` field.
         * ``application/json`` body with the custom-data payload directly.
 
         OpenAPI:
@@ -829,6 +829,7 @@ def init_app(app: Flask) -> None:
 
         # Parse the incoming data
         data = None
+        project_id = None
         if request.content_type and 'multipart/form-data' in request.content_type:
             uploaded = request.files.get('file')
             if not uploaded or not uploaded.filename:
@@ -837,21 +838,35 @@ def init_app(app: Flask) -> None:
                 data = _json.load(uploaded.stream)
             except Exception:
                 return {"error": "Invalid JSON file"}, 400
+            project_id = request.form.get('project_id')
         elif request.content_type and 'application/json' in request.content_type:
             data = request.get_json(silent=True)
             if data is None:
                 return {"error": "Invalid JSON body"}, 400
+            project_id = data.get('project_id')
         else:
             return {"error": "Expected multipart/form-data or application/json"}, 400
 
         if not isinstance(data, dict) or "version" not in data:
             return {"error": "Invalid custom-data format. Expected {version, assessments, ...}"}, 400
 
+        if not isinstance(project_id, str) or not project_id:
+            return {"error": "project_id is required"}, 400
+        project_uuid, err = parse_uuid_or_400(project_id, "project_id")
+        if err:
+            return err
+        if project_uuid is None:
+            return {"error": "Internal error"}, 500
+
+        from ..models.project import Project as DBProject
+        if DBProject.get_by_id(project_uuid) is None:
+            return {"error": "Project not found"}, 404
+
         timestamp_policy = data.get('timestamp_policy', 'current')
         if timestamp_policy not in {'original', 'current'}:
             return {"error": "timestamp_policy must be 'original' or 'current'"}, 400
 
-        variant_by_name = build_variant_by_name_map()
+        variant_by_name = build_variant_by_name_map(project_uuid)
         result = import_custom_data(
             data,
             variant_by_name,

--- a/tests/cli_tests/test_cmd_assessments.py
+++ b/tests/cli_tests/test_cmd_assessments.py
@@ -261,3 +261,75 @@ class TestImportTimestampOptions:
             imported = Assessment.get_by_origin([variant_id], origin="custom")
             assert len(imported) == 1
             assert ensure_utc_iso(imported[0].timestamp) == original_timestamp
+
+
+class TestImportCrossInstanceVariantId:
+    """The VulnScout JSON's ``variant_id`` is only meaningful within the
+    instance that exported it: another database mints its own variant UUIDs,
+    so re-importing the file elsewhere must not trust that UUID as-is.
+    """
+
+    def test_foreign_variant_id_falls_back_to_variant_name(self, app, tmp_path):
+        from src.models.assessment import Assessment
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        with app.app_context():
+            project = Project.create("CrossInstanceProject")
+            variant = Variant.create("x86", project.id)
+            project_name = project.name
+            variant_id = variant.id
+
+        foreign_variant_id = "99999999-9999-9999-9999-999999999999"
+        import_file = tmp_path / "custom-vulnscout-foreign.json"
+        import_file.write_text(json.dumps({
+            "version": 1,
+            "assessments": [{
+                "vuln_id": "CVE-2099-20001",
+                "status": "affected",
+                "packages": ["cross-instance@1.0"],
+                "variant_id": foreign_variant_id,
+                "variant": "x86",
+            }],
+        }))
+
+        result = app.test_cli_runner().invoke(args=[
+            "import-custom-vulnscout-data",
+            "--project", project_name,
+            str(import_file),
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert "Imported 1 assessments" in result.output
+        with app.app_context():
+            imported = Assessment.get_by_origin([variant_id], origin="custom")
+            assert len(imported) == 1
+            assert imported[0].vuln_id == "CVE-2099-20001"
+
+    def test_foreign_variant_id_without_name_is_reported_as_error(self, app, tmp_path):
+        from src.models.project import Project
+
+        with app.app_context():
+            project = Project.create("CrossInstanceProjectNoName")
+            project_name = project.name
+
+        foreign_variant_id = "99999999-9999-9999-9999-999999999999"
+        import_file = tmp_path / "custom-vulnscout-foreign-no-name.json"
+        import_file.write_text(json.dumps({
+            "version": 1,
+            "assessments": [{
+                "vuln_id": "CVE-2099-20002",
+                "status": "affected",
+                "packages": ["cross-instance-noname@1.0"],
+                "variant_id": foreign_variant_id,
+            }],
+        }))
+
+        result = app.test_cli_runner().invoke(args=[
+            "import-custom-vulnscout-data",
+            "--project", project_name,
+            str(import_file),
+        ])
+
+        assert result.exit_code != 0
+        assert foreign_variant_id in result.output

--- a/tests/unit_tests/test_assessment_io_coverage.py
+++ b/tests/unit_tests/test_assessment_io_coverage.py
@@ -221,7 +221,7 @@ class TestImportCustomDataAssessments:
             }]
         }
         with app.app_context():
-            result = import_custom_data(data, {})
+            result = import_custom_data(data, {var.name: var})
         assert result["assessments_imported"] == 1
         assert result["errors"] == []
 
@@ -237,7 +237,7 @@ class TestImportCustomDataAssessments:
             }]
         }
         with app.app_context():
-            result = import_custom_data(data, {})
+            result = import_custom_data(data, {var.name: var})
         assert result["assessments_imported"] == 1
         assert result["errors"] == []
 
@@ -253,8 +253,8 @@ class TestImportCustomDataAssessments:
             }]
         }
         with app.app_context():
-            import_custom_data(data, {})
-            result = import_custom_data(data, {})
+            import_custom_data(data, {var.name: var})
+            result = import_custom_data(data, {var.name: var})
         assert result["assessments_skipped"] == 1
 
     def test_variant_name_resolution_via_variant_by_name(self, app, variant_and_project):
@@ -287,9 +287,9 @@ class TestImportCustomDataAssessments:
             }]
         }
         with app.app_context():
-            result = import_custom_data(data, {})
+            result = import_custom_data(data, {var.name: var})
             imported = Assessment.get_by_origin([var.id], origin="ai")
-            duplicate_result = import_custom_data(data, {})
+            duplicate_result = import_custom_data(data, {var.name: var})
 
         assert result["ai_assessments_imported"] == 1
         assert result["assessments_imported"] == 0
@@ -353,7 +353,7 @@ class TestImportCustomDataCvss:
                     "version": "3.1",
                 }]
             }
-            result = import_custom_data(data, {})
+            result = import_custom_data(data, {var.name: var})
         assert result["cvss_imported"] == 1
 
 
@@ -415,7 +415,7 @@ class TestImportCustomDataTimeEstimates:
                     "pessimistic": "PT4H",
                 }]
             }
-            result = import_custom_data(data, {})
+            result = import_custom_data(data, {var.name: var})
         assert result["time_estimates_imported"] == 1
 
     def test_final_status_error_when_only_errors(self, app, variant_and_project):

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -1113,6 +1113,7 @@ def _custom_data_payload(assessments=None, cvss=None, time_estimates=None):
     return {
         "version": 1,
         "exported_at": "2025-01-01T00:00:00Z",
+        "project_id": str(PROJECT_UUID),
         "assessments": assessments or [],
         "cvss": cvss or [],
         "time_estimates": time_estimates or [],
@@ -1166,6 +1167,25 @@ def test_import_custom_data_assessments(client):
     result = json.loads(resp.data)
     assert result["status"] == "success"
     assert result["assessments_imported"] >= 1
+
+
+def test_import_custom_data_multipart_accepts_unmodified_export(client):
+    """A custom-data export can be uploaded with its destination as form data."""
+    _create_handmade_assessment(client)
+    exported = client.get("/api/assessments/review/export-custom-data")
+    assert exported.status_code == 200
+
+    response = client.post(
+        "/api/assessments/review/import-custom-data",
+        data={
+            "file": (io.BytesIO(exported.data), "custom_data.json"),
+            "project_id": str(PROJECT_UUID),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.data)["status"] == "success"
 
 
 def test_import_custom_data_uses_original_timestamp(app, client):
@@ -1371,6 +1391,83 @@ def test_import_custom_data_foreign_variant_id_falls_back_to_name(client):
     assert listing.status_code == 200
     vuln_ids = [a["vuln_id"] for a in json.loads(listing.data)]
     assert "CVE-2020-35492" in vuln_ids
+
+
+def test_import_custom_data_scopes_duplicate_variant_names_to_project(app, client):
+    """A name fallback must not resolve a variant in another project."""
+    from src.extensions import db
+    from src.models.assessment import Assessment
+    from src.models.metrics import Metrics
+    from src.models.project import Project
+    from src.models.time_estimate import TimeEstimate
+    from src.models.variant import Variant
+
+    with app.app_context():
+        Metrics.reset_cache()
+        foreign_project = Project.create("foreign-project")
+        foreign_variant = Variant.create("default", foreign_project.id)
+        foreign_local_variant_id = foreign_variant.id
+
+    foreign_variant_id = str(uuid.uuid4())
+    payload = _custom_data_payload(
+        assessments=[{
+            "vuln_id": "CVE-2020-35492",
+            "status": "affected",
+            "packages": ["cairo@1.16.0"],
+            "variant_id": foreign_variant_id,
+            "variant": "default",
+            "origin": "custom",
+        }],
+        cvss=[{
+            "vuln_id": "CVE-2020-35492",
+            "version": "3.1",
+            "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "base_score": 7.5,
+            "variant_id": foreign_variant_id,
+            "variant": "default",
+        }],
+        time_estimates=[{
+            "vuln_id": "CVE-2020-35492",
+            "optimistic": "PT1H",
+            "likely": "PT2H",
+            "pessimistic": "PT3H",
+            "variant_id": foreign_variant_id,
+            "variant": "default",
+        }],
+    )
+    payload["project_id"] = str(PROJECT_UUID)
+
+    response = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload,
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    import_result = json.loads(response.data)
+    assert import_result["assessments_imported"] == 1, import_result
+    with app.app_context():
+        imported_assessments = Assessment.get_by_origin([VARIANT_UUID], origin="custom")
+        foreign_assessments = Assessment.get_by_origin([foreign_local_variant_id], origin="custom")
+        imported_metrics = db.session.execute(
+            db.select(Metrics).where(
+                Metrics.vulnerability_id == "CVE-2020-35492",
+                Metrics.vector == "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            )
+        ).scalars().all()
+        imported_estimates = db.session.execute(
+            db.select(TimeEstimate).where(TimeEstimate.variant_id == VARIANT_UUID)
+        ).scalars().all()
+        foreign_estimates = db.session.execute(
+            db.select(TimeEstimate).where(TimeEstimate.variant_id == foreign_local_variant_id)
+        ).scalars().all()
+
+    assert len(imported_assessments) == 1
+    assert not foreign_assessments
+    assert len(imported_metrics) == 1
+    assert imported_metrics[0].variant_id == VARIANT_UUID
+    assert imported_estimates
+    assert not foreign_estimates
 
 
 def test_import_custom_data_foreign_variant_id_without_name_is_rejected(client):
@@ -1840,6 +1937,7 @@ def test_export_import_custom_data_round_trip(client):
     exported = json.loads(export_resp.data)
     assert exported["version"] == 1
     assert len(exported["assessments"]) >= 1
+    exported["project_id"] = str(PROJECT_UUID)
 
     # Import back
     import_resp = client.post(

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -1340,6 +1340,62 @@ def test_import_custom_data_assessments_with_variant_name(client):
     assert result["assessments_imported"] >= 1
 
 
+def test_import_custom_data_foreign_variant_id_falls_back_to_name(client):
+    """A ``variant_id`` from another VulnScout instance never matches a local
+    variant (each instance mints its own UUIDs). Importing it as-is used to
+    attach the assessment to a variant_id no query would ever find, so it
+    silently disappeared from the Review page while remaining in the DB.
+    The import must fall back to the ``variant`` name field instead.
+    """
+    foreign_variant_id = str(uuid.uuid4())
+    assert foreign_variant_id != str(VARIANT_UUID)
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2020-35492",
+        "status": "affected",
+        "packages": ["cairo@1.16.0"],
+        "variant_id": foreign_variant_id,
+        "variant": "default",
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload,
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = json.loads(resp.data)
+    assert result["status"] == "success"
+    assert result["assessments_imported"] == 1
+
+    # Visible through the same variant-scoped query the Review page uses.
+    listing = client.get(f"/api/assessments/review?variant_id={VARIANT_UUID}")
+    assert listing.status_code == 200
+    vuln_ids = [a["vuln_id"] for a in json.loads(listing.data)]
+    assert "CVE-2020-35492" in vuln_ids
+
+
+def test_import_custom_data_foreign_variant_id_without_name_is_rejected(client):
+    """A foreign variant_id with no local ``variant`` name to fall back to
+    must be reported as an error instead of silently attaching to a
+    variant_id that does not exist in this database.
+    """
+    foreign_variant_id = str(uuid.uuid4())
+    payload = _custom_data_payload(assessments=[{
+        "vuln_id": "CVE-2020-35492",
+        "status": "affected",
+        "packages": ["cairo@1.16.0"],
+        "variant_id": foreign_variant_id,
+    }])
+    resp = client.post(
+        "/api/assessments/review/import-custom-data",
+        json=payload,
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    result = json.loads(resp.data)
+    assert result["assessments_imported"] == 0
+    assert any(foreign_variant_id in e.get("error", "") for e in result["errors"])
+
+
 def test_import_custom_data_duplicate_skipped(client):
     """Same assessment imported twice → second is skipped."""
     payload = _custom_data_payload(assessments=[{


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

A variant_id from another VulnScout instance's export never matches a variant in this database since each instance mints its own UUIDs. Trusting it as-is silently attached the assessment to a variant_id no local query would ever match, so it disappeared from the Review page while remaining in the DB.

Now the import falls back to the human-readable variant name when the variant_id is unknown locally, and reports an error if neither resolves to an existing variant.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Import a Vulnscout JSON into a new instance where the exported variant does not exist. You should get an error indicating that some of the variants are absent from your current DB, you can create those in the Settings tab then try again.

### Related Issue

#474

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


