### PR TITLE
feat(vuln-modal): make atomic refresh API-only

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -394,7 +394,6 @@ type VariantScopedSnapshot = {
     const [refreshing, setRefreshing] = useState(false);
     const [refreshError, setRefreshError] = useState<string | null>(null);
     const [refreshedList, setRefreshedList] = useState<string[]>([]);
-    const [nvdMode, setNvdMode] = useState<"local" | "api">("local");
 
     const modalRef = useRef<HTMLDivElement>(null);
     const shortcutButtonRef = useRef<HTMLButtonElement>(null);
@@ -510,7 +509,7 @@ type VariantScopedSnapshot = {
                 }
             } else {
                 const [nvdResult, epssResult] = await Promise.allSettled([
-                    NvdRefreshHandler.triggerSingleRefresh(vuln.id, nvdMode),
+                    NvdRefreshHandler.triggerSingleRefresh(vuln.id, "api"),
                     EpssRefreshHandler.triggerSingleRefresh(vuln.id),
                 ]);
 
@@ -525,9 +524,7 @@ type VariantScopedSnapshot = {
                     } else if (nvdValue?.kind === "error" && nvdValue.code === "unauthorized") {
                         errors.push("NVD API key rejected. Check your key in Settings.");
                     } else {
-                        errors.push(nvdMode === "api"
-                            ? "NVD API unavailable. Try again or switch to Local mode."
-                            : "NVD data unavailable. Try again or run an sbom-cve-check scan.");
+                        errors.push("NVD API unavailable. Please try again later.");
                     }
                 }
                 if (epssResult.status === "rejected" || epssResult.value === null) {
@@ -570,7 +567,7 @@ type VariantScopedSnapshot = {
         } finally {
             setRefreshing(false);
         }
-    }, [vuln, patchVuln, nvdMode]);
+    }, [vuln, patchVuln]);
 
     const handleEditAssessment = (assessmentId: string, group: AssessmentGroup) => {
         setEditingAssessmentId(assessmentId);
@@ -1444,35 +1441,6 @@ type VariantScopedSnapshot = {
 
                             {!readOnly && (
                                 <div className="flex items-center gap-2 flex-wrap">
-                                    {!isGhsaVuln && (
-                                        <span className="flex items-center gap-1.5 text-xs text-gray-400">
-                                            NVD source:
-                                            <label className="flex items-center gap-1 cursor-pointer">
-                                                <input
-                                                    type="radio"
-                                                    name={`nvd-mode-${vuln.id}`}
-                                                    value="local"
-                                                    checked={nvdMode === "local"}
-                                                    onChange={() => setNvdMode("local")}
-                                                    disabled={refreshing}
-                                                    className="accent-cyan-500"
-                                                />
-                                                <span className="text-gray-300">Git repository</span>
-                                            </label>
-                                            <label className="flex items-center gap-1 cursor-pointer">
-                                                <input
-                                                    type="radio"
-                                                    name={`nvd-mode-${vuln.id}`}
-                                                    value="api"
-                                                    checked={nvdMode === "api"}
-                                                    onChange={() => setNvdMode("api")}
-                                                    disabled={refreshing}
-                                                    className="accent-cyan-500"
-                                                />
-                                                <span className="text-gray-300">API</span>
-                                            </label>
-                                        </span>
-                                    )}
                                     <button
                                         onClick={handleRefresh}
                                         disabled={refreshing}

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2955,15 +2955,7 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         });
     });
 
-    test('renders NVD source selector defaulting to Local mode', () => {
-        render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-        const localRadio = screen.getByRole('radio', { name: 'Git repository' });
-        const apiRadio = screen.getByRole('radio', { name: 'API' });
-        expect(localRadio).toBeChecked();
-        expect(apiRadio).not.toBeChecked();
-    });
-
-    test('switching NVD source to API sends mode "api" to the nvd-refresh endpoint', async () => {
+    test('single refresh always sends mode "api" to the nvd-refresh endpoint', async () => {
         fetchMock.resetMocks();
         fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
         fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
@@ -2972,10 +2964,6 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
 
         render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
-
-        const apiRadio = screen.getByRole('radio', { name: 'API' });
-        await user.click(apiRadio);
-        expect(apiRadio).toBeChecked();
 
         await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
 
@@ -2986,27 +2974,10 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         });
     });
 
-    test('switching back to Local mode sends mode "local" to the nvd-refresh endpoint', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
-        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
-        fetchMock.mockResponseOnce(JSON.stringify({ vulnerabilities: [updatedVulnPayload] })); // nvd-refresh
-        fetchMock.mockResponseOnce(JSON.stringify({ vulnerabilities: [updatedVulnPayload] })); // epss-refresh
-
+    test('does not render an NVD source selector', () => {
         render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-        const user = userEvent.setup();
-
-        await user.click(screen.getByRole('radio', { name: 'API' }));
-        await user.click(screen.getByRole('radio', { name: 'Git repository' }));
-        expect(screen.getByRole('radio', { name: 'Git repository' })).toBeChecked();
-
-        await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
-
-        await waitFor(() => {
-            const nvdCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/nvd-refresh'));
-            expect(nvdCall).toBeDefined();
-            expect(JSON.parse(String(nvdCall![1]!.body))).toEqual({ mode: 'local' });
-        });
+        expect(screen.queryByRole('radio', { name: 'Git repository' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: 'API' })).not.toBeInTheDocument();
     });
 
     test('shows API-key-rejected message when NVD returns unauthorized', async () => {
@@ -3022,7 +2993,6 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
         const user = userEvent.setup();
 
-        await user.click(screen.getByRole('radio', { name: 'API' }));
         await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
 
         await waitFor(() => {
@@ -3030,25 +3000,7 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         });
     });
 
-    test('shows API-mode hint when NVD is unavailable in API mode', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
-        fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
-        fetchMock.mockResponseOnce('Service Unavailable', { status: 503 }); // nvd-refresh
-        fetchMock.mockResponseOnce(JSON.stringify({ vulnerabilities: [updatedVulnPayload] })); // epss-refresh
-
-        render(<VulnModal vuln={vulnerability} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-        const user = userEvent.setup();
-
-        await user.click(screen.getByRole('radio', { name: 'API' }));
-        await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
-
-        await waitFor(() => {
-            expect(screen.getByText(/NVD API unavailable.*switch to Local/i)).toBeInTheDocument();
-        });
-    });
-
-    test('shows local-mode hint when NVD data is unavailable in Local mode', async () => {
+    test('shows API-unavailable hint when NVD is unavailable', async () => {
         fetchMock.resetMocks();
         fetchMock.mockResponseOnce(JSON.stringify([])); // variants mount fetch
         fetchMock.mockResponseOnce(JSON.stringify([])); // assessments mount fetch
@@ -3061,7 +3013,7 @@ describe('NVD & EPSS refresh button in VulnModal', () => {
         await user.click(screen.getByTitle('Refresh from NVD & EPSS'));
 
         await waitFor(() => {
-            expect(screen.getByText(/NVD data unavailable.*sbom-cve-check/i)).toBeInTheDocument();
+            expect(screen.getByText(/NVD API unavailable/i)).toBeInTheDocument();
         });
     });
 


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* The single-vulnerability refresh in the modal offered an "NVD source" toggle (Git repository vs API). Remove the toggle and always refresh NVD from the API. Drop the nvdMode state and simplify the NVD-unavailable error message accordingly. 

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Check VulnModal on a vulnerability:

<img width="1823" height="661" alt="image" src="https://github.com/user-attachments/assets/a4e923ae-8fca-429c-ae3f-c38f1c904c90" />

