### PR TITLE
feat(exports): add guided export workflow

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -690,6 +690,34 @@ Generate a report from a template or export an SBOM in the requested format.
 
 **Response:** File download with appropriate `Content-Type` and `Content-Disposition` headers. Supports JSON, XML, PDF, and HTML outputs depending on the template.
 
+### Export Multiple Documents
+
+```
+POST /api/documents/export
+```
+
+Renders selected document formats for every variant in one project. `consolidated` creates one project-wide file per selection; `per_variant` creates one file per selection and variant. Both modes return a ZIP archive.
+
+**Request body:**
+
+```json
+{
+  "project_id": "11111111-1111-1111-1111-111111111111",
+  "variant_ids": [
+    "22222222-2222-2222-2222-222222222222"
+  ],
+  "mode": "per_variant",
+  "documents": [
+    { "name": "summary.adoc", "extension": "pdf" },
+    { "name": "CycloneDX 1.6", "extension": "json" }
+  ]
+}
+```
+
+`variant_ids` selects one or more variants belonging to the project. When omitted, all project variants are exported. Reports support either output mode. SBOM selections require `per_variant` mode and cannot be mixed with reports in the same request. Document and extension pairs must match non-asset entries returned by `GET /api/documents`. Custom assets are resources used by report templates and cannot be exported directly.
+
+**Response:** ZIP file download (`Content-Type: application/zip`).
+
 ---
 
 ## Scans

--- a/frontend/src/components/CustomExportContentManager.tsx
+++ b/frontend/src/components/CustomExportContentManager.tsx
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCloudArrowUp, faFileLines, faImage, faSpinner, faXmark } from "@fortawesome/free-solid-svg-icons";
+import type { ExportDocument } from "./ExportWizard";
+
+const assetExtensions = new Set(["png", "jpg", "jpeg", "gif", "webp"]);
+const templateAccept = ".adoc,.asciidoc,.html,.htm,.md,.markdown,.csv,.txt,.json,.xml,.tex,.j2,.jinja,.jinja2";
+const assetAccept = ".png,.jpg,.jpeg,.gif,.webp";
+
+const asExportDocument = (data: any): ExportDocument | [] => {
+    if (typeof data !== "object" || typeof data?.id !== "string") return [];
+    return {
+        id: data.id,
+        category: Array.isArray(data.category)
+            ? data.category.filter((entry: any) => typeof entry === "string")
+            : [],
+        extension: typeof data.extension === "string"
+            ? data.extension
+            : data.id.split(".").at(-1) ?? "unk",
+    };
+};
+
+export default function CustomExportContentManager() {
+    const [documents, setDocuments] = useState<ExportDocument[]>([]);
+    const [dragActive, setDragActive] = useState(false);
+    const [uploading, setUploading] = useState(false);
+    const [uploadError, setUploadError] = useState<string | null>(null);
+    const [uploadSuccess, setUploadSuccess] = useState<string | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const loadDocuments = useCallback(() => {
+        fetch(import.meta.env.VITE_API_URL + "/api/documents", { mode: "cors" })
+            .then(response => response.json())
+            .then(data => setDocuments(Array.isArray(data) ? data.flatMap(asExportDocument) : []))
+            .catch(() => setDocuments([]));
+    }, []);
+
+    useEffect(() => loadDocuments(), [loadDocuments]);
+
+    const upload = useCallback((file: File) => {
+        const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+        const isAsset = assetExtensions.has(extension);
+        const body = new FormData();
+        body.append("file", file);
+        setUploadError(null);
+        setUploadSuccess(null);
+        setUploading(true);
+        fetch(import.meta.env.VITE_API_URL + `/api/documents/${isAsset ? "assets" : "templates"}`, {
+            mode: "cors",
+            method: "POST",
+            body,
+        })
+            .then(async response => {
+                const data = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    throw new Error(data?.error || `${isAsset ? "Upload" : "Import"} failed (${response.status})`);
+                }
+                setUploadSuccess(isAsset
+                    ? `Uploaded "${data?.name ?? file.name}".`
+                    : `Imported "${data?.id ?? file.name}".`);
+                loadDocuments();
+            })
+            .catch(reason => setUploadError(reason instanceof Error ? reason.message : String(reason)))
+            .finally(() => setUploading(false));
+    }, [loadDocuments]);
+
+    const onFilesSelected = useCallback((files: FileList | null) => {
+        if (files?.[0]) upload(files[0]);
+    }, [upload]);
+
+    const customReports = documents.filter(document => document.category.includes("custom"));
+    const assets = documents.filter(document => document.category.includes("assets"));
+
+    return <div className="space-y-5">
+        <div>
+            <h2 className="text-xl font-bold text-white">Custom reports and assets</h2>
+            <p className="mt-1 text-sm text-zinc-400">Upload report templates and the image assets used by those templates.</p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <section className="rounded-lg border border-slate-600 bg-slate-900/40 p-4" aria-labelledby="custom-reports-heading">
+                <h3 id="custom-reports-heading" className="flex items-center gap-2 text-sm font-semibold text-white"><FontAwesomeIcon icon={faFileLines} className="text-cyan-400" />Custom reports ({customReports.length})</h3>
+                <ul className="mt-3 max-h-44 space-y-2 overflow-y-auto text-sm text-zinc-300">
+                    {customReports.map(report => <li key={report.id} className="rounded border border-slate-700 bg-neutral-800 px-3 py-2">{report.id}</li>)}
+                    {customReports.length === 0 && <li className="italic text-zinc-500">No custom reports installed.</li>}
+                </ul>
+            </section>
+            <section className="rounded-lg border border-slate-600 bg-slate-900/40 p-4" aria-labelledby="custom-assets-heading">
+                <h3 id="custom-assets-heading" className="flex items-center gap-2 text-sm font-semibold text-white"><FontAwesomeIcon icon={faImage} className="text-cyan-400" />Custom assets ({assets.length})</h3>
+                <ul className="mt-3 max-h-44 space-y-2 overflow-y-auto text-sm text-zinc-300">
+                    {assets.map(asset => <li key={asset.id} className="rounded border border-slate-700 bg-neutral-800 px-3 py-2">{asset.id}</li>)}
+                    {assets.length === 0 && <li className="italic text-zinc-500">No custom assets installed.</li>}
+                </ul>
+            </section>
+        </div>
+
+        <input ref={fileInputRef} type="file" className="hidden" accept={`${templateAccept},${assetAccept}`} onChange={event => { onFilesSelected(event.target.files); event.target.value = ""; }} />
+        <button
+            type="button"
+            onClick={() => !uploading && fileInputRef.current?.click()}
+            onDragOver={event => { event.preventDefault(); setDragActive(true); }}
+            onDragEnter={event => { event.preventDefault(); setDragActive(true); }}
+            onDragLeave={event => { event.preventDefault(); setDragActive(false); }}
+            onDrop={event => { event.preventDefault(); setDragActive(false); onFilesSelected(event.dataTransfer.files); }}
+            aria-label="Upload a custom report or asset"
+            className={`flex w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed px-6 py-7 text-center transition-colors ${dragActive ? "border-sky-400 bg-sky-900/40 text-white" : "border-white/20 bg-gray-700/40 text-white/70 hover:border-white/35 hover:text-white"} ${uploading ? "cursor-wait opacity-70" : ""}`}
+            disabled={uploading}
+        >
+            <FontAwesomeIcon icon={uploading ? faSpinner : faCloudArrowUp} className={`text-2xl ${uploading ? "animate-spin" : ""}`} aria-hidden="true" />
+            <span className="text-base font-medium">{uploading ? "Uploading file..." : "Drag and drop a custom report or asset here, or click to browse"}</span>
+            <span className="text-xs text-white/60">Reports: .adoc, .html, .md, .csv, .txt, .json, .xml, .tex, .j2 | Assets: .png, .jpg, .webp, .gif</span>
+        </button>
+
+        {uploadError && <div role="alert" className="rounded-lg border border-red-700 bg-red-900/40 px-4 py-2 text-sm text-red-300">{uploadError}</div>}
+        {uploadSuccess && <div role="status" className="flex items-start justify-between gap-2 rounded-lg border border-green-700 bg-green-900/40 px-4 py-2 text-sm text-green-300">
+            <span>{uploadSuccess}</span>
+            <button type="button" onClick={() => setUploadSuccess(null)} aria-label="Dismiss message" className="text-green-300/80 hover:text-white"><FontAwesomeIcon icon={faXmark} /></button>
+        </div>}
+    </div>;
+}

