### PR TITLE
fix(epss): remove CVE-count cap that blocked bulk EPSS refresh

### DIFF
--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -239,8 +239,9 @@ def init_app(app: Flask) -> None:
         cve_ids = [c for c in cve_ids if _CVE_RE.match(c)]
         if not cve_ids:
             return jsonify({"error": "cve_ids must contain valid CVE identifiers (e.g. CVE-2024-1234)"}), 400
-        if len(cve_ids) > _MAX_CVE_IDS:
-            return jsonify({"error": f"cve_ids must contain at most {_MAX_CVE_IDS} entries"}), 400
+        # No hard cap here: the refresh below chunks the CVE list into batches
+        # of _EPSS_BATCH_SIZE against the FIRST.org API, so an arbitrarily large
+        # database (which the frontend sends in full) is handled gracefully.
 
         total = len(cve_ids)
         if not EPSSProgressTracker.start_if_idle("bulk_epss_refresh"):

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -47,6 +47,11 @@ _GHSA_SLEEP_INTERVAL = 1.0
 # EUVD enrichment annotates from already-cached ENISA dumps (no per-CVE network
 # call), so it is fast; commit in larger batches than the network-bound refreshes.
 _EUVD_COMMIT_EVERY = 200
+# Chunk size for the "which of these CVE IDs exist?" lookup. Kept well under
+# SQLite's 999 bound-parameter limit so the intersection can be done with
+# indexed ``WHERE id IN (...)`` queries bounded by the request size, instead of
+# materializing the whole vulnerabilities table.
+_DB_LOOKUP_CHUNK = 500
 
 
 def _nvd_sleep_interval() -> float:
@@ -220,9 +225,16 @@ def init_app(app: Flask) -> None:
 
         Body: ``{"cve_ids": ["CVE-A", "CVE-B", ...]}``
 
+        The submitted IDs are deduplicated and intersected with the CVEs stored
+        in the database, so the background work is bounded by the database size
+        regardless of how large the request body is. The singleton refresh is
+        reserved *before* any database access, so a request that arrives while a
+        refresh is already running returns 409 without querying the database.
+
         Returns 202 immediately and runs the refresh in a background thread.
         Returns 409 if a refresh is already in progress.
-        Returns 400 if cve_ids is empty or contains no valid CVE identifiers.
+        Returns 400 if cve_ids is empty, contains no valid CVE identifiers, or
+        none of the submitted CVEs exist in the database.
 
         OpenAPI:
         body JsonObject optional JSON body containing cve_ids.
@@ -235,17 +247,47 @@ def init_app(app: Flask) -> None:
         if not raw_ids or not isinstance(raw_ids, list):
             return jsonify({"error": "cve_ids must be a non-empty list"}), 400
 
+        # Cheap, request-bounded normalization and de-duplication (no DB access).
         cve_ids = [c.strip().upper() for c in raw_ids if isinstance(c, str) and c.strip()]
-        cve_ids = [c for c in cve_ids if _CVE_RE.match(c)]
+        cve_ids = [c for c in dict.fromkeys(cve_ids) if _CVE_RE.match(c)]
         if not cve_ids:
             return jsonify({"error": "cve_ids must contain valid CVE identifiers (e.g. CVE-2024-1234)"}), 400
-        # No hard cap here: the refresh below chunks the CVE list into batches
-        # of _EPSS_BATCH_SIZE against the FIRST.org API, so an arbitrarily large
-        # database (which the frontend sends in full) is handled gracefully.
 
-        total = len(cve_ids)
+        # Reserve the singleton BEFORE touching the database. This endpoint is
+        # unauthenticated with permissive CORS, so a request that arrives while a
+        # refresh is already running must be rejected without doing any database
+        # work; otherwise a burst of concurrent requests could each scan the
+        # vulnerabilities table and multiply database/memory load.
         if not EPSSProgressTracker.start_if_idle("bulk_epss_refresh"):
             return jsonify({"error": "A bulk EPSS refresh is already in progress"}), 409
