### PR TITLE
Remove variants filter and unscope assessment history

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -184,12 +184,13 @@ type VariantScopedSnapshot = {
         return () => controller.abort();
     }, [vuln.id, projectId]);
 
-    // Fetch ALL assessments for this vuln (unfiltered) so variant tags are
-    // complete even when a variant filter is active in the explorer.
+    // Fetch all assessments for this vulnerability in the current project so
+    // its history remains complete when the Explorer is variant-scoped.
     useEffect(() => {
         const controller = new AbortController();
         setAllVulnAssessments([]);
-        fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/assessments`, { mode: 'cors', signal: controller.signal })
+        const projectQuery = projectId ? `?project_id=${encodeURIComponent(projectId)}` : '';
+        fetch(import.meta.env.VITE_API_URL + `/api/vulnerabilities/${encodeURIComponent(vuln.id)}/assessments${projectQuery}`, { mode: 'cors', signal: controller.signal })
             .then(r => r.json())
             .then((data: any[]) => {
                 if (Array.isArray(data)) {
@@ -203,7 +204,7 @@ type VariantScopedSnapshot = {
             })
             .catch(() => {});
         return () => controller.abort();
-    }, [vuln]);
+    }, [vuln, projectId]);
 
     // In all-variants mode, default to all variant targets for custom CVSS/time edits.
     useEffect(() => {
@@ -911,7 +912,13 @@ type VariantScopedSnapshot = {
             .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
     };
 
-    const groupedAssessments = groupAssessments(vuln.assessments);
+    // Prefer the project-wide response so history includes every variant. The
+    // scoped vulnerability rows remain a fallback for unavailable or empty
+    // history responses.
+    const groupedAssessments = groupAssessments(
+        (allVulnAssessments.length > 0 ? allVulnAssessments : vuln.assessments)
+            .filter(assessment => assessment.origin !== 'ai')
+    );
     const pendingAiAssessments = allVulnAssessments.filter(a =>
         a.origin === "ai" && (!variantId || a.variant_id === variantId));
     const pendingAiByVariant = new Map<string, Assessment[]>();

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -176,7 +176,6 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
     const [selectedJustifications, setSelectedJustifications] = useState<string[]>([]);
     const [selectedSuppliers, setSelectedSuppliers] = useState<string[]>([]);
-    const [deselectedVariants, setDeselectedVariants] = useState<string[]>([]);
     const [showOnlyOutdated, setShowOnlyOutdated] = useState(false);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
@@ -416,29 +415,6 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
 
     const hasSupplierInfo = useMemo(() => supplierList.length > 0, [supplierList]);
 
-    const variantList = useMemo(() => {
-        const set = new Set<string>();
-        for (const a of [...assessments, ...aiAssessments]) {
-            const vids = (a as any)._variantIds ?? (a.variant_id ? [a.variant_id] : []);
-            for (const vid of vids) {
-                const name = variantNames[vid];
-                if (name) set.add(name);
-            }
-        }
-        return [...set].sort();
-    }, [assessments, aiAssessments, variantNames]);
-
-    // All variants are checked by default; a variant only leaves the selection
-    // once the user explicitly unchecks it. Deriving the selection during render
-    // (instead of populating it from an effect) prevents a first-render flash.
-    const selectedVariants = useMemo(
-        () => variantList.filter(v => !deselectedVariants.includes(v)),
-        [variantList, deselectedVariants]
-    );
-    const setSelectedVariants = useCallback((values: string[]) => {
-        setDeselectedVariants(variantList.filter(v => !values.includes(v)));
-    }, [variantList]);
-
     const filteredAssessments = useMemo(() => assessments.filter((a) => {
         if (showOnlyOutdated && !hasOutdatedAssessment(a)) {
             return false;
@@ -453,13 +429,8 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             const rowSuppliers = a.packages.map(p => extractSupplierName(splitPkgId(p).supplier));
             if (!selectedSuppliers.some(s => rowSuppliers.includes(s))) return false;
         }
-        {
-            const vids = (a as any)._variantIds ?? (a.variant_id ? [a.variant_id] : []);
-            const rowVariants = vids.map((vid: string) => variantNames[vid]).filter(Boolean);
-            if (rowVariants.length && !selectedVariants.some(v => rowVariants.includes(v))) return false;
-        }
         return true;
-    }), [assessments, selectedStatuses, selectedJustifications, selectedSuppliers, selectedVariants, variantNames, showOnlyOutdated]);
+    }), [assessments, selectedStatuses, selectedJustifications, selectedSuppliers, showOnlyOutdated]);
 
     // Records the display order (filtered + sorted, deduped by vuln_id) of the
     // currently visible tab's table so the modal can navigate across it. Only one
@@ -482,7 +453,6 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         setSelectedStatuses([]);
         setSelectedJustifications([]);
         setSelectedSuppliers([]);
-        setSelectedVariants(variantList);
         setShowOnlyOutdated(false);
     };
 
@@ -1361,11 +1331,6 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             const rowSuppliers = a.packages.map(p => extractSupplierName(splitPkgId(p).supplier));
             if (!selectedSuppliers.some(s => rowSuppliers.includes(s))) return false;
         }
-        {
-            const vids = (a as any)._variantIds ?? (a.variant_id ? [a.variant_id] : []);
-            const rowVariants = vids.map((vid: string) => variantNames[vid]).filter(Boolean);
-            if (rowVariants.length && !selectedVariants.some(v => rowVariants.includes(v))) return false;
-        }
         return true;
     });
 
@@ -1480,15 +1445,6 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                                 options={supplierList}
                                 selected={selectedSuppliers}
                                 setSelected={setSelectedSuppliers}
-                            />
-                        )}
-
-                        {variantList.length > 0 && (
-                            <FilterOption
-                                label="Variants"
-                                options={variantList}
-                                selected={selectedVariants}
-                                setSelected={setSelectedVariants}
                             />
                         )}
 

--- a/frontend/src/pages/TablePackages.tsx
+++ b/frontend/src/pages/TablePackages.tsx
@@ -1,6 +1,6 @@
 import type { Package, VulnCounts } from "../handlers/packages";
 import { createColumnHelper, Row } from '@tanstack/react-table'
-import { useMemo, useState, useRef, useEffect, useCallback } from "react";
+import { useMemo, useState, useRef, useEffect } from "react";
 import TableGeneric from "../components/TableGeneric";
 import FilterOption from "../components/FilterOption";
 import ToggleSwitch from "../components/ToggleSwitch";
@@ -53,10 +53,6 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
     const [matchCondition, setMatchCondition] = useState('');
     const [matchingVulnerabilityIds, setMatchingVulnerabilityIds] = useState<string[] | null>(null);
     const [matchConditionError, setMatchConditionError] = useState('');
-    // Track variants the user has explicitly unchecked. All variants (including
-    // any discovered later) are considered selected unless present here, which
-    // avoids a first-render flash where variant rows briefly disappear.
-    const [deselectedVariants, setDeselectedVariants] = useState<string[]>([]);
     const [showShortcutHelper, setShowShortcutHelper] = useState(false);
     const [showSearchHelper, setShowSearchHelper] = useState(false);
     const [showMatchConditionHelper, setShowMatchConditionHelper] = useState(false);
@@ -194,25 +190,6 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
         return acc.sort();
     }, []), [packages])
 
-    const variants_list = useMemo(() => packages.reduce((acc: string[], pkg) => {
-        for (const variant of pkg.variants) {
-            if (variant !== '' && !acc.includes(variant))
-                acc.push(variant);
-        }
-        return acc.sort();
-    }, []), [packages])
-
-    // All variants are checked by default; a variant only leaves the selection
-    // once the user explicitly unchecks it. Deriving the selection during render
-    // (instead of populating it from an effect) prevents a first-render flash.
-    const selectedVariants = useMemo(
-        () => variants_list.filter(v => !deselectedVariants.includes(v)),
-        [variants_list, deselectedVariants]
-    );
-    const setSelectedVariants = useCallback((values: string[]) => {
-        setDeselectedVariants(variants_list.filter(v => !values.includes(v)));
-    }, [variants_list]);
-
     // Matched IDs are a snapshot of a server-side evaluation; drop them whenever
     // the vulnerability data changes so the filter never shows stale results.
     useEffect(() => {
@@ -267,7 +244,6 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
         setSelectedSources([]);
         setSelectedSbomDocs([]);
         setSelectedSuppliers([]);
-        setSelectedVariants(variants_list);
         setMatchCondition('');
         setMatchingVulnerabilityIds(null);
         setMatchConditionError('');
@@ -501,12 +477,9 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
             if (selectedSuppliers.length && !selectedSuppliers.includes(extractSupplierName(el.supplier))) {
                 return false;
             }
-            if (el.variants.length && !selectedVariants.some(variant => el.variants.includes(variant))) {
-                return false;
-            }
             return true;
         });
-    }, [packages, packagesWithOutdated, vulnerabilities, showOnlyOutdated, matchingVulnerabilityIds, selectedSources, selectedSbomDocs, selectedSuppliers, selectedVariants]);
+    }, [packages, packagesWithOutdated, vulnerabilities, showOnlyOutdated, matchingVulnerabilityIds, selectedSources, selectedSbomDocs, selectedSuppliers]);
 
     return (<>
         {showOnlyOutdated && outdatedLoading && (
@@ -655,15 +628,6 @@ function TablePackages({ packages, vulnerabilities = [], onShowVulns, onLoadOutd
                 selected={selectedSbomDocs}
                 setSelected={setSelectedSbomDocs}
             />
-
-            {variants_list.length > 0 && (
-                <FilterOption
-                    label="Variants"
-                    options={variants_list}
-                    selected={selectedVariants}
-                    setSelected={setSelectedVariants}
-                />
-            )}
 
             <ToggleSwitch
                 enabled={showOnlyOutdated}

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -442,10 +442,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
     const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
     const [selectedSources, setSelectedSources] = useState<string[]>([]);
     const [selectedPackages, setSelectedPackages] = useState<string[]>([]);
-    // Track variants the user has explicitly unchecked. All variants (including
-    // any discovered later) are considered selected unless present here, which
-    // avoids a first-render flash where variant rows briefly disappear.
-    const [deselectedVariants, setDeselectedVariants] = useState<string[]>([]);
     const [publishedDateFilterType, setPublishedDateFilterType] = useState<string>('');
     const [publishedDateValue, setPublishedDateValue] = useState<string>('');
     const [publishedDaysValue, setPublishedDaysValue] = useState<string>('');
@@ -761,25 +757,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         () => sources_list.map(formatSourceName),
         [sources_list]
     );
-
-    const variants_list = useMemo(() => vulnerabilities.reduce((acc: string[], vuln) => {
-        vuln.variants.forEach(variant => {
-            if (!acc.includes(variant) && variant != '')
-                acc.push(variant)
-        });
-        return acc.sort();
-    }, []), [vulnerabilities])
-
-    // All variants are checked by default; a variant only leaves the selection
-    // once the user explicitly unchecks it. Deriving the selection during render
-    // (instead of populating it from an effect) prevents a first-render flash.
-    const selectedVariants = useMemo(
-        () => variants_list.filter(v => !deselectedVariants.includes(v)),
-        [variants_list, deselectedVariants]
-    );
-    const setSelectedVariants = useCallback((values: string[]) => {
-        setDeselectedVariants(variants_list.filter(v => !values.includes(v)));
-    }, [variants_list]);
 
     // Distinct raw package ids across all vulnerabilities, sorted by display label.
     // Currently selected packages are always included so a stale or absent
@@ -1296,7 +1273,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
             }
             if (selectedSources.length && !selectedSources.some(src => el.found_by.includes(src))) return false;
             if (selectedPackages.length && !selectedPackages.some(pkg => el.packages_current.includes(pkg))) return false;
-            if (el.variants.length && !selectedVariants.some(variant => el.variants.includes(variant))) return false;
 
             // Published date filter
             if (publishedDateFilterType && el.published) {
@@ -1388,7 +1364,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
 
             return true;
         });
-    }, [vulnerabilities, filterVulnerabilityIds, selectedSeverities, selectedStatuses, selectedSources, selectedPackages, selectedVariants, publishedDateFilterType, publishedDateValue, publishedDaysValue, publishedDateFrom, publishedDateTo, showCustomSeverityFilter, severityRange, showCustomEpssFilter, epssRange, selectedAttackVectors, selectedFirstScanDates, aiSuggestionFilter, aiSuggestionVulnIds]);
+    }, [vulnerabilities, filterVulnerabilityIds, selectedSeverities, selectedStatuses, selectedSources, selectedPackages, publishedDateFilterType, publishedDateValue, publishedDaysValue, publishedDateFrom, publishedDateTo, showCustomSeverityFilter, severityRange, showCustomEpssFilter, epssRange, selectedAttackVectors, selectedFirstScanDates, aiSuggestionFilter, aiSuggestionVulnIds]);
 
     const searchableData = useMemo(() => dataToDisplay.map(vuln => ({
         ...vuln,
@@ -1471,7 +1447,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         setSelectedSeverities([]);
         setSelectedStatuses([]);
         setSelectedPackages([]);
-        setSelectedVariants(variants_list);
         setPublishedDateFilterType('');
         setPublishedDateValue('');
         setPublishedDaysValue('');
@@ -1710,15 +1685,6 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
                 searchable
                 formatLabel={formatPkgId}
             />
-
-            {variants_list.length > 0 && (
-                <FilterOption
-                    label="Variants"
-                    options={variants_list}
-                    selected={selectedVariants}
-                    setSelected={setSelectedVariants}
-                />
-            )}
 
             {/* Published Date Filter Dropdown */}
             <PublishedDateFilter

--- a/frontend/tests/unit_tests/test_pkg_table.tsx
+++ b/frontend/tests/unit_tests/test_pkg_table.tsx
@@ -418,8 +418,7 @@ describe('Packages Table', () => {
         });
     })
 
-    test('filter by variant', async () => {
-        // ARRANGE: packages spread across two variants
+    test('does not provide a variants filter', () => {
         const packagesWithVariants: Package[] = [
             { ...packages[0], variants: ['variant-a'] },
             { ...packages[1], variants: ['variant-b'] },
@@ -427,38 +426,6 @@ describe('Packages Table', () => {
         ];
         render(<TablePackages packages={packagesWithVariants} />);
 
-        const user = userEvent.setup();
-
-        // Open the "Variants" filter dropdown
-        const variants_btn = await screen.getByRole('button', { name: /^variants$/i });
-        await user.click(variants_btn);
-
-        // All variants are checked by default. ACT: uncheck "variant-a"
-        const variantACheckbox = await screen.getByRole('checkbox', { name: /variant-a/i });
-        await user.click(variantACheckbox);
-
-        // aaabbbccc is only in variant-a, so it must disappear
-        await waitFor(() => {
-            expect(document.body.innerHTML).not.toContain('aaabbbccc');
-        }, { timeout: 2000 });
-
-        // xxxyyyzzz (variant-b) and dddeeefff (variant-a + variant-b) remain
-        expect(screen.getAllByRole('cell', { name: /xxxyyyzzz/ }).length).toBeGreaterThan(0);
-        expect(screen.getAllByRole('cell', { name: /dddeeefff/ }).length).toBeGreaterThan(0);
-
-        // REVERT CHANGE: re-check "variant-a"
-        await user.click(variantACheckbox);
-
-        await waitFor(() => {
-            expect(screen.getAllByRole('cell', { name: /aaabbbccc/ }).length).toBeGreaterThan(0);
-        });
-    })
-
-    test('variant filter is hidden when no package has variants', async () => {
-        // ARRANGE: the default packages have no variants
-        render(<TablePackages packages={packages} />);
-
-        // ASSERT: the "Variants" filter button is not rendered
         expect(screen.queryByRole('button', { name: /^variants$/i })).toBeNull();
     })
 

--- a/frontend/tests/unit_tests/test_review.tsx
+++ b/frontend/tests/unit_tests/test_review.tsx
@@ -1184,6 +1184,14 @@ describe('Review — Time Estimates & Custom CVSS tab navigation', () => {
 // ===========================================================================
 
 describe('Review — filters, search and keyboard', () => {
+    test('does not provide a variants filter', async () => {
+        mockNetwork([makeAssessment('a1', 'v1'), makeAssessment('a2', 'v2')]);
+        render(<Review projectId="proj1" />);
+
+        await screen.findByText('CVE-2020-1111');
+        expect(screen.queryByRole('button', { name: /^variants$/i })).toBeNull();
+    });
+
     test('the outdated toggle includes rows with mixed current and outdated assessments', async () => {
         const mixedOutdated = {
             ...makeAssessment('outdated', 'v1'),

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2548,12 +2548,14 @@ describe('Vulnerability Modal', () => {
             ]
         };
 
-        render(<VulnModal vuln={vulnWithVariantAssessments} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        render(<VulnModal vuln={vulnWithVariantAssessments} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} projectId="proj1" />);
 
-        // Wait for variant tags to render (variant names now appear both in the
-        // per-variant recap and on the assessment history entries)
-        expect((await screen.findAllByText('Production')).length).toBeGreaterThan(0);
-        expect(screen.getAllByText('Staging').length).toBeGreaterThan(0);
+        const history = screen.getByText('Assessment history').nextElementSibling as HTMLElement;
+        await waitFor(() => {
+            expect(within(history).getByText(/Production/)).toBeInTheDocument();
+            expect(within(history).getByText(/Staging/)).toBeInTheDocument();
+        });
+        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('assessments?project_id=proj1'))).toBe(true);
     });
 
     test('recap shows the latest status for each variant', async () => {

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -659,37 +659,12 @@ describe('Vulnerability Table', () => {
         expect(pkg_xyz).toBeInTheDocument();
     })
 
-    test('filter by variant', async () => {
-        // ARRANGE
+    test('does not provide a variant filter', async () => {
         const vulnerabilitiesWithVariants = vulnerabilities.map((vuln, index) => ({
             ...vuln,
             variants: index === 0 ? ['variant-a'] : index === 1 ? ['variant-b'] : ['variant-a', 'variant-b']
         }));
         render(<TableVulnerabilities vulnerabilities={vulnerabilitiesWithVariants} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-
-        const user = userEvent.setup();
-        const variantBtn = await screen.getByRole('button', { name: /^variants$/i });
-        expect(variantBtn).toBeInTheDocument();
-        await user.click(variantBtn);
-
-        // All variants are checked by default; unchecking variant-a removes rows
-        // that belong only to variant-a (the first vuln). Rows that also belong to
-        // variant-b stay visible.
-        const variantCheckbox = await screen.getByRole('checkbox', { name: 'variant-a' });
-        expect(variantCheckbox).toBeChecked();
-        await user.click(variantCheckbox);
-
-        await waitFor(() => {
-            expect(screen.queryByRole('cell', {name: /CVE-2010-1234/})).toBeNull();
-        }, { timeout: 5000 });
-
-        expect(await screen.getByRole('cell', {name: /CVE-2018-5678/})).toBeInTheDocument();
-        expect(await screen.getByRole('cell', {name: /CVE-2024-56730/})).toBeInTheDocument();
-    })
-
-    test('variant filter is hidden when no vulnerability has variants', async () => {
-        // ARRANGE
-        render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         expect(screen.queryByRole('button', { name: /^variants$/i })).toBeNull();
     })

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -880,13 +880,29 @@ def init_app(app: Flask) -> None:
 
         OpenAPI:
         query format string optional Response format such as list or dict.
+        query project_id uuid optional Restrict results to one project.
         response 200 JsonObject Assessment collection for the vulnerability.
         """
+        project_uuid: UUID | None = None
+        project_id = request.args.get('project_id')
+        if project_id:
+            project_uuid, err = parse_uuid_or_400(project_id, "project_id")
+            if err:
+                return err
+
+        project_variant_ids: set[UUID] | None = None
+        if project_uuid is not None:
+            project_variant_ids = set(db.session.execute(
+                select(DBVariant.id).where(DBVariant.project_id == project_uuid)
+            ).scalars())
+
         # Get findings for this vulnerability then load their assessments
         findings = Finding.get_by_vulnerability(vuln_id)
         assessments = []
         for f in findings:
             for a in DBAssessment.get_by_finding(f.id):
+                if project_variant_ids is not None and a.variant_id not in project_variant_ids:
+                    continue
                 assessments.append(a.to_dict())
         annotate_assessments_outdated(assessments)
         if request.args.get('format', 'list') == "dict":

--- a/tests/webapp_tests/test_assessment_outdated.py
+++ b/tests/webapp_tests/test_assessment_outdated.py
@@ -239,6 +239,39 @@ class TestOutdatedFlag:
         assert custom[0]["outdated"] is True
         assert custom[0]["superseded_by"] == ["firefox@2.0"]
 
+    def test_list_assess_by_vuln_scopes_to_project(self):
+        """Project-scoped history includes all of its variants, not other projects."""
+        other_project_id = uuid.UUID("99999999-9999-9999-9999-999999999999")
+        other_variant_id = uuid.UUID("88888888-8888-8888-8888-888888888888")
+        other_assessment_id = uuid.UUID("77777777-7777-7777-7777-777777777777")
+        with self.app.app_context():
+            other_project = Project(id=other_project_id, name="other")
+            other_variant = Variant(id=other_variant_id, name="other", project_id=other_project_id)
+            finding = Finding.get_by_vulnerability(CVE_ID)[0]
+            other_assessment = Assessment(
+                id=other_assessment_id,
+                status="affected",
+                simplified_status="Exploitable",
+                origin="custom",
+                source="analyst",
+                status_notes="",
+                justification="",
+                impact_statement="",
+                responses=[],
+                workaround="",
+                finding_id=finding.id,
+                variant_id=other_variant_id,
+                timestamp=datetime(2024, 1, 3, tzinfo=timezone.utc),
+            )
+            _db.session.add_all([other_project, other_variant, other_assessment])
+            _db.session.commit()
+
+        resp = self.client.get(f"/api/vulnerabilities/{CVE_ID}/assessments?project_id={PROJECT_ID}")
+        assert resp.status_code == 200
+        assessment_ids = {item["id"] for item in json.loads(resp.data)}
+        assert str(self.assess_id) in assessment_ids
+        assert str(other_assessment_id) not in assessment_ids
+
     def test_outdated_flag_always_present(self):
         """Every assessment dict returned has the 'outdated' key."""
         resp = self.client.get(f"/api/assessments?variant_id={VARIANT_ID}")


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Remove variants filter in vulnerabilities table
*  Unscope assessment history in vulnmodal

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

### How to verify this change

1. Open the web dashboard, go to vulnerabilities table, observe there is no variants filter anymore.
2. Pick a vuln, then observe that you are able to work with all variants from the current project

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


