### PR TITLE
Cherry-pick previous PR

### DIFF
--- a/frontend/src/components/RefreshVulnerabilityData.tsx
+++ b/frontend/src/components/RefreshVulnerabilityData.tsx
@@ -28,7 +28,6 @@ function RefreshVulnerabilityData({ vulnerabilities, getRefreshVulnerabilities, 
     const [refreshMenuOpen, setRefreshMenuOpen] = useState(false);
     const [refreshMode, setRefreshMode] = useState<'complete' | 'custom'>('complete');
     const [selectedRefreshTypes, setSelectedRefreshTypes] = useState<Set<RefreshType>>(new Set(['nvd', 'epss', 'ghsa', 'euvd']));
-    const [nvdRefreshMode, setNvdRefreshMode] = useState<'local' | 'api'>('local');
     const [cancelling, setCancelling] = useState<Set<RefreshType>>(new Set());
     const refreshMenuRef = useRef<HTMLDivElement>(null);
     const cveIds = vulnerabilities.map(vulnerability => vulnerability.id).filter(id => id.toUpperCase().startsWith('CVE-'));
@@ -103,7 +102,7 @@ function RefreshVulnerabilityData({ vulnerabilities, getRefreshVulnerabilities, 
         });
         const queued = queueVulnerabilityRefresh({
             refreshTypes: queuedRefreshTypes,
-            nvdMode: nvdRefreshMode,
+            nvdMode: 'local',
             loadVulnerabilities: getRefreshVulnerabilities ?? (() => Promise.resolve(vulnerabilities)),
             onRefreshComplete,
         });
@@ -223,23 +222,6 @@ function RefreshVulnerabilityData({ vulnerabilities, getRefreshVulnerabilities, 
                                     >{cancelling.has(source) ? 'Cancelling…' : 'Cancel'}</button>
                                 )}
                             </div>
-                            {source === 'nvd' && selectedRefreshTypes.has('nvd') && !inProgress.nvd && (
-                                <div className="px-1 py-1.5 border-t border-sky-800/40 mt-1">
-                                    <div className="text-xs text-sky-300 mb-1">NVD data source:</div>
-                                    <div className="flex gap-3">
-                                        <label className="flex items-center gap-1.5 cursor-pointer text-xs">
-                                            <input type="radio" name="nvd-refresh-mode" value="local" checked={nvdRefreshMode === 'local'} onChange={() => setNvdRefreshMode('local')} className="accent-cyan-500" />
-                                            <span className="text-neutral-200">Git repository</span>
-                                        </label>
-                                        <HintButton heading="Git repository" ariaLabel="Git repository NVD data details" text="Uses the locally cloned NVD CVE data repository. This is faster and works without an API key, but reflects the repository's last update." />
-                                        <label className="flex items-center gap-1.5 cursor-pointer text-xs">
-                                            <input type="radio" name="nvd-refresh-mode" value="api" checked={nvdRefreshMode === 'api'} onChange={() => setNvdRefreshMode('api')} className="accent-cyan-500" />
-                                            <span className="text-neutral-200">NVD REST API</span>
-                                        </label>
-                                        <HintButton heading="NVD REST API" ariaLabel="NVD REST API data details" text="Queries the NVD REST API for current CVE data. This requires network access and may be rate-limited without an NVD API key." />
-                                    </div>
-                                </div>
-                            )}
                         </div>
                             ))}
                         </div>

--- a/frontend/src/pages/AIContext.tsx
+++ b/frontend/src/pages/AIContext.tsx
@@ -379,6 +379,24 @@ function AIContext() {
 
                 {/* Import / Export controls */}
                 <div className="ml-auto flex items-center gap-2">
+                    <button
+                        type="button"
+                        aria-label="Import context"
+                        onClick={() => importInputRef.current?.click()}
+                        disabled={ioBusy}
+                        className={btnTransfer}
+                    >
+                        <FontAwesomeIcon icon={faFileImport} />
+                        Import
+                    </button>
+                    <input
+                        ref={importInputRef}
+                        type="file"
+                        accept="application/json,.json"
+                        aria-label="Import context file"
+                        className="hidden"
+                        onChange={handleImportFile}
+                    />
                     <div className="relative" ref={exportMenuRef}>
                         <button
                             type="button"
@@ -441,24 +459,6 @@ function AIContext() {
                             </div>
                         )}
                     </div>