--- a/frontend/src/components/ExportWizard.tsx
+++ b/frontend/src/components/ExportWizard.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBoxArchive, faDownload, faFileLines, faLayerGroup, faShieldHalved, faXmark } from "@fortawesome/free-solid-svg-icons";
+import type { Project } from "../handlers/project";
+import type { Variant } from "../handlers/variant";
+import { queueExport } from "../handlers/exportQueue";
+
+export type ExportDocument = {
+    id: string;
+    category: string[];
+    extension: string;
+};
+
+type ExportMode = "consolidated" | "per_variant";
+type ExportType = "reports" | "sbom";
+type WizardStep = "scope" | "type" | "documents";
+
+type Selection = {
+    key: string;
+    name: string;
+    extension: string;
+    category: string[];
+};
+
+type Props = {
+    isOpen: boolean;
+    embedded?: boolean;
+    project?: Project;
+    variants: Variant[];
+    documents: ExportDocument[];
+    onClose?: () => void;
+};
+
+const reportCategories = [
+    ["all", "All reports"],
+    ["built-in", "Built-in reports"],
+    ["custom", "Custom reports"],
+] as const;
+
+export default function ExportWizard({ isOpen, embedded = false, project, variants, documents, onClose }: Readonly<Props>) {
+    const [step, setStep] = useState<WizardStep>("scope");
+    const [exportType, setExportType] = useState<ExportType | null>(null);
+    const [mode, setMode] = useState<ExportMode>("consolidated");
+    const [category, setCategory] = useState("all");
+    const [selected, setSelected] = useState<Set<string>>(new Set());
+    const [enabledDocuments, setEnabledDocuments] = useState<Set<string>>(new Set());
+    const [selectedVariantIds, setSelectedVariantIds] = useState<Set<string>>(new Set());
+    const [exporting, setExporting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const stepHeadingRef = useRef<HTMLHeadingElement>(null);
+    const focusStepHeadingOnChange = useRef(false);
+
+    const selections = useMemo<Selection[]>(() => documents
+        .filter(document => !document.category.includes("assets") && !document.id.startsWith("assets/"))
+        .flatMap(document =>
+        document.extension.split("|").map(extension => {
+            const normalizedExtension = extension.trim();
+            return {
+                key: `${document.id}\0${normalizedExtension}`,
+                name: document.id,
+                extension: normalizedExtension,
+                category: document.category,
+            };
+        })), [documents]);
+    const visibleSelections = selections.filter(selection => {
+        if (exportType === "sbom") return selection.category.includes("sbom");
+        if (exportType === "reports") {
+            return !selection.category.includes("sbom")
+                && (category === "all" || selection.category.includes(category));
+        }
+        return false;
+    });
+    const selectionGroups = Array.from(visibleSelections.reduce((groups, selection) => {
+        const group = groups.get(selection.name) ?? [];
+        group.push(selection);
+        groups.set(selection.name, group);
+        return groups;
+    }, new Map<string, Selection[]>()));
+    const activeSteps: WizardStep[] = ["scope", "type", "documents"];
+    const stepLabels: Record<WizardStep, string> = {
+        scope: "Scope",
+        type: "Export type",
+        documents: "Documents",
+    };
+    const stepIndex = activeSteps.indexOf(step);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        setStep("scope");
+        setExportType(null);
+        setMode("consolidated");
+        setCategory("all");
+        setSelected(new Set());
+        setEnabledDocuments(new Set());
+        setError(null);
+        dialogRef.current?.focus();
+    }, [isOpen]);
+
+    useEffect(() => {
+        if (isOpen) setSelectedVariantIds(new Set(variants.map(variant => variant.id)));
+    }, [isOpen, variants]);
+
+    useEffect(() => {
+        if (!focusStepHeadingOnChange.current) return;
+        focusStepHeadingOnChange.current = false;
+        stepHeadingRef.current?.focus();
+    }, [step]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.key === "Escape" && !exporting && !embedded) onClose?.();
+        };
+        document.addEventListener("keydown", handleEscape);
+        return () => document.removeEventListener("keydown", handleEscape);
+    }, [embedded, exporting, isOpen, onClose]);
+
+    if (!isOpen) return null;
+
+    const navigateToStep = (nextStep: WizardStep) => {
+        focusStepHeadingOnChange.current = true;
+        setStep(nextStep);
+    };
+
+    const toggleSelection = (key: string) => {
+        setSelected(current => {
+            const next = new Set(current);
+            if (next.has(key)) next.delete(key);
+            else next.add(key);
+            return next;
+        });
+    };
+
+    const selectVisible = () => {
+        setEnabledDocuments(current => new Set([
+            ...current,
+            ...selectionGroups.map(([name]) => name),
+        ]));
+        setSelected(current => {
+            const next = new Set(current);
+            visibleSelections.forEach(selection => next.add(selection.key));
+            return next;
+        });
+    };
+
+    const clearVisible = () => {
+        setEnabledDocuments(current => {
+            const next = new Set(current);
+            selectionGroups.forEach(([name]) => next.delete(name));
+            return next;
+        });
+        setSelected(current => {
+            const next = new Set(current);
+            visibleSelections.forEach(selection => next.delete(selection.key));
+            return next;
+        });
+    };
+
+    const toggleDocument = (name: string, documentSelections: Selection[]) => {
+        const disabling = enabledDocuments.has(name);
+        setEnabledDocuments(current => {
+            const next = new Set(current);
+            if (disabling) next.delete(name);
+            else next.add(name);
+            return next;
+        });
+        if (disabling || documentSelections.length === 1) {
+            setSelected(current => {
+                const next = new Set(current);
+                documentSelections.forEach(selection => {
+                    if (disabling) next.delete(selection.key);
+                    else next.add(selection.key);
+                });
+                return next;
+            });
+        }
+    };
+
+    const toggleVariant = (variantId: string) => setSelectedVariantIds(current => {
+        const next = new Set(current);
+        if (next.has(variantId)) next.delete(variantId);
+        else next.add(variantId);
+        return next;
+    });
+
+    const launchExport = async () => {
+        if (!project || selectedVariantIds.size === 0 || selected.size === 0) return;
+        setExporting(true);
+        setError(null);
+        try {
+            await queueExport({
+                project_id: project.id,
+                variant_ids: variants
+                    .filter(variant => selectedVariantIds.has(variant.id))
+                    .map(variant => variant.id),
+                mode: exportType === "sbom" ? "per_variant" : mode,
+                documents: selections
+                    .filter(selection => selected.has(selection.key))
+                    .map(({ name, extension }) => ({ name, extension })),
+            }, project.name);
+            if (embedded) {
+                setStep("scope");
+                setExportType(null);
+                setSelected(new Set());
+                setEnabledDocuments(new Set());
+                setSelectedVariantIds(new Set(variants.map(variant => variant.id)));
+            } else {
+                onClose?.();
+            }
+        } catch (reason) {
+            setError(reason instanceof Error ? reason.message : String(reason));
+        } finally {
+            setExporting(false);
+        }
+    };
+
+    return (
+        <div
+            className={embedded ? "w-full" : "fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"}
+            onMouseDown={event => {
+                if (!embedded && event.target === event.currentTarget && !exporting) onClose?.();
+            }}
+        >
+            <div ref={dialogRef} tabIndex={-1} role={embedded ? "region" : "dialog"} aria-modal={embedded ? undefined : true} aria-labelledby="export-wizard-title" className={`w-full rounded-lg border border-gray-600 bg-gray-800 shadow-xl outline-none ${embedded ? "[&_.text-xs]:!text-base [&_.text-sm]:!text-lg [&_h3]:!text-2xl [&_h4]:!text-xl [&_input]:h-5 [&_input]:w-5" : "max-w-2xl"}`}>
+                <div className={`border-b border-neutral-700 ${embedded ? "px-10 py-8" : "px-6 py-4"}`}>
+                    <div className="flex items-center justify-between gap-4">
+                        <div>
+                            <h2 id="export-wizard-title" className={`${embedded ? "text-3xl" : "text-lg"} font-semibold text-white`}>Create export</h2>
+                            <p className="mt-1 text-sm text-neutral-400">Step {stepIndex + 1} of {activeSteps.length}</p>
+                        </div>
+                        {!embedded && <button type="button" onClick={onClose} disabled={exporting} className="text-neutral-400 hover:text-white disabled:text-neutral-600" aria-label="Close export wizard">
+                            <FontAwesomeIcon icon={faXmark} aria-hidden="true" />
+                        </button>}
+                    </div>
+                    <ol className={`${embedded ? "mt-6" : "mt-4"} grid grid-cols-3 gap-3 text-xs`}>
+                        {activeSteps.map((currentStep, index) => (
+                            <li key={currentStep} className={index <= stepIndex ? "text-cyan-300" : "text-neutral-500"}>
+                                <span aria-hidden="true" className="mr-1 font-semibold">{index + 1}.</span>{stepLabels[currentStep]}
+                            </li>
+                        ))}
+                    </ol>
+                </div>
+
+                <div className={`${embedded ? "min-h-[38rem] px-10 py-9" : "min-h-80 px-6 py-5"}`}>
+                    {step === "scope" && <>
+                        <h3 ref={stepHeadingRef} tabIndex={-1} className="text-base font-semibold text-white">Project scope</h3>
+                        {project ? <>
+                            <p className="mt-1 text-sm text-neutral-400">Choose the variants to export from <span className="font-semibold text-white">{project.name}</span>.</p>
+                            <p className="mt-1 text-xs text-neutral-500">Use the project selector in the navigation bar to export another project.</p>
+                            <div className={`mt-5 rounded-lg border border-slate-600 bg-slate-900/40 ${embedded ? "p-6" : "p-4"}`}>
+                                <div className="flex items-center justify-between gap-3">
+                                    <h4 className="text-sm font-semibold text-white">Variants ({selectedVariantIds.size} of {variants.length} selected)</h4>
+                                    {variants.length > 1 && <div className="flex gap-3 text-xs">
+                                        <button type="button" onClick={() => setSelectedVariantIds(new Set(variants.map(variant => variant.id)))} className="rounded border border-cyan-700 px-2.5 py-1 font-medium text-cyan-300 hover:bg-cyan-950/40 hover:text-white">Select all</button>
+                                        <button type="button" onClick={() => setSelectedVariantIds(new Set())} className="rounded border border-neutral-600 px-2.5 py-1 font-medium text-neutral-300 hover:bg-neutral-800 hover:text-white">Clear</button>
+                                    </div>}
+                                </div>
+                                <div className="mt-3 grid max-h-48 grid-cols-1 gap-2 overflow-y-auto pr-1">
+                                    {variants.map(variant => <label key={variant.id} className={`flex cursor-pointer items-center gap-4 rounded-lg border transition-colors ${embedded ? "px-5 py-4" : "px-3 py-2"} text-sm ${selectedVariantIds.has(variant.id) ? "border-cyan-500 bg-cyan-950/40 text-white" : "border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500"}`}>
+                                        <input type="checkbox" checked={selectedVariantIds.has(variant.id)} onChange={() => toggleVariant(variant.id)} className="accent-cyan-500" />
+                                        <span className="truncate font-medium">{variant.name}</span>
+                                    </label>)}
+                                </div>
+                                {variants.length === 0 && <p className="mt-3 text-sm italic text-neutral-500">This project has no variants.</p>}
+                            </div>
+                        </> : <p className="mt-4 rounded border border-amber-700/60 bg-amber-950/30 p-3 text-sm text-amber-200">Select a project from the navigation bar before creating an export.</p>}
+                    </>}
+
+                    {step === "type" && <>
+                        <h3 ref={stepHeadingRef} tabIndex={-1} className="text-base font-semibold text-white">What do you want to export?</h3>
+                        <p className="mt-1 text-sm text-neutral-400">Choose one export family. You will select its individual files in the final step.</p>
+                        <div className={`mt-6 grid grid-cols-1 ${embedded ? "gap-5 xl:grid-cols-2" : "grid-cols-2 gap-3"}`}>
+                            <label className={`flex cursor-pointer items-start rounded-lg border ${embedded ? "gap-5 p-7" : "gap-3 p-4"} ${exportType === "reports" ? "border-cyan-500 bg-cyan-950/40" : "border-slate-600 bg-slate-900/40 hover:border-slate-500"}`}>
+                                <input type="radio" name="export-type" checked={exportType === "reports"} onChange={() => { setExportType("reports"); setSelected(new Set()); setEnabledDocuments(new Set()); }} className="mt-1 accent-cyan-500" />
+                                <FontAwesomeIcon icon={faFileLines} className="mt-0.5 text-cyan-400" aria-hidden="true" />
+                                <span><span className="block font-medium text-white">Reports</span><span className="mt-1 block text-xs text-zinc-400">Built-in and custom reports, consolidated or separated by variant.</span></span>
+                            </label>
+                            <label className={`flex cursor-pointer items-start rounded-lg border ${embedded ? "gap-5 p-7" : "gap-3 p-4"} ${exportType === "sbom" ? "border-cyan-500 bg-cyan-950/40" : "border-slate-600 bg-slate-900/40 hover:border-slate-500"}`}>
+                                <input type="radio" name="export-type" checked={exportType === "sbom"} onChange={() => { setExportType("sbom"); setMode("per_variant"); setSelected(new Set()); setEnabledDocuments(new Set()); }} className="mt-1 accent-cyan-500" />
+                                <FontAwesomeIcon icon={faShieldHalved} className="mt-0.5 text-cyan-400" aria-hidden="true" />
+                                <span><span className="block font-medium text-white">SBOM files</span><span className="mt-1 block text-xs text-zinc-400">Generated per variant and downloaded together as a ZIP archive.</span></span>
+                            </label>
+                        </div>
+                        {exportType === "reports" && <section className="mt-6 border-t border-neutral-700 pt-5" aria-labelledby="output-layout-heading">
+                            <h4 id="output-layout-heading" className="text-sm font-semibold text-white">Output layout</h4>
+                            <p className="mt-1 text-xs text-neutral-400">Choose how project variants are represented in the archive.</p>
+                            <div className={`mt-4 grid grid-cols-1 ${embedded ? "gap-5 xl:grid-cols-2" : "grid-cols-2 gap-3"}`}>
+                            <label className={`flex cursor-pointer items-start rounded-lg border ${embedded ? "gap-5 p-7" : "gap-3 p-4"} ${mode === "consolidated" ? "border-cyan-500 bg-cyan-950/40" : "border-slate-600 bg-slate-900/40 hover:border-slate-500"}`}>
+                                <input type="radio" name="export-mode" checked={mode === "consolidated"} onChange={() => setMode("consolidated")} className="mt-1 accent-cyan-500" />
+                                <FontAwesomeIcon icon={faLayerGroup} className="mt-0.5 text-cyan-400" aria-hidden="true" />
+                                <span><span className="block font-medium text-white">Consolidated</span><span className="mt-1 block text-xs text-zinc-400">Each selected document combines all project variants.</span></span>
+                            </label>
+                            <label className={`flex cursor-pointer items-start rounded-lg border ${embedded ? "gap-5 p-7" : "gap-3 p-4"} ${mode === "per_variant" ? "border-cyan-500 bg-cyan-950/40" : "border-slate-600 bg-slate-900/40 hover:border-slate-500"}`}>
+                                <input type="radio" name="export-mode" checked={mode === "per_variant"} onChange={() => setMode("per_variant")} className="mt-1 accent-cyan-500" />
+                                <FontAwesomeIcon icon={faBoxArchive} className="mt-0.5 text-cyan-400" aria-hidden="true" />
+                                <span><span className="block font-medium text-white">One set per variant</span><span className="mt-1 block text-xs text-zinc-400">The ZIP contains a folder and selected files for each variant.</span></span>
+                            </label>
+                            </div>
+                        </section>}
+                    </>}
+
+                    {step === "documents" && <>
+                        <div className="flex items-start justify-between gap-4">
+                            <div><h3 ref={stepHeadingRef} tabIndex={-1} className="text-base font-semibold text-white">Select {exportType === "sbom" ? "SBOM files" : "reports"}</h3><p className="mt-1 text-sm text-neutral-400">Choose every file to include in the export.</p></div>
+                            <span className="text-sm font-semibold text-cyan-300">{selected.size} selected</span>
+                        </div>
+                        <div className="mt-4 flex flex-wrap gap-1 border-b border-neutral-700 pb-3">
+                            {exportType === "reports" && reportCategories.map(([key, label]) => <button key={key} type="button" onClick={() => setCategory(key)} className={`rounded px-2.5 py-1 text-xs font-medium ${category === key ? "bg-cyan-800 text-white" : "text-neutral-400 hover:bg-neutral-800 hover:text-white"}`}>{label}</button>)}
+                            <div className="ml-auto flex gap-2">
+                                <button type="button" onClick={selectVisible} className="rounded border border-cyan-700 px-2.5 py-1 text-xs font-medium text-cyan-300 hover:bg-cyan-950/40 hover:text-white">Select visible</button>
+                                <button type="button" onClick={clearVisible} className="rounded border border-neutral-600 px-2.5 py-1 text-xs font-medium text-neutral-300 hover:bg-neutral-800 hover:text-white">Clear visible</button>
+                            </div>
+                        </div>
+                        <div className={`mt-3 grid grid-cols-1 gap-2 overflow-y-auto pr-1 ${embedded ? "max-h-96" : "max-h-56"}`}>
+                            {selectionGroups.map(([name, documentSelections]) => {
+                                const documentEnabled = enabledDocuments.has(name);
+                                return <fieldset key={name} className={`rounded-lg border text-sm ${embedded ? "px-5 py-4" : "px-3 py-2.5"} ${documentEnabled ? "border-cyan-500 bg-cyan-950/40" : "border-slate-600 bg-slate-900/40"}`}>
+                                    <legend className="sr-only">{name}</legend>
+                                    <div className="flex items-center gap-3">
+                                        <FontAwesomeIcon icon={faFileLines} className="w-4 text-neutral-400" aria-hidden="true" />
+                                        <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 font-medium text-white">
+                                            <input type="checkbox" aria-label="Include" checked={documentEnabled} onChange={() => toggleDocument(name, documentSelections)} className="accent-cyan-500" />
+                                            <span aria-hidden="true" className="truncate">{name}</span>
+                                        </label>
+                                    </div>
+                                    <div className={`mt-2 flex flex-wrap items-center gap-4 border-t border-slate-700 pt-2 pl-7 ${documentEnabled ? "" : "opacity-40"}`}>
+                                        {documentSelections.map(selection => <label key={selection.key} className={`flex items-center gap-1.5 text-xs font-medium uppercase text-neutral-300 ${documentEnabled && documentSelections.length > 1 ? "cursor-pointer" : "cursor-not-allowed"}`}>
+                                            <input type="checkbox" checked={selected.has(selection.key)} disabled={!documentEnabled || documentSelections.length === 1} onChange={() => toggleSelection(selection.key)} className="accent-cyan-500" />
+                                            {selection.extension}
+                                        </label>)}
+                                    </div>
+                                </fieldset>;
+                            })}
+                            {visibleSelections.length === 0 && <p className="py-8 text-center text-sm text-neutral-500">No documents in this category.</p>}
+                        </div>
+                        {error && <div role="alert" className="mt-3 rounded border border-red-700 bg-red-950/40 px-3 py-2 text-sm text-red-300">{error}</div>}
+                    </>}
+                </div>
+
+                <div className={`flex items-center justify-between border-t border-neutral-700 ${embedded ? "px-10 py-7 [&_button]:px-6 [&_button]:py-3" : "px-6 py-4"}`}>
+                    <button type="button" onClick={() => navigateToStep(activeSteps[stepIndex - 1])} disabled={stepIndex === 0 || exporting} className="rounded px-3 py-1.5 text-sm font-semibold text-neutral-300 hover:bg-neutral-800 disabled:cursor-not-allowed disabled:text-neutral-600">Back</button>
+                    {step !== "documents" ? <button type="button" onClick={() => navigateToStep(activeSteps[stepIndex + 1])} disabled={(step === "scope" && (!project || selectedVariantIds.size === 0)) || (step === "type" && exportType === null)} className="rounded bg-cyan-800 px-3 py-1.5 text-sm font-semibold text-white hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-neutral-700 disabled:text-neutral-500">Next</button> : <button type="button" onClick={launchExport} disabled={selected.size === 0 || exporting} className="rounded bg-cyan-800 px-3 py-1.5 text-sm font-semibold text-white hover:bg-cyan-700 disabled:cursor-not-allowed disabled:bg-neutral-700 disabled:text-neutral-500"><FontAwesomeIcon icon={faDownload} className="mr-2" aria-hidden="true" />{exporting ? "Preparing export..." : "Download export"}</button>}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/OperationQueueModal.tsx
+++ b/frontend/src/components/OperationQueueModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useSyncExternalStore } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBug, faShieldHalved, faLeaf, faCrosshairs, faXmark, faArrowsRotate } from "@fortawesome/free-solid-svg-icons";
+import { faBug, faShieldHalved, faLeaf, faCrosshairs, faXmark, faArrowsRotate, faFileExport } from "@fortawesome/free-solid-svg-icons";
 import OperationQueuePanel from "./OperationQueuePanel";
 import { subscribe as grypeSubscribe, getSnapshot as grypeGetSnapshot, dismiss as grypeDismiss } from "../handlers/grypeScanState";
 import { subscribe as nvdSubscribe, getSnapshot as nvdGetSnapshot, dismiss as nvdDismiss } from "../handlers/nvdScanState";
