### PR TITLE
Refresh vulnerabilities after queue completion

### DIFF
--- a/frontend/src/components/RefreshVulnerabilityData.tsx
+++ b/frontend/src/components/RefreshVulnerabilityData.tsx
@@ -21,9 +21,10 @@ type Props = {
     epssProgress?: EPSSProgress | null;
     ghsaProgress?: GHSAProgress | null;
     euvdProgress?: EUVDProgress | null;
+    onRefreshComplete?: () => void;
 };
 
-function RefreshVulnerabilityData({ vulnerabilities, getRefreshVulnerabilities, triggerBanner, hideBanner, nvdProgress, epssProgress, ghsaProgress, euvdProgress }: Readonly<Props>) {
+function RefreshVulnerabilityData({ vulnerabilities, getRefreshVulnerabilities, triggerBanner, hideBanner, nvdProgress, epssProgress, ghsaProgress, euvdProgress, onRefreshComplete }: Readonly<Props>) {
     const [refreshMenuOpen, setRefreshMenuOpen] = useState(false);
     const [refreshMode, setRefreshMode] = useState<'complete' | 'custom'>('complete');
     const [selectedRefreshTypes, setSelectedRefreshTypes] = useState<Set<RefreshType>>(new Set(['nvd', 'epss', 'ghsa', 'euvd']));
@@ -104,6 +105,7 @@ function RefreshVulnerabilityData({ vulnerabilities, getRefreshVulnerabilities, 
             refreshTypes: queuedRefreshTypes,
             nvdMode: nvdRefreshMode,
             loadVulnerabilities: getRefreshVulnerabilities ?? (() => Promise.resolve(vulnerabilities)),
+            onRefreshComplete,
         });
         if (queued) {
             setRefreshMenuOpen(false);

--- a/frontend/src/handlers/activeScanQueue.ts
+++ b/frontend/src/handlers/activeScanQueue.ts
@@ -26,6 +26,7 @@ type QueueOptions = {
     refreshTypes: RefreshType[];
     nvdMode: "local" | "api";
     loadVulnerabilities: () => Promise<Vulnerability[]>;
+    onRefreshComplete?: () => void;
 };
 
 type RefreshSource = {
@@ -254,7 +255,7 @@ async function runRefresh(type: RefreshType, cveIds: string[], ghsaIds: string[]
     }
 }
 
-export function queueVulnerabilityRefresh({ refreshTypes, nvdMode, loadVulnerabilities }: QueueOptions): boolean {
+export function queueVulnerabilityRefresh({ refreshTypes, nvdMode, loadVulnerabilities, onRefreshComplete }: QueueOptions): boolean {
     if (refreshSnapshot.some(entry => isActive(entry.status))) return false;
     const selectedTypes = REFRESH_ORDER.filter(type => refreshTypes.includes(type));
     if (selectedTypes.length === 0) return false;
@@ -298,6 +299,7 @@ export function queueVulnerabilityRefresh({ refreshTypes, nvdMode, loadVulnerabi
                 setRefreshEntry(type, { status: "error", error: message, progress: null, logs: [message] });
             }
         }
+        onRefreshComplete?.();
     })();
     return true;
 }

--- a/frontend/src/pages/TableVulnerabilities.tsx
+++ b/frontend/src/pages/TableVulnerabilities.tsx
@@ -2006,6 +2006,7 @@ function TableVulnerabilities ({ vulnerabilities, filterLabel, filterValue, filt
                 <RefreshVulnerabilityData
                     vulnerabilities={vulnerabilities}
                     getRefreshVulnerabilities={() => Vulnerabilities.list(variantId, projectId, baseVariantId, compareOperation, variantIds, multiOperation)}
+                    onRefreshComplete={onRefreshComplete}
                     triggerBanner={triggerBanner}
                     hideBanner={closeBanner}
                     nvdProgress={nvdProgress}

--- a/frontend/tests/handlers/activeScanQueue.test.ts
+++ b/frontend/tests/handlers/activeScanQueue.test.ts
@@ -57,6 +57,7 @@ describe('active scan queue', () => {
     });
 
     it('queues separate sources and waits for backend completion before advancing', async () => {
+        const onRefreshComplete = jest.fn();
         (BulkNvdRefreshHandler.trigger as jest.Mock).mockResolvedValue({ total: 1 });
         (BulkEpssRefreshHandler.trigger as jest.Mock).mockResolvedValue({ total: 1 });
         (NVDProgressHandler.getProgress as jest.Mock)
@@ -72,6 +73,7 @@ describe('active scan queue', () => {
             refreshTypes: ['nvd', 'epss'],
             nvdMode: 'local',
             loadVulnerabilities: async () => [{ id: 'CVE-2024-0001' }] as never,
+            onRefreshComplete,
         })).toBe(true);
         expect(getRefreshQueueSnapshot().map(entry => [entry.variantId, entry.status])).toEqual([
             ['nvd', 'queued'],
@@ -90,9 +92,11 @@ describe('active scan queue', () => {
         await jest.advanceTimersByTimeAsync(3000);
         expect(BulkEpssRefreshHandler.trigger).toHaveBeenCalledTimes(1);
         expect(getRefreshQueueSnapshot().map(entry => entry.status)).toEqual(['done', 'running']);
+        expect(onRefreshComplete).not.toHaveBeenCalled();
 
         await jest.advanceTimersByTimeAsync(6000);
         expect(getRefreshQueueSnapshot().map(entry => entry.status)).toEqual(['done', 'done']);
+        expect(onRefreshComplete).toHaveBeenCalledTimes(1);
 
         dismissRefreshQueueEntry('nvd');
         expect(getRefreshQueueSnapshot().map(entry => entry.variantId)).toEqual(['epss']);

--- a/frontend/tests/unit_tests/test_refresh_vulnerability_data.tsx
+++ b/frontend/tests/unit_tests/test_refresh_vulnerability_data.tsx
@@ -132,6 +132,7 @@ describe('RefreshVulnerabilityData', () => {
         const queueRefresh = queueVulnerabilityRefresh as jest.Mock;
         const mockHideBanner = jest.fn();
         const loadVulnerabilities = jest.fn().mockResolvedValue(refreshVulnerabilities(['CVE-2024-0001']));
+        const onRefreshComplete = jest.fn();
 
         const props = {
             ...mockProps,
@@ -139,6 +140,7 @@ describe('RefreshVulnerabilityData', () => {
             getRefreshVulnerabilities: loadVulnerabilities,
             triggerBanner: jest.fn(),
             hideBanner: mockHideBanner,
+            onRefreshComplete,
         };
 
         render(<RefreshVulnerabilityData {...props} />);
@@ -151,6 +153,7 @@ describe('RefreshVulnerabilityData', () => {
             refreshTypes: ['nvd', 'epss', 'euvd'],
             nvdMode: 'local',
             loadVulnerabilities,
+            onRefreshComplete,
         });
         expect(screen.queryByRole('button', { name: /^Start$/i })).not.toBeInTheDocument();
     });


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Refresh vulnerabilities after queue completion

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Launch a refresh vulns and observe that you no longer need to F5 to get the UI updates.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