+
+        # Holding the reservation, exactly one request reaches this point at a
+        # time. Bound the work to CVEs that actually exist by intersecting the
+        # requested IDs with the database through chunked, primary-key-indexed
+        # ``IN`` lookups. Cost is bounded by the (deduplicated) request size, not
+        # the size of the whole vulnerabilities table, so it scales to the large
+        # databases this endpoint targets. Release the reservation if nothing
+        # remains so a later request is not wrongly rejected with 409.
+        known_ids: set[str] = set()
+        try:
+            for i in range(0, len(cve_ids), _DB_LOOKUP_CHUNK):
+                chunk = cve_ids[i:i + _DB_LOOKUP_CHUNK]
+                rows = db.session.query(Vulnerability.id).filter(Vulnerability.id.in_(chunk)).all()
+                known_ids.update(row[0] for row in rows)
+        except Exception as exc:
+            # The tracker is already reserved, so a failing lookup must release
+            # it; otherwise ``in_progress`` would stay true and every later EPSS
+            # refresh would be rejected with 409 until the process restarts.
+            db.session.rollback()
+            EPSSProgressTracker.error(str(exc)[:200])
+            print(f"[bulk EPSS refresh] lookup error: {exc}", flush=True)
+            return jsonify({"error": "Failed to look up CVEs in the database"}), 500
+        cve_ids = [c for c in cve_ids if c in known_ids]
+        if not cve_ids:
+            EPSSProgressTracker.complete("No known CVEs to refresh")
+            return jsonify({"error": "cve_ids must contain at least one known CVE identifier"}), 400
+
+        total = len(cve_ids)
         EPSSProgressTracker.update("bulk_epss_refresh", 0, total, f"Starting bulk EPSS refresh: 0/{total}")
 
         def _run() -> None:

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -282,16 +282,24 @@ class TestBulkEpssRefreshEndpoint:
         assert resp.status_code == 400
         assert "valid CVE" in resp.get_json()["error"]
 
-    def test_returns_400_when_count_exceeds_max(self, client):
-        """400 when more than _MAX_CVE_IDS valid IDs are submitted."""
+    def test_accepts_more_than_max_cve_ids(self, client):
+        """EPSS refresh has no hard cap: large CVE lists are batched, not rejected.
+
+        The frontend sends every CVE in the database, which can exceed
+        _MAX_CVE_IDS. The background job chunks the list against the FIRST.org
+        API, so the request must be accepted (202) rather than rejected (400).
+        """
         from src.routes.bulk_refresh import _MAX_CVE_IDS
         ids = [f"CVE-2024-{i:05d}" for i in range(_MAX_CVE_IDS + 1)]
-        resp = client.post(
-            "/api/vulnerabilities/bulk-epss-refresh",
-            json={"cve_ids": ids},
-        )
-        assert resp.status_code == 400
-        assert "at most" in resp.get_json()["error"]
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-epss-refresh",
+                json={"cve_ids": ids},
+            )
+        assert resp.status_code == 202
+        assert resp.get_json()["total"] == len(ids)
+        MockThread.return_value.start.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -243,7 +243,48 @@ class TestBulkEpssRefreshEndpoint:
         assert resp.status_code == 409
         assert "already in progress" in resp.get_json()["error"]
 
