### PR TITLE
feat(ui): rename "Scan progress" to "Operation queue"

### DIFF
--- a/doc/source/interactive-mode.md
+++ b/doc/source/interactive-mode.md
@@ -128,7 +128,7 @@ Each row has a checkbox on the left. Selecting one or more rows reveals the **mu
 
 The vulnerabilities table also exposes a **Refresh Vulnerability Data** dropdown. Unlike the scanners on the Scan History page — which discover *which* CVEs affect your packages — these refreshers **enrich the vulnerabilities you already have** with up-to-date metadata pulled directly from upstream databases. The refresh operates on the vulnerabilities in the current scope.
 
-The dropdown defaults to **Complete refresh**, which updates every available source for the current scope. Choose **Custom refresh** to select the sources to update. Each refresh runs in the background; a progress banner appears below the toolbar with a live counter, and a per-source **Cancel** button lets you stop a run in progress. Because every source runs independently, several refreshes can be active at once.
+The dropdown defaults to **Complete refresh**, which updates every available source for the current scope. Choose **Custom refresh** to select the sources to update. Each refresh is added to the **Operation queue** and runs in the background; a progress banner appears below the toolbar with a live counter, and a per-source **Cancel** button lets you stop a run in progress. Because every source runs independently, several refreshes can be active at once.
 
 The available sources are:
 
@@ -226,6 +226,8 @@ The **Run Scans** button in the top-right corner of the Scan History page opens 
 - **Variants** — checkboxes for the available variants. When a specific variant is selected in the project scope, only that variant appears here. When viewing a project, all variants within the project are listed. "Select all" and "Select none" shortcuts help when managing many variants.
 
 The bottom of the menu shows a summary button ("Run N scans on M variants") that launches the selected scans. Each scan runs independently and displays a per-variant progress panel below the toolbar, showing real-time logs, a progress bar, and the current step. Grype scans are queued and run one at a time; NVD and OSV scans can run in parallel.
+
+Every scan and vulnerability-data refresh is also tracked in the **Operation queue** in the navigation bar. A counter shows how many operations have finished out of the total tracked; clicking it opens the Operation queue window, where each running or finished operation has its own progress panel. The window can be closed at any time without interrupting the operations, which keep running in the background.
 
 ### Source Visibility Toggles
 

--- a/frontend/src/components/NavigationBar.tsx
+++ b/frontend/src/components/NavigationBar.tsx
@@ -19,10 +19,10 @@ type Props = {
   trackedScanCount?: number;
   finishedScanCount?: number;
   activeScanCount?: number;
-  onOpenScanProgress?: () => void;
+  onOpenOperationQueue?: () => void;
 };
 