@@ -8,6 +8,7 @@ import { subscribe as osvSubscribe, getSnapshot as osvGetSnapshot, dismiss as os
 import { subscribe as sccSubscribe, getSnapshot as sccGetSnapshot, dismiss as sccDismiss } from "../handlers/sccScanState";
 import { subscribeToRefreshQueue, getRefreshQueueSnapshot, dismissRefreshQueueEntry } from "../handlers/activeScanQueue";
 import type { RefreshType } from "../handlers/activeScanQueue";
+import { subscribe as exportSubscribe, getSnapshot as exportGetSnapshot, dismiss as exportDismiss } from "../handlers/exportQueue";
 
 type Props = {
     isOpen: boolean;
@@ -19,6 +20,7 @@ const nvdColors = { border: "border-orange-700/60", headerBg: "bg-orange-900/40"
 const osvColors = { border: "border-green-700/60", headerBg: "bg-green-900/40", iconText: "text-green-400", titleText: "text-green-200", subtitleText: "text-green-300/80", bar: "bg-green-500" };
 const sccColors = { border: "border-sky-700/60", headerBg: "bg-sky-900/40", iconText: "text-sky-400", titleText: "text-sky-200", subtitleText: "text-sky-300/80", bar: "bg-sky-500" };
 const refreshColors = { border: "border-cyan-700/60", headerBg: "bg-cyan-900/40", iconText: "text-cyan-400", titleText: "text-cyan-200", subtitleText: "text-cyan-300/80", bar: "bg-cyan-500" };
+const exportColors = { border: "border-teal-700/60", headerBg: "bg-teal-900/40", iconText: "text-teal-400", titleText: "text-teal-200", subtitleText: "text-teal-300/80", bar: "bg-teal-500" };
 
 function OperationQueueModal({ isOpen, onClose }: Readonly<Props>) {
     const overlayRef = useRef<HTMLDivElement>(null);
@@ -27,6 +29,7 @@ function OperationQueueModal({ isOpen, onClose }: Readonly<Props>) {
     const osvEntries = useSyncExternalStore(osvSubscribe, osvGetSnapshot);
     const sccEntries = useSyncExternalStore(sccSubscribe, sccGetSnapshot);
     const refreshEntries = useSyncExternalStore(subscribeToRefreshQueue, getRefreshQueueSnapshot);
+    const exportEntries = useSyncExternalStore(exportSubscribe, exportGetSnapshot);
 
     useEffect(() => {
         if (!isOpen) return;
@@ -40,7 +43,7 @@ function OperationQueueModal({ isOpen, onClose }: Readonly<Props>) {
 
     if (!isOpen) return null;
 
-    const hasEntries = grypeEntries.length + nvdEntries.length + osvEntries.length + sccEntries.length + refreshEntries.length > 0;
+    const hasEntries = grypeEntries.length + nvdEntries.length + osvEntries.length + sccEntries.length + refreshEntries.length + exportEntries.length > 0;
 
     return (
         <div
@@ -85,6 +88,9 @@ function OperationQueueModal({ isOpen, onClose }: Readonly<Props>) {
                             ))}
                             {refreshEntries.map(entry => (
                                 <OperationQueuePanel key={entry.variantId} entry={entry} label="Vulnerability Data Refresh" icon={faArrowsRotate} colors={refreshColors} onDismiss={() => dismissRefreshQueueEntry(entry.variantId as RefreshType)} />
+                            ))}
+                            {exportEntries.map(entry => (
+                                <OperationQueuePanel key={entry.variantId} entry={entry} label="Export" icon={faFileExport} colors={exportColors} onDismiss={() => exportDismiss(entry.variantId)} />
                             ))}
                         </div>
                     ) : (

--- a/frontend/src/handlers/exportDocuments.ts
+++ b/frontend/src/handlers/exportDocuments.ts
@@ -1,0 +1,25 @@
+export type ExportDocument = {
+    id: string;
+    category: string[];
+    extension: string;
+};
+
+export function asExportDocument(data: unknown): ExportDocument | [] {
+    if (typeof data !== "object" || data === null || !("id" in data) || typeof data.id !== "string") {
+        return [];
+    }
+    const category = "category" in data && Array.isArray(data.category)
+        ? data.category.filter((entry): entry is string => typeof entry === "string")
+        : [];
+    const extension = "extension" in data && typeof data.extension === "string"
+        ? data.extension
+        : data.id.split(".").at(-1) ?? "unk";
+    return { id: data.id, category, extension };
+}
+
+export async function listExportDocuments(): Promise<ExportDocument[]> {
+    const response = await fetch(import.meta.env.VITE_API_URL + "/api/documents", { mode: "cors" });
+    if (!response.ok) throw new Error(`Failed to load custom reports and assets (${response.status})`);
+    const data: unknown = await response.json();
+    return Array.isArray(data) ? data.flatMap(asExportDocument) : [];
+}

--- a/frontend/src/handlers/exportQueue.ts
+++ b/frontend/src/handlers/exportQueue.ts
@@ -1,0 +1,144 @@
+import type { ScanEntryState, ScanManagerSnapshot } from "./scanStateManager";
+
+export type ExportRequest = {
+    project_id: string;
+    variant_ids: string[];
+    mode: "consolidated" | "per_variant";
+    documents: Array<{ name: string; extension: string }>;
+};
+
+type ExportStatus = {
+    status: "running" | "done" | "error";
+    current: number;
+    total: number;
+    progress: string;
+    logs: string[];
+    error: string | null;
+};
+
+const POLL_INTERVAL_MS = 1000;
+const MAX_POLL_FAILURES = 3;
+const states = new Map<string, ScanEntryState>();
+const listeners = new Set<() => void>();
+let snapshot: ScanManagerSnapshot = [];
+let nextOperationId = 1;
+
+function publish() {
+    snapshot = [...states.values()];
+    listeners.forEach(listener => listener());
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+}
+
+function responseFilename(response: Response, fallback: string): string {
+    const disposition = response.headers.get("Content-Disposition") ?? "";
+    return disposition.match(/filename="?([^";]+)/)?.[1] ?? fallback;
+}
+
+function updateEntry(localId: string, update: Partial<ScanEntryState>) {
+    const current = states.get(localId);
+    if (!current) return;
+    states.set(localId, { ...current, ...update });
+    publish();
+}
+
+async function pollExport(
+    localId: string,
+    jobId: string,
+    fallbackFilename: string,
+    failedAttempts = 0,
+): Promise<void> {
+    try {
+        const response = await fetch(`${import.meta.env.VITE_API_URL}/api/documents/export/${jobId}`, { mode: "cors" });
+        if (!response.ok) throw new Error(`Failed to check export progress (${response.status})`);
+        const status = await response.json() as ExportStatus;
+        updateEntry(localId, {
+            status: status.status === "error" ? "error" : status.status === "done" ? "done" : "running",
+            error: status.error,
+            progress: status.progress,
+            logs: status.logs,
+            total: status.total,
+            doneCount: status.status === "done" ? status.total : Math.max(0, status.current - 1),
+        });
+
+        if (status.status === "running") {
+            setTimeout(() => void pollExport(localId, jobId, fallbackFilename), POLL_INTERVAL_MS);
+            return;
+        }
+        if (status.status === "error") return;
+
+        const download = await fetch(`${import.meta.env.VITE_API_URL}/api/documents/export/${jobId}/download`, { mode: "cors" });
+        if (!download.ok) throw new Error(`Failed to download export (${download.status})`);
+        downloadBlob(await download.blob(), responseFilename(download, fallbackFilename));
+    } catch (reason) {
+        const message = reason instanceof Error ? reason.message : String(reason);
+        if (failedAttempts < MAX_POLL_FAILURES) {
+            updateEntry(localId, { status: "running", error: null, progress: "Reconnecting to export", logs: [message] });
+            setTimeout(
+                () => void pollExport(localId, jobId, fallbackFilename, failedAttempts + 1),
+                POLL_INTERVAL_MS,
+            );
+            return;
+        }
+        updateEntry(localId, { status: "error", error: message, progress: "Export failed", logs: [message] });
+    }
+}
+
+export const subscribe = (listener: () => void): (() => void) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+};
+
+export const getSnapshot = (): ScanManagerSnapshot => snapshot;
+
+export const dismiss = (localId: string) => {
+    const state = states.get(localId);
+    if (!state || state.status === "running" || state.status === "queued") return;
+    states.delete(localId);
+    publish();
+};
+
+export async function queueExport(request: ExportRequest, projectName: string): Promise<void> {
+    const localId = `export-${nextOperationId++}`;
+    const scopeCount = request.mode === "per_variant" ? request.variant_ids.length : 1;
+    states.set(localId, {
+        variantId: localId,
+        variantName: projectName,
+        status: "running",
+        error: null,
+        progress: "Queued",
+        logs: [],
+        total: scopeCount * request.documents.length,
+        doneCount: 0,
+    });
+    publish();
+
+    try {
+        const response = await fetch(import.meta.env.VITE_API_URL + "/api/documents/export", {
+            method: "POST",
+            mode: "cors",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ ...request, async: true }),
+        });
+        const body = await response.json().catch(() => ({}));
+        if (!response.ok || typeof body.job_id !== "string") {
+            throw new Error(body.error || `Export failed (${response.status})`);
+        }
+        const suffix = request.mode === "consolidated" ? "consolidated" : "by_variant";
+        const fallbackFilename = `${projectName}_${suffix}_export.zip`;
+        void pollExport(localId, body.job_id, fallbackFilename);
+    } catch (reason) {
+        const message = reason instanceof Error ? reason.message : String(reason);
+        updateEntry(localId, { status: "error", error: message, progress: "Export failed", logs: [message] });
+        throw reason;
+    }
+}

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from "react";
 import NavigationBar from "../components/NavigationBar";
 import OperationQueueModal from "../components/OperationQueueModal";
+import { subscribe as exportSubscribe, getSnapshot as exportGetSnapshot } from "../handlers/exportQueue";
 import MessageBanner from "../components/MessageBanner";
 import Popup from "../components/Popup";
 import type { Package } from "../handlers/packages";
@@ -87,7 +88,8 @@ function Explorer() {
     const osvScanEntries = useSyncExternalStore(osvSubscribe, osvGetSnapshot);
     const sccScanEntries = useSyncExternalStore(sccSubscribe, sccGetSnapshot);
     const refreshQueueEntries = useSyncExternalStore(subscribeToRefreshQueue, getRefreshQueueSnapshot);
-    const scanEntries = [...grypeScanEntries, ...nvdScanEntries, ...osvScanEntries, ...sccScanEntries, ...refreshQueueEntries];
+    const exportEntries = useSyncExternalStore(exportSubscribe, exportGetSnapshot);
+    const scanEntries = [...grypeScanEntries, ...nvdScanEntries, ...osvScanEntries, ...sccScanEntries, ...refreshQueueEntries, ...exportEntries];
     const trackedScanCount = scanEntries.length;
     const finishedScanCount = scanEntries
         .filter(entry => entry.status === "done" || entry.status === "error" || entry.status === "cancelled").length;

--- a/frontend/src/pages/Exports.tsx
+++ b/frontend/src/pages/Exports.tsx
@@ -1,351 +1,90 @@
-import { useEffect, useState, useCallback, useRef } from "react";
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-    faThumbTack, faFolderOpen, faFileShield, faBoxes, faCloudArrowUp, faSpinner, faXmark, faImage,
-} from "@fortawesome/free-solid-svg-icons";
-import FileTag from "../components/FileTag";
-import PopupExportOptions from "../components/PopupExportOptions";
-import type { Options as PopupOptions } from "../components/PopupExportOptions";
-import ConfirmationModal from "../components/ConfirmationModal";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faGear } from "@fortawesome/free-solid-svg-icons";
+import ExportWizard from "../components/ExportWizard";
+import type { ExportDocument } from "../components/ExportWizard";
 import Projects from "../handlers/project";
 import type { Project } from "../handlers/project";
 import Variants from "../handlers/variant";
 import type { Variant } from "../handlers/variant";
 
-
-type ExportDoc = {
-    id: string;
-    category: string[];
-    extension: string;
-}
-
-const assetExtensions = new Set(["png", "jpg", "jpeg", "gif", "webp"]);
-const templateAccept = ".adoc,.asciidoc,.html,.htm,.md,.markdown,.csv,.txt,.json,.xml,.tex,.j2,.jinja,.jinja2";
-const assetAccept = ".png,.jpg,.jpeg,.gif,.webp";
-
-const asExportDoc = (data: any): ExportDoc | [] => {
-    if (typeof data !== "object") return [];
-    if (typeof data?.id !== "string") return [];
-    let item: ExportDoc = {
+const asExportDocument = (data: any): ExportDocument | [] => {
+    if (typeof data !== "object" || typeof data?.id !== "string") return [];
+    return {
         id: data.id,
-        category: [],
-        extension: "unk"
+        category: Array.isArray(data.category)
+            ? data.category.filter((entry: any) => typeof entry === "string")
+            : [],
+        extension: typeof data.extension === "string"
+            ? data.extension
+            : data.id.split(".").at(-1) ?? "unk",
     };
-    if (Array.isArray(data?.category))
-        item.category = data.category.filter((e: any) => typeof e === "string");
-    if (typeof data?.extension === "string")
-        item.extension = data.extension;
-    else if (typeof data?.id?.split('.')?.at(-1) === "string")
-        item.extension = data.id.split('.').at(-1);
-    return item
-}
-
-
-type PendingDownload = {
-  exportType: string;
-  url: string;
 };
 
 type Props = {
-  variantId?: string;
-  projectId?: string;
-  variantIds?: string[];
+    projectId?: string;
+    variantId?: string;
+    variantIds?: string[];
 };
 
-function Exports ({ variantId, projectId, variantIds }: Readonly<Props>) {
-    const [tab, setTab] = useState<string>("all");
-    const [docs, setDocs] = useState<ExportDoc[]>([]);
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [variants, setVariants] = useState<Variant[]>([]);
-    const [openDl, setOpenDl] = useState<string | null>(null);
-  const [pendingDownload, setPendingDownload] = useState<PendingDownload | null>(null);
-    const [popupOptions, setPopupOptions] = useState<PopupOptions|undefined>(undefined);
-    const [dragActive, setDragActive] = useState<boolean>(false);
-    const [uploading, setUploading] = useState<boolean>(false);
-    const [uploadError, setUploadError] = useState<string | null>(null);
-    const [uploadSuccess, setUploadSuccess] = useState<string | null>(null);
-    const fileInputRef = useRef<HTMLInputElement>(null);
+function Exports({ projectId }: Readonly<Props>) {
+    const [documents, setDocuments] = useState<ExportDocument[]>([]);
+    const [projects, setProjects] = useState<Project[]>([]);
+    const [variants, setVariants] = useState<Variant[]>([]);
+    const variantLoadGeneration = useRef(0);
 
-    const loadDocs = useCallback(() => {
-        fetch(import.meta.env.VITE_API_URL + "/api/documents", {
-            mode: 'cors'
-        })
-        .then(res => res.json())
-        .then(data => {
-            if (Array.isArray(data)) {
-                setDocs(data.flatMap(asExportDoc));
-            }
-        })
-        .catch(error => {
-            console.error('Error:', error);
-        })
+    const loadDocuments = useCallback(() => {
+        fetch(import.meta.env.VITE_API_URL + "/api/documents", { mode: "cors" })
+            .then(response => response.json())
+            .then(data => setDocuments(Array.isArray(data) ? data.flatMap(asExportDocument) : []))
+            .catch(error => {
+                console.error("Error:", error);
+                setDocuments([]);
+            });
     }, []);
 
+    useEffect(() => loadDocuments(), [loadDocuments]);
     useEffect(() => {
-        loadDocs();
-    }, [loadDocs]);
-
-    useEffect(() => {
-      Projects.list().then(setProjects).catch(() => setProjects([]));
+        Projects.list().then(setProjects).catch(() => setProjects([]));
     }, []);
-
     useEffect(() => {
-      if (!projectId) {
+        const generation = ++variantLoadGeneration.current;
         setVariants([]);
-        return;
-      }
-      Variants.list(projectId).then(setVariants).catch(() => setVariants([]));
+        if (!projectId) {
+            return;
+        }
+        Variants.list(projectId)
+            .then(result => {
+                if (generation === variantLoadGeneration.current) setVariants(result);
+            })
+            .catch(() => {
+                if (generation === variantLoadGeneration.current) setVariants([]);
+            });
     }, [projectId]);
 
-    const uploadTemplate = useCallback((file: File) => {
-        setUploadError(null);
-        setUploadSuccess(null);
-        setUploading(true);
-        const body = new FormData();
-        body.append("file", file);
-        fetch(import.meta.env.VITE_API_URL + "/api/documents/templates", {
-            mode: 'cors',
-            method: 'POST',
-            body,
-        })
-        .then(async (res) => {
-            const data = await res.json().catch(() => ({}));
-            if (!res.ok) {
-                throw new Error(data?.error || `Import failed (${res.status})`);
-            }
-            setUploadSuccess(`Imported "${data?.id ?? file.name}".`);
-            setTab("custom");
-            loadDocs();
-        })
-        .catch((error) => {
-            setUploadError(error instanceof Error ? error.message : String(error));
-        })
-        .finally(() => {
-            setUploading(false);
-        });
-    }, [loadDocs]);
+    const project = projects.find(current => current.id === projectId);
 
-    const uploadAsset = useCallback((file: File) => {
-        setUploadError(null);
-        setUploadSuccess(null);
-        setUploading(true);
-        const body = new FormData();
-        body.append("file", file);
-        fetch(import.meta.env.VITE_API_URL + "/api/documents/assets", {
-            mode: 'cors',
-            method: 'POST',
-            body,
-        })
-        .then(async (res) => {
-            const data = await res.json().catch(() => ({}));
-            if (!res.ok) {
-                throw new Error(data?.error || `Upload failed (${res.status})`);
-            }
-            setUploadSuccess(`Uploaded "${data?.name ?? file.name}".`);
-            setTab("assets");
-            loadDocs();
-        })
-        .catch((error) => {
-            setUploadError(error instanceof Error ? error.message : String(error));
-        })
-        .finally(() => {
-            setUploading(false);
-        });
-    }, [loadDocs]);
-
-    const onFilesSelected = useCallback((files: FileList | null) => {
-        if (files && files.length > 0) {
-        const extension = files[0].name.split(".").pop()?.toLowerCase() ?? "";
-        if (tab === "assets" || (tab === "all" && assetExtensions.has(extension))) {
-                uploadAsset(files[0]);
-            } else {
-                uploadTemplate(files[0]);
-            }
-        }
-    }, [tab, uploadAsset, uploadTemplate]);
-
-    const onDrop = useCallback((e: React.DragEvent<HTMLElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-        setDragActive(false);
-        onFilesSelected(e.dataTransfer.files);
-    }, [onFilesSelected]);
-
-    const visibleDocs = docs.filter((doc) =>
-      (doc.category.includes(tab) || tab === "all")
-      && (tab !== "custom" || !assetExtensions.has(doc.extension.toLowerCase()))
-    );
-    const selectedVariantIds = variantIds?.length ? variantIds : (variantId ? [variantId] : []);
-    const scopedVariants = selectedVariantIds.length
-      ? variants.filter(variant => selectedVariantIds.includes(variant.id))
-      : variants;
-    const projectName = projects.find(project => project.id === projectId)?.name ?? 'the selected project';
-
-    const handleContinueDownload = () => {
-      if (!pendingDownload) return;
-      window.open(pendingDownload.url, '_blank', 'noopener,noreferrer');
-      setPendingDownload(null);
-    };
-
-
-    return (<>
-        <div className="w-full pt-32 flex justify-center" onClick={() => setOpenDl(null)}>
-        <div className="w-[70%]">
-            <h1 className="text-3xl font-bold mb-4">Export</h1>
-            <p className="mb-6">Generate reports and SBOM files from your scan results.</p>
-
-            {/* Tabs */}
-            <div className="flex gap-2 bg-sky-800 rounded-2xl p-2 shadow-lg backdrop-blur-md justify-center">
-            {[
-                { key: "all", icon: faBoxes, label: "All" },
-
-                { key: "built-in", icon: faThumbTack, label: "Built-in reports" },
-                { key: "custom", icon: faFolderOpen, label: "Custom reports" },
-                { key: "assets", icon: faImage, label: "Custom assets" },
-                { key: "sbom", icon: faFileShield, label: "SBOM files" },
-            ].map(({ key, icon, label }) => (
-                <button
-                key={key}
-                onClick={(e) => {
-                    e.stopPropagation()
-                    setTab(key)
-                    setOpenDl(null)
-                }}
-                className={[
-                    "flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200",
-                    tab === key
-                    ? "bg-white/20 text-white shadow-inner"
-                    : "text-white/70 hover:text-white hover:bg-white/10",
-                ].join(" ")}
-                >
-                <FontAwesomeIcon icon={icon} className="w-4 h-4" />
-                {label}
-                </button>
-            ))}
+    return <div className="w-full space-y-6">
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-3xl font-bold text-white">Export</h1>
+                <p className="mt-2 text-base text-neutral-400">Generate reports and SBOM files for the selected project.</p>
             </div>
-    </div>
-</div>
 
-<div className="w-full pt-4 flex justify-center">
-  <div className="w-[70%] bg-gray-700 from-zinc-800 to-zinc-900 rounded-3xl p-6 grid grid-cols-3 gap-6 justify-center shadow-xl border border-white/10 backdrop-blur-sm">
-    {visibleDocs.map((doc) => (
-      <FileTag
-        name={doc.id}
-        key={encodeURIComponent(doc.id)}
-        extension={doc.extension}
-        variantId={variantId}
-        projectId={projectId}
-        opened={openDl === doc.id}
-        onOpen={() => openDl === doc.id ? setOpenDl(null) : setOpenDl(doc.id)}
-        onRequestDownload={(exportType, url) => setPendingDownload({ exportType, url })}
-      />
-    ))}
+            <div className="flex items-center gap-4 rounded-lg border border-sky-800/70 bg-sky-950/30 px-6 py-5 text-lg text-sky-100">
+                <FontAwesomeIcon icon={faGear} className="shrink-0 text-sky-400" aria-hidden="true" />
+                <p>Custom report templates and their image assets can be managed from <span className="font-semibold text-white">Settings &gt; Custom reports &amp; assets</span>.</p>
+            </div>
 
-    {visibleDocs.length === 0 && (
-      <div className="col-span-2 flex flex-col items-center justify-center text-white/70 w-full py-10">
-        <div className="text-lg font-medium">No documents found</div>
-        {tab === 'custom' && (
-          <div className="mt-2 text-sm">
-            You can upload your own templates in
-            <code className="p-1 mx-1 bg-white/10 rounded">.vulnscout/templates</code>
-          </div>
-        )}
-      </div>
-    )}
-  </div>
-</div>
-
-{(tab === 'custom' || tab === 'assets' || tab === 'all') && (
-<div className="w-full pt-4 flex justify-center">
-  <div className="w-[70%]">
-    <input
-      ref={fileInputRef}
-      type="file"
-      className="hidden"
-      accept={tab === "assets" ? assetAccept : tab === "all" ? `${templateAccept},${assetAccept}` : templateAccept}
-      onChange={(e) => { onFilesSelected(e.target.files); e.target.value = ""; }}
-    />
-    <button
-      type="button"
-      onClick={() => !uploading && fileInputRef.current?.click()}
-      onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true); }}
-      onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true); }}
-      onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(false); }}
-      onDrop={onDrop}
-      aria-label="Upload a custom report or asset"
-      className={[
-        "w-full flex flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed",
-        "px-6 py-8 text-center transition-colors duration-150 cursor-pointer",
-        dragActive
-          ? "border-sky-400 bg-sky-900/40 text-white"
-          : "border-white/20 bg-gray-700/40 text-white/70 hover:border-white/35 hover:text-white",
-        uploading && "cursor-wait opacity-70",
-      ].filter(Boolean).join(" ")}
-      disabled={uploading}
-    >
-      <FontAwesomeIcon
-        icon={uploading ? faSpinner : faCloudArrowUp}
-        className={["text-2xl", uploading && "animate-spin"].filter(Boolean).join(" ")}
-        aria-hidden="true"
-      />
-      <div className="text-base font-medium">
-        {uploading ? "Uploading file…" : "Drag & drop a custom report or asset here, or click to browse"}
-      </div>
-      <div className="text-xs text-white/60">
-        {tab === "assets"
-          ? "Assets: .png, .jpg, .webp, .gif (SVG is not accepted for upload)"
-          : tab === "custom"
-            ? "Reports: .adoc, .html, .md, .csv, .txt, .json, .xml, .tex, .j2"
-            : "Reports: .adoc, .html, .md, .csv, .txt, .json, .xml, .tex, .j2 · Assets: .png, .jpg, .webp, .gif"}
-      </div>
-    </button>
-    {uploadError && (
-      <div role="alert" className="mt-3 text-sm text-red-300 bg-red-900/40 border border-red-700 rounded-lg px-4 py-2">
-        {uploadError}
-      </div>
-    )}
-    {uploadSuccess && (
-      <div role="status" className="mt-3 flex items-start justify-between gap-2 text-sm text-green-300 bg-green-900/40 border border-green-700 rounded-lg px-4 py-2">
-        <span>{uploadSuccess}</span>
-        <button
-          type="button"
-          onClick={() => setUploadSuccess(null)}
-          aria-label="Dismiss message"
-          className="shrink-0 text-green-300/80 hover:text-white transition-colors"
-        >
-          <FontAwesomeIcon icon={faXmark} className="w-4 h-4" />
-        </button>
-      </div>
-    )}
-
-  </div>
-</div>
-)}
-
-
-
-        {popupOptions && <PopupExportOptions
-            docName={popupOptions.docName}
-            extension={popupOptions.extension}
-            onClose={() => {setPopupOptions(undefined)}}
-        ></PopupExportOptions>}
-        <ConfirmationModal
-          isOpen={pendingDownload !== null}
-          title="Confirm export"
-          message=""
-          confirmText="Continue"
-          cancelText="Cancel"
-          onConfirm={handleContinueDownload}
-          onCancel={() => setPendingDownload(null)}
-        >
-          <p>This will export {pendingDownload?.exportType} for the project {projectName}.</p>
-          <p className="mt-4">It covers the following variants:</p>
-          <ul className="mt-2 list-disc list-inside text-left">
-            {scopedVariants.map(variant => <li key={variant.id}>{variant.name}</li>)}
-          </ul>
-          <p className="mt-4">You can change the export scope using the selector in the upper-right corner of the page.</p>
-        </ConfirmationModal>
-    </>);
+            <ExportWizard
+                isOpen={true}
+                embedded={true}
+                project={project}
+                variants={variants}
+                documents={documents}
+            />
+        </div>
+    </div>;
 }
 
 export default Exports;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -18,6 +18,7 @@ import {
   faGear,
   faRightLeft,
   faCircleQuestion,
+  faFileExport,
 } from "@fortawesome/free-solid-svg-icons";
 import Projects from "../handlers/project";
 import type { Project } from "../handlers/project";