-    def test_409_only_after_valid_input(self, client, existing_cve_id):
+    def test_busy_request_does_not_query_vulnerabilities(self, client, existing_cve_id):
+        """A request arriving while a refresh runs returns 409 without any DB work.
+
+        The singleton is reserved before the database is touched, so a burst of
+        concurrent requests cannot each scan the vulnerabilities table.
+        """
+        with patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker, \
+             patch("src.routes.bulk_refresh.db") as MockDb, \
+             patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockTracker.start_if_idle.return_value = False
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-epss-refresh",
+                json={"cve_ids": [existing_cve_id]},
+            )
+        assert resp.status_code == 409
+        MockDb.session.query.assert_not_called()
+        MockThread.return_value.start.assert_not_called()
+
+    def test_lookup_failure_releases_tracker(self, client, existing_cve_id):
+        """A failing DB lookup rolls back and releases the reserved tracker.
+
+        The tracker is reserved before the lookup runs, so a query failure must
+        mark it errored and roll back the session; otherwise ``in_progress``
+        would stay true and every later refresh would be rejected with 409.
+        """
+        with patch("src.routes.bulk_refresh.EPSSProgressTracker") as MockTracker, \
+             patch("src.routes.bulk_refresh.db") as MockDb, \
+             patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockTracker.start_if_idle.return_value = True
+            MockDb.session.query.side_effect = RuntimeError("db is down")
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-epss-refresh",
+                json={"cve_ids": [existing_cve_id]},
+            )
+        assert resp.status_code == 500
+        MockDb.session.rollback.assert_called_once()
+        MockTracker.error.assert_called_once()
+        MockThread.return_value.start.assert_not_called()
+
+
         """Invalid input returns 400, not 409, even when tracker is running."""
         with patch(
             "src.routes.bulk_refresh.EPSSProgressTracker.start_if_idle",
@@ -282,12 +323,13 @@ class TestBulkEpssRefreshEndpoint:
         assert resp.status_code == 400
         assert "valid CVE" in resp.get_json()["error"]
 
-    def test_accepts_more_than_max_cve_ids(self, client):
-        """EPSS refresh has no hard cap: large CVE lists are batched, not rejected.
+    def test_rejects_large_body_of_unknown_cve_ids(self, client):
+        """A huge body of well-formed but unknown CVE IDs is rejected (400).
 
-        The frontend sends every CVE in the database, which can exceed
-        _MAX_CVE_IDS. The background job chunks the list against the FIRST.org
-        API, so the request must be accepted (202) rather than rejected (400).
+        The endpoint is unauthenticated, so it must not enqueue work
+        proportional to the request body. IDs that do not exist in the database
+        are dropped; when none remain the request is rejected instead of
+        starting a job.
         """
         from src.routes.bulk_refresh import _MAX_CVE_IDS
         ids = [f"CVE-2024-{i:05d}" for i in range(_MAX_CVE_IDS + 1)]
@@ -297,8 +339,26 @@ class TestBulkEpssRefreshEndpoint:
                 "/api/vulnerabilities/bulk-epss-refresh",
                 json={"cve_ids": ids},
             )
+        assert resp.status_code == 400
+        assert "known CVE" in resp.get_json()["error"]
+
+    def test_bounds_work_to_known_cves_and_deduplicates(self, client, existing_cve_id):
+        """Work is bounded by the database: unknown and duplicate IDs are dropped.
+
+        A body mixing many unknown IDs with the one known CVE repeated several
+        times is accepted, but the job total reflects only the single known,
+        de-duplicated CVE rather than the size of the request body.
+        """
+        unknown = [f"CVE-2024-{i:05d}" for i in range(500)]
+        ids = unknown + [existing_cve_id, existing_cve_id.lower(), existing_cve_id]
+        with patch("src.routes.bulk_refresh.threading.Thread") as MockThread:
+            MockThread.return_value = MagicMock()
+            resp = client.post(
+                "/api/vulnerabilities/bulk-epss-refresh",
+                json={"cve_ids": ids},
+            )
         assert resp.status_code == 202
-        assert resp.get_json()["total"] == len(ids)
+        assert resp.get_json()["total"] == 1
         MockThread.return_value.start.assert_called_once()
 
 
@@ -582,9 +642,19 @@ class TestBulkEpssRefreshBackground:
 
         MockTracker.complete.assert_called()
 
-    def test_run_processes_multiple_chunks(self, client):
+    def test_run_processes_multiple_chunks(self, app, client):
         """_run() batches CVEs into chunks of _EPSS_BATCH_SIZE (100)."""
+        from src.models.vulnerability import Vulnerability
+        from src.extensions import db
+
         cve_ids = [f"CVE-2024-{i:05d}" for i in range(150)]
+        # The route only refreshes CVEs that exist in the database, so persist
+        # the records first; this also exercises the real chunking path.
+        with app.app_context():
+            for cve in cve_ids:
+                Vulnerability.create_record(id=cve, description="test", status="low")
+            db.session.commit()
+
         target = self._capture_target(client, cve_ids)
 
         with patch("src.routes.bulk_refresh.EPSS_DB") as MockEPSS, \
@@ -837,9 +907,18 @@ class TestBulkEpssRefreshCancellation:
     def _capture_target(self, client, cve_ids):
         return _capture_refresh_target(client, "/api/vulnerabilities/bulk-epss-refresh", cve_ids)
 
-    def test_run_stops_and_commits_when_cancelled(self, client):
+    def test_run_stops_and_commits_when_cancelled(self, app, client):
         """_run() commits pending work and calls mark_cancelled when flag is set."""
+        from src.models.vulnerability import Vulnerability
+        from src.extensions import db
+
         cve_ids = [f"CVE-2024-{i:05d}" for i in range(150)]  # 2 chunks
+        # Only CVEs stored in the database are refreshed, so persist them first.
+        with app.app_context():
+            for cve in cve_ids:
+                Vulnerability.create_record(id=cve, description="test", status="low")
+            db.session.commit()
+
         target = self._capture_target(client, cve_ids)
 
         chunk_count = {"n": 0}


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

The bulk EPSS refresh rejected any request with more than _MAX_CVE_IDS (1000) CVEs with a 400, but the frontend sends every CVE in the loaded database. On any database with >1000 CVEs the refresh always failed to start ("Failed to start EPSS refresh").

The background job already chunks the CVE list into _EPSS_BATCH_SIZE batches against the FIRST.org API and tolerates per-batch failures, so the hard cap is unnecessary. Remove it and accept arbitrarily large lists. Update the route test to assert a >1000 CVE request now returns 202 instead of 400.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

EPSS refresh does not fail anymore

<img width="664" height="150" alt="image" src="https://github.com/user-attachments/assets/9e1e8395-6e98-4426-9c8f-b0e336844aae" />