-function NavigationBar({ tab, changeTab, defaultProject, defaultVariant, defaultScope, onApply, trackedScanCount = 0, finishedScanCount = 0, activeScanCount = 0, onOpenScanProgress }: Readonly<Props>) {
+function NavigationBar({ tab, changeTab, defaultProject, defaultVariant, defaultScope, onApply, trackedScanCount = 0, finishedScanCount = 0, activeScanCount = 0, onOpenOperationQueue }: Readonly<Props>) {
   return (
   <nav aria-label="Main navigation">
     <ul className={["flex flex-row font-bold items-stretch", bgColor].join(' ')}>
@@ -125,14 +125,14 @@ function NavigationBar({ tab, changeTab, defaultProject, defaultVariant, default
         <li className="flex items-stretch">
           <button
             type="button"
-            onClick={onOpenScanProgress}
-            title={activeScanCount > 0 ? `${activeScanCount} scan${activeScanCount === 1 ? '' : 's'} in progress` : 'Open scan progress'}
-            aria-label={`Open scan progress, ${finishedScanCount} of ${trackedScanCount} finished`}
+            onClick={onOpenOperationQueue}
+            title={activeScanCount > 0 ? `${activeScanCount} operation${activeScanCount === 1 ? '' : 's'} in progress` : 'Open operation queue'}
+            aria-label={`Open operation queue, ${finishedScanCount} of ${trackedScanCount} finished`}
             className={`flex h-full items-center px-4 py-2 transition-colors ${bgHoverColor}`}
           >
             <FontAwesomeIcon icon={activeScanCount > 0 ? faArrowsRotate : faCheck} className={`mr-2 ${activeScanCount > 0 ? 'animate-spin text-cyan-200' : 'text-green-300'}`} />
             <span className="flex flex-col items-start leading-tight">
-              <span className="text-sm font-bold">Scan progress</span>
+              <span className="text-sm font-bold">Operation queue</span>
               <span className="text-xs font-normal tabular-nums opacity-75">{finishedScanCount} / {trackedScanCount} finished</span>
             </span>
           </button>

--- a/frontend/src/components/OperationQueueModal.tsx
+++ b/frontend/src/components/OperationQueueModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useSyncExternalStore } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBug, faShieldHalved, faLeaf, faCrosshairs, faXmark, faArrowsRotate } from "@fortawesome/free-solid-svg-icons";
-import ScanProgressPanel from "./ScanProgressPanel";
+import OperationQueuePanel from "./OperationQueuePanel";
 import { subscribe as grypeSubscribe, getSnapshot as grypeGetSnapshot, dismiss as grypeDismiss } from "../handlers/grypeScanState";
 import { subscribe as nvdSubscribe, getSnapshot as nvdGetSnapshot, dismiss as nvdDismiss } from "../handlers/nvdScanState";
 import { subscribe as osvSubscribe, getSnapshot as osvGetSnapshot, dismiss as osvDismiss } from "../handlers/osvScanState";
@@ -20,7 +20,7 @@ const osvColors = { border: "border-green-700/60", headerBg: "bg-green-900/40", 
 const sccColors = { border: "border-sky-700/60", headerBg: "bg-sky-900/40", iconText: "text-sky-400", titleText: "text-sky-200", subtitleText: "text-sky-300/80", bar: "bg-sky-500" };
 const refreshColors = { border: "border-cyan-700/60", headerBg: "bg-cyan-900/40", iconText: "text-cyan-400", titleText: "text-cyan-200", subtitleText: "text-cyan-300/80", bar: "bg-cyan-500" };
 
-function ScanProgressModal({ isOpen, onClose }: Readonly<Props>) {
+function OperationQueueModal({ isOpen, onClose }: Readonly<Props>) {
     const overlayRef = useRef<HTMLDivElement>(null);
     const grypeEntries = useSyncExternalStore(grypeSubscribe, grypeGetSnapshot);
     const nvdEntries = useSyncExternalStore(nvdSubscribe, nvdGetSnapshot);
@@ -47,7 +47,7 @@ function ScanProgressModal({ isOpen, onClose }: Readonly<Props>) {
             ref={overlayRef}
             role="dialog"
             aria-modal="true"
-            aria-labelledby="scan-progress-title"
+            aria-labelledby="operation-queue-title"
             className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4"
             onMouseDown={event => {
                 if (event.target === overlayRef.current) onClose();
@@ -56,13 +56,13 @@ function ScanProgressModal({ isOpen, onClose }: Readonly<Props>) {
             <div className="flex max-h-[min(42rem,calc(100vh-2rem))] w-full max-w-3xl flex-col overflow-hidden rounded-lg bg-neutral-900 shadow-xl">
                 <div className="flex items-center justify-between border-b border-neutral-700 px-4 py-3">
                     <div>
-                        <h2 id="scan-progress-title" className="text-lg font-semibold text-white">Scan progress</h2>
-                        <p className="text-sm text-neutral-400">This window can be safely closed. Track scan progress in the navigation bar.</p>
+                        <h2 id="operation-queue-title" className="text-lg font-semibold text-white">Operation queue</h2>
+                        <p className="text-sm text-neutral-400">This window can be safely closed. Track the operation queue in the navigation bar.</p>
                     </div>
                     <button
                         type="button"
                         onClick={onClose}
-                        aria-label="Close scan progress"
+                        aria-label="Close operation queue"
                         className="inline-flex h-8 w-8 items-center justify-center rounded text-neutral-400 transition-colors hover:bg-neutral-700 hover:text-white"
                     >
                         <FontAwesomeIcon icon={faXmark} />
@@ -72,23 +72,23 @@ function ScanProgressModal({ isOpen, onClose }: Readonly<Props>) {
                     {hasEntries ? (
                         <div className="overflow-hidden rounded-lg border border-neutral-700 divide-y divide-neutral-700">
                             {grypeEntries.map(entry => (
-                                <ScanProgressPanel key={`grype-${entry.variantId}`} entry={entry} label="Grype Scan" icon={faBug} colors={grypeColors} onDismiss={() => grypeDismiss(entry.variantId)} />
+                                <OperationQueuePanel key={`grype-${entry.variantId}`} entry={entry} label="Grype Scan" icon={faBug} colors={grypeColors} onDismiss={() => grypeDismiss(entry.variantId)} />
                             ))}
                             {nvdEntries.map(entry => (
-                                <ScanProgressPanel key={`nvd-${entry.variantId}`} entry={entry} label="NVD Scan" icon={faShieldHalved} colors={nvdColors} onDismiss={() => nvdDismiss(entry.variantId)} />
+                                <OperationQueuePanel key={`nvd-${entry.variantId}`} entry={entry} label="NVD Scan" icon={faShieldHalved} colors={nvdColors} onDismiss={() => nvdDismiss(entry.variantId)} />
                             ))}
                             {osvEntries.map(entry => (
-                                <ScanProgressPanel key={`osv-${entry.variantId}`} entry={entry} label="OSV Scan" icon={faLeaf} colors={osvColors} onDismiss={() => osvDismiss(entry.variantId)} />
+                                <OperationQueuePanel key={`osv-${entry.variantId}`} entry={entry} label="OSV Scan" icon={faLeaf} colors={osvColors} onDismiss={() => osvDismiss(entry.variantId)} />
                             ))}
                             {sccEntries.map(entry => (
-                                <ScanProgressPanel key={`scc-${entry.variantId}`} entry={entry} label="sbom-cve-check Scan" icon={faCrosshairs} colors={sccColors} onDismiss={() => sccDismiss(entry.variantId)} />
+                                <OperationQueuePanel key={`scc-${entry.variantId}`} entry={entry} label="sbom-cve-check Scan" icon={faCrosshairs} colors={sccColors} onDismiss={() => sccDismiss(entry.variantId)} />
                             ))}
                             {refreshEntries.map(entry => (
-                                <ScanProgressPanel key={entry.variantId} entry={entry} label="Vulnerability Data Refresh" icon={faArrowsRotate} colors={refreshColors} onDismiss={() => dismissRefreshQueueEntry(entry.variantId as RefreshType)} />
+                                <OperationQueuePanel key={entry.variantId} entry={entry} label="Vulnerability Data Refresh" icon={faArrowsRotate} colors={refreshColors} onDismiss={() => dismissRefreshQueueEntry(entry.variantId as RefreshType)} />
                             ))}
                         </div>
                     ) : (
-                        <p className="py-8 text-center text-sm text-neutral-400">No scan progress to display.</p>
+                        <p className="py-8 text-center text-sm text-neutral-400">No operations to display.</p>
                     )}
                 </div>
             </div>
@@ -96,4 +96,4 @@ function ScanProgressModal({ isOpen, onClose }: Readonly<Props>) {
     );
 }
 
-export default ScanProgressModal;
+export default OperationQueueModal;

--- a/frontend/src/components/OperationQueuePanel.tsx
+++ b/frontend/src/components/OperationQueuePanel.tsx
@@ -1,5 +1,5 @@
 /**
- * ScanProgressPanel — reusable per-variant scan progress / log panel.
+ * OperationQueuePanel — reusable per-variant operation progress / log panel.
  *
  * Renders a collapsible card with:
  *  - coloured header showing scan type + variant name
@@ -31,7 +31,7 @@ type Props = {
     onDismiss: () => void;
 };
 
-export default function ScanProgressPanel({ entry, label, icon, colors, onDismiss }: Props) {
+export default function OperationQueuePanel({ entry, label, icon, colors, onDismiss }: Props) {
     const { status, variantName, variantPosition, variantCount, progress, logs, total, doneCount } = entry;
     const pct = status === "done" ? 100 : total > 0 ? Math.max(0, Math.min(100, Math.round((doneCount / total) * 100))) : 0;
     const hasProgressContent = logs.length > 0 || total > 0 || doneCount > 0;

--- a/frontend/src/components/RefreshVulnerabilityData.tsx
+++ b/frontend/src/components/RefreshVulnerabilityData.tsx
@@ -105,7 +105,7 @@ function RefreshVulnerabilityData({ vulnerabilities, getRefreshVulnerabilities, 
         });
         if (queued) {
             setRefreshMenuOpen(false);
-            triggerBanner('Vulnerability data refresh added to the scan queue', 'success');
+            triggerBanner('Vulnerability data refresh added to the operation queue', 'success');
         }
     };
 
@@ -221,7 +221,7 @@ function RefreshVulnerabilityData({ vulnerabilities, getRefreshVulnerabilities, 
                         <button
                             className="w-full py-1 rounded text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-cyan-700 hover:bg-cyan-600 text-white disabled:bg-neutral-700 disabled:text-neutral-500"
                             disabled={cannotStartRefresh}
-                            title={cannotStartRefresh ? 'All available targets are already refreshing' : 'Add refresh to the scan queue'}
+                            title={cannotStartRefresh ? 'All available targets are already refreshing' : 'Add refresh to the operation queue'}
                             onClick={startRefresh}
                         >
                             Start

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from "react";
 import NavigationBar from "../components/NavigationBar";
-import ScanProgressModal from "../components/ScanProgressModal";
+import OperationQueueModal from "../components/OperationQueueModal";
 import MessageBanner from "../components/MessageBanner";
 import type { Package } from "../handlers/packages";
 import type { CVSS, Vulnerability } from "../handlers/vulnerabilities";
@@ -72,7 +72,7 @@ function Explorer() {
     const [currentOperation, setCurrentOperation] = useState<string | undefined>(undefined);
     const [currentVariantIds, setCurrentVariantIds] = useState<string[] | undefined>(undefined);
     const [currentMultiOperation, setCurrentMultiOperation] = useState<string | undefined>(undefined);
-    const [scanProgressOpen, setScanProgressOpen] = useState(false);
+    const [operationQueueOpen, setOperationQueueOpen] = useState(false);
     const hadActiveScans = useRef(false);
     const grypeScanEntries = useSyncExternalStore(grypeSubscribe, grypeGetSnapshot);
     const nvdScanEntries = useSyncExternalStore(nvdSubscribe, nvdGetSnapshot);
@@ -88,7 +88,7 @@ function Explorer() {
 
     useEffect(() => {
         if (activeScanCount > 0 && !hadActiveScans.current) {
-            setScanProgressOpen(true);
+            setOperationQueueOpen(true);
         }
         hadActiveScans.current = activeScanCount > 0;
     }, [activeScanCount]);
@@ -410,10 +410,10 @@ function Explorer() {
                     trackedScanCount={trackedScanCount}
                     finishedScanCount={finishedScanCount}
                     activeScanCount={activeScanCount}
-                    onOpenScanProgress={() => setScanProgressOpen(true)}
+                    onOpenOperationQueue={() => setOperationQueueOpen(true)}
                 />
             </header>
-            <ScanProgressModal isOpen={scanProgressOpen} onClose={() => setScanProgressOpen(false)} />
+            <OperationQueueModal isOpen={operationQueueOpen} onClose={() => setOperationQueueOpen(false)} />
 
             <main id="main-content" aria-label={tabLabels[tab] ?? 'Content'} className="flex-1 flex flex-col overflow-hidden">
             <div className="px-8 pt-4">

--- a/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
+++ b/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
@@ -95,11 +95,11 @@ jest.mock('../../src/handlers/assessments', () => ({
 
 jest.mock('../../src/components/NavigationBar', () => ({
     __esModule: true,
-    default: ({ defaultProject, defaultScope, changeTab, onOpenScanProgress }: {
+    default: ({ defaultProject, defaultScope, changeTab, onOpenOperationQueue }: {
         defaultProject?: { id: string } | null;
         defaultScope?: { project_id: string } | null;
         changeTab: (tab: string) => void;
-        onOpenScanProgress: () => void;
+        onOpenOperationQueue: () => void;
     }) => (
         <div>
             <span data-testid="default-project">{defaultProject?.id ?? ''}</span>
@@ -107,7 +107,7 @@ jest.mock('../../src/components/NavigationBar', () => ({
             {['metrics', 'packages', 'vulnerabilities', 'scans', 'review', 'settings'].map(tab => (
                 <button key={tab} onClick={() => changeTab(tab)}>{tab}</button>
             ))}
-            <button onClick={onOpenScanProgress}>progress</button>
+            <button onClick={onOpenOperationQueue}>progress</button>
         </div>
     ),
 }));
@@ -119,7 +119,7 @@ jest.mock('../../src/components/MessageBanner', () => ({
 }));
 
 jest.mock('../../src/components/VersionDisplay', () => ({ __esModule: true, default: () => null }));
-jest.mock('../../src/components/ScanProgressModal', () => ({
+jest.mock('../../src/components/OperationQueueModal', () => ({
     __esModule: true,
     default: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => isOpen ? <button onClick={onClose}>close progress</button> : null,
 }));

--- a/frontend/tests/unit_tests/test_operation_queue_modal.tsx
+++ b/frontend/tests/unit_tests/test_operation_queue_modal.tsx
@@ -7,27 +7,27 @@ jest.mock('../../src/handlers/activeScanQueue', () => ({
     dismissRefreshQueueEntry: jest.fn(),
 }));
 
-import ScanProgressModal from '../../src/components/ScanProgressModal';
+import OperationQueueModal from '../../src/components/OperationQueueModal';
 import { getRefreshQueueSnapshot } from '../../src/handlers/activeScanQueue';
 
-describe('ScanProgressModal', () => {
+describe('OperationQueueModal', () => {
     beforeEach(() => (getRefreshQueueSnapshot as jest.Mock).mockReturnValue([]));
 
     it('closes from its close button, backdrop, and Escape key', () => {
         const onClose = jest.fn();
-        const { rerender } = render(<ScanProgressModal isOpen={true} onClose={onClose} />);
+        const { rerender } = render(<OperationQueueModal isOpen={true} onClose={onClose} />);
 
-        expect(screen.getByRole('dialog', { name: 'Scan progress' })).toBeInTheDocument();
-    expect(screen.getByText('This window can be safely closed. Track scan progress in the navigation bar.')).toBeInTheDocument();
-        expect(screen.getByText('No scan progress to display.')).toBeInTheDocument();
+        expect(screen.getByRole('dialog', { name: 'Operation queue' })).toBeInTheDocument();
+    expect(screen.getByText('This window can be safely closed. Track the operation queue in the navigation bar.')).toBeInTheDocument();
+        expect(screen.getByText('No operations to display.')).toBeInTheDocument();
 
-        fireEvent.click(screen.getByRole('button', { name: 'Close scan progress' }));
-        fireEvent.mouseDown(screen.getByRole('dialog', { name: 'Scan progress' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Close operation queue' }));
+        fireEvent.mouseDown(screen.getByRole('dialog', { name: 'Operation queue' }));
         fireEvent.keyDown(document, { key: 'Escape' });
         expect(onClose).toHaveBeenCalledTimes(3);
 
-        rerender(<ScanProgressModal isOpen={false} onClose={onClose} />);
-        expect(screen.queryByRole('dialog', { name: 'Scan progress' })).not.toBeInTheDocument();
+        rerender(<OperationQueueModal isOpen={false} onClose={onClose} />);
+        expect(screen.queryByRole('dialog', { name: 'Operation queue' })).not.toBeInTheDocument();
     });
 
     it('renders each vulnerability refresh source as an independent collapse', () => {
@@ -35,7 +35,7 @@ describe('ScanProgressModal', () => {
             { variantId: 'nvd', variantName: 'NVD', status: 'queued', error: null, progress: 'Queued', logs: ['Waiting'], total: 0, doneCount: 0 },
             { variantId: 'epss', variantName: 'EPSS', status: 'queued', error: null, progress: 'Queued', logs: ['Waiting'], total: 0, doneCount: 0 },
         ]);
-        render(<ScanProgressModal isOpen={true} onClose={jest.fn()} />);
+        render(<OperationQueueModal isOpen={true} onClose={jest.fn()} />);
 
         const nvdCollapse = screen.getByRole('button', { name: /vulnerability data refresh.*nvd queued/i });
         const epssCollapse = screen.getByRole('button', { name: /vulnerability data refresh.*epss queued/i });

--- a/frontend/tests/unit_tests/test_operation_queue_panel.tsx
+++ b/frontend/tests/unit_tests/test_operation_queue_panel.tsx
@@ -3,10 +3,10 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 
-import ScanProgressPanel from '../../src/components/ScanProgressPanel';
+import OperationQueuePanel from '../../src/components/OperationQueuePanel';
 import type { ScanEntryState } from '../../src/handlers/scanStateManager';
 
-describe('ScanProgressPanel', () => {
+describe('OperationQueuePanel', () => {
     const colors = {
         border: 'border-cyan-500/60',
         headerBg: 'bg-cyan-900/40',
@@ -30,7 +30,7 @@ describe('ScanProgressPanel', () => {
 
     it('keeps a scan queued until progress content arrives', async () => {
         const { rerender } = render(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('queued', { progress: 'Queued', logs: ['Waiting for previous scan to finish…'] })}
                 label="Grype Scan"
                 icon={faCircleInfo}
@@ -45,7 +45,7 @@ describe('ScanProgressPanel', () => {
         expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
 
         rerender(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('running', { progress: 'starting', total: 0, doneCount: 0 })}
                 label="Grype Scan"
                 icon={faCircleInfo}
@@ -58,7 +58,7 @@ describe('ScanProgressPanel', () => {
             .toHaveAttribute('aria-expanded', 'false');
 
         rerender(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('running', { progress: '1 / 4', logs: ['Scanning package metadata'] })}
                 label="Grype Scan"
                 icon={faCircleInfo}
@@ -74,7 +74,7 @@ describe('ScanProgressPanel', () => {
 
     it('shows the queued state without a dismiss button', () => {
         render(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('queued', { progress: 'Queued', logs: ['Waiting for previous scan to finish…'] })}
                 label="Grype Scan"
                 icon={faCircleInfo}
@@ -90,7 +90,7 @@ describe('ScanProgressPanel', () => {
 
     it('shows the position for a multi-variant scan', () => {
         render(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('running', {
                     variantName: 'hyper-v',
                     variantPosition: 2,
@@ -108,7 +108,7 @@ describe('ScanProgressPanel', () => {
 
     it('omits the position for a single-variant scan', () => {
         render(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('running', { variantPosition: 1, variantCount: 1 })}
                 label="NVD Scan"
                 icon={faCircleInfo}
@@ -126,7 +126,7 @@ describe('ScanProgressPanel', () => {
         const onDismiss = jest.fn();
 
         const { rerender } = render(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('running', {
                     progress: '2 / 4',
                         logs: ['[ERROR] scanning', '✓ finished step'],
@@ -144,7 +144,7 @@ describe('ScanProgressPanel', () => {
         expect(screen.getByText('✓ finished step')).toHaveClass('text-green-400', 'font-semibold');
 
         rerender(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('done', {
                     progress: '4 / 4',
                     logs: ['✓ completed'],
@@ -169,7 +169,7 @@ describe('ScanProgressPanel', () => {
     it('renders zero-total completion at 100% and clamps excessive progress', async () => {
         const user = userEvent.setup();
         const { container, rerender } = render(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('done', { total: 0, doneCount: 0 })}
                 label="NVD Scan"
                 icon={faCircleInfo}
@@ -181,7 +181,7 @@ describe('ScanProgressPanel', () => {
         expect(container.querySelector('.bg-green-500')).toHaveStyle({ width: '100%' });
 
         rerender(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('running', { total: 2, doneCount: 3, logs: ['Finishing'] })}
                 label="NVD Scan"
                 icon={faCircleInfo}
@@ -194,7 +194,7 @@ describe('ScanProgressPanel', () => {
 
     it('labels cancellation without a success indicator', () => {
         render(
-            <ScanProgressPanel
+            <OperationQueuePanel
                 entry={makeEntry('cancelled', { progress: 'Cancelled', doneCount: 1, total: 4 })}
                 label="Vulnerability Data Refresh"
                 icon={faCircleInfo}


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

Rename the navigation-bar scan-progress widget and its modal to "Operation queue" so it reflects that it tracks both scans and vulnerability-data refreshes.

- Rename ScanProgressModal -> OperationQueueModal and ScanProgressPanel -> OperationQueuePanel (files + identifiers).
- Update NavigationBar label, title, aria-label and the onOpenScanProgress -> onOpenOperationQueue prop.
- Update Explorer state/props usage.
- Reword the vulnerability-data refresh banner and button to reference the operation queue.
- Rename and update the related frontend tests.
- Update interactive-mode documentation.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Operation Queue is used in banners, doc and nav bar

<img width="259" height="92" alt="image" src="https://github.com/user-attachments/assets/052647df-c913-4be4-98b8-5a59140f6663" />