-                    <button
-                        type="button"
-                        aria-label="Import context"
-                        onClick={() => importInputRef.current?.click()}
-                        disabled={ioBusy}
-                        className={btnTransfer}
-                    >
-                        <FontAwesomeIcon icon={faFileImport} />
-                        Import
-                    </button>
-                    <input
-                        ref={importInputRef}
-                        type="file"
-                        accept="application/json,.json"
-                        aria-label="Import context file"
-                        className="hidden"
-                        onChange={handleImportFile}
-                    />
                     <div className="relative" ref={importHelpRef}>
                         <button
                             type="button"

--- a/frontend/tests/unit_tests/test_ai_context_page.tsx
+++ b/frontend/tests/unit_tests/test_ai_context_page.tsx
@@ -397,6 +397,17 @@ describe('AIContext page', () => {
             clickSpy.mockRestore();
         });
 
+        test('shows Import before Export', async () => {
+            fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+            render(<AIContext />);
+            await screen.findByRole('option', { name: 'Project A' });
+
+            const transferActions = screen.getAllByRole('button')
+                .map(button => button.getAttribute('aria-label'))
+                .filter(label => label === 'Import context' || label === 'Export context');
+            expect(transferActions).toEqual(['Import context', 'Export context']);
+        });
+
         test('export menu loads variants and downloads selected', async () => {
             fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }])); // projects
             render(<AIContext />);

--- a/frontend/tests/unit_tests/test_refresh_vulnerability_data.tsx
+++ b/frontend/tests/unit_tests/test_refresh_vulnerability_data.tsx
@@ -158,6 +158,20 @@ describe('RefreshVulnerabilityData', () => {
         expect(screen.queryByRole('button', { name: /^Start$/i })).not.toBeInTheDocument();
     });
 
+    test('does not offer an NVD data source choice', async () => {
+        render(<RefreshVulnerabilityData
+            {...mockProps}
+            vulnerabilities={refreshVulnerabilities(['CVE-2024-0001'])}
+        />);
+
+        await userEvent.click(screen.getByTestId('refresh-dropdown-toggle'));
+        await selectCustomRefresh();
+
+        expect(screen.queryByText('NVD data source:')).not.toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: 'Git repository' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: 'NVD REST API' })).not.toBeInTheDocument();
+    });
+
     test('does not trigger NVD refresh when NVD is already in progress', async () => {
         const mockTriggerBanner = jest.fn();
         const queueRefresh = queueVulnerabilityRefresh as jest.Mock;

--- a/frontend/tests/unit_tests/test_review.tsx
+++ b/frontend/tests/unit_tests/test_review.tsx
@@ -1466,6 +1466,22 @@ describe('Review — deleting an assessment', () => {
 // ===========================================================================
 
 describe('Review — import and export', () => {
+    test('shows Import before Export on the Assessments and AI Assessments tabs', async () => {
+        mockNetwork([makeAssessment('a1', 'v1')], { aiReviewList: [makeAssessment('ai1', 'v1')] });
+        render(<Review projectId="proj1" />);
+        const user = userEvent.setup();
+
+        const transferActions = () => screen.getAllByRole('button')
+            .map(button => button.textContent?.trim())
+            .filter(label => label === 'Export' || label === 'Import');
+
+        await screen.findByTitle('Edit assessment');
+        expect(transferActions()).toEqual(['Import', 'Export']);
+
+        await user.click(screen.getByText('AI Assessments'));
+        expect(transferActions()).toEqual(['Import', 'Export']);
+    });
+
     test('exports selected variants as VulnScout JSON', async () => {
         mockNetwork([makeAssessment('a1', 'v1')]);
         render(<Review projectId="proj1" />);


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

* Restore the PR #477 for import feature in Review tab
* Restore the "Refresh Vulnerability Data" options
* Revert AI button Export/Import to Import/Export

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Vulnerability tab: 

<img width="214" height="274" alt="image" src="https://github.com/user-attachments/assets/aef543ad-4279-4fbd-80aa-eaa4efeea611" />

Review tab: 

<img width="426" height="346" alt="image" src="https://github.com/user-attachments/assets/0b66d76f-ad06-46b6-8b04-d814b682d657" />

AI tab: 

<img width="236" height="67" alt="image" src="https://github.com/user-attachments/assets/db88f952-c9d4-4db4-9636-bdf7468f24b7" />