@@ -38,6 +39,7 @@ import {
   vulnerabilityRefreshSources,
 } from "../helpers/refreshSources";
 import type { RefreshMode } from "../helpers/refreshSources";
+import CustomExportContentManager from "../components/CustomExportContentManager";
 
 type Props = {
   onDataChanged?: (message?: string) => void;
@@ -46,7 +48,7 @@ type Props = {
   initialTab?: SettingsTab;
 };
 
-type SettingsTab = "general" | "transfer" | "projects" | "variants";
+type SettingsTab = "general" | "transfer" | "custom-export" | "projects" | "variants";
 type FeedbackMsg = { text: string; type: "success" | "error" } | null;
 type AdditionalCleanup =
   | { kind: "empty-scans"; scans: EmptyScanPreview[] }
@@ -754,6 +756,9 @@ function Settings({ onDataChanged, onLoadingMessage, projectId, initialTab }: Re
   } else if (activeTab === "transfer") {
     crumbs.push("Transfer");
     pageTitle = "Transfer Assessments";
+  } else if (activeTab === "custom-export") {
+    crumbs.push("Custom reports & assets");
+    pageTitle = "Custom reports & assets";
   } else {
     crumbs.push("General Settings");
   }
@@ -787,6 +792,17 @@ function Settings({ onDataChanged, onLoadingMessage, projectId, initialTab }: Re
             >
               <FontAwesomeIcon icon={faRightLeft} className="w-4 text-sky-400" aria-hidden="true" />
               Transfer Assessments
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab("custom-export")}
+              aria-current={activeTab === "custom-export" ? "page" : undefined}
+              className={`mt-1 flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                activeTab === "custom-export" ? "bg-sky-900 text-white" : "text-slate-300 hover:bg-slate-700 hover:text-white"
+              }`}
+            >
+              <FontAwesomeIcon icon={faFileExport} className="w-4 text-sky-400" aria-hidden="true" />
+              Custom reports &amp; assets
             </button>
 
             <div className="my-3 border-t border-slate-700" />
@@ -1399,6 +1415,10 @@ function Settings({ onDataChanged, onLoadingMessage, projectId, initialTab }: Re
 
         {activeTab === "transfer" && (
           <Transfer projectId={projectId} onDataChanged={onDataChanged} />
+        )}
+
+        {activeTab === "custom-export" && (
+          <CustomExportContentManager />
         )}
 
         {/* ======== Variants Settings tab ======== */}

--- a/frontend/tests/unit_tests/test_custom_export_content_manager.tsx
+++ b/frontend/tests/unit_tests/test_custom_export_content_manager.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+// @ts-expect-error TS6133
+import React from 'react';
+import CustomExportContentManager from '../../src/components/CustomExportContentManager';
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+    return {
+        ok,
+        status,
+        json: jest.fn().mockResolvedValue(body),
+    } as unknown as Response;
+}
+
+describe('CustomExportContentManager', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn();
+    });
+
+    test('falls back to empty lists when loading documents fails', async () => {
+        const fetch = global.fetch as jest.MockedFunction<typeof global.fetch>;
+        fetch.mockRejectedValueOnce(new Error('Network unavailable'));
+
+        render(<CustomExportContentManager />);
+
+        expect(await screen.findByText('No custom reports installed.')).toBeInTheDocument();
+        expect(screen.getByText('No custom assets installed.')).toBeInTheDocument();
+    });
+
+    test('uploads an asset by drag and drop, reloads documents, and dismisses success', async () => {
+        const fetch = global.fetch as jest.MockedFunction<typeof global.fetch>;
+        fetch
+            .mockResolvedValueOnce(jsonResponse([]))
+            .mockResolvedValueOnce(jsonResponse({ name: 'logo.png' }))
+            .mockResolvedValueOnce(jsonResponse([
+                { id: 'logo.png', category: ['assets'], extension: 'png' },
+            ]));
+        render(<CustomExportContentManager />);
+        const upload = await screen.findByRole('button', { name: 'Upload a custom report or asset' });
+        const file = new File(['image'], 'logo.PNG', { type: 'image/png' });
+
+        fireEvent.dragEnter(upload);
+        expect(upload.className).toContain('border-sky-400');
+        fireEvent.dragLeave(upload);
+        expect(upload.className).not.toContain('border-sky-400');
+        fireEvent.dragOver(upload);
+        fireEvent.drop(upload, { dataTransfer: { files: [file] } });
+
+        expect(await screen.findByText('Uploaded "logo.png".')).toBeInTheDocument();
+        expect(await screen.findByText('logo.png')).toBeInTheDocument();
+        const uploadCall = fetch.mock.calls.find(([url, options]) =>
+            String(url).endsWith('/api/documents/assets') && options?.method === 'POST');
+        expect(uploadCall).toBeDefined();
+        expect((uploadCall?.[1]?.body as FormData).get('file')).toBe(file);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Dismiss message' }));
+        expect(screen.queryByText('Uploaded "logo.png".')).not.toBeInTheDocument();
+    });
+
+    test('shows the server fallback error and restores the upload control', async () => {
+        const fetch = global.fetch as jest.MockedFunction<typeof global.fetch>;
+        fetch
+            .mockResolvedValueOnce(jsonResponse([]))
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 415,
+                json: jest.fn().mockRejectedValue(new Error('Invalid JSON')),
+            } as unknown as Response);
+        const { container } = render(<CustomExportContentManager />);
+        await screen.findByText('No custom reports installed.');
+        const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+        fireEvent.change(input, {
+            target: { files: [new File(['report'], 'report.adoc', { type: 'text/asciidoc' })] },
+        });
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Import failed (415)');
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Upload a custom report or asset' })).toBeEnabled());
+        expect(fetch).toHaveBeenCalledWith('http://localhost/api/documents/templates', expect.objectContaining({ method: 'POST' }));
+    });
+
+    test('shows a network error from an upload', async () => {
+        const fetch = global.fetch as jest.MockedFunction<typeof global.fetch>;
+        fetch
+            .mockResolvedValueOnce(jsonResponse([]))
+            .mockRejectedValueOnce('Connection lost');
+        const { container } = render(<CustomExportContentManager />);
+        await screen.findByText('No custom assets installed.');
+
+        fireEvent.change(container.querySelector('input[type="file"]')!, {
+            target: { files: [new File(['image'], 'logo.webp', { type: 'image/webp' })] },
+        });
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Connection lost');
+    });
+});

--- a/frontend/tests/unit_tests/test_export_docs.tsx
+++ b/frontend/tests/unit_tests/test_export_docs.tsx
@@ -1,512 +1,265 @@
 import fetchMock from 'jest-fetch-mock';
 fetchMock.enableMocks();
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
 // @ts-expect-error TS6133
 import React from 'react';
-
 import Exports from '../../src/pages/Exports';
 
