### PR TITLE
feat(vuln-table): render columns in a fixed canonical order

### DIFF
--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -369,6 +369,35 @@ function PublishedDateFilter({
 const SEVERITY_RANGE_MIN = 0;
 const SEVERITY_RANGE_MAX = 10;
 
+// Canonical, fixed order for the vulnerability table columns. The rendered
+// order and the "Columns" filter list both follow this array so a column
+// always appears in the same position regardless of the order in which the
+// user toggled it on. (The 'Select' and 'Actions' columns are always pinned
+// first and last respectively and are not part of this list.)
+const VULN_COLUMN_ORDER = [
+    'ID',
+    'Severity',
+    'EU KEV',
+    'EPSS Score',
+    'Attack Vector',
+    'SBOM Affected',
+    'Variants',
+    'Status',
+    'Published Date',
+    'Estimated Effort',
+    'Last Assessed',
+    'First Scan Date',
+    'Last Fetched',
+    'Last Updated',
+    'Sources',
+] as const;
+
+// Columns shown by default (a subset of VULN_COLUMN_ORDER, kept in the same
+// canonical order).
+const DEFAULT_VISIBLE_COLUMNS = [
+    'ID', 'Severity', 'EU KEV', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Assessed',
+];
+
 function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filterVulnerabilityIds, preferenceScopeKey = 'unscoped', appendAssessment, appendCVSS, patchVuln, variantId, projectId, baseVariantId, compareOperation, variantIds, multiOperation, onRefreshComplete, missingEuvdDataBannerDismissed, onMissingEuvdDataBannerDismissedChange, missingPublishedDateDataBannerDismissed, onMissingPublishedDateDataBannerDismissedChange }: Readonly<Props>) {
     const preferenceKey = `vulnscout.tables.vulnerabilities.${encodeURIComponent(preferenceScopeKey)}`;
 
@@ -470,7 +499,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
     const [localMissingPublishedDateDataBannerDismissed, setLocalMissingPublishedDateDataBannerDismissed] = useState(false);
     const [searchFilteredData, setSearchFilteredData] = useState<Vulnerability[]>([]);
     const [visibleColumns, setVisibleColumns] = useLocalStorageState<string[]>(`${preferenceKey}.visibleColumns`, [
-        'ID', 'Severity', 'EU KEV', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Assessed'
+        ...DEFAULT_VISIBLE_COLUMNS
     ]);
     const [focusedRowIndex, setFocusedRowIndex] = useState<number | null>(null);
 
@@ -1254,7 +1283,8 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
                 column,
             ])
         );
-        const selectedColumns = visibleColumns.flatMap(displayName => {
+        const selectedColumns = VULN_COLUMN_ORDER.flatMap(displayName => {
+            if (!visibleColumns.includes(displayName)) return [];
             const column = columnByDisplayName.get(displayName);
             return column ? [column] : [];
         });
@@ -1479,7 +1509,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
         setPublishedDateFrom('');
         setPublishedDateTo('');
         setSelectedRows({});
-        setVisibleColumns(['ID', 'Severity', 'EU KEV', 'EPSS Score', 'SBOM Affected', 'Variants', 'Status', 'Last Assessed']);
+        setVisibleColumns([...DEFAULT_VISIBLE_COLUMNS]);
         setShowCustomSeverityFilter(false);
         setSeverityRange({ min: SEVERITY_RANGE_MIN, max: SEVERITY_RANGE_MAX });
         setShowCustomEpssFilter(false);
@@ -1646,23 +1676,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
 
             <FilterOption
                 label="Columns"
-                options={[
-                    'ID',
-                    'Severity',
-                    'EPSS Score',
-                    'SBOM Affected',
-                    'Variants',
-                    'Attack Vector',
-                    'Status',
-                    'Estimated Effort',
-                    'Last Assessed',
-                    'Published Date',
-                    'First Scan Date',
-                    'Last Fetched',
-                    'Last Updated',
-                    'Sources',
-                    'EU KEV'
-                ]}
+                options={[...VULN_COLUMN_ORDER]}
                 selected={visibleColumns}
                 setSelected={setVisibleColumns}
             />

--- a/frontend/tests/unit_tests/test_vuln_table.tsx
+++ b/frontend/tests/unit_tests/test_vuln_table.tsx
@@ -335,6 +335,27 @@ describe('Vulnerability Table', () => {
         expect(source_header).toBeInTheDocument();
     })
 
+    test('renders columns in a fixed canonical order regardless of saved toggle order', async () => {
+        // ARRANGE - a scrambled visibleColumns order in local storage
+        window.localStorage.setItem(
+            'vulnscout.tables.vulnerabilities.unscoped.visibleColumns',
+            JSON.stringify(['Sources', 'ID', 'Attack Vector', 'EU KEV', 'Severity', 'EPSS Score']),
+        );
+
+        render(<TableVulnerabilities vulnerabilities={[]} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        // ACT - collect the rendered data column headers in DOM order
+        const headers = await screen.findAllByRole('columnheader');
+        const canonical = ['ID', 'Severity', 'EU KEV', 'EPSS Score', 'Attack Vector', 'Sources'];
+        const renderedOrder = headers
+            .map(header => header.textContent?.trim() ?? '')
+            .map(text => canonical.find(name => text === name || text.startsWith(name)))
+            .filter((name): name is string => Boolean(name));
+
+        // ASSERT - rendered order follows the canonical order, not the saved order
+        expect(renderedOrder).toEqual(canonical);
+    })
+
     test('restores visible columns from local storage', async () => {
         window.localStorage.setItem('vulnscout.tables.vulnerabilities.unscoped.visibleColumns', JSON.stringify(['ID']));
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Same as SBOM tab, the vulnerability tab columns and now aligned withe he column filter, and turned-on columns are not placed at the end of the array anymore

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Enable/disable some columns in Vulnerability tab:

<img width="366" height="522" alt="image" src="https://github.com/user-attachments/assets/0540e004-2354-4162-aa6c-55eb572ce585" />