### PR TITLE
Clarify vulnerability table empty states and missing-data banner

### DIFF
--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -41,6 +41,7 @@ type Vulnerability = {
     data_updated_at?: string;
     nvd_fetched_at?: string;
     ghsa_fetched_at?: string;
+    euvd_fetched_at?: string;
     first_scan_date?: string;
     texts: {
         title: string;
@@ -281,6 +282,7 @@ const asVulnerability = (data: any): Vulnerability | [] => {
     if (typeof data?.data_updated_at === "string") vuln.data_updated_at = data.data_updated_at
     if (typeof data?.nvd_fetched_at === "string") vuln.nvd_fetched_at = data.nvd_fetched_at
     if (typeof data?.ghsa_fetched_at === "string") vuln.ghsa_fetched_at = data.ghsa_fetched_at
+    if (typeof data?.euvd_fetched_at === "string") vuln.euvd_fetched_at = data.euvd_fetched_at
     if (typeof data?.first_scan_date === "string") vuln.first_scan_date = data.first_scan_date
     if (data?.euvd && typeof data.euvd === "object") {
         vuln.euvd = {

--- a/frontend/src/handlers/vulnerabilities.ts
+++ b/frontend/src/handlers/vulnerabilities.ts
@@ -39,6 +39,8 @@ type Vulnerability = {
     published?: string;
     data_fetched_at?: string;
     data_updated_at?: string;
+    nvd_fetched_at?: string;
+    ghsa_fetched_at?: string;
     first_scan_date?: string;
     texts: {
         title: string;
@@ -277,6 +279,8 @@ const asVulnerability = (data: any): Vulnerability | [] => {
     if (typeof data?.published === "string") vuln.published = data.published
     if (typeof data?.data_fetched_at === "string") vuln.data_fetched_at = data.data_fetched_at
     if (typeof data?.data_updated_at === "string") vuln.data_updated_at = data.data_updated_at
+    if (typeof data?.nvd_fetched_at === "string") vuln.nvd_fetched_at = data.nvd_fetched_at
+    if (typeof data?.ghsa_fetched_at === "string") vuln.ghsa_fetched_at = data.ghsa_fetched_at
     if (typeof data?.first_scan_date === "string") vuln.first_scan_date = data.first_scan_date
     if (data?.euvd && typeof data.euvd === "object") {
         vuln.euvd = {

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -578,14 +578,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         if (missingPublishedDateDataBannerDismissed === undefined) setLocalMissingPublishedDateDataBannerDismissed(dismissed);
     }, [missingPublishedDateDataBannerDismissed, onMissingPublishedDateDataBannerDismissedChange]);
 
-    // The EU KEV column renders a badge only when a vulnerability is flagged
-    // known_exploited; every other row shows an empty placeholder. The backend
-    // also always serialises an `euvd` object (often with just an alias id and
-    // known_exploited=false), so object presence does not indicate KEV data.
-    // Mirror the column: KEV data "exists" only when at least one vulnerability
-    // is actually known-exploited.
     const hasAnyEuvdData = useMemo(
-        () => vulnerabilities.some(v => v.euvd?.known_exploited === true),
+        () => vulnerabilities.some(v => typeof v.euvd_fetched_at === "string" && v.euvd_fetched_at !== ""),
         [vulnerabilities]
     );
     const previousHasAnyEuvdData = useRef(hasAnyEuvdData);

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -603,11 +603,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
 
     const shouldShowMissingDataBanner = shouldShowMissingEuvdDataBanner || shouldShowMissingPublishedDateDataBanner;
 
-    const missingDataBannerMessage = shouldShowMissingEuvdDataBanner && shouldShowMissingPublishedDateDataBanner
-        ? <><strong className="font-bold">EU KEV data</strong> and <strong className="font-bold">published date data</strong> need updating. Use the "Refresh vulnerability data" button to update them.</>
-        : shouldShowMissingEuvdDataBanner
-            ? <><strong className="font-bold">EU KEV data</strong> needs updating. Use the "Refresh vulnerability data" button to update it.</>
-            : <><strong className="font-bold">Published date data</strong> needs updating. Use the "Refresh vulnerability data" button to update it.</>;
+    const missingDataBannerMessage = <>Vulnerabilities are incomplete and need updating. Use the "Refresh vulnerability data" button to update them.</>;
 
     const dismissMissingDataBanner = () => {
         if (shouldShowMissingEuvdDataBanner) setMissingEuvdDataBannerDismissed(true);

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -1081,7 +1081,14 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
                     return <div className="flex items-center justify-center h-full text-center"><span className="text-xs text-gray-500 italic">fetching…</span></div>;
                 }
                 if (!published) {
-                    return <div className="flex items-center justify-center h-full text-center text-gray-400">Requires a NVD refresh</div>;
+                    // A published date is provided by the NVD refresh (CVEs) or the
+                    // GitHub Security Advisory refresh (GHSA ids). Show "-" only when
+                    // such a refresh has already run and still returned no date;
+                    // otherwise prompt the user to refresh the vulnerability data.
+                    const refreshed = Boolean(info.row.original.nvd_fetched_at || info.row.original.ghsa_fetched_at);
+                    return refreshed
+                        ? <div className="flex items-center justify-center h-full text-center text-gray-400">-</div>
+                        : <div className="flex items-center justify-center h-full text-center text-gray-400">Requires Refresh Vulnerability Data</div>;
                 }
                 const publishedDate = new Date(published);
                 const formattedDate = publishedDate.toLocaleDateString(undefined, {

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -1087,7 +1087,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
                     // otherwise prompt the user to refresh the vulnerability data.
                     const refreshed = Boolean(info.row.original.nvd_fetched_at || info.row.original.ghsa_fetched_at);
                     return refreshed
-                        ? <div className="flex items-center justify-center h-full text-center text-gray-400">-</div>
+                        ? <div className="flex items-center justify-center h-full text-center text-gray-400">—</div>
                         : <div className="flex items-center justify-center h-full text-center text-gray-400">Requires Refresh Vulnerability Data</div>;
                 }
                 const publishedDate = new Date(published);
@@ -1236,16 +1236,26 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
             </>,
             cell: info => {
                 const euvd = info.getValue();
-                if (!euvd?.known_exploited) {
-                    return <div className="flex items-center justify-center h-full text-center text-gray-500">—</div>;
+                if (euvd?.known_exploited) {
+                    return (
+                        <div className="flex items-center justify-center h-full">
+                            <span className="px-1.5 py-0.5 rounded text-xs font-semibold bg-red-900/60 text-red-200">
+                                Known Exploited
+                            </span>
+                        </div>
+                    );
                 }
-                return (
-                    <div className="flex items-center justify-center h-full">
-                        <span className="px-1.5 py-0.5 rounded text-xs font-semibold bg-red-900/60 text-red-200">
-                            Known Exploited
-                        </span>
-                    </div>
-                );
+                const fetching = euvdProgress?.in_progress;
+                if (fetching) {
+                    return <div className="flex items-center justify-center h-full text-center"><span className="text-xs text-gray-500 italic">fetching…</span></div>;
+                }
+                // The EU KEV signal comes from the ENISA EUVD refresh. Show "-" only
+                // when that refresh has already run and the vulnerability was not on
+                // the KEV list; otherwise prompt the user to refresh the data.
+                const refreshed = Boolean(info.row.original.euvd_fetched_at);
+                return refreshed
+                    ? <div className="flex items-center justify-center h-full text-center text-gray-500">—</div>
+                    : <div className="flex items-center justify-center h-full text-center text-gray-400">Requires Refresh Vulnerability Data</div>;
             },
             sortingFn: (rowA, rowB) => {
                 const a = rowA.original.euvd?.known_exploited ? 1 : 0;
@@ -1277,7 +1287,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
                 size: 20
             })
         ]
-    }, [handleEditClick, searchFilteredData, showCustomSeverityFilter, severityRange, nvdProgress, epssProgress]);
+    }, [handleEditClick, searchFilteredData, showCustomSeverityFilter, severityRange, nvdProgress, epssProgress, euvdProgress]);
 
     const columns = useMemo(() => {
         const columnByDisplayName = new Map(

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -2238,7 +2238,7 @@ describe('Vulnerability Table', () => {
         });
     });
 
-    test('published date column shows "Requires a NVD refresh" for vulnerabilities without published date', async () => {
+    test('published date column shows "Requires Refresh Vulnerability Data" for vulnerabilities never refreshed', async () => {
         const vulnsWithMissing: Vulnerability[] = [
             ...vulnerabilities,
             {
@@ -2268,7 +2268,7 @@ describe('Vulnerability Table', () => {
                 simplified_status: 'Pending Assessment',
                 assessments: [],
                 variants: [],
-                // no 'published' field
+                // no 'published' field and never refreshed (no nvd_fetched_at)
             }
         ];
 
@@ -2282,11 +2282,61 @@ describe('Vulnerability Table', () => {
         const publishedDateCheckbox = await screen.getByRole('checkbox', { name: 'Published Date' });
         await user.click(publishedDateCheckbox);
 
-        // Now "Requires a NVD refresh" should appear for the vuln without published date
+        // "Requires Refresh Vulnerability Data" should appear for the never-refreshed vuln
         await waitFor(() => {
-            const refreshElements = screen.getAllByText('Requires a NVD refresh');
+            const refreshElements = screen.getAllByText('Requires Refresh Vulnerability Data');
             expect(refreshElements.length).toBeGreaterThan(0);
         });
+    });
+
+    test('published date column shows "-" when NVD refresh ran but found no published date', async () => {
+        const vulnsWithMissing: Vulnerability[] = [
+            {
+                id: 'CVE-NO-DATE',
+                aliases: [],
+                related_vulnerabilities: [],
+                namespace: 'nvd:cve',
+                found_by: ['hardcoded'],
+                datasource: 'test',
+                packages: ['nodatepkg@1.0.0'],
+                packages_current: [],
+                urls: [],
+                texts: [{ title: 'description', content: 'No date vuln' }],
+                severity: {
+                    severity: 'medium',
+                    min_score: 5,
+                    max_score: 5,
+                    cvss: []
+                },
+                epss: { score: undefined, percentile: undefined },
+                effort: {
+                    optimistic: new Iso8601Duration('PT1H'),
+                    likely: new Iso8601Duration('PT2H'),
+                    pessimistic: new Iso8601Duration('PT4H')
+                },
+                fix: { state: 'unknown' },
+                simplified_status: 'Pending Assessment',
+                assessments: [],
+                variants: [],
+                // refreshed against NVD, but still no published date found
+                nvd_fetched_at: '2026-01-01T00:00:00+00:00',
+            }
+        ];
+
+        render(<TableVulnerabilities vulnerabilities={vulnsWithMissing} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+        const user = userEvent.setup();
+
+        // Published Date column is hidden by default, so enable it first
+        const buttons = await screen.getAllByRole('button', { name: /columns/i });
+        await user.click(buttons[0]);
+
+        const publishedDateCheckbox = await screen.getByRole('checkbox', { name: 'Published Date' });
+        await user.click(publishedDateCheckbox);
+
+        await waitFor(() => {
+            expect(screen.getByText('-')).toBeInTheDocument();
+        });
+        expect(screen.queryByText('Requires Refresh Vulnerability Data')).not.toBeInTheDocument();
     });
 
     test('published date filter type change clears previous date values', async () => {

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -2318,8 +2318,9 @@ describe('Vulnerability Table', () => {
                 simplified_status: 'Pending Assessment',
                 assessments: [],
                 variants: [],
-                // refreshed against NVD, but still no published date found
+                // refreshed against NVD and EUVD, but still no published date found
                 nvd_fetched_at: '2026-01-01T00:00:00+00:00',
+                euvd_fetched_at: '2026-01-01T00:00:00+00:00',
             }
         ];
 
@@ -2333,8 +2334,82 @@ describe('Vulnerability Table', () => {
         const publishedDateCheckbox = await screen.getByRole('checkbox', { name: 'Published Date' });
         await user.click(publishedDateCheckbox);
 
+        // Both the published date and EU KEV columns render "—" for this row
         await waitFor(() => {
-            expect(screen.getByText('-')).toBeInTheDocument();
+            expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+        });
+        expect(screen.queryByText('Requires Refresh Vulnerability Data')).not.toBeInTheDocument();
+    });
+
+    test('EU KEV column shows "Requires Refresh Vulnerability Data" for vulnerabilities never refreshed', async () => {
+        const vulnsWithMissing: Vulnerability[] = [
+            {
+                id: 'CVE-NO-KEV',
+                aliases: [],
+                related_vulnerabilities: [],
+                namespace: 'nvd:cve',
+                found_by: ['hardcoded'],
+                datasource: 'test',
+                packages: ['nokevpkg@1.0.0'],
+                packages_current: [],
+                urls: [],
+                texts: [{ title: 'description', content: 'No KEV vuln' }],
+                severity: { severity: 'medium', min_score: 5, max_score: 5, cvss: [] },
+                epss: { score: undefined, percentile: undefined },
+                effort: {
+                    optimistic: new Iso8601Duration('PT1H'),
+                    likely: new Iso8601Duration('PT2H'),
+                    pessimistic: new Iso8601Duration('PT4H')
+                },
+                fix: { state: 'unknown' },
+                simplified_status: 'Pending Assessment',
+                assessments: [],
+                variants: [],
+                // never refreshed against EUVD (no euvd_fetched_at)
+            }
+        ];
+
+        render(<TableVulnerabilities vulnerabilities={vulnsWithMissing} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        // EU KEV column is visible by default
+        await waitFor(() => {
+            expect(screen.getByText('Requires Refresh Vulnerability Data')).toBeInTheDocument();
+        });
+    });
+
+    test('EU KEV column shows "-" when EUVD refresh ran but vuln is not on the KEV list', async () => {
+        const vulnsWithMissing: Vulnerability[] = [
+            {
+                id: 'CVE-NO-KEV',
+                aliases: [],
+                related_vulnerabilities: [],
+                namespace: 'nvd:cve',
+                found_by: ['hardcoded'],
+                datasource: 'test',
+                packages: ['nokevpkg@1.0.0'],
+                packages_current: [],
+                urls: [],
+                texts: [{ title: 'description', content: 'No KEV vuln' }],
+                severity: { severity: 'medium', min_score: 5, max_score: 5, cvss: [] },
+                epss: { score: undefined, percentile: undefined },
+                effort: {
+                    optimistic: new Iso8601Duration('PT1H'),
+                    likely: new Iso8601Duration('PT2H'),
+                    pessimistic: new Iso8601Duration('PT4H')
+                },
+                fix: { state: 'unknown' },
+                simplified_status: 'Pending Assessment',
+                assessments: [],
+                variants: [],
+                // refreshed against EUVD, but not on the KEV list
+                euvd_fetched_at: '2026-01-01T00:00:00+00:00',
+            }
+        ];
+
+        render(<TableVulnerabilities vulnerabilities={vulnsWithMissing} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        await waitFor(() => {
+            expect(screen.getByText('—')).toBeInTheDocument();
         });
         expect(screen.queryByText('Requires Refresh Vulnerability Data')).not.toBeInTheDocument();
     });

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -1641,16 +1641,15 @@ describe('Vulnerability Table', () => {
     // Published Date Feature Tests
     // =========================================================================
 
-    test('shows an EU KEV sync information banner when EU KEV data is absent', async () => {
+    test('shows an information banner when EU KEV data is absent', async () => {
         render(<TableVulnerabilities vulnerabilities={vulnerabilities} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         expect(await screen.findByRole('alert')).toHaveTextContent(
-            'EU KEV data needs updating. Use the "Refresh vulnerability data" button to update it.'
+            'Vulnerabilities are incomplete and need updating. Use the "Refresh vulnerability data" button to update them.'
         );
-        expect(screen.getByText('EU KEV data').classList.contains('font-bold')).toBe(true);
     });
 
-    test('shows a published date sync information banner when published date data is absent', async () => {
+    test('shows an information banner when published date data is absent', async () => {
         const withEuvdData = vulnerabilities.map(v => ({
             ...v,
             published: undefined,
@@ -1665,22 +1664,19 @@ describe('Vulnerability Table', () => {
         render(<TableVulnerabilities vulnerabilities={withEuvdData} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         expect(await screen.findByRole('alert')).toHaveTextContent(
-            'Published date data needs updating. Use the "Refresh vulnerability data" button to update it.'
+            'Vulnerabilities are incomplete and need updating. Use the "Refresh vulnerability data" button to update them.'
         );
-        expect(screen.getByText('Published date data').classList.contains('font-bold')).toBe(true);
     });
 
-    test('combines missing EU KEV and published date data into one banner', async () => {
+    test('shows a single information banner when both EU KEV and published date data are missing', async () => {
         const withoutPublishedDates = vulnerabilities.map(v => ({ ...v, published: undefined }));
         render(<TableVulnerabilities vulnerabilities={withoutPublishedDates} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
         const alerts = await screen.findAllByRole('alert');
         expect(alerts).toHaveLength(1);
         expect(alerts[0]).toHaveTextContent(
-            'EU KEV data and published date data need updating. Use the "Refresh vulnerability data" button to update them.'
+            'Vulnerabilities are incomplete and need updating. Use the "Refresh vulnerability data" button to update them.'
         );
-        expect(screen.getByText('EU KEV data').classList.contains('font-bold')).toBe(true);
-        expect(screen.getByText('published date data').classList.contains('font-bold')).toBe(true);
     });
 
     test('keeps a dismissed EU KEV banner hidden after the table remounts', async () => {
@@ -1703,7 +1699,7 @@ describe('Vulnerability Table', () => {
 
         render(<VulnerabilityTab />);
 
-        expect(await screen.findByRole('alert')).toHaveTextContent('EU KEV data needs updating');
+        expect(await screen.findByRole('alert')).toHaveTextContent('Vulnerabilities are incomplete and need updating');
         fireEvent.click(screen.getAllByRole('button', { name: 'Dismiss' })[0]);
         expect(screen.queryByRole('alert')).not.toBeInTheDocument();
 

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -1649,6 +1649,29 @@ describe('Vulnerability Table', () => {
         );
     });
 
+    test('hides the EU KEV banner after a refresh even when no vulnerability is known-exploited', async () => {
+        // A successful EUVD sync stamps euvd_fetched_at on every processed CVE
+        // even when none of them are on the KEV list. The banner must clear
+        // based on that per-row timestamp rather than a positive known_exploited
+        // match, otherwise it would stay visible forever.
+        const refreshedNoKev = vulnerabilities.map(v => ({
+            ...v,
+            euvd_fetched_at: '2026-01-01T00:00:00+00:00',
+            euvd: {
+                id: null,
+                known_exploited: false,
+                sources: [],
+                date_added: null,
+                url: null,
+            },
+        }));
+        render(<TableVulnerabilities vulnerabilities={refreshedNoKev} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        // Let any async progress effects settle, then confirm no incomplete banner.
+        expect(await screen.findByText('CVE-2010-1234')).toBeInTheDocument();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
     test('shows an information banner when published date data is absent', async () => {
         const withEuvdData = vulnerabilities.map(v => ({
             ...v,

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -472,10 +472,24 @@ class VulnerabilitiesController:
                         )
                         updated += 1
                     else:
-                        # No EUVD entry for this CVE, but still record that it was
-                        # checked so the UI can tell "synced, not on KEV list" apart
-                        # from "never refreshed".
-                        rec.update_record(euvd_fetched_at=now, commit=False)
+                        had_euvd_data = (
+                            rec.euvd_id is not None
+                            or rec.euvd_known_exploited
+                            or rec.euvd_kev_sources
+                            or rec.euvd_date_added is not None
+                        )
+                        if had_euvd_data:
+                            rec.euvd_id = None
+                            rec.euvd_known_exploited = False
+                            rec.euvd_kev_sources = []
+                            rec.euvd_date_added = None
+                            rec.update_record(
+                                euvd_fetched_at=now,
+                                euvd_data_updated_at=now,
+                                commit=False,
+                            )
+                        else:
+                            rec.update_record(euvd_fetched_at=now, commit=False)
             except Exception as e:
                 verbose(f"[fetch_euvd_data {vuln_id!r}] {e}")
                 failed += 1

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -457,21 +457,25 @@ class VulnerabilitiesController:
                 continue
             kev = kev_map.get(vuln_id)
             euvd_id = full_map.get(vuln_id) or (kev.get("euvd_id") if kev else None)
-            if euvd_id is None:
-                continue
             try:
                 rec = self._db_record_cache.get(vuln_id) or Vulnerability.get_by_id(vuln_id)
                 if rec is not None:
-                    rec.update_record(
-                        euvd_id=euvd_id,
-                        euvd_known_exploited=kev is not None,
-                        euvd_kev_sources=(kev.get("sources") or []) if kev else [],
-                        euvd_date_added=kev.get("date_added") if kev else None,
-                        euvd_fetched_at=now,
-                        euvd_data_updated_at=now,
-                        commit=False,
-                    )
-                    updated += 1
+                    if euvd_id is not None:
+                        rec.update_record(
+                            euvd_id=euvd_id,
+                            euvd_known_exploited=kev is not None,
+                            euvd_kev_sources=(kev.get("sources") or []) if kev else [],
+                            euvd_date_added=kev.get("date_added") if kev else None,
+                            euvd_fetched_at=now,
+                            euvd_data_updated_at=now,
+                            commit=False,
+                        )
+                        updated += 1
+                    else:
+                        # No EUVD entry for this CVE, but still record that it was
+                        # checked so the UI can tell "synced, not on KEV list" apart
+                        # from "never refreshed".
+                        rec.update_record(euvd_fetched_at=now, commit=False)
             except Exception as e:
                 verbose(f"[fetch_euvd_data {vuln_id!r}] {e}")
                 failed += 1

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -497,6 +497,7 @@ class Vulnerability(Base):
             ),
             "nvd_fetched_at": ensure_utc_iso(self.nvd_fetched_at),
             "ghsa_fetched_at": ensure_utc_iso(self.ghsa_fetched_at),
+            "euvd_fetched_at": ensure_utc_iso(self.euvd_fetched_at),
         }
 
     @staticmethod

--- a/src/models/vulnerability.py
+++ b/src/models/vulnerability.py
@@ -495,6 +495,8 @@ class Vulnerability(Base):
                 self.ghsa_data_updated_at,
                 self.euvd_data_updated_at,
             ),
+            "nvd_fetched_at": ensure_utc_iso(self.nvd_fetched_at),
+            "ghsa_fetched_at": ensure_utc_iso(self.ghsa_fetched_at),
         }
 
     @staticmethod

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -547,9 +547,9 @@ def init_app(app: Flask) -> None:
 
                         kev = kev_map.get(cve_id)
                         euvd_id = full_map.get(cve_id) or (kev["euvd_id"] if kev else None)
-                        if euvd_id:
-                            rec = db.session.get(Vulnerability, cve_id)
-                            if rec is not None:
+                        rec = db.session.get(Vulnerability, cve_id)
+                        if rec is not None:
+                            if euvd_id:
                                 known_exploited = kev is not None
                                 rec.update_record(
                                     euvd_id=euvd_id,
@@ -563,6 +563,11 @@ def init_app(app: Flask) -> None:
                                 matched += 1
                                 if known_exploited:
                                     kev_matched += 1
+                            else:
+                                # No EUVD entry for this CVE, but still record that it
+                                # was checked during this refresh so the UI can tell
+                                # "synced, not on KEV list" apart from "never refreshed".
+                                rec.update_record(euvd_fetched_at=now, commit=False)
 
                         done += 1
                         EUVDProgressTracker.update(

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -564,10 +564,24 @@ def init_app(app: Flask) -> None:
                                 if known_exploited:
                                     kev_matched += 1
                             else:
-                                # No EUVD entry for this CVE, but still record that it
-                                # was checked during this refresh so the UI can tell
-                                # "synced, not on KEV list" apart from "never refreshed".
-                                rec.update_record(euvd_fetched_at=now, commit=False)
+                                had_euvd_data = (
+                                    rec.euvd_id is not None
+                                    or rec.euvd_known_exploited
+                                    or rec.euvd_kev_sources
+                                    or rec.euvd_date_added is not None
+                                )
+                                if had_euvd_data:
+                                    rec.euvd_id = None
+                                    rec.euvd_known_exploited = False
+                                    rec.euvd_kev_sources = []
+                                    rec.euvd_date_added = None
+                                    rec.update_record(
+                                        euvd_fetched_at=now,
+                                        euvd_data_updated_at=now,
+                                        commit=False,
+                                    )
+                                else:
+                                    rec.update_record(euvd_fetched_at=now, commit=False)
 
                         done += 1
                         EUVDProgressTracker.update(

--- a/tests/integration_tests/test_vulnerabilities.py
+++ b/tests/integration_tests/test_vulnerabilities.py
@@ -235,6 +235,46 @@ def test_fetch_euvd_data_empty_mappings_reports_failure(vuln_controller, monkeyp
     assert not result.completed
 
 
+def test_fetch_euvd_data_clears_stale_kev_when_no_longer_matched(vuln_controller, monkeypatch):
+    """A CVE previously flagged known-exploited but now absent from both mappings
+    has its stale EUVD/KEV fields cleared (not just its fetch timestamp bumped),
+    so the UI stops showing 'Known Exploited'."""
+    cve = "CVE-2022-0001"
+    vuln_controller.add(Vulnerability(cve, ["test"], "test", "test"))
+
+    stale_rec = MagicMock()
+    stale_rec.euvd_id = "EUVD-2021-34768"
+    stale_rec.euvd_known_exploited = True
+    stale_rec.euvd_kev_sources = ["cisa_kev"]
+    stale_rec.euvd_date_added = "2025-10-06"
+    vuln_controller._db_record_cache[cve] = stale_rec
+
+    # Non-empty mapping (so the refresh runs) that no longer contains our CVE.
+    monkeypatch.setattr(
+        "src.controllers.euvd_db.EUVD_DB.get_full_mapping",
+        lambda self: {"CVE-2099-9999": "EUVD-2099-0001"},
+    )
+    monkeypatch.setattr(
+        "src.controllers.euvd_db.EUVD_DB.get_mapping", lambda self: {},
+    )
+
+    result = vuln_controller.fetch_euvd_data()
+
+    # Stale EUVD/KEV fields are cleared directly on the record.
+    assert stale_rec.euvd_id is None
+    assert stale_rec.euvd_known_exploited is False
+    assert stale_rec.euvd_kev_sources == []
+    assert stale_rec.euvd_date_added is None
+    # The record is stamped with both a sync time and a data-changed time.
+    stale_rec.update_record.assert_called_once()
+    kwargs = stale_rec.update_record.call_args.kwargs
+    assert kwargs.get("euvd_fetched_at") is not None
+    assert kwargs.get("euvd_data_updated_at") is not None
+    assert kwargs.get("commit") is False
+    assert result.completed
+
+
+
 # ---------------------------------------------------------------------------
 # DB-fallback and alias-chain paths
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_vulnerability_to_dict_timestamps.py
+++ b/tests/unit_tests/test_vulnerability_to_dict_timestamps.py
@@ -18,9 +18,11 @@ def test_data_fetched_at_is_max_of_non_null_handles_mixed_tzinfo():
     v = _vuln(nvd_fetched_at=naive, epss_fetched_at=aware, ghsa_fetched_at=None)
     d = v.to_dict()
     assert d["data_fetched_at"] == "2024-01-02T12:00:00+00:00"
-    assert "nvd_fetched_at" not in d
+    # Per-source published-date fetch timestamps are surfaced so the UI can tell
+    # "never refreshed" apart from "refreshed but no published date found".
+    assert d["nvd_fetched_at"] == "2024-01-01T12:00:00+00:00"
+    assert d["ghsa_fetched_at"] is None
     assert "nvd_data_updated_at" not in d
-    assert "ghsa_fetched_at" not in d
 
 
 def test_data_updated_at_is_max_of_non_null():

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -1898,7 +1898,7 @@ class TestBulkEuvdRefreshBackground:
         MockTracker.error.assert_called_once()
         MockTracker.complete.assert_not_called()
 
-    def test_run_skips_unmatched_cve(self, client):
+    def test_run_stamps_fetched_at_for_unmatched_cve(self, client):
         target = self._capture_target(client, ["CVE-2099-0001"])
         mock_rec = MagicMock()
 
@@ -1912,7 +1912,14 @@ class TestBulkEuvdRefreshBackground:
             mock_db.session.get.return_value = mock_rec
             target()
 
-        mock_rec.update_record.assert_not_called()
+        # Unmatched CVEs are still stamped so the UI can tell "synced, not on the
+        # KEV list" apart from "never refreshed"; only the fetch timestamp is set.
+        mock_rec.update_record.assert_called_once()
+        call_kwargs = mock_rec.update_record.call_args.kwargs
+        assert call_kwargs.get("euvd_fetched_at") is not None
+        assert call_kwargs.get("commit") is False
+        assert "euvd_id" not in call_kwargs
+        assert "euvd_known_exploited" not in call_kwargs
         MockTracker.complete.assert_called_once()
 
     def test_run_stops_and_commits_when_cancelled(self, client):

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -1901,6 +1901,11 @@ class TestBulkEuvdRefreshBackground:
     def test_run_stamps_fetched_at_for_unmatched_cve(self, client):
         target = self._capture_target(client, ["CVE-2099-0001"])
         mock_rec = MagicMock()
+        # This record has never had EUVD data, so nothing needs clearing.
+        mock_rec.euvd_id = None
+        mock_rec.euvd_known_exploited = False
+        mock_rec.euvd_kev_sources = []
+        mock_rec.euvd_date_added = None
 
         with patch("src.routes.bulk_refresh.EUVD_DB") as MockEuvd, \
              patch("src.routes.bulk_refresh.db") as mock_db, \
@@ -1913,13 +1918,51 @@ class TestBulkEuvdRefreshBackground:
             target()
 
         # Unmatched CVEs are still stamped so the UI can tell "synced, not on the
-        # KEV list" apart from "never refreshed"; only the fetch timestamp is set.
+        # KEV list" apart from "never refreshed"; only the fetch timestamp is set
+        # and no data-changed timestamp is bumped since nothing changed.
         mock_rec.update_record.assert_called_once()
         call_kwargs = mock_rec.update_record.call_args.kwargs
         assert call_kwargs.get("euvd_fetched_at") is not None
         assert call_kwargs.get("commit") is False
         assert "euvd_id" not in call_kwargs
         assert "euvd_known_exploited" not in call_kwargs
+        assert "euvd_data_updated_at" not in call_kwargs
+        MockTracker.complete.assert_called_once()
+
+    def test_run_clears_stale_kev_when_cve_no_longer_matched(self, client):
+        # A CVE previously flagged known-exploited is now absent from both the
+        # full mapping and the KEV mapping. The refresh must clear the stale
+        # EUVD/KEV fields so the UI stops showing "Known Exploited", not just
+        # advance the fetch timestamp.
+        cve = "CVE-2021-44228"
+        target = self._capture_target(client, [cve])
+        mock_rec = MagicMock()
+        mock_rec.euvd_id = "EUVD-2021-34768"
+        mock_rec.euvd_known_exploited = True
+        mock_rec.euvd_kev_sources = ["cisa_kev"]
+        mock_rec.euvd_date_added = "2025-10-06"
+
+        with patch("src.routes.bulk_refresh.EUVD_DB") as MockEuvd, \
+             patch("src.routes.bulk_refresh.db") as mock_db, \
+             patch("src.routes.bulk_refresh.EUVDProgressTracker") as MockTracker:
+            MockTracker.is_cancelled.return_value = False
+            instance = MockEuvd.return_value
+            instance.get_full_mapping.return_value = {"CVE-2099-9999": "EUVD-2099-0001"}
+            instance.get_mapping.return_value = {}
+            mock_db.session.get.return_value = mock_rec
+            target()
+
+        # Stale EUVD/KEV fields are cleared directly on the record.
+        assert mock_rec.euvd_id is None
+        assert mock_rec.euvd_known_exploited is False
+        assert mock_rec.euvd_kev_sources == []
+        assert mock_rec.euvd_date_added is None
+        # The refresh records both the sync time and a data-changed time.
+        mock_rec.update_record.assert_called_once()
+        call_kwargs = mock_rec.update_record.call_args.kwargs
+        assert call_kwargs.get("euvd_fetched_at") is not None
+        assert call_kwargs.get("euvd_data_updated_at") is not None
+        assert call_kwargs.get("commit") is False
         MockTracker.complete.assert_called_once()
 
     def test_run_stops_and_commits_when_cancelled(self, client):


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Replaced the EU KEV / published-date specific banner messages with a single generic message telling users to use the "Refresh vulnerability data" button, so the banner no longer depends on which data source is missing.

*euvd_fetched_at is now stamped for every CVE processed during an EUVD sync (both bulk refresh and initial enrichment), not only CVEs matched to an EUVD entry. This lets the EU KEV column show — for vulnerabilities that were synced but are not known-exploited, versus Requires Refresh Vulnerability Data for vulnerabilities never synced.

*The Published Date column now shows an em-dash — only when an NVD or GHSA refresh has actually run but returned no date, and Requires Refresh Vulnerability Data when no refresh has run yet. 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Look at Vulnerability tab:

- Add vulnerabilities (e.g via sbom-cve-check) and new Vulnerabilities will display "Requires Refresh Vulnerability Data" until a new sync is performed
- Sync data now display properly "-" if not found/not known exploitable