+const documents = [
+    { id: 'summary.adoc', category: ['built-in'], extension: 'adoc | pdf' },
+    { id: 'assets/lolcat.jpg', category: ['custom'], extension: 'jpg' },
+    { id: 'SPDX 2.3', category: ['sbom'], extension: 'json | xml' },
+    { id: 'CycloneDX 1.6', category: ['sbom'], extension: 'json' },
+    { id: 'logo.png', category: ['assets'], extension: 'png' },
+];
+
+function loadProject() {
+    fetchMock
+        .mockResponseOnce(JSON.stringify(documents))
+        .mockResponseOnce(JSON.stringify([{ id: 'project-1', name: 'Demo Project' }]))
+        .mockResponseOnce(JSON.stringify([
+            { id: 'variant-1', name: 'alpha', project_id: 'project-1' },
+            { id: 'variant-2', name: 'beta', project_id: 'project-1' },
+        ]));
+}
+
 describe('Exports Page', () => {
+    beforeEach(() => fetchMock.resetMocks());
 
-    test('render file and allow direct download', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            {
-                id: "hello.adoc",
-                category: ['misc'],
-                extension: "adoc|pdf"
-            }
-        ]));
-
-        // ARRANGE
-        render(<Exports />);
-
-        // ASSERT - Just test that it renders without crashing
-        const exportTitle = await screen.findByText(/export/i);
-        expect(exportTitle).toBeInTheDocument();
-    })
-
-    test('handles empty response', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        // ARRANGE
-        render(<Exports />);
-
-        // ASSERT - Component should render without crashing
-        const exportTitle = await screen.findByText(/export/i);
-        expect(exportTitle).toBeInTheDocument();
-    })
-
-    test('handles fetch error gracefully', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockRejectOnce(new Error('Network error'));
-        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-        // ARRANGE & ACT
-        render(<Exports />);
-
-        // ASSERT - Component should still render without crashing
-        const exportTitle = await screen.findByText(/export/i);
-        expect(exportTitle).toBeInTheDocument();
-        await waitFor(() => {
-            expect(consoleSpy).toHaveBeenCalledWith('Error:', expect.any(Error));
-        });
-        consoleSpy.mockRestore();
-    })
-
-    test('handles invalid document data gracefully', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { invalid: "data" },
-            { id: "valid.txt", category: ['misc'] }
-        ]));
-
-        // ARRANGE & ACT
-        render(<Exports />);
-
-        // ASSERT - Component should still render without crashing
-        const exportTitle = await screen.findByText(/export/i);
-        expect(exportTitle).toBeInTheDocument();
-    })
-
-    test('renders and displays documents in all tab', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { id: "report.adoc", category: ['built-in'], extension: "adoc" },
-            { id: "custom.pdf", category: ['custom'], extension: "pdf" },
-            { id: "sbom.json", category: ['sbom'], extension: "json" }
-        ]));
-
-        render(<Exports />);
-
-        await waitFor(() => {
-            expect(screen.getByText(/report\.adoc/i)).toBeInTheDocument();
-        });
-
-        expect(screen.getByText(/custom\.pdf/i)).toBeInTheDocument();
-        expect(screen.getByText(/sbom\.json/i)).toBeInTheDocument();
-    })
-
-    test('filters documents by built-in tab', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { id: "report.adoc", category: ['built-in'], extension: "adoc" },
-            { id: "custom.pdf", category: ['custom'], extension: "pdf" },
-            { id: "sbom.json", category: ['sbom'], extension: "json" }
-        ]));
-
-        render(<Exports />);
-
-        await waitFor(() => {
-            expect(screen.getByText(/report\.adoc/i)).toBeInTheDocument();
-        });
-
-        const builtInButton = screen.getByText('Built-in reports');
-        fireEvent.click(builtInButton);
-
-        await waitFor(() => {
-            expect(screen.getByText(/report\.adoc/i)).toBeInTheDocument();
-        });
-        expect(screen.queryByText(/custom\.pdf/i)).not.toBeInTheDocument();
-        expect(screen.queryByText(/sbom\.json/i)).not.toBeInTheDocument();
-    })
-
-    test('filters documents by custom tab', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { id: "report.adoc", category: ['built-in'], extension: "adoc" },
-            { id: "custom.pdf", category: ['custom'], extension: "pdf" }
-        ]));
-
-        render(<Exports />);
-
-        await waitFor(() => {
-            expect(screen.getByText(/report\.adoc/i)).toBeInTheDocument();
-        });
-
-        const customButton = screen.getByText('Custom reports');
-        fireEvent.click(customButton);
-
-        await waitFor(() => {
-            expect(screen.getByText(/custom\.pdf/i)).toBeInTheDocument();
-        });
-        expect(screen.queryByText(/report\.adoc/i)).not.toBeInTheDocument();
-    })
-
-    test('keeps custom assets separate from custom reports', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { id: "report.adoc", category: ['built-in'], extension: "adoc" },
-            { id: "custom.pdf", category: ['custom'], extension: "pdf" }
-        ]));
-
-        const { container } = render(<Exports />);
-        await screen.findByText(/custom\.pdf/i);
-
-        fireEvent.click(screen.getByRole('button', { name: 'Custom assets' }));
-
-        expect(screen.queryByText(/report\.adoc/i)).not.toBeInTheDocument();
-        expect(screen.queryByText(/custom\.pdf/i)).not.toBeInTheDocument();
-        expect(screen.getByText('No documents found')).toBeInTheDocument();
-        expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
-        expect(screen.getByText(/Assets: \.png, \.jpg, \.webp, \.gif/i)).toBeInTheDocument();
-    })
-
-    test('filters documents by sbom tab', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { id: "report.adoc", category: ['built-in'], extension: "adoc" },
-            { id: "sbom.json", category: ['sbom'], extension: "json" }
-        ]));
-
-        render(<Exports />);
-
-        await waitFor(() => {
-            expect(screen.getByText(/report\.adoc/i)).toBeInTheDocument();
-        });
-
-        const sbomButton = screen.getByText('SBOM files');
-        fireEvent.click(sbomButton);
-
-        await waitFor(() => {
-            expect(screen.getByText(/sbom\.json/i)).toBeInTheDocument();
-        });
-        expect(screen.queryByText(/report\.adoc/i)).not.toBeInTheDocument();
-    })
-
-    test('shows no documents message when filter has no results', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { id: "report.adoc", category: ['built-in'], extension: "adoc" }
-        ]));
-
-        render(<Exports />);
-
-        await waitFor(() => {
-            expect(screen.getByText(/report\.adoc/i)).toBeInTheDocument();
-        });
-
-        const customButton = screen.getByText('Custom reports');
-        fireEvent.click(customButton);
-
-        await waitFor(() => {
-            expect(screen.getByText('No documents found')).toBeInTheDocument();
-        });
-    })
-
-    test('shows custom template message for custom tab with no documents', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        render(<Exports />);
-
-        const customButton = await screen.findByText('Custom reports');
-        fireEvent.click(customButton);
-
-        await waitFor(() => {
-            expect(screen.getByText('No documents found')).toBeInTheDocument();
-            expect(screen.getByText(/You can upload your own templates/i)).toBeInTheDocument();
-        });
-    })
-
-    test('handles documents without extension field', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { id: "report.txt", category: ['built-in'] }
-        ]));
-
-        render(<Exports />);
-
-        await waitFor(() => {
-            expect(screen.getByText(/report\.txt/i)).toBeInTheDocument();
-        });
-    })
-
-    test('switches back to all tab', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { id: "report.adoc", category: ['built-in'], extension: "adoc" },
-            { id: "custom.pdf", category: ['custom'], extension: "pdf" }
-        ]));
-
-        render(<Exports />);
-
-        await waitFor(() => {
-            expect(screen.getByText(/report\.adoc/i)).toBeInTheDocument();
-        });
-
-        const customButton = screen.getByText('Custom reports');
-        fireEvent.click(customButton);
-
-        await waitFor(() => {
-            expect(screen.queryByText(/report\.adoc/i)).not.toBeInTheDocument();
-        });
-
-        const allButton = screen.getByText('All');
-        fireEvent.click(allButton);
-
-        await waitFor(() => {
-            expect(screen.getByText(/report\.adoc/i)).toBeInTheDocument();
-            expect(screen.getByText(/custom\.pdf/i)).toBeInTheDocument();
-        });
-    })
-
-    test('handles non-array response from API', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify({ invalid: 'response' }));
-
-        render(<Exports />);
-
-        const exportTitle = await screen.findByText(/export/i);
-        expect(exportTitle).toBeInTheDocument();
-    })
-
-    test('clicking a file tag toggles its opened state', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { id: "report.adoc", category: ['built-in'], extension: "adoc" }
-        ]));
-
-        render(<Exports />);
-
-        const fileButton = await screen.findByText(/report\.adoc/i);
-        fireEvent.click(fileButton);
-
-        // Clicking the file tag should toggle the download options
-        await waitFor(() => {
-            expect(screen.getByText(/Download/i)).toBeInTheDocument();
-        });
-
-        // Clicking again should close it
-        fireEvent.click(fileButton);
-    })
-
-    const uploadInput = (container: HTMLElement): HTMLInputElement =>
-        container.querySelector('input[type="file"]') as HTMLInputElement;
-
-    test('renders one upload dropzone for reports and assets', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        const { container } = render(<Exports />);
-
-        await screen.findByText(/export/i);
-        expect(screen.getByRole('button', { name: /Upload a custom report or asset/i }))
-            .toBeInTheDocument();
-        expect(screen.getByText(/Drag & drop a custom report or asset here, or click to browse/i)).toBeInTheDocument();
-        expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
-    })
-
-    test('routes report uploads through the shared file input', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        const { container } = render(<Exports />);
-        await screen.findByText(/export/i);
-
-        fetchMock.mockResponseOnce(JSON.stringify({ id: 'report.adoc' }));
-        fireEvent.change(uploadInput(container), {
-            target: { files: [new File(['report'], 'report.adoc', { type: 'text/asciidoc' })] }
-        });
-
-        await screen.findByText(/Imported "report\.adoc"/i);
-        const [url] = fetchMock.mock.calls[fetchMock.mock.calls.length - 2];
-        expect(url).toContain('/api/documents/templates');
-    })
-
-    test('uploads an image asset successfully via the file input', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        const { container } = render(<Exports />);
-        await screen.findByText(/export/i);
-
-        fetchMock.mockResponseOnce(JSON.stringify({ name: 'logo.png' }));
-        fetchMock.mockResponseOnce(JSON.stringify([
-            { id: 'logo.png', category: ['assets'], extension: 'png' }
-        ]));
-
-        const file = new File(['binary'], 'logo.png', { type: 'image/png' });
-        fireEvent.change(uploadInput(container), { target: { files: [file] } });
-
-        await screen.findByText(/Uploaded "logo\.png"/i);
-    await screen.findByRole('button', { name: /logo\.png/i });
-
-        const assetRequest = fetchMock.mock.calls.find(([request]) =>
-            (typeof request === 'string' ? request : request?.url ?? '')
-                .includes('/api/documents/assets')
-        );
-        expect(assetRequest).toBeDefined();
-        const [url, options] = assetRequest!;
-        expect(typeof url === 'string' ? url : url?.url)
-            .toContain('/api/documents/assets');
-        expect(options?.method).toBe('POST');
-        const body = options?.body as FormData;
-        expect(body.get('file')).toBeInstanceOf(File);
-    })
-
-    test('shows the server error message when asset upload fails', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        const { container } = render(<Exports />);
-        await screen.findByText(/export/i);
-
-        fetchMock.mockResponseOnce(JSON.stringify({ error: 'Invalid file type' }), { status: 400 });
-
-        const file = new File(['data'], 'bad.exe', { type: 'application/octet-stream' });
-        fireEvent.change(uploadInput(container), { target: { files: [file] } });
-
-        await screen.findByRole('alert');
-        expect(screen.getByText('Invalid file type')).toBeInTheDocument();
-    })
-
-    test('shows a generic error message when asset upload fails without a JSON body', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        const { container } = render(<Exports />);
-        await screen.findByText(/export/i);
-
-        fetchMock.mockResponseOnce('', { status: 500 });
-
-        const file = new File(['data'], 'bad.png', { type: 'image/png' });
-        fireEvent.change(uploadInput(container), { target: { files: [file] } });
-
-        await screen.findByText(/Upload failed \(500\)/i);
-    })
-
-    test('shows an error message when asset upload fails due to a network error', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        const { container } = render(<Exports />);
-        await screen.findByText(/export/i);
-
-        fetchMock.mockRejectOnce(new Error('Network down'));
-
-        const file = new File(['data'], 'logo.png', { type: 'image/png' });
-        fireEvent.change(uploadInput(container), { target: { files: [file] } });
-
-        await screen.findByText('Network down');
-    })
-
-    test('shows an uploading state while the asset upload is in progress', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        const { container } = render(<Exports />);
-        await screen.findByText(/export/i);
-
-        let resolveUpload: (response: Response) => void = () => {};
-        fetchMock.mockImplementationOnce(() => new Promise((resolve) => { resolveUpload = resolve; }));
-
-        const file = new File(['binary'], 'logo.png', { type: 'image/png' });
-        fireEvent.change(uploadInput(container), { target: { files: [file] } });
-
-        await screen.findByText(/Uploading file…/i);
-
-        resolveUpload({
-            ok: true,
-            json: () => Promise.resolve({ name: 'logo.png' })
-        } as Response);
-
-        await screen.findByText(/Uploaded "logo\.png"/i);
-    })
-
-    test('dismisses the asset upload success message', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        const { container } = render(<Exports />);
-        await screen.findByText(/export/i);
-
-        fetchMock.mockResponseOnce(JSON.stringify({ name: 'logo.png' }));
-
-        const file = new File(['binary'], 'logo.png', { type: 'image/png' });
-        fireEvent.change(uploadInput(container), { target: { files: [file] } });
-
-        await screen.findByText(/Uploaded "logo\.png"/i);
-
-        fireEvent.click(screen.getByRole('button', { name: 'Dismiss message' }));
-
-        await waitFor(() => {
-            expect(screen.queryByText(/Uploaded "logo\.png"/i)).not.toBeInTheDocument();
-        });
-    })
-
-    test('drag and drop uploads an image asset and toggles the active drag style', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        render(<Exports />);
-        await screen.findByText(/export/i);
-
-        fetchMock.mockResponseOnce(JSON.stringify({ name: 'dropped.png' }));
-
-        const dropzone = screen.getByRole('button', { name: /Upload a custom report or asset/i });
-        const file = new File(['binary'], 'dropped.png', { type: 'image/png' });
-
-        fireEvent.dragEnter(dropzone);
-        expect(dropzone.className).toContain('border-sky-400');
-
-        fireEvent.dragLeave(dropzone);
-        expect(dropzone.className).not.toContain('border-sky-400');
-
-        fireEvent.dragOver(dropzone);
-        expect(dropzone.className).toContain('border-sky-400');
-
-        fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
-
-        await screen.findByText(/Uploaded "dropped\.png"/i);
-        expect(dropzone.className).not.toContain('border-sky-400');
-    })
-
-    test('clicking the asset dropzone opens the file browser', async () => {
-        fetchMock.resetMocks();
-        fetchMock.mockResponseOnce(JSON.stringify([]));
-
-        render(<Exports />);
-        await screen.findByText(/export/i);
-
-        const clickSpy = jest.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {});
-
-        const dropzone = screen.getByRole('button', { name: /Upload a custom report or asset/i });
-        fireEvent.click(dropzone);
-
-        expect(clickSpy).toHaveBeenCalled();
-        clickSpy.mockRestore();
-    })
-
-    test('confirms the export scope before downloading', async () => {
-        fetchMock.resetMocks();
+    test('shows the in-page wizard and Settings management reminder', async () => {
         fetchMock
+            .mockResponseOnce(JSON.stringify(documents))
+            .mockResponseOnce(JSON.stringify([]));
+
+        render(<Exports />);
+
+        expect(await screen.findByRole('heading', { name: 'Export' })).toBeInTheDocument();
+        expect(screen.getByRole('region', { name: 'Create export' })).toBeInTheDocument();
+        expect(screen.getByText(/Settings > Custom reports & assets/i)).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /upload a custom report or asset/i })).not.toBeInTheDocument();
+    });
+
+    test('shows report layout with export type before document selection', async () => {
+        loadProject();
+        render(<Exports projectId="project-1" variantId="variant-1" variantIds={['variant-1']} />);
+
+        expect(await screen.findByText(/choose the variants to export/i)).toHaveTextContent('Demo Project');
+        const alpha = screen.getByRole('checkbox', { name: 'alpha' });
+        const beta = screen.getByRole('checkbox', { name: 'beta' });
+        expect(alpha).toBeChecked();
+        expect(beta).toBeChecked();
+        fireEvent.click(beta);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+        fireEvent.click(screen.getByRole('radio', { name: /^Reports/i }));
+        expect(screen.getByRole('heading', { name: 'Output layout' })).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('radio', { name: /one set per variant/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+        expect(screen.queryByRole('checkbox', { name: /logo\.png/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('checkbox', { name: /lolcat\.jpg/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Custom assets' })).not.toBeInTheDocument();
+        const summary = screen.getByRole('group', { name: 'summary.adoc' });
+        const adoc = within(summary).getByRole('checkbox', { name: /^adoc$/i });
+        const pdf = within(summary).getByRole('checkbox', { name: /^pdf$/i });
+        expect(adoc).toBeDisabled();
+        expect(pdf).toBeDisabled();
+        const includeSummary = within(summary).getByRole('checkbox', { name: 'Include' });
+        expect(within(summary).queryByRole('checkbox', { name: 'summary.adoc' })).not.toBeInTheDocument();
+        fireEvent.click(includeSummary);
+        expect(adoc).toBeEnabled();
+        expect(pdf).toBeEnabled();
+        fireEvent.click(adoc);
+        expect(screen.queryByRole('checkbox', { name: /cyclonedx/i })).not.toBeInTheDocument();
+
+        fetchMock
+            .mockResponseOnce(JSON.stringify({ job_id: 'export-job-1' }), { status: 202 })
+            .mockResponseOnce(JSON.stringify({
+                status: 'done', current: 1, total: 1, progress: 'Export ready', logs: ['Generating 1 of 1 element: summary.adoc (adoc)'], error: null,
+            }))
+            .mockResponseOnce('zip-content', {
+            headers: {
+                'Content-Type': 'application/zip',
+                'Content-Disposition': 'attachment; filename="Demo_Project_by_variant_export.zip"',
+            },
+            });
+        const createObjectURL = jest.fn(() => 'blob:export');
+        const revokeObjectURL = jest.fn();
+        Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+        Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+        const click = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+        fireEvent.click(screen.getByRole('button', { name: /download export/i }));
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/api/documents/export'),
+            expect.objectContaining({ method: 'POST' }),
+        ));
+        const exportRequest = fetchMock.mock.calls.find(([, request]) => request?.method === 'POST');
+        expect(JSON.parse(String(exportRequest?.[1]?.body))).toEqual({
+            async: true,
+            project_id: 'project-1',
+            variant_ids: ['variant-1'],
+            mode: 'per_variant',
+            documents: [
+                { name: 'summary.adoc', extension: 'adoc' },
+            ],
+        });
+        await waitFor(() => expect(click).toHaveBeenCalled());
+
+        expect(createObjectURL).toHaveBeenCalled();
+        expect(revokeObjectURL).toHaveBeenCalledWith('blob:export');
+        delete (URL as Partial<typeof URL>).createObjectURL;
+        delete (URL as Partial<typeof URL>).revokeObjectURL;
+        click.mockRestore();
+    });
+
+    test('focuses each step heading after wizard navigation', async () => {
+        loadProject();
+        render(<Exports projectId="project-1" />);
+
+        await screen.findByRole('checkbox', { name: 'alpha' });
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+        expect(screen.getByRole('heading', { name: 'What do you want to export?' })).toHaveFocus();
+
+        fireEvent.click(screen.getByRole('radio', { name: /^Reports/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+        expect(screen.getByRole('heading', { name: 'Select reports' })).toHaveFocus();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+        expect(screen.getByRole('heading', { name: 'What do you want to export?' })).toHaveFocus();
+    });
+
+    test('skips layout and forces per-variant ZIP for SBOM exports', async () => {
+        loadProject();
+        render(<Exports projectId="project-1" />);
+
+        await screen.findByRole('checkbox', { name: 'alpha' });
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+        fireEvent.click(screen.getByRole('radio', { name: /^SBOM files/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+        expect(screen.getByRole('heading', { name: 'Select SBOM files' })).toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: /Consolidated/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('checkbox', { name: /summary\.adoc/i })).not.toBeInTheDocument();
+        const spdx = screen.getByRole('group', { name: 'SPDX 2.3' });
+        const spdxJson = within(spdx).getByRole('checkbox', { name: /json/i });
+        const spdxXml = within(spdx).getByRole('checkbox', { name: /xml/i });
+        expect(spdxJson).toBeDisabled();
+        expect(spdxXml).toBeDisabled();
+        fireEvent.click(within(spdx).getByRole('checkbox', { name: 'Include' }));
+        expect(spdxJson).toBeEnabled();
+        expect(spdxXml).toBeEnabled();
+        fireEvent.click(spdxXml);
+        expect(spdxXml).toBeChecked();
+        fireEvent.click(within(spdx).getByRole('checkbox', { name: 'Include' }));
+        expect(spdxXml).toBeDisabled();
+        expect(spdxXml).not.toBeChecked();
+        fireEvent.click(within(spdx).getByRole('checkbox', { name: 'Include' }));
+        fireEvent.click(spdxXml);
+
+        const cycloneDx = screen.getByRole('group', { name: 'CycloneDX 1.6' });
+        fireEvent.click(within(cycloneDx).getByRole('checkbox', { name: 'Include' }));
+        const cycloneDxJson = within(cycloneDx).getByRole('checkbox', { name: /json/i });
+        expect(cycloneDxJson).toBeChecked();
+        expect(cycloneDxJson).toBeDisabled();
+
+        fetchMock
+            .mockResponseOnce(JSON.stringify({ job_id: 'export-job-2' }), { status: 202 })
+            .mockResponseOnce(JSON.stringify({
+                status: 'done', current: 4, total: 4, progress: 'Export ready', logs: ['Generating 4 of 4 element: beta: CycloneDX 1.6 (json)'], error: null,
+            }))
+            .mockResponseOnce('zip-content', {
+                headers: { 'Content-Type': 'application/zip' },
+            });
+        Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: jest.fn(() => 'blob:sbom') });
+        Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: jest.fn() });
+        const click = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+        fireEvent.click(screen.getByRole('button', { name: /download export/i }));
+
+        await waitFor(() => expect(click).toHaveBeenCalled());
+        const exportRequest = fetchMock.mock.calls.find(([, request]) => request?.method === 'POST');
+        expect(JSON.parse(String(exportRequest?.[1]?.body))).toEqual({
+            async: true,
+            project_id: 'project-1',
+            variant_ids: ['variant-1', 'variant-2'],
+            mode: 'per_variant',
+            documents: [
+                { name: 'SPDX 2.3', extension: 'xml' },
+                { name: 'CycloneDX 1.6', extension: 'json' },
+            ],
+        });
+
+        delete (URL as Partial<typeof URL>).createObjectURL;
+        delete (URL as Partial<typeof URL>).revokeObjectURL;
+        click.mockRestore();
+    });
+
+    test('requires at least one selected variant', async () => {
+        loadProject();
+        render(<Exports projectId="project-1" />);
+
+        await screen.findByRole('checkbox', { name: 'alpha' });
+        fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+
+        expect(screen.getByText(/0 of 2 selected/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+        fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
+        expect(screen.getByText(/2 of 2 selected/i)).toBeInTheDocument();
+    });
+
+    test('selects and clears all reports visible in a category', async () => {
+        loadProject();
+        render(<Exports projectId="project-1" />);
+
+        await screen.findByRole('checkbox', { name: 'alpha' });
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+        fireEvent.click(screen.getByRole('radio', { name: /^Reports/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Built-in reports' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Select visible' }));
+        expect(screen.getByText('2 selected')).toBeInTheDocument();
+        expect(within(screen.getByRole('group', { name: 'summary.adoc' })).getByRole('checkbox', { name: 'Include' })).toBeChecked();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Clear visible' }));
+        expect(screen.getByText('0 selected')).toBeInTheDocument();
+        expect(within(screen.getByRole('group', { name: 'summary.adoc' })).getByRole('checkbox', { name: 'Include' })).not.toBeChecked();
+    });
+
+    test('requires a navbar project selection', async () => {
+        fetchMock
+            .mockResponseOnce(JSON.stringify(documents))
+            .mockResponseOnce(JSON.stringify([]));
+        render(<Exports />);
+
+        expect(await screen.findByText(/select a project from the navigation bar/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+    });
+
+    test('ignores variants returned for an earlier project', async () => {
+        let resolveFirst: (value: Response) => void = () => undefined;
+        fetchMock
+            .mockResponseOnce(JSON.stringify(documents))
             .mockResponseOnce(JSON.stringify([
-                { id: "report.adoc", category: ['built-in'], extension: "pdf" }
+                { id: 'project-1', name: 'First' },
+                { id: 'project-2', name: 'Second' },
             ]))
+            .mockImplementationOnce(() => new Promise<Response>(resolve => { resolveFirst = resolve; }))
             .mockResponseOnce(JSON.stringify([
-                { id: "project-1", name: "Demo Project" }
-            ]))
-            .mockResponseOnce(JSON.stringify([
-                { id: "variant-1", name: "v1", project_id: "project-1" },
-                { id: "variant-2", name: "v2", project_id: "project-1" }
+                { id: 'variant-2', name: 'second variant', project_id: 'project-2' },
             ]));
+        const { rerender } = render(<Exports projectId="project-1" />);
+        rerender(<Exports projectId="project-2" />);
 
-        render(<Exports projectId="project-1" variantIds={["variant-1", "variant-2"]} />);
+        expect(await screen.findByRole('checkbox', { name: 'second variant' })).toBeInTheDocument();
+        resolveFirst(new Response(JSON.stringify([
+            { id: 'variant-1', name: 'first variant', project_id: 'project-1' },
+        ]), { status: 200 }));
 
-        const fileButton = await screen.findByText(/report\.adoc/i);
-        fireEvent.click(fileButton);
-        fireEvent.click(screen.getByRole('link', { name: /download pdf/i }));
-
-        expect(await screen.findByText(/this will export report\.adoc \(pdf document\) for the project demo project/i)).toBeInTheDocument();
-        expect(screen.getByText('v1')).toBeInTheDocument();
-        expect(screen.getByText('v2')).toBeInTheDocument();
-        expect(screen.getByText(/change the export scope using the selector/i)).toBeInTheDocument();
-
-        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-        expect(screen.queryByText(/this will export/i)).not.toBeInTheDocument();
-    })
+        await waitFor(() => expect(screen.queryByRole('checkbox', { name: 'first variant' })).not.toBeInTheDocument());
+    });
 });

--- a/frontend/tests/unit_tests/test_export_queue.ts
+++ b/frontend/tests/unit_tests/test_export_queue.ts
@@ -1,0 +1,171 @@
+import type { ExportRequest } from '../../src/handlers/exportQueue';
+
+const request: ExportRequest = {
+    project_id: 'project-1',
+    variant_ids: ['variant-1', 'variant-2'],
+    mode: 'per_variant',
+    documents: [
+        { name: 'summary.adoc', extension: 'pdf' },
+        { name: 'SPDX 2.3', extension: 'json' },
+    ],
+};
+
+function response({
+    body = {},
+    ok = true,
+    status = 200,
+    headers = {},
+    blob = new Blob(['zip-content']),
+}: {
+    body?: unknown;
+    ok?: boolean;
+    status?: number;
+    headers?: Record<string, string>;
+    blob?: Blob;
+} = {}): Response {
+    return {
+        ok,
+        status,
+        headers: new Headers(headers),
+        json: jest.fn().mockResolvedValue(body),
+        blob: jest.fn().mockResolvedValue(blob),
+    } as unknown as Response;
+}
+
+describe('export queue', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.useFakeTimers();
+        global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+        delete (URL as Partial<typeof URL>).createObjectURL;
+        delete (URL as Partial<typeof URL>).revokeObjectURL;
+    });
+
+    test('publishes progress, downloads the completed archive, and dismisses it', async () => {
+        const fetch = global.fetch as jest.MockedFunction<typeof global.fetch>;
+        fetch
+            .mockResolvedValueOnce(response({ body: { job_id: 'job-1' }, status: 202 }))
+            .mockResolvedValueOnce(response({ body: {
+                status: 'running', current: 2, total: 4, progress: 'Generating 2 of 4', logs: ['second file'], error: null,
+            } }))
+            .mockResolvedValueOnce(response({ body: {
+                status: 'done', current: 4, total: 4, progress: 'Export ready', logs: ['complete'], error: null,
+            } }))
+            .mockResolvedValueOnce(response({
+                headers: { 'Content-Disposition': 'attachment; filename="project-files.zip"' },
+            }));
+        Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: jest.fn(() => 'blob:export') });
+        Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: jest.fn() });
+        const click = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+        const queue = await import('../../src/handlers/exportQueue');
+        const listener = jest.fn();
+        const unsubscribe = queue.subscribe(listener);
+
+        await queue.queueExport(request, 'Demo Project');
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(queue.getSnapshot()).toEqual([expect.objectContaining({
+            status: 'running',
+            progress: 'Generating 2 of 4',
+            total: 4,
+            doneCount: 1,
+        })]);
+        queue.dismiss('export-1');
+        expect(queue.getSnapshot()).toHaveLength(1);
+
+        await jest.advanceTimersByTimeAsync(1000);
+
+        expect(queue.getSnapshot()).toEqual([expect.objectContaining({
+            status: 'done',
+            progress: 'Export ready',
+            doneCount: 4,
+        })]);
+        expect(click).toHaveBeenCalledTimes(1);
+        expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:export');
+        expect(document.querySelector('a')).toBeNull();
+
+        queue.dismiss('export-1');
+        expect(queue.getSnapshot()).toEqual([]);
+        expect(listener).toHaveBeenCalled();
+        unsubscribe();
+    });
+
+    test('records and rethrows an error when the export cannot be queued', async () => {
+        const fetch = global.fetch as jest.MockedFunction<typeof global.fetch>;
+        fetch.mockResolvedValueOnce(response({ body: { error: 'No export documents selected' }, ok: false, status: 400 }));
+        const queue = await import('../../src/handlers/exportQueue');
+
+        await expect(queue.queueExport(request, 'Demo Project')).rejects.toThrow('No export documents selected');
+
+        expect(queue.getSnapshot()).toEqual([expect.objectContaining({
+            status: 'error',
+            error: 'No export documents selected',
+            progress: 'Export failed',
+            logs: ['No export documents selected'],
+        })]);
+        expect(fetch).toHaveBeenCalledWith('http://localhost/api/documents/export', expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ ...request, async: true }),
+        }));
+    });
+
+    test('records polling and download failures without rejecting queue creation', async () => {
+        const fetch = global.fetch as jest.MockedFunction<typeof global.fetch>;
+        fetch
+            .mockResolvedValueOnce(response({ body: { job_id: 'job-2' }, status: 202 }))
+            .mockResolvedValueOnce(response({ body: {
+                status: 'done', current: 4, total: 4, progress: 'Export ready', logs: [], error: null,
+            } }))
+            .mockResolvedValueOnce(response({ ok: false, status: 503 }));
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+            fetch
+                .mockResolvedValueOnce(response({ body: {
+                    status: 'done', current: 4, total: 4, progress: 'Export ready', logs: [], error: null,
+                } }))
+                .mockResolvedValueOnce(response({ ok: false, status: 503 }));
+        }
+        const queue = await import('../../src/handlers/exportQueue');
+
+        await expect(queue.queueExport(request, 'Demo Project')).resolves.toBeUndefined();
+        await jest.advanceTimersByTimeAsync(0);
+        await jest.advanceTimersByTimeAsync(3000);
+
+        expect(queue.getSnapshot()).toEqual([expect.objectContaining({
+            status: 'error',
+            error: 'Failed to download export (503)',
+            logs: ['Failed to download export (503)'],
+        })]);
+        queue.dismiss('missing-operation');
+        expect(queue.getSnapshot()).toHaveLength(1);
+    });
+
+    test('recovers after a transient polling failure', async () => {
+        const fetch = global.fetch as jest.MockedFunction<typeof global.fetch>;
+        fetch
+            .mockResolvedValueOnce(response({ body: { job_id: 'job-3' }, status: 202 }))
+            .mockResolvedValueOnce(response({ ok: false, status: 503 }))
+            .mockResolvedValueOnce(response({ body: {
+                status: 'done', current: 4, total: 4, progress: 'Export ready', logs: [], error: null,
+            } }))
+            .mockResolvedValueOnce(response());
+        Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: jest.fn(() => 'blob:export') });
+        Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: jest.fn() });
+        jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+        const queue = await import('../../src/handlers/exportQueue');
+
+        await queue.queueExport(request, 'Demo Project');
+        await jest.advanceTimersByTimeAsync(0);
+        expect(queue.getSnapshot()).toEqual([expect.objectContaining({
+            status: 'running', progress: 'Reconnecting to export',
+        })]);
+
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(queue.getSnapshot()).toEqual([expect.objectContaining({ status: 'done' })]);
+    });
+});

--- a/frontend/tests/unit_tests/test_operation_queue_modal.tsx
+++ b/frontend/tests/unit_tests/test_operation_queue_modal.tsx
@@ -6,12 +6,57 @@ jest.mock('../../src/handlers/activeScanQueue', () => ({
     getRefreshQueueSnapshot: jest.fn(),
     dismissRefreshQueueEntry: jest.fn(),
 }));
+jest.mock('../../src/handlers/grypeScanState', () => ({
+    subscribe: () => () => undefined,
+    getSnapshot: jest.fn(),
+    dismiss: jest.fn(),
+}));
+jest.mock('../../src/handlers/nvdScanState', () => ({
+    subscribe: () => () => undefined,
+    getSnapshot: jest.fn(),
+    dismiss: jest.fn(),
+}));
+jest.mock('../../src/handlers/osvScanState', () => ({
+    subscribe: () => () => undefined,
+    getSnapshot: jest.fn(),
+    dismiss: jest.fn(),
+}));
+jest.mock('../../src/handlers/sccScanState', () => ({
+    subscribe: () => () => undefined,
+    getSnapshot: jest.fn(),
+    dismiss: jest.fn(),
+}));
+jest.mock('../../src/handlers/exportQueue', () => ({
+    subscribe: () => () => undefined,
+    getSnapshot: jest.fn(),
+    dismiss: jest.fn(),
+}));
 
 import OperationQueueModal from '../../src/components/OperationQueueModal';
