### PR TITLE
feat(assessments): remove false positive option from new assessment status

### DIFF
--- a/doc/source/templates.md
+++ b/doc/source/templates.md
@@ -196,7 +196,7 @@ When exporting, users can add filters to export only some vulnerabilities. To by
 | `in_triage`, `under_investigation` | Vulnerability found but presence not confirmed. Default status. | `status_pending`, `status_active` |
 | `affected`, `exploitable` | Vulnerability confirmed and affecting the product. | `status_affected`, `status_active` |
 | `fixed`, `resolved`, `resolved_with_pedigree` | Vulnerability is fixed and no longer exploitable. | `status_fixed`, `status_inactive` |
-| `not_affected`, `false_positive` | Vulnerability is a false positive or not affecting us. | `status_ignored`, `status_inactive` |
+| `not_affected` | Vulnerability is a false positive or not affecting us. | `status_ignored`, `status_inactive` |
 
 #### Possible values for `justification`
 
@@ -245,7 +245,7 @@ In addition to [Jinja built-in filters](https://jinja.palletsprojects.com/en/3.1
 | `status_pending` | Shorthand for `in_triage` + `under_investigation`. |
 | `status_affected` | Shorthand for `affected` + `exploitable`. |
 | `status_fixed` | Shorthand for `fixed` + `resolved` + `resolved_with_pedigree`. |
-| `status_ignored` | Shorthand for `not_affected` + `false_positive`. |
+| `status_ignored` | Shorthand for `not_affected`. |
 | `status_active` | `status_pending` + `status_affected`. |
 | `status_inactive` | `status_fixed` + `status_ignored`. |
 

--- a/frontend/src/components/CopyAssessmentsReviewModal.tsx
+++ b/frontend/src/components/CopyAssessmentsReviewModal.tsx
@@ -109,7 +109,6 @@ function statusBadgeClass(simplified: string): string {
         case "Exploitable":        return "bg-red-800 text-red-100";
         case "Fixed":              return "bg-teal-700 text-teal-100";
         case "Pending Assessment": return "bg-amber-700 text-amber-100";
-        case "False Positive":     return "bg-purple-700 text-purple-100";
         default:                   return "bg-slate-600 text-zinc-200";
     }
 }

