### PR TITLE
fix(scope): silently fall back to default scope on DB switch

### DIFF
--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -167,11 +167,13 @@ function Explorer() {
         Config.get()
             .then(async config => {
                 let scope = Config.getFrontendScope();
-                let discardedScope = false;
                 // Validate the saved scope against the live project/variant
                 // lists. A transient fetch failure here must not discard the
                 // successfully-loaded config: fall back to the server default
                 // scope while keeping the config and loading default data.
+                // When the saved scope simply no longer exists (e.g. after
+                // loading a different DB), silently fall back to the default
+                // scope without surfacing an error banner.
                 try {
                     if (scope) {
                         const projects = await Projects.list();
@@ -180,13 +182,11 @@ function Explorer() {
                         if (!projectExists && canConfirmProjectAbsence) {
                             Config.clearFrontendScope();
                             scope = null;
-                            discardedScope = true;
                         } else if (projectExists) {
                             const variants = await Variants.list(scope.project_id);
                             if (!Config.isFrontendScopeAvailable(scope, projects.map(project => project.id), variants.map(variant => variant.id))) {
                                 Config.clearFrontendScope();
                                 scope = null;
-                                discardedScope = true;
                             }
                         }
                     }
@@ -198,9 +198,6 @@ function Explorer() {
                 if (cancelled) return;
                 setDefaultConfig(config);
                 setFrontendScope(scope);
-                if (discardedScope) {
-                    triggerBanner("Saved selection is no longer available; using the default scope", "error");
-                }
                 const multiActive = scope?.mode === 'select' && scope.variant_ids.length >= 2;
                 const compareActive = scope?.mode === 'compare';
                 const variantId = compareActive

--- a/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
+++ b/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
@@ -217,7 +217,7 @@ describe('Explorer saved-scope validation', () => {
         jest.clearAllMocks();
     });
 
-    test('clears a stale project scope and shows a fallback banner', async () => {
+    test('clears a stale project scope and silently falls back to the default scope', async () => {
         mockGetFrontendScope.mockReturnValue(savedScope('deleted-project', ['old-variant']));
         mockProjectsList.mockResolvedValue([{ id: 'other-project', name: 'Other Project' }]);
 
@@ -227,8 +227,8 @@ describe('Explorer saved-scope validation', () => {
             expect(mockClearFrontendScope).toHaveBeenCalledTimes(1);
             expect(screen.getByTestId('default-project')).toHaveTextContent('default-project');
             expect(screen.getByTestId('frontend-scope')).toBeEmptyDOMElement();
-            expect(screen.getByRole('alert')).toHaveTextContent('Saved selection is no longer available');
         });
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
 
     test('clears a scope whose saved variant is no longer available', async () => {
@@ -241,8 +241,8 @@ describe('Explorer saved-scope validation', () => {
         await waitFor(() => {
             expect(mockClearFrontendScope).toHaveBeenCalledTimes(1);
             expect(screen.getByTestId('frontend-scope')).toBeEmptyDOMElement();
-            expect(screen.getByRole('alert')).toHaveTextContent('Saved selection is no longer available');
         });
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
 
     test('keeps a saved scope when an empty projects response cannot confirm its absence', async () => {


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

When a saved frontend scope no longer matches the loaded database (e.g. after loading a different DB), fall back to the server default scope without surfacing a red error banner. The scope is still validated and cleared as before; only the misleading error banner is removed.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Look at the code, this banner does not exist anymore

<img width="1911" height="136" alt="image" src="https://github.com/user-attachments/assets/eb67e791-c441-4879-a6d9-35e46df476f8" />