-import { getRefreshQueueSnapshot } from '../../src/handlers/activeScanQueue';
+import { dismissRefreshQueueEntry, getRefreshQueueSnapshot } from '../../src/handlers/activeScanQueue';
+import { dismiss as grypeDismiss, getSnapshot as grypeGetSnapshot } from '../../src/handlers/grypeScanState';
+import { dismiss as nvdDismiss, getSnapshot as nvdGetSnapshot } from '../../src/handlers/nvdScanState';
+import { dismiss as osvDismiss, getSnapshot as osvGetSnapshot } from '../../src/handlers/osvScanState';
+import { dismiss as sccDismiss, getSnapshot as sccGetSnapshot } from '../../src/handlers/sccScanState';
+import { dismiss as exportDismiss, getSnapshot as exportGetSnapshot } from '../../src/handlers/exportQueue';
+
+const completedEntry = (variantId: string, variantName: string) => ({
+    variantId,
+    variantName,
+    status: 'done',
+    error: null,
+    progress: 'Complete',
+    logs: [],
+    total: 1,
+    doneCount: 1,
+});
 
 describe('OperationQueueModal', () => {
-    beforeEach(() => (getRefreshQueueSnapshot as jest.Mock).mockReturnValue([]));
+    beforeEach(() => {
+        jest.clearAllMocks();
+        [getRefreshQueueSnapshot, grypeGetSnapshot, nvdGetSnapshot, osvGetSnapshot, sccGetSnapshot, exportGetSnapshot]
+            .forEach(snapshot => (snapshot as jest.Mock).mockReturnValue([]));
+    });
 
     it('closes from its close button, backdrop, and Escape key', () => {
         const onClose = jest.fn();
@@ -45,5 +90,24 @@ describe('OperationQueueModal', () => {
         fireEvent.click(nvdCollapse);
         expect(nvdCollapse).toHaveAttribute('aria-expanded', 'true');
         expect(epssCollapse).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('dismisses completed operations through their owning queues', () => {
+        (grypeGetSnapshot as jest.Mock).mockReturnValue([completedEntry('grype-id', 'Grype')]);
+        (nvdGetSnapshot as jest.Mock).mockReturnValue([completedEntry('nvd-id', 'NVD')]);
+        (osvGetSnapshot as jest.Mock).mockReturnValue([completedEntry('osv-id', 'OSV')]);
+        (sccGetSnapshot as jest.Mock).mockReturnValue([completedEntry('scc-id', 'SCC')]);
+        (getRefreshQueueSnapshot as jest.Mock).mockReturnValue([completedEntry('epss', 'EPSS')]);
+        (exportGetSnapshot as jest.Mock).mockReturnValue([completedEntry('export-id', 'Project export')]);
+
+        render(<OperationQueueModal isOpen={true} onClose={jest.fn()} />);
+        screen.getAllByTitle('Close').forEach(button => fireEvent.click(button));
+
+        expect(grypeDismiss).toHaveBeenCalledWith('grype-id');
+        expect(nvdDismiss).toHaveBeenCalledWith('nvd-id');
+        expect(osvDismiss).toHaveBeenCalledWith('osv-id');
+        expect(sccDismiss).toHaveBeenCalledWith('scc-id');
+        expect(dismissRefreshQueueEntry).toHaveBeenCalledWith('epss');
+        expect(exportDismiss).toHaveBeenCalledWith('export-id');
     });
 });

--- a/frontend/tests/unit_tests/test_settings_page.tsx
+++ b/frontend/tests/unit_tests/test_settings_page.tsx
@@ -353,6 +353,37 @@ describe("Settings scoped project and variant views", () => {
     expect(await screen.findByRole("heading", { name: "Report Metadata" })).toBeInTheDocument();
   });
 
+  test("manages custom reports and assets from its Settings tab", async () => {
+    const fetchFunction = global.fetch as jest.Mock;
+    fetchFunction.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([
+        { id: "custom.adoc", category: ["custom"], extension: "adoc" },
+        { id: "logo.png", category: ["assets"], extension: "png" },
+      ]),
+    } as Response);
+    const { container } = render(<Settings />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Custom reports & assets" }));
+
+    expect(await screen.findByRole("heading", { name: "Custom reports (1)" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Custom assets (1)" })).toBeInTheDocument();
+    expect(screen.getByText("custom.adoc")).toBeInTheDocument();
+    expect(screen.getByText("logo.png")).toBeInTheDocument();
+
+    fetchFunction
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: "new.adoc" }) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) } as Response);
+    fireEvent.change(container.querySelector('input[type="file"][accept*=".adoc"]')!, {
+      target: { files: [new File(["report"], "new.adoc", { type: "text/asciidoc" })] },
+    });
+
+    expect(await screen.findByText(/Imported "new\.adoc"/)).toBeInTheDocument();
+    expect(fetchFunction.mock.calls.some(([url, options]) =>
+      String(url).includes("/api/documents/templates") && options?.method === "POST"
+    )).toBe(true);
+  });
+
   test("opens and cancels editing an existing NVD API key", async () => {
     nvdApiKeyGet.mockResolvedValueOnce({ has_key: true, masked_key: "abcd...wxyz" });
     render(<Settings />);

--- a/src/helpers/export_scope.py
+++ b/src/helpers/export_scope.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
+from collections.abc import Iterable
 
 from .active_scans import (
     active_sbom_scan_ids_for_variant,
@@ -45,16 +46,32 @@ class ExportScope:
     variant_ids: set[uuid.UUID] = field(default_factory=set)
 
 
-def _as_uuid(value) -> uuid.UUID:
+def _as_uuid(value: uuid.UUID | str) -> uuid.UUID:
     return value if isinstance(value, uuid.UUID) else uuid.UUID(str(value))
 
 
-def compute_export_scope(*, project_id=None, variant_id=None) -> ExportScope | None:
-    """Build an :class:`ExportScope` for *variant_id* or *project_id*.
+def compute_export_scope(
+    *,
+    project_id: uuid.UUID | str | None = None,
+    variant_id: uuid.UUID | str | None = None,
+    variant_ids: Iterable[uuid.UUID | str] | None = None,
+) -> ExportScope | None:
+    """Build an :class:`ExportScope` for selected variants, one variant, or a project.
 
-    ``variant_id`` takes precedence over ``project_id``. Returns ``None`` when
-    neither is provided (i.e. a global, unscoped export).
+    ``variant_ids`` takes precedence over ``variant_id`` and ``project_id``.
+    Returns ``None`` when no scope is provided (i.e. a global export).
     """
+    if variant_ids is not None:
+        selected_ids: set[uuid.UUID] = {_as_uuid(value) for value in variant_ids}
+        scan_ids: list[uuid.UUID] = [
+            scan_id
+            for selected_id in selected_ids
+            for scan_id in active_sbom_scan_ids_for_variant(selected_id)
+        ]
+        return ExportScope(
+            package_ids=active_package_ids_for_scans(scan_ids),
+            variant_ids=selected_ids,
+        )
     if variant_id is not None:
         vid = _as_uuid(variant_id)
         scan_ids = active_sbom_scan_ids_for_variant(vid)

--- a/src/routes/documents.py
+++ b/src/routes/documents.py
@@ -1,29 +1,50 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
-from flask import Flask, request, make_response, send_file
+from flask import Flask, Response, copy_current_request_context, request, make_response, send_file
 from flask.typing import ResponseReturnValue
+import atexit
+from concurrent.futures import ThreadPoolExecutor
 import io
 import json
 import os
 import mimetypes
+import re
+import tempfile
+import threading
+import time
 import traceback
+import uuid
+import zipfile
 from datetime import date
 from PIL import Image
 from ..controllers import ControllersCache
+from ..models.project import Project
+from ..models.variant import Variant
 from ..views.templates import Templates, find_asset
 from ..views.cyclonedx import CycloneDx
 from ..views.spdx import SPDX
 from ..views.spdx3 import SPDX3
 from ..views.openvex import OpenVex
-from ..helpers.export_scope import compute_export_scope
+from ..helpers.export_scope import ExportScope, compute_export_scope
 from ._scan_helpers import parse_uuid_or_400
-from typing import Dict, List, Optional
+from typing import BinaryIO, Callable, cast, Dict, List, Optional
 
 
 # You can associate specific files to specific categories
 # "example.adoc": ["misc", "category_name"]
 CategoriesDictionary: Dict[str, List[str]] = {}
+ASCIIDOC_MIME = "text/asciidoc"
+_export_jobs: Dict[str, Dict[str, object]] = {}
+_export_jobs_lock = threading.Lock()
+EXPORT_JOB_TTL_SECONDS = 3600
+EXPORT_MAX_WORKERS = 2
+EXPORT_MAX_QUEUED_JOBS = 4
+EXPORT_MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
+EXPORT_MAX_RETAINED_ARCHIVE_BYTES = 512 * 1024 * 1024
+_export_executor = ThreadPoolExecutor(max_workers=EXPORT_MAX_WORKERS, thread_name_prefix="document-export")
+_export_capacity = threading.BoundedSemaphore(EXPORT_MAX_WORKERS + EXPORT_MAX_QUEUED_JOBS)
+_sync_export_capacity = threading.BoundedSemaphore(EXPORT_MAX_WORKERS)
 
 
 # Directories searched for user-provided templates, most-preferred first. This
@@ -180,9 +201,341 @@ def guess_mime_type(doc_name: Optional[str]) -> Optional[str]:
     guess = mimetypes.guess_type(doc_name)[0]
     if guess is not None:
         return guess
-    if doc_name.endswith(".adoc") or doc_name.endswith(".asciidoc"):
-        return "text/asciidoc"
+    if doc_name.endswith((".adoc", ".asciidoc")):
+        return ASCIIDOC_MIME
     return "application/octet-stream"
+
+
+def _download_filename(response: Response, fallback: str) -> str:
+    disposition = response.headers.get("Content-Disposition", "")
+    match = re.search(r'filename="?([^";]+)', disposition)
+    return os.path.basename(match.group(1)) if match else fallback
+
+
+def _safe_archive_name(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", value).strip("._")
+    return safe or "export"
+
+
+def _normalize_document(doc: Dict[str, object]) -> None:
+    doc_id = str(doc["id"])
+    if "extension" not in doc:
+        doc["extension"] = doc_id.rsplit(".", 1)[-1] if "." in doc_id else "bin"
+        if doc["extension"] in ["adoc", "asciidoc"]:
+            doc["extension"] = "adoc | pdf | html"
+
+    categories = doc.setdefault("category", [])
+    if not isinstance(categories, list):
+        return
+    for category in CategoriesDictionary.get(doc_id, []):
+        if category not in categories:
+            categories.append(category)
+
+
+def _list_documents() -> List[Dict[str, object]]:
+    controllers = ControllersCache()
+    controllers.vulnerabilities = None  # type: ignore
+    docs = Templates(controllers).list_documents()
+    docs.extend([
+        {"id": "SPDX 2.3", "extension": "json | xml", "is_template": False, "category": ["sbom"]},
+        {"id": "SPDX 3.0", "extension": "json", "is_template": False, "category": ["sbom"]},
+        {"id": "CycloneDX 1.4", "extension": "json", "is_template": False, "category": ["sbom"]},
+        {"id": "CycloneDX 1.5", "extension": "json", "is_template": False, "category": ["sbom"]},
+        {"id": "CycloneDX 1.6", "extension": "json", "is_template": False, "category": ["sbom"]},
+        {"id": "OpenVex", "extension": "json", "is_template": False, "category": ["sbom"]},
+    ])
+    docs.extend(list_assets())
+
+    for doc in docs:
+        _normalize_document(doc)
+    return docs
+
+
+def _export_metadata(app: Flask) -> Dict[str, str | float]:
+    metadata: Dict[str, str | float] = {
+        "author": request.args.get("author") or os.getenv('AUTHOR_NAME', 'Savoir-faire Linux') or '',
+        "client_name": request.args.get("client_name") or os.getenv('CLIENT_NAME', "") or '',
+        "export_date": request.args.get("export_date") or date.today().isoformat(),
+        "ignore_before": request.args.get("ignore_before") or "1970-01-01T00:00",
+        "only_epss_greater": 0.0,
+        "scan_date": app.config["SCAN_DATE"] or "unknown date",
+    }
+    try:
+        metadata["only_epss_greater"] = float(request.args.get("only_epss_greater") or "0.0")
+    except ValueError:
+        pass
+    return metadata
+
+
+def _render_template_document(
+    doc_name: str,
+    base_mime: str,
+    expected_mime: str,
+    templ: Templates,
+    metadata: Dict[str, str | float],
+) -> Response:
+    content = templ.render(doc_name, **metadata)
+    if base_mime == expected_mime:
+        response = make_response(content)
+        response.headers["Content-Type"] = base_mime
+        response.headers["Content-Disposition"] = f"attachment; filename={doc_name}"
+        return response
+    if base_mime == ASCIIDOC_MIME and expected_mime == "application/pdf":
+        response = make_response(templ.adoc_to_pdf(content))
+        response.headers["Content-Type"] = "application/pdf"
+        response.headers["Content-Disposition"] = f"attachment; filename={doc_name}.pdf"
+        return response
+    if base_mime == ASCIIDOC_MIME and expected_mime == "text/html":
+        response = make_response(templ.adoc_to_html(content))
+        response.headers["Content-Type"] = "text/html"
+        response.headers["Content-Disposition"] = f"attachment; filename={doc_name}.html"
+        return response
+    return make_response({"error": f"Cannot convert {base_mime} to {expected_mime}"}, 400)
+
+
+def _render_document(
+    app: Flask,
+    doc_name: str,
+    extension: Optional[str],
+    scope: ExportScope | None,
+) -> Response:
+    base_mime = guess_mime_type(doc_name)
+    if base_mime is None:
+        return make_response({"error": "Unsupported document type"}, 400)
+    expected_mime = guess_mime_type(extension) or base_mime
+
+    asset_path = find_asset(doc_name)
+    if asset_path is not None:
+        return send_file(
+            asset_path,
+            mimetype=base_mime,
+            as_attachment=True,
+            download_name=doc_name,
+        )
+
+    metadata = _export_metadata(app)
+    ctrls = ControllersCache(scope=scope)
+    ctrls.packages._preload_cache()
+
+    if (
+        doc_name.startswith("CycloneDX ")
+        or doc_name == "OpenVex"
+        or doc_name.startswith("SPDX")
+    ):
+        return make_response(handle_sbom_exports(doc_name, ctrls, expected_mime, metadata))
+    return _render_template_document(doc_name, base_mime, expected_mime, Templates(ctrls), metadata)
+
+
+def _select_project_variants(
+    project_uuid: uuid.UUID,
+    raw_variant_ids: object,
+) -> tuple[list[Variant] | None, ResponseReturnValue | None]:
+    project_variants = Variant.get_by_project(project_uuid)
+    if not project_variants:
+        return None, ({"error": "The selected project has no variants"}, 400)
+    if raw_variant_ids is None:
+        return project_variants, None
+    if not isinstance(raw_variant_ids, list) or not raw_variant_ids:
+        return None, ({"error": "variant_ids must contain at least one variant"}, 400)
+
+    selected_variant_ids = set()
+    for raw_variant_id in raw_variant_ids:
+        if not isinstance(raw_variant_id, str):
+            return None, ({"error": "variant_ids must contain UUID strings"}, 400)
+        selected_variant_id, err = parse_uuid_or_400(raw_variant_id, "variant_ids")
+        if err is not None:
+            return None, err
+        selected_variant_ids.add(selected_variant_id)
+    if not selected_variant_ids.issubset({variant.id for variant in project_variants}):
+        return None, ({"error": "Every selected variant must belong to the selected project"}, 400)
+    return [variant for variant in project_variants if variant.id in selected_variant_ids], None
+
+
+def _document_selection_catalog() -> tuple[set[tuple[str, str]], set[tuple[str, str]]]:
+    allowed: set[tuple[str, str]] = set()
+    sbom_selections: set[tuple[str, str]] = set()
+    for doc in _list_documents():
+        categories = doc.get("category")
+        if isinstance(categories, list) and "assets" in categories:
+            continue
+        document_selections = {
+            (str(doc["id"]), extension.strip())
+            for extension in str(doc["extension"]).split("|")
+        }
+        allowed.update(document_selections)
+        if isinstance(categories, list) and "sbom" in categories:
+            sbom_selections.update(document_selections)
+    return allowed, sbom_selections
+
+
+def _parse_document_selection(
+    item: object,
+    allowed: set[tuple[str, str]],
+) -> tuple[tuple[str, str] | None, ResponseReturnValue | None]:
+    if not isinstance(item, dict):
+        return None, ({"error": "Each document selection must be an object"}, 400)
+    name = item.get("name")
+    extension = item.get("extension")
+    if not isinstance(name, str) or not name or not isinstance(extension, str) or not extension:
+        return None, ({"error": "Each document requires a name and extension"}, 400)
+    if (name, extension) not in allowed:
+        return None, ({"error": f"Unsupported document selection: {name} ({extension})"}, 400)
+    return (name, extension), None
+
+
+def _validate_document_selections(
+    requested_docs: object,
+    mode: object,
+) -> tuple[list[tuple[str, str]] | None, ResponseReturnValue | None]:
+    if not isinstance(requested_docs, list) or not requested_docs or len(requested_docs) > 100:
+        return None, ({"error": "documents must contain between 1 and 100 selections"}, 400)
+
+    allowed, sbom_selections = _document_selection_catalog()
+    selections: list[tuple[str, str]] = []
+    for item in requested_docs:
+        selection, selection_error = _parse_document_selection(item, allowed)
+        if selection_error is not None:
+            return None, selection_error
+        assert selection is not None
+        selections.append(selection)
+
+    selected_sboms = [selection for selection in selections if selection in sbom_selections]
+    if selected_sboms and len(selected_sboms) != len(selections):
+        return None, ({"error": "Reports and SBOM files must be exported separately"}, 400)
+    if selected_sboms and mode != "per_variant":
+        return None, ({"error": "SBOM files must be exported per variant as a ZIP archive"}, 400)
+    return selections, None
+
+
+class ExportGenerationError(Exception):
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class _SizeLimitedArchive:
+    def __init__(self, output: BinaryIO, max_bytes: int) -> None:
+        self.output = output
+        self.max_bytes = max_bytes
+        self.size = 0
+
+    def write(self, data: bytes) -> int:
+        end = self.tell() + len(data)
+        self.size = max(self.size, end)
+        if self.size > self.max_bytes:
+            raise ExportGenerationError("Export archive exceeds the maximum allowed size", 413)
+        return self.output.write(data)
+
+    def tell(self) -> int:
+        return self.output.tell()
+
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        return self.output.seek(offset, whence)
+
+    def flush(self) -> None:
+        self.output.flush()
+
+
+def _delete_archive(job: Dict[str, object]) -> None:
+    archive_path = job.get("archive_path")
+    if isinstance(archive_path, str):
+        try:
+            os.remove(archive_path)
+        except FileNotFoundError:
+            pass
+
+
+def _prune_export_jobs() -> None:
+    cutoff = time.monotonic() - EXPORT_JOB_TTL_SECONDS
+    expired = []
+    for job_id, job in _export_jobs.items():
+        finished_at = job.get("finished_at")
+        if isinstance(finished_at, float) and finished_at < cutoff:
+            expired.append(job_id)
+    for job_id in expired:
+        _delete_archive(_export_jobs.pop(job_id))
+
+
+def _reserve_retained_archive(archive_bytes: int) -> None:
+    retained = [
+        (job_id, job) for job_id, job in _export_jobs.items()
+        if isinstance(job.get("archive_path"), str)
+    ]
+
+    def finished_at(item: tuple[str, Dict[str, object]]) -> float:
+        value = item[1].get("finished_at")
+        return value if isinstance(value, float) else 0.0
+
+    retained.sort(key=finished_at)
+    retained_bytes = sum(
+        os.path.getsize(str(job["archive_path"]))
+        for _, job in retained
+        if os.path.isfile(str(job["archive_path"]))
+    )
+    for job_id, job in retained:
+        if retained_bytes + archive_bytes <= EXPORT_MAX_RETAINED_ARCHIVE_BYTES:
+            break
+        path = str(job["archive_path"])
+        if os.path.isfile(path):
+            retained_bytes -= os.path.getsize(path)
+        _delete_archive(_export_jobs.pop(job_id))
+
+
+def _unique_archive_path(path: str, used_paths: set[str]) -> str:
+    candidate = path
+    stem, extension = os.path.splitext(path)
+    index = 2
+    while candidate in used_paths:
+        candidate = f"{stem}_{index}{extension}"
+        index += 1
+    used_paths.add(candidate)
+    return candidate
+
+
+def _cleanup_export_archives() -> None:
+    with _export_jobs_lock:
+        for job in _export_jobs.values():
+            _delete_archive(job)
+
+
+atexit.register(_cleanup_export_archives)
+
+
+def _build_export_archive(
+    app: Flask,
+    scopes: list[tuple[Variant | None, ExportScope | None]],
+    selections: list[tuple[str, str]],
+    archive: BinaryIO,
+    progress: Callable[[int, int, str], None] | None = None,
+) -> None:
+    total = len(scopes) * len(selections)
+    current = 0
+    used_paths: set[str] = set()
+    limited_archive = _SizeLimitedArchive(archive, EXPORT_MAX_ARCHIVE_BYTES)
+    with zipfile.ZipFile(cast(BinaryIO, limited_archive), "w", compression=zipfile.ZIP_DEFLATED) as output:
+        for variant, scope in scopes:
+            for doc_name, extension in selections:
+                current += 1
+                element_name = (
+                    f"{variant.name}: {doc_name} ({extension})"
+                    if variant is not None
+                    else f"{doc_name} ({extension})"
+                )
+                if progress is not None:
+                    progress(current, total, element_name)
+                rendered = _render_document(app, doc_name, extension, scope)
+                if rendered.status_code >= 400:
+                    message = rendered.get_json(silent=True) or {}
+                    raise ExportGenerationError(
+                        message.get("error", f"Failed to export {doc_name}"),
+                        rendered.status_code,
+                    )
+                fallback = f"{_safe_archive_name(doc_name)}.{_safe_archive_name(extension)}"
+                filename = _download_filename(rendered, fallback)
+                if variant is not None:
+                    filename = f"{_safe_archive_name(variant.name)}/{filename}"
+                filename = _unique_archive_path(filename, used_paths)
+                output.writestr(filename, rendered.get_data())
 
 
 def init_app(app: Flask) -> None:
@@ -195,36 +548,8 @@ def init_app(app: Flask) -> None:
         response 200 JsonObject Available document descriptors.
         response 500 Error Document discovery failed.
         """
-        controllers = ControllersCache()
-        controllers.vulnerabilities = None  # type: ignore
-        # to avoid pre-loading cache, TODO change that, maybe by moving list_documents somewhere else
-        templ = Templates(controllers)
         try:
-            docs = templ.list_documents()
-
-            docs.append({"id": "SPDX 2.3", "extension": "json | xml", "is_template": False, "category": ["sbom"]})
-            docs.append({"id": "SPDX 3.0", "extension": "json", "is_template": False, "category": ["sbom"]})
-            docs.append({"id": "CycloneDX 1.4", "extension": "json", "is_template": False, "category": ["sbom"]})
-            docs.append({"id": "CycloneDX 1.5", "extension": "json", "is_template": False, "category": ["sbom"]})
-            docs.append({"id": "CycloneDX 1.6", "extension": "json", "is_template": False, "category": ["sbom"]})
-            docs.append({"id": "OpenVex", "extension": "json", "is_template": False, "category": ["sbom"]})
-            docs.extend(list_assets())
-
-            for doc in docs:
-                if "extension" not in doc:
-                    if "." in doc["id"]:
-                        doc["extension"] = doc["id"].split(".")[-1]
-                    else:
-                        doc["extension"] = "bin"
-                    if doc["extension"] in ["adoc", "asciidoc"]:
-                        doc["extension"] = "adoc | pdf | html"
-
-                    if doc["id"] in CategoriesDictionary:
-                        for cat in CategoriesDictionary[doc["id"]]:
-                            if cat not in doc["category"]:
-                                doc["category"].append(cat)
-
-            return docs
+            return _list_documents()
         except Exception as e:
             print(e)
             return {"error": str(e)}, 500
@@ -319,6 +644,178 @@ def init_app(app: Flask) -> None:
 
         return {"name": safe_name, "message": "Asset uploaded."}, 201
 
+    @app.route('/api/documents/export', methods=['POST'])
+    def export_documents() -> ResponseReturnValue:
+        """Render selected documents for every variant of one project."""
+        body = request.get_json(silent=True) or {}
+        raw_project_id = body.get("project_id")
+        if not isinstance(raw_project_id, str):
+            return {"error": "project_id is required"}, 400
+        project_uuid, err = parse_uuid_or_400(raw_project_id, "project_id")
+        if err is not None:
+            return err
+        assert project_uuid is not None
+        project = Project.get_by_id(project_uuid)
+        if project is None:
+            return {"error": "Project not found"}, 404
+
+        mode = body.get("mode")
+        if mode not in {"consolidated", "per_variant"}:
+            return {"error": "mode must be 'consolidated' or 'per_variant'"}, 400
+
+        selections, document_error = _validate_document_selections(body.get("documents"), mode)
+        if document_error is not None:
+            return document_error
+        assert selections is not None
+
+        variants, selection_error = _select_project_variants(project_uuid, body.get("variant_ids"))
+        if selection_error is not None:
+            return selection_error
+        assert variants is not None
+
+        scopes: list[tuple[Variant | None, ExportScope | None]] = (
+            [(None, compute_export_scope(variant_ids=[variant.id for variant in variants]))]
+            if mode == "consolidated"
+            else [(variant, compute_export_scope(variant_id=variant.id)) for variant in variants]
+        )
+        project_name = _safe_archive_name(project.name)
+        suffix = "consolidated" if mode == "consolidated" else "by_variant"
+        filename = f"{project_name}_{suffix}_export.zip"
+
+        if body.get("async") is True:
+            if not _export_capacity.acquire(blocking=False):
+                response = make_response({"error": "Export queue is full; retry later"}, 503)
+                response.headers["Retry-After"] = "5"
+                return response
+
+            job_id = str(uuid.uuid4())
+            with _export_jobs_lock:
+                _prune_export_jobs()
+                _export_jobs[job_id] = {
+                    "status": "running",
+                    "current": 0,
+                    "total": len(scopes) * len(selections),
+                    "progress": "Queued",
+                    "logs": [],
+                    "error": None,
+                    "filename": filename,
+                }
+
+            @copy_current_request_context
+            def generate_archive() -> None:
+                def update_progress(current: int, total: int, element_name: str) -> None:
+                    message = f"Generating {current} of {total} element: {element_name}"
+                    with _export_jobs_lock:
+                        job = _export_jobs[job_id]
+                        job.update({"current": current, "total": total, "progress": message})
+                        logs = job["logs"]
+                        assert isinstance(logs, list)
+                        logs.append(message)
+
+                archive_path: str | None = None
+                try:
+                    with tempfile.NamedTemporaryFile(
+                        prefix="vulnscout_export_", suffix=".zip", delete=False
+                    ) as archive:
+                        archive_path = archive.name
+                        _build_export_archive(app, scopes, selections, cast(BinaryIO, archive), update_progress)
+                    with _export_jobs_lock:
+                        _prune_export_jobs()
+                        _reserve_retained_archive(os.path.getsize(archive_path))
+                        _export_jobs[job_id].update({
+                            "status": "done",
+                            "progress": "Export ready",
+                            "archive_path": archive_path,
+                            "finished_at": time.monotonic(),
+                        })
+                    archive_path = None
+                except (ExportGenerationError, FileNotFoundError) as exc:
+                    message = str(exc)
+                    if isinstance(exc, FileNotFoundError):
+                        message = "Required conversion tool was not found"
+                    with _export_jobs_lock:
+                        _export_jobs[job_id].update({
+                            "status": "error",
+                            "error": message,
+                            "progress": "Export failed",
+                            "finished_at": time.monotonic(),
+                        })
+                except Exception:
+                    app.logger.exception("Export job %s failed", job_id)
+                    with _export_jobs_lock:
+                        _export_jobs[job_id].update({
+                            "status": "error",
+                            "error": "Export generation failed",
+                            "progress": "Export failed",
+                            "finished_at": time.monotonic(),
+                        })
+                finally:
+                    if archive_path is not None:
+                        _delete_archive({"archive_path": archive_path})
+
+            try:
+                future = _export_executor.submit(generate_archive)
+            except RuntimeError:
+                with _export_jobs_lock:
+                    del _export_jobs[job_id]
+                _export_capacity.release()
+                return {"error": "Export service is unavailable"}, 503
+            future.add_done_callback(lambda _future: _export_capacity.release())
+            return {"job_id": job_id}, 202
+
+        if not _sync_export_capacity.acquire(blocking=False):
+            response = make_response({"error": "Export service is busy; retry later"}, 503)
+            response.headers["Retry-After"] = "5"
+            return response
+        try:
+            try:
+                archive = tempfile.SpooledTemporaryFile(max_size=10 * 1024 * 1024)
+                _build_export_archive(app, scopes, selections, cast(BinaryIO, archive))
+            except ExportGenerationError as exc:
+                return {"error": str(exc)}, exc.status_code
+            except FileNotFoundError:
+                return {"error": "Required conversion tool was not found"}, 503
+        finally:
+            _sync_export_capacity.release()
+
+        archive.seek(0)
+        return send_file(
+            cast(BinaryIO, archive),
+            mimetype="application/zip",
+            as_attachment=True,
+            download_name=filename,
+        )
+
+    @app.route('/api/documents/export/<job_id>', methods=['GET'])
+    def export_status(job_id: str) -> ResponseReturnValue:
+        with _export_jobs_lock:
+            _prune_export_jobs()
+            job = _export_jobs.get(job_id)
+            if job is None:
+                return {"error": "Export job not found"}, 404
+            return {key: value for key, value in job.items() if key not in {"archive", "filename", "finished_at"}}
+
+    @app.route('/api/documents/export/<job_id>/download', methods=['GET'])
+    def download_export(job_id: str) -> ResponseReturnValue:
+        with _export_jobs_lock:
+            _prune_export_jobs()
+            job = _export_jobs.get(job_id)
+            if job is None:
+                return {"error": "Export job not found"}, 404
+            if job["status"] != "done" or "archive_path" not in job:
+                return {"error": "Export is not ready"}, 409
+            archive_path = job["archive_path"]
+            if not isinstance(archive_path, str):
+                return {"error": "Export archive is invalid"}, 500
+            try:
+                archive = open(archive_path, "rb")
+            except FileNotFoundError:
+                _delete_archive(_export_jobs.pop(job_id))
+                return {"error": "Export archive is no longer available"}, 410
+            filename = str(_export_jobs.pop(job_id)["filename"])
+            os.remove(archive_path)
+        return send_file(archive, mimetype="application/zip", as_attachment=True, download_name=filename)
+
     @app.route('/api/documents/<doc_name>', methods=['GET'])
     def doc_by_name(doc_name: str) -> ResponseReturnValue:
         """Render or export a document template or SBOM format.
@@ -337,33 +834,6 @@ def init_app(app: Flask) -> None:
         response 503 Error Required conversion tool not available.
         """
         try:
-            base_mime = guess_mime_type(doc_name)
-            if base_mime is None:
-                return {"error": "Unsupported document type"}, 400
-            expected_mime = guess_mime_type(request.args.get("ext")) or base_mime
-
-            asset_path = find_asset(doc_name)
-            if asset_path is not None:
-                return send_file(
-                    asset_path,
-                    mimetype=base_mime,
-                    as_attachment=True,
-                    download_name=doc_name,
-                )
-
-            metadata: Dict[str, str | float] = {
-                "author": request.args.get("author") or os.getenv('AUTHOR_NAME', 'Savoir-faire Linux') or '',
-                "client_name": request.args.get("client_name") or os.getenv('CLIENT_NAME', "") or '',
-                "export_date": request.args.get("export_date") or date.today().isoformat(),
-                "ignore_before": request.args.get("ignore_before") or "1970-01-01T00:00",
-                "only_epss_greater": 0.0,
-                "scan_date": app.config["SCAN_DATE"] or "unknown date"  # don't use actual datetime by default.
-            }
-            try:
-                metadata["only_epss_greater"] = float(request.args.get("only_epss_greater") or "0.0")
-            except ValueError:
-                pass
-
             # Resolve the optional project/variant scope from the "Project &
             # Variant" selection. It applies to BOTH SBOM/VEX exports and
             # reports (templates) so that every document only contains the
@@ -382,39 +852,7 @@ def init_app(app: Flask) -> None:
                 if err is not None:
                     return err
                 scope = compute_export_scope(project_id=project_uuid)
-
-            ctrls = ControllersCache(scope=scope)
-            ctrls.packages._preload_cache()
-
-            if (
-                doc_name.startswith("CycloneDX ")
-                or doc_name == "OpenVex"
-                or doc_name.startswith("SPDX")
-            ):
-                return handle_sbom_exports(doc_name, ctrls, expected_mime, metadata)
-
-            templ = Templates(ctrls)
-            content = templ.render(doc_name, **metadata)
-
-            if base_mime == expected_mime:
-                return content, 200, {
-                    "Content-Type": base_mime,
-                    "Content-Disposition": f"attachment; filename={doc_name}"
-                }
-
-            if base_mime == "text/asciidoc" and expected_mime == "application/pdf":
-                resp = make_response(templ.adoc_to_pdf(content))
-                resp.headers["Content-Type"] = "application/pdf"
-                resp.headers["Content-Disposition"] = f"attachment; filename={doc_name}.pdf"
-                return resp
-
-            if base_mime == "text/asciidoc" and expected_mime == "text/html":
-                resp = make_response(templ.adoc_to_html(content))
-                resp.headers["Content-Type"] = "text/html"
-                resp.headers["Content-Disposition"] = f"attachment; filename={doc_name}.html"
-                return resp
-
-            return {"error": f"Cannot convert {base_mime} to {expected_mime}"}, 400
+            return _render_document(app, doc_name, request.args.get("ext"), scope)
         except FileNotFoundError as e:
             print(e, flush=True)
             return {"error": f"Required conversion tool not found: {e.filename}"}, 503
@@ -459,7 +897,7 @@ def handle_sbom_exports(
                         "Content-Type": expected_mime,
                         "Content-Disposition": f"attachment; filename={new_name}.json"
                     }
-            if expected_mime == "text/xml":
+            if expected_mime in {"application/xml", "text/xml"}:
                 content = spdx.output_as_xml(author)
                 if content is not None:
                     new_name = doc_name.lower().replace(' ', '_v').replace('.', '_')

--- a/src/views/spdx.py
+++ b/src/views/spdx.py
@@ -176,10 +176,8 @@ class SPDX:
                     data_license="CC0-1.0",
                     spdx_id="SPDXRef-DOCUMENT",
                     name=f"{getenv('PRODUCT_NAME', 'PRODUCT_NAME')}-{getenv('PRODUCT_VERSION', '1.0.0')}",
-                    document_namespace=getenv(
-                        'DOCUMENT_URL',
-                        f"https://spdx.org/spdxdocs/{uuid7(as_type='str')}.spdx.json"
-                    ),
+                    document_namespace=getenv('DOCUMENT_URL')
+                    or f"https://spdx.org/spdxdocs/{uuid7(as_type='str')}.spdx.json",
                     creators=[
                         Actor(
                             actor_type=ActorType.ORGANIZATION,

--- a/src/views/templates.py
+++ b/src/views/templates.py
@@ -394,9 +394,15 @@ class Templates:
     def list_documents(self):
         docs = []
         try:
-            internal = self.internal_loader.list_templates()
+            internal = [
+                template for template in self.internal_loader.list_templates()
+                if not template.startswith("assets/")
+            ]
             docs.extend([{"id": doc, "is_template": True, "category": ["built-in"]} for doc in internal])
-            external = self.external_loader.list_templates()
+            external = [
+                template for template in self.external_loader.list_templates()
+                if not template.startswith("assets/")
+            ]
             docs.extend([{"id": doc, "is_template": True, "category": ["custom"]} for doc in external])
         except Exception as e:
             print(e)

--- a/tests/integration_tests/test_spdx_export.py
+++ b/tests/integration_tests/test_spdx_export.py
@@ -8,6 +8,7 @@ from src.views.spdx import SPDX
 from src.models.package import Package
 from src.controllers import ControllersCache
 import json
+from xml.etree import ElementTree
 
 
 @pytest.fixture
@@ -31,6 +32,16 @@ def test_export_empty_json(spdx_parser):
     except Exception as e:
         print(json.dumps(output, indent=2))
         raise e
+
+
+def test_export_uses_generated_namespace_when_document_url_is_blank(monkeypatch, spdx_parser):
+    monkeypatch.setenv("DOCUMENT_URL", "")
+
+    json_output = json.loads(spdx_parser.output_as_json(True, "MY_AUTHOR_NAME"))
+    assert json_output["documentNamespace"].startswith("https://spdx.org/spdxdocs/")
+
+    xml_output = spdx_parser.output_as_xml(True, "MY_AUTHOR_NAME")
+    assert ElementTree.fromstring(xml_output).tag == "Document"
 
 
 def test_export_components_json(spdx_parser):

--- a/tests/unit_tests/test_templates.py
+++ b/tests/unit_tests/test_templates.py
@@ -207,12 +207,13 @@ class TestListDocumentsError:
     def test_list_documents_success(self, templates_instance):
         """Test successful list_documents"""
         # Mock the loaders to return template lists
-        with patch.object(templates_instance.internal_loader, 'list_templates', return_value=["template1.jinja2"]):
-            with patch.object(templates_instance.external_loader, 'list_templates', return_value=["custom.jinja2"]):
+        with patch.object(templates_instance.internal_loader, 'list_templates', return_value=["template1.jinja2", "assets/logo.png"]):
+            with patch.object(templates_instance.external_loader, 'list_templates', return_value=["custom.jinja2", "assets/lolcat.jpg"]):
                 result = templates_instance.list_documents()
                 assert len(result) == 2
                 assert {"id": "template1.jinja2", "is_template": True, "category": ["built-in"]} in result
                 assert {"id": "custom.jinja2", "is_template": True, "category": ["custom"]} in result
+                assert all(not document["id"].startswith("assets/") for document in result)
 
 
 class TestFilterEpssScoreException:

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -4,7 +4,11 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import pytest
+import io
 import json
+import os
+import time
+import zipfile
 from src.bin.webapp import create_app
 from . import write_demo_files, setup_demo_db
 
@@ -282,6 +286,231 @@ def test_render_document_adoc(client):
     content = response.data.decode("utf-8")
     assert "Vulnerabilities Report" in content
     assert "| Fixed\n^.^| 0\n^.^| 1\n" in content
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_name"),
+    [
+        ("consolidated", "summary.adoc"),
+        ("per_variant", "default/summary.adoc"),
+    ],
+)
+def test_export_documents_archive(client, mode, expected_name):
+    response = client.post("/api/documents/export", json={
+        "project_id": "11111111-1111-1111-1111-111111111111",
+        "mode": mode,
+        "documents": [{"name": "summary.adoc", "extension": "adoc"}],
+    })
+
+    assert response.status_code == 200
+    assert response.mimetype == "application/zip"
+    with zipfile.ZipFile(io.BytesIO(response.data)) as archive:
+        assert archive.namelist() == [expected_name]
+        assert b"Vulnerabilities Report" in archive.read(expected_name)
+
+
+def test_export_documents_archive_selected_variants(app, client):
+    import uuid
+    from src.models.variant import Variant
+
+    with app.app_context():
+        Variant.create("secondary", uuid.UUID("11111111-1111-1111-1111-111111111111"))
+
+    response = client.post("/api/documents/export", json={
+        "project_id": "11111111-1111-1111-1111-111111111111",
+        "variant_ids": ["22222222-2222-2222-2222-222222222222"],
+        "mode": "per_variant",
+        "documents": [{"name": "summary.adoc", "extension": "adoc"}],
+    })
+
+    assert response.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(response.data)) as archive:
+        assert archive.namelist() == ["default/summary.adoc"]
+
+
+def test_export_documents_disambiguates_colliding_archive_paths(app, client):
+    import uuid
+    from src.models.variant import Variant
+
+    with app.app_context():
+        Variant.create("default!", uuid.UUID("11111111-1111-1111-1111-111111111111"))
+
+    response = client.post("/api/documents/export", json={
+        "project_id": "11111111-1111-1111-1111-111111111111",
+        "mode": "per_variant",
+        "documents": [{"name": "summary.adoc", "extension": "adoc"}],
+    })
+
+    assert response.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(response.data)) as archive:
+        assert archive.namelist() == ["default/summary.adoc", "default/summary_2.adoc"]
+
+
+def test_export_documents_async_progress_and_download(client):
+    response = client.post("/api/documents/export", json={
+        "project_id": "11111111-1111-1111-1111-111111111111",
+        "mode": "consolidated",
+        "async": True,
+        "documents": [{"name": "summary.adoc", "extension": "adoc"}],
+    })
+
+    assert response.status_code == 202
+    job_id = response.get_json()["job_id"]
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        status = client.get(f"/api/documents/export/{job_id}").get_json()
+        if status["status"] != "running":
+            break
+        time.sleep(0.01)
+
+    assert status["status"] == "done"
+    assert status["current"] == status["total"] == 1
+    assert status["logs"] == ["Generating 1 of 1 element: summary.adoc (adoc)"]
+
+    from src.routes.documents import _export_jobs, _export_jobs_lock
+    with _export_jobs_lock:
+        archive_path = str(_export_jobs[job_id]["archive_path"])
+    assert os.path.isfile(archive_path)
+
+    download = client.get(f"/api/documents/export/{job_id}/download")
+    assert download.status_code == 200
+    assert download.mimetype == "application/zip"
+    with zipfile.ZipFile(io.BytesIO(download.data)) as archive:
+        assert archive.namelist() == ["summary.adoc"]
+    assert not os.path.exists(archive_path)
+    assert client.get(f"/api/documents/export/{job_id}").status_code == 404
+
+
+def test_export_documents_rejects_when_async_queue_is_full(client):
+    from src.routes.documents import EXPORT_MAX_QUEUED_JOBS, EXPORT_MAX_WORKERS, _export_capacity
+
+    capacity = EXPORT_MAX_WORKERS + EXPORT_MAX_QUEUED_JOBS
+    for _ in range(capacity):
+        assert _export_capacity.acquire(blocking=False)
+    try:
+        response = client.post("/api/documents/export", json={
+            "project_id": "11111111-1111-1111-1111-111111111111",
+            "mode": "consolidated",
+            "async": True,
+            "documents": [{"name": "summary.adoc", "extension": "adoc"}],
+        })
+    finally:
+        for _ in range(capacity):
+            _export_capacity.release()
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "5"
+    assert response.get_json() == {"error": "Export queue is full; retry later"}
+
+
+def test_export_documents_rejects_when_sync_capacity_is_full(client):
+    from src.routes.documents import EXPORT_MAX_WORKERS, _sync_export_capacity
+
+    for _ in range(EXPORT_MAX_WORKERS):
+        assert _sync_export_capacity.acquire(blocking=False)
+    try:
+        response = client.post("/api/documents/export", json={
+            "project_id": "11111111-1111-1111-1111-111111111111",
+            "mode": "consolidated",
+            "documents": [{"name": "summary.adoc", "extension": "adoc"}],
+        })
+    finally:
+        for _ in range(EXPORT_MAX_WORKERS):
+            _sync_export_capacity.release()
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "5"
+
+
+def test_export_retention_evicts_oldest_archive(monkeypatch, tmp_path):
+    from src.routes import documents
+
+    old_archive = tmp_path / "old.zip"
+    old_archive.write_bytes(b"1234")
+    job_id = "retention-test-job"
+    with documents._export_jobs_lock:
+        documents._export_jobs[job_id] = {
+            "archive_path": str(old_archive),
+            "finished_at": 1.0,
+        }
+        monkeypatch.setattr(documents, "EXPORT_MAX_RETAINED_ARCHIVE_BYTES", 5)
+        documents._reserve_retained_archive(3)
+
+    assert job_id not in documents._export_jobs
+    assert not old_archive.exists()
+
+
+def test_export_missing_tool_does_not_disclose_server_path(monkeypatch, client):
+    def missing_tool(*_args, **_kwargs):
+        raise FileNotFoundError(2, "missing", "/private/server/bin/converter")
+
+    monkeypatch.setattr("src.routes.documents._build_export_archive", missing_tool)
+    response = client.post("/api/documents/export", json={
+        "project_id": "11111111-1111-1111-1111-111111111111",
+        "mode": "consolidated",
+        "documents": [{"name": "summary.adoc", "extension": "pdf"}],
+    })
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "Required conversion tool was not found"}
+    assert "/private/server" not in response.get_data(as_text=True)
+
+
+def test_export_documents_rejects_assets(monkeypatch, client):
+    monkeypatch.setattr("src.routes.documents.list_assets", lambda: [
+        {"id": "logo.png", "extension": "png", "is_template": False, "category": ["assets"]},
+    ])
+
+    response = client.post("/api/documents/export", json={
+        "project_id": "11111111-1111-1111-1111-111111111111",
+        "mode": "consolidated",
+        "documents": [{"name": "logo.png", "extension": "png"}],
+    })
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Unsupported document selection: logo.png (png)"
+
+
+def test_export_documents_rejects_consolidated_sbom(client):
+    response = client.post("/api/documents/export", json={
+        "project_id": "11111111-1111-1111-1111-111111111111",
+        "variant_ids": ["22222222-2222-2222-2222-222222222222"],
+        "mode": "consolidated",
+        "documents": [{"name": "CycloneDX 1.6", "extension": "json"}],
+    })
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "SBOM files must be exported per variant as a ZIP archive"
+
+
+def test_export_documents_archive_multiple_sboms(client):
+    response = client.post("/api/documents/export", json={
+        "project_id": "11111111-1111-1111-1111-111111111111",
+        "variant_ids": ["22222222-2222-2222-2222-222222222222"],
+        "mode": "per_variant",
+        "documents": [
+            {"name": "SPDX 2.3", "extension": "json"},
+            {"name": "SPDX 2.3", "extension": "xml"},
+            {"name": "SPDX 3.0", "extension": "json"},
+            {"name": "CycloneDX 1.4", "extension": "json"},
+            {"name": "CycloneDX 1.5", "extension": "json"},
+            {"name": "CycloneDX 1.6", "extension": "json"},
+            {"name": "OpenVex", "extension": "json"},
+        ],
+    })
+
+    assert response.status_code == 200
+    assert response.mimetype == "application/zip"
+    with zipfile.ZipFile(io.BytesIO(response.data)) as archive:
+        assert archive.namelist() == [
+            "default/spdx_v2_3.json",
+            "default/spdx_v2_3.xml",
+            "default/spdx_v3_0.json",
+            "default/cyclonedx_v1_4.json",
+            "default/cyclonedx_v1_5.json",
+            "default/cyclonedx_v1_6.json",
+            "default/openvex.json",
+        ]
 
 
 def test_render_document_with_options(client):


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

* Add guided export workflow
* Move Custom Reports to Settings tab
* Add exports as an async queue job

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open web dashboard, go to the Export tab and follow the new workflow, observe that it creates a new job in the Operations Queue.
Go to Settings and observe the new Custom reports tab.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