--- a/frontend/src/components/EditAssessment.tsx
+++ b/frontend/src/components/EditAssessment.tsx
@@ -47,7 +47,12 @@ function EditAssessment({
     variantFindingsMap,
     findingsLoading = false
 }: Readonly<Props>) {
-    const isImpactStatus = assessment.status === 'not_affected' || assessment.status === 'false_positive';
+    // `false_positive` was removed as a distinct status; any legacy or imported
+    // value is treated as `not_affected` throughout the editor.
+    const initialStatus = assessment.status === 'false_positive'
+        ? 'not_affected'
+        : (assessment.status || "under_investigation");
+    const isImpactStatus = initialStatus === 'not_affected';
     const hasSelectedOutdatedFinding = useMemo(() => {
         const selectedPackages = new Set(defaultSelectedPackages ?? []);
         const variantIds = defaultSelectedVariantIds ?? Object.keys(variantFindingsMap ?? {});
@@ -57,7 +62,7 @@ function EditAssessment({
             )
         );
     }, [defaultSelectedPackages, defaultSelectedVariantIds, variantFindingsMap]);
-    const [status, setStatus] = useState(assessment.status || "under_investigation");
+    const [status, setStatus] = useState(initialStatus);
     const [justification, setJustification] = useState(assessment.justification || "none");
     // For non-impact statuses (fixed, affected, …) Yocto stores its notes in impact_statement.
     // Pre-fill status_notes with that value so users see it in the right field.
@@ -201,7 +206,7 @@ function EditAssessment({
     useEffect(() => {
         const initialStatusNotes = assessment.status_notes || (!isImpactStatus ? (assessment.impact_statement || "") : "");
         const hasChanges = (
-            status !== assessment.status ||
+            status !== initialStatus ||
             justification !== (assessment.justification || "none") ||
             statusNotes !== initialStatusNotes ||
             workaround !== (assessment.workaround || "") ||
@@ -209,7 +214,7 @@ function EditAssessment({
             !keepCurrentTimestamp
         );
         onFieldsChange?.(hasChanges);
-    }, [status, justification, statusNotes, workaround, impact, keepCurrentTimestamp, onFieldsChange, assessment, isImpactStatus]);
+    }, [status, justification, statusNotes, workaround, impact, keepCurrentTimestamp, onFieldsChange, assessment, isImpactStatus, initialStatus]);
 
     // Auto-select single variant when availableVariants load asynchronously (e.g. Edit from Actions column)
     useEffect(() => {
@@ -245,10 +250,10 @@ function EditAssessment({
             return;
         }
 
-        // Justification only applies to not_affected; the impact statement
-        // applies to both not_affected and false_positive (mirrors StatusEditor).
+        // Justification and the impact statement only apply to not_affected
+        // (mirrors StatusEditor).
         const includeJustification = status == "not_affected";
-        const includeImpact = status == "not_affected" || status == "false_positive";
+        const includeImpact = status == "not_affected";
 
         onSaveAssessment({
             id: assessment.id,
@@ -265,7 +270,7 @@ function EditAssessment({
     }
 
     const resetToOriginal = useCallback(() => {
-        setStatus(assessment.status || "under_investigation");
+        setStatus(initialStatus);
         setJustification(assessment.justification || "none");
         setStatusNotes(assessment.status_notes || (!isImpactStatus ? (assessment.impact_statement || "") : ""));
         setWorkaround(assessment.workaround || "");
@@ -274,7 +279,7 @@ function EditAssessment({
         setKeepCurrentTimestamp(true);
         setSelectedVariantIds(defaultSelectedVariantIds ?? (availableVariants?.length === 1 ? [availableVariants[0].id] : []));
         setSelectedPackages(defaultSelectedPackages ?? (availablePackages?.length === 1 ? [availablePackages[0]] : []));
-    }, [assessment, isImpactStatus, defaultSelectedVariantIds, defaultSelectedPackages, availableVariants, availablePackages, hasSelectedOutdatedFinding]);
+    }, [assessment, isImpactStatus, defaultSelectedVariantIds, defaultSelectedPackages, availableVariants, availablePackages, hasSelectedOutdatedFinding, initialStatus]);
 
     useEffect(() => {
         if (shouldClearFields) {
@@ -307,7 +312,6 @@ function EditAssessment({
                     <option value="affected">Affected / exploitable</option>
                     <option value="fixed">Fixed / patched</option>
                     <option value="not_affected">Not applicable</option>
-                    <option value="false_positive">False positive</option>
                 </select>
                 {status == "not_affected" && <>
                     Justification:
@@ -442,7 +446,7 @@ function EditAssessment({
                 </button>
             </div>
 
-            {(status === 'not_affected' || status === 'false_positive') && (
+            {status === 'not_affected' && (
                 <><textarea
                         value={impact}
                         onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => setImpact(event.target.value)}

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -209,14 +209,6 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             }
             return;
         }
-        if (status == "false_positive" && impact == '') {
-            if (triggerBanner) {
-                triggerBanner("You must provide an impact statement for false positive status", "error");
-            } else {
-                internalTriggerBanner("You must provide an impact statement for false positive status", "error");
-            }
-            return;
-        }
         if (variants && variants.length > 0 && selectedVariantIds.length === 0) {
             if (triggerBanner) {
                 triggerBanner("You must select at least one variant", "error");
@@ -238,7 +230,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
             justification: status == "not_affected" ? justification : undefined,
             status_notes: statusNotes,
             workaround,
-            impact_statement: (status == "not_affected" || status == "false_positive") ? impact : undefined,
+            impact_statement: status == "not_affected" ? impact : undefined,
             variant_ids: selectedVariantIds.length > 0 ? selectedVariantIds : undefined,
             packages: selectedPackages.length > 0 ? selectedPackages : (availablePackages ?? [])
         });
@@ -286,7 +278,6 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                 <option value="affected">Affected / exploitable</option>
                 <option value="fixed">Fixed / patched</option>
                 <option value="not_affected">Not applicable</option>
-                <option value="false_positive">False positive</option>
             </select>
             {status == "not_affected" && <>
                 Justification:
@@ -394,7 +385,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
                 </div>
             </div>
         )}
-        {(status == "not_affected" || status == "false_positive") && <>
+        {status == "not_affected" && <>
             <textarea
                 value={impact}
                 onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => setImpact(event.target.value)}

--- a/frontend/src/components/StatusEditor.tsx
+++ b/frontend/src/components/StatusEditor.tsx
@@ -14,6 +14,18 @@ type PostAssessment = {
     variant_ids?: string[]
 }
 
+// Statuses that can be created through this editor (must match the <option>
+// values rendered in the Status <select>).
+const CREATABLE_STATUSES = ["under_investigation", "affected", "fixed", "not_affected"] as const;
+
+// Callers (MultiEditBar uniformStatus, VulnModal derived default) may pass a
+// legacy/unsupported status such as "false_positive". Normalize it to an
+// allowed creation status so it can never be re-submitted through the hidden
+// option.
+function normalizeCreatableStatus (status: string): string {
+    return (CREATABLE_STATUSES as readonly string[]).includes(status) ? status : "under_investigation";
+}
+
 type Props = {
     onAddAssessment: (data: PostAssessment) => void;
     progressBar?: number;
@@ -58,7 +70,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
         return [];
     }, [defaultSelectedPackages, currentPackages]);
 
-    const [status, setStatus] = useState(defaultStatus);
+    const [status, setStatus] = useState(normalizeCreatableStatus(defaultStatus));
     const [justification, setJustification] = useState("none");
     const [statusNotes, setStatusNotes] = useState("");
     const [workaround, setWorkaround] = useState("");
@@ -183,13 +195,13 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
 
     // Update status when defaultStatus prop changes
     useEffect(() => {
-        setStatus(defaultStatus);
+        setStatus(normalizeCreatableStatus(defaultStatus));
     }, [defaultStatus]);
 
     // Check if fields have changes
     useEffect(() => {
         const hasChanges = (
-            status !== defaultStatus ||
+            status !== normalizeCreatableStatus(defaultStatus) ||
             justification !== "none" ||
             statusNotes !== "" ||
             workaround !== "" ||
@@ -237,7 +249,7 @@ function StatusEditor ({onAddAssessment, progressBar, clearFields: shouldClearFi
     }
 
     const clearInputs = useCallback(() => {
-        setStatus(defaultStatus);
+        setStatus(normalizeCreatableStatus(defaultStatus));
         setJustification("none");
         setStatusNotes("");
         setWorkaround("");

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -727,7 +727,7 @@ type VariantScopedSnapshot = {
         const normalise = (raw: unknown): Assessment | null => {
             const a = asAssessment(raw);
             if (Array.isArray(a) || typeof a !== 'object') return null;
-            const isRelevant = a.status === 'not_affected' || a.status === 'false_positive';
+            const isRelevant = a.status === 'not_affected';
             if (!isRelevant) {
                 a.justification = undefined;
                 a.impact_statement = undefined;

--- a/frontend/src/handlers/assessments.ts
+++ b/frontend/src/handlers/assessments.ts
@@ -1,7 +1,6 @@
 const STATUS_VEX_TO_GRAPH: { [key: string]: string } = {
     "under_investigation": "Pending Assessment",
     "in_triage": "Pending Assessment",
-    "false_positive": "Not affected",
     "not_affected": "Not affected",
     "exploitable": "Exploitable",
     "affected": "Exploitable",

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -314,7 +314,7 @@ class Vulnerabilities {
                     effort_min: vulnerability.effort.optimistic.total_seconds || false,
                     effort_max: vulnerability.effort.pessimistic.total_seconds || false,
                     fixed: lastAssessment ? ['fixed', 'resolved', 'resolved_with_pedigree'].includes(lastAssessment.status) : false,
-                    ignored: lastAssessment ? ['not_affected', 'false_positive'].includes(lastAssessment.status) : false,
+                    ignored: lastAssessment ? ['not_affected'].includes(lastAssessment.status) : false,
                     affected: lastAssessment ? ['affected', 'exploitable'].includes(lastAssessment.status) : false,
                     pending: lastAssessment ? ['under_investigation', 'in_triage'].includes(lastAssessment.status) : true,
                     new: !lastAssessment,

--- a/frontend/tests/unit_tests/test_assessments_handler.ts
+++ b/frontend/tests/unit_tests/test_assessments_handler.ts
@@ -54,7 +54,7 @@ describe('asAssessment validation', () => {
   });
 
   test('known statuses map simplified_status', () => {
-    const statuses = ['under_investigation','in_triage','false_positive','not_affected','exploitable','affected','resolved','fixed','resolved_with_pedigree'];
+    const statuses = ['under_investigation','in_triage','not_affected','exploitable','affected','resolved','fixed','resolved_with_pedigree'];
     statuses.forEach(st => {
       const data = { id: `k-${st}`, vuln_id: 'CVE-Z', status: st, timestamp: '2024-03-01T00:00:00', packages: [], responses: [] };
       const assessed = asAssessment(data as any) as any;

--- a/frontend/tests/unit_tests/test_copy_assessments_review_modal.tsx
+++ b/frontend/tests/unit_tests/test_copy_assessments_review_modal.tsx
@@ -280,7 +280,6 @@ describe('CopyAssessmentsReviewModal', () => {
 
     test.each([
         ['Pending Assessment', 'bg-amber-700'],
-        ['False Positive',     'bg-purple-700'],
         ['Unknown',            'bg-slate-600'],
     ])('status badge renders correct colour for "%s"', (simplified) => {
         const groups: CopyAssessmentsPreviewGroup[] = [{

--- a/frontend/tests/unit_tests/test_edit_assessment.tsx
+++ b/frontend/tests/unit_tests/test_edit_assessment.tsx
@@ -282,7 +282,7 @@ describe('EditAssessment Component', () => {
         expect(screen.getByText('Edit Assessment')).toBeInTheDocument();
     });
 
-    test('saves assessment for false_positive status without changing status', async () => {
+    test('normalizes a legacy false_positive assessment to not_affected on save', async () => {
         const fpAssessment: Assessment = {
             ...mockAssessment,
             status: 'false_positive'
@@ -300,14 +300,14 @@ describe('EditAssessment Component', () => {
         const saveButton = screen.getByText('Save Changes');
         await user.click(saveButton);
 
+        // false_positive was removed as a distinct status; it is normalized to
+        // not_affected, for which the impact statement is preserved.
         expect(mockOnSave).toHaveBeenCalledWith({
             id: 'test-assessment-id',
-            status: 'false_positive',
-            justification: undefined,
+            status: 'not_affected',
+            justification: 'test justification',
             status_notes: 'test notes',
             workaround: 'test workaround',
-            // The impact statement (reasoning) must be preserved for false_positive,
-            // not wiped, since the impact textarea is shown and editable for it.
             impact_statement: 'test impact',
             packages: [],
             variant_ids: undefined,
@@ -315,7 +315,7 @@ describe('EditAssessment Component', () => {
         });
     });
 
-    test('preserves an edited impact statement for false_positive status', async () => {
+    test('preserves an edited impact statement for a normalized false_positive assessment', async () => {
         const fpAssessment: Assessment = {
             ...mockAssessment,
             status: 'false_positive',
@@ -338,9 +338,8 @@ describe('EditAssessment Component', () => {
         await user.click(screen.getByText('Save Changes'));
 
         expect(mockOnSave).toHaveBeenCalledWith(expect.objectContaining({
-            status: 'false_positive',
+            status: 'not_affected',
             impact_statement: 'updated reason',
-            justification: undefined,
         }));
     });
 
@@ -471,7 +470,7 @@ describe('EditAssessment Component', () => {
         });
     });
 
-    test('changes status to false_positive and shows impact field', async () => {
+    test('changes status to not_affected and shows impact field', async () => {
         render(
             <EditAssessment
                 assessment={mockAssessment}
@@ -483,7 +482,7 @@ describe('EditAssessment Component', () => {
         const user = userEvent.setup();
         const statusSelect = screen.getByDisplayValue(/Affected \/ exploitable/i);
 
-        await user.selectOptions(statusSelect, 'false_positive');
+        await user.selectOptions(statusSelect, 'not_affected');
 
         // Impact field should appear
         await waitFor(() => {

--- a/frontend/tests/unit_tests/test_sbom_match_condition.tsx
+++ b/frontend/tests/unit_tests/test_sbom_match_condition.tsx
@@ -183,7 +183,6 @@ describe('SBOM match condition', () => {
         ['resolved', 'fixed'],
         ['resolved_with_pedigree', 'fixed'],
         ['not_affected', 'ignored'],
-        ['false_positive', 'ignored'],
         ['affected', 'affected'],
         ['exploitable', 'affected'],
         ['under_investigation', 'pending'],

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -244,50 +244,6 @@ describe('StatusEditor', () => {
         });
     });
 
-    test('should show impact input when status is false_positive', async () => {
-        const user = userEvent.setup();
-        render(<StatusEditor {...defaultProps} />);
-
-        const statusSelect = screen.getByRole('combobox');
-
-        // Test false_positive
-        await user.selectOptions(statusSelect, 'false_positive');
-        expect(screen.getByPlaceholderText('why this vulnerability is not exploitable ?')).toBeInTheDocument();
-    });
-
-    test('should show error when false_positive has no impact and external triggerBanner', async () => {
-        const triggerBanner = jest.fn();
-        const user = userEvent.setup();
-        render(<StatusEditor {...defaultProps} triggerBanner={triggerBanner} />);
-
-        const statusSelect = screen.getByRole('combobox');
-        await user.selectOptions(statusSelect, 'false_positive');
-
-        const addButton = screen.getByRole('button', { name: 'Add assessment' });
-        await user.click(addButton);
-
-        expect(triggerBanner).toHaveBeenCalledWith(
-            'You must provide an impact statement for false positive status',
-            'error'
-        );
-        expect(defaultProps.onAddAssessment).not.toHaveBeenCalled();
-    });
-
-    test('should show internal banner when false_positive has no impact', async () => {
-        const user = userEvent.setup();
-        render(<StatusEditor {...defaultProps} />);
-
-        const statusSelect = screen.getByRole('combobox');
-        await user.selectOptions(statusSelect, 'false_positive');
-
-        const addButton = screen.getByRole('button', { name: 'Add assessment' });
-        await user.click(addButton);
-
-        expect(screen.getByTestId('message-banner')).toBeInTheDocument();
-        expect(screen.getByText('You must provide an impact statement for false positive status')).toBeInTheDocument();
-        expect(defaultProps.onAddAssessment).not.toHaveBeenCalled();
-    });
-
     test('should render variant checkboxes when variants prop is provided', () => {
         const variants = [
             { id: 'v1', name: 'default', project_id: 'p1' },

--- a/frontend/tests/unit_tests/test_status_editor.tsx
+++ b/frontend/tests/unit_tests/test_status_editor.tsx
@@ -36,6 +36,25 @@ describe('StatusEditor', () => {
         expect(screen.getByRole('button', { name: 'Add assessment' })).toBeInTheDocument();
     });
 
+    test('normalizes an unsupported defaultStatus (false_positive) to under_investigation and never submits it', async () => {
+        const user = userEvent.setup();
+        const onAddAssessment = jest.fn();
+
+        render(<StatusEditor {...defaultProps} onAddAssessment={onAddAssessment} defaultStatus="false_positive" />);
+
+        // The hidden false_positive option must not leak into the control.
+        const statusSelect = screen.getByRole('combobox');
+        expect(statusSelect).toHaveValue('under_investigation');
+
+        // Submitting without touching the status must post the normalized status.
+        const addButton = screen.getByRole('button', { name: 'Add assessment' });
+        await user.click(addButton);
+
+        expect(onAddAssessment).toHaveBeenCalledTimes(1);
+        expect(onAddAssessment.mock.calls[0][0].status).toBe('under_investigation');
+        expect(onAddAssessment.mock.calls[0][0].status).not.toBe('false_positive');
+    });
+
     test('should render progress bar when progressBar prop is provided', () => {
         render(<StatusEditor {...defaultProps} progressBar={0.5} />);
 

--- a/src/bin/cmd_process.py
+++ b/src/bin/cmd_process.py
@@ -100,7 +100,7 @@ def evaluate_condition(
                 last_assessment = assessment
         if last_assessment:
             data["fixed"] = last_assessment.status in ["fixed", "resolved", "resolved_with_pedigree"]
-            data["ignored"] = last_assessment.status in ["not_affected", "false_positive"]
+            data["ignored"] = last_assessment.status in ["not_affected"]
             data["affected"] = last_assessment.status in ["affected", "exploitable"]
             data["pending"] = last_assessment.status in ["under_investigation", "in_triage"]
             data["new"] = False

--- a/src/models/assessment.py
+++ b/src/models/assessment.py
@@ -22,11 +22,10 @@ from .variant import Variant
 # ---------------------------------------------------------------------------
 
 VALID_STATUS_OPENVEX = ["under_investigation", "not_affected", "affected", "fixed"]
-VALID_STATUS_CDX_VEX = ["in_triage", "false_positive", "not_affected", "exploitable",
+VALID_STATUS_CDX_VEX = ["in_triage", "not_affected", "exploitable",
                         "resolved", "resolved_with_pedigree"]
 STATUS_CDX_VEX_TO_OPENVEX = {
     "in_triage": "under_investigation",
-    "false_positive": "not_affected",
     "not_affected": "not_affected",
     "exploitable": "affected",
     "resolved": "fixed",
@@ -42,7 +41,6 @@ STATUS_OPENVEX_TO_CDX_VEX = {
 STATUS_TO_SIMPLIFIED = {
     "under_investigation": "Pending Assessment",
     "in_triage": "Pending Assessment",
-    "false_positive": "Not affected",
     "not_affected": "Not affected",
     "exploitable": "Exploitable",
     "affected": "Exploitable",
@@ -243,8 +241,14 @@ class Assessment(Base):
     def set_status(self, status: str) -> bool:
         """Validate and set the assessment status (OpenVEX or CDX VEX).
 
+        ``false_positive`` was removed as a distinct status; any incoming value
+        (for example from an imported CycloneDX VEX document) is absorbed into
+        ``not_affected`` so it is never stored as a first-class status.
+
         Return ``True`` if the status was accepted, ``False`` otherwise.
         """
+        if status == "false_positive":
+            status = "not_affected"
         if status in VALID_STATUS_OPENVEX or status in VALID_STATUS_CDX_VEX:
             self.status = status
             return True
@@ -394,9 +398,6 @@ class Assessment(Base):
         if self.justification:
             openvex_justif = self.get_justification_openvex()
 
-        if self.status == "false_positive" and self.justification not in VALID_JUSTIFICATION_OPENVEX:
-            openvex_justif = "component_not_present"
-
         if (openvex_status == "not_affected"
            and openvex_justif not in VALID_JUSTIFICATION_OPENVEX
            and not self.impact_statement):
@@ -435,10 +436,6 @@ class Assessment(Base):
         cdx_justif: Optional[str] = ""
         if self.justification:
             cdx_justif = self.get_justification_cdx_vex()
-
-        if self.status == "not_affected" and self.justification == "component_not_present":
-            cdx_state = "false_positive"
-            cdx_justif = ""
 
         cdx_response = list(self.responses or [])
         if self.workaround in RESPONSES_CDX_VEX:

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -1296,7 +1296,7 @@ def init_app(app: Flask) -> None:
         if "status" in payload_data and isinstance(payload_data["status"], str):
             if not mem_assess.set_status(payload_data["status"]):
                 return {"error": "Invalid status"}, 400
-            if mem_assess.status not in ["not_affected", "false_positive"]:
+            if mem_assess.status not in ["not_affected"]:
                 mem_assess.justification = ""
                 mem_assess.impact_statement = ""
 

--- a/src/views/cyclonedx.py
+++ b/src/views/cyclonedx.py
@@ -44,7 +44,6 @@ class CycloneDx:
         "resolved_with_pedigree": ImpactAnalysisState.RESOLVED_WITH_PEDIGREE,
         "exploitable": ImpactAnalysisState.EXPLOITABLE,
         "in_triage": ImpactAnalysisState.IN_TRIAGE,
-        "false_positive": ImpactAnalysisState.FALSE_POSITIVE,
         "not_affected": ImpactAnalysisState.NOT_AFFECTED,
     }
 

--- a/src/views/templates.py
+++ b/src/views/templates.py
@@ -466,7 +466,7 @@ class TemplatesExtensions:
         )
         jinjaEnv.filters["status_ignored"] = lambda value: TemplatesExtensions.filter_status(
             value,
-            ["not_affected", "false_positive"]
+            ["not_affected"]
         )
         jinjaEnv.filters["status_affected"] = lambda value: TemplatesExtensions.filter_status(
             value,
@@ -479,7 +479,7 @@ class TemplatesExtensions:
         )
         jinjaEnv.filters["status_inactive"] = lambda value: TemplatesExtensions.filter_status(
             value,
-            ["not_affected", "false_positive", "fixed", "resolved", "resolved_with_pedigree"]
+            ["not_affected", "fixed", "resolved", "resolved_with_pedigree"]
         )
         jinjaEnv.filters["severity"] = TemplatesExtensions.filter_severity
         jinjaEnv.filters["as_list"] = TemplatesExtensions.filter_as_list

--- a/src/views/templates/vulnerability_summary.txt
+++ b/src/views/templates/vulnerability_summary.txt
@@ -12,7 +12,7 @@ Overview
 --------
 This report provides a summary of all vulnerabilities, organized by their current status and severity, with lists of affected packages.
 {% set active_statuses = ['under_investigation', 'in_triage', 'affected', 'exploitable'] %}
-{% set inactive_statuses = ['fixed', 'resolved', 'resolved_with_pedigree', 'not_affected', 'false_positive'] %}
+{% set inactive_statuses = ['fixed', 'resolved', 'resolved_with_pedigree', 'not_affected'] %}
 {% set severity_order = ['critical', 'high', 'medium', 'low', 'none', 'unknown'] %}
 
 {% macro render_vulnerability_section(vulns, section_title) -%}

--- a/tests/unit_tests/test_assessment.py
+++ b/tests/unit_tests/test_assessment.py
@@ -246,26 +246,28 @@ def test_export_import_assessment(assessment_not_affected):
 
 def test_specific_handling_false_positive():
     """
-    GIVEN a vulnerability with false_positive status
-    WHEN converting to OpenVEX
-    THEN convert to the equivalent 'not_affected' + 'component_not_present' status
+    GIVEN a legacy/imported false_positive status
+    WHEN setting it on an assessment
+    THEN it is absorbed into not_affected and is never emitted as false_positive
     """
     from_cdx = Assessment.new_dto("CVE-000", [])
-    from_cdx.set_status("false_positive")
+    # false_positive was removed as a distinct status; it is absorbed on import.
+    assert from_cdx.set_status("false_positive") is True
+    assert from_cdx.status == "not_affected"
     from_cdx.set_justification("code_not_present")
 
     assert {
         "status": "not_affected",
-        "justification": "component_not_present",
+        "justification": "vulnerable_code_not_present",
     }.items() <= from_cdx.to_openvex_dict().items()
 
     from_openvex = Assessment.new_dto("CVE-000", [])
     from_openvex.set_status("not_affected")
     from_openvex.set_justification("component_not_present")
 
-    assert {
-        "state": "false_positive",
-    }.items() <= from_openvex.to_cdx_vex_dict()['analysis'].items()
+    # not_affected + component_not_present must no longer be exported as
+    # false_positive in CycloneDX VEX.
+    assert from_openvex.to_cdx_vex_dict()['analysis']['state'] == "not_affected"
 
 
 def test_merge_assessments(assessment_initial, assessment_active, assessment_fixed, assessment_not_affected):
@@ -339,7 +341,6 @@ def test_status_to_simplified_mapping():
 
     assert STATUS_TO_SIMPLIFIED["under_investigation"] == "Pending Assessment"
     assert STATUS_TO_SIMPLIFIED["in_triage"] == "Pending Assessment"
-    assert STATUS_TO_SIMPLIFIED["false_positive"] == "Not affected"
     assert STATUS_TO_SIMPLIFIED["not_affected"] == "Not affected"
     assert STATUS_TO_SIMPLIFIED["exploitable"] == "Exploitable"
     assert STATUS_TO_SIMPLIFIED["affected"] == "Exploitable"

--- a/tests/webapp_tests/test_assessments_coverage.py
+++ b/tests/webapp_tests/test_assessments_coverage.py
@@ -837,7 +837,7 @@ def test_post_assessments_batch_missing_variant_id_returns_error(client):
 # ---------------------------------------------------------------------------
 
 def test_patch_assessment_clears_justification_and_impact(client):
-    """PATCH to a non-not_affected/false_positive status clears justification (line 271)."""
+    """PATCH to a non-not_affected status clears justification (line 271)."""
     # Create an assessment with not_affected + justification
     response = client.post("/api/vulnerabilities/CVE-2021-99999/assessments", json={
         "packages": ["test@1.0.0"],


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Restrict new assessment statuses to pending assessment, affected, not applicable and fixed. Drop the now-unreachable false_positive branches in StatusEditor and remove the obsolete tests.


### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

False positive not available anymore in "Add a new assessment" menu: 

<img width="1403" height="187" alt="image" src="https://github.com/user-attachments/assets/b1b640c5-1bf8-4797-8be8-0f8403904390" />
 