### PR TITLE
Add initial setup assistant popup

### DIFF
--- a/frontend/src/handlers/project.ts
+++ b/frontend/src/handlers/project.ts
@@ -10,7 +10,7 @@ class Projects {
         const response = await fetch(import.meta.env.VITE_API_URL + "/api/projects", {
             mode: "cors",
         });
-        if (!response.ok) return [];
+        if (!response.ok) throw new Error(`Failed to list projects (${response.status})`);
         const data = await response.json();
         if (!Array.isArray(data)) return [];
         return data.filter(

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from "
 import NavigationBar from "../components/NavigationBar";
 import OperationQueueModal from "../components/OperationQueueModal";
 import MessageBanner from "../components/MessageBanner";
+import Popup from "../components/Popup";
 import type { Package } from "../handlers/packages";
 import type { CVSS, Vulnerability } from "../handlers/vulnerabilities";
 import type { Assessment } from "../handlers/assessments";
@@ -73,6 +74,12 @@ function Explorer() {
     const [currentVariantIds, setCurrentVariantIds] = useState<string[] | undefined>(undefined);
     const [currentMultiOperation, setCurrentMultiOperation] = useState<string | undefined>(undefined);
     const [operationQueueOpen, setOperationQueueOpen] = useState(false);
+    const [setupRequirement, setSetupRequirement] = useState<
+        { kind: 'project' } | { kind: 'variant'; projectId: string } | null
+    >(null);
+    const [settingsDestination, setSettingsDestination] = useState<
+        { tab: 'projects'; projectId?: string } | null
+    >(null);
     const hadActiveScans = useRef(false);
     const grypeScanEntries = useSyncExternalStore(grypeSubscribe, grypeGetSnapshot);
     const nvdScanEntries = useSyncExternalStore(nvdSubscribe, nvdGetSnapshot);
@@ -108,6 +115,24 @@ function Explorer() {
         }).catch(() => undefined);
         return () => { cancelled = true; };
     }, []);
+
+    const loadSetupRequirement = useCallback(() => {
+        return Promise.all([Projects.list(), Variants.listAll()])
+            .then(([projects, variants]) => {
+                if (projects.length === 0) {
+                    setSetupRequirement({ kind: 'project' });
+                } else if (variants.length === 0) {
+                    setSetupRequirement({ kind: 'variant', projectId: projects[0].id });
+                } else {
+                    setSetupRequirement(null);
+                }
+            })
+            .catch(() => undefined);
+    }, []);
+
+    useEffect(() => {
+        void loadSetupRequirement();
+    }, [loadSetupRequirement]);
 
     const triggerBanner = (message: string, type: 'error' | 'success') => {
         setBannerMessage(message);
@@ -387,6 +412,7 @@ function Explorer() {
             setFilterValue(undefined);
             setFilterVulnerabilityIds(undefined);
         }
+        if (newTab === 'settings') setSettingsDestination(null);
         setTab(newTab);
     }
 
@@ -414,6 +440,35 @@ function Explorer() {
                 />
             </header>
             <OperationQueueModal isOpen={operationQueueOpen} onClose={() => setOperationQueueOpen(false)} />
+            <Popup
+                isOpen={tab === 'metrics' && setupRequirement !== null}
+                title={setupRequirement?.kind === 'project' ? 'Add your first project' : 'Add a project variant'}
+                onClose={() => setSetupRequirement(null)}
+                testId="setup-required-popup"
+            >
+                <p className="text-sm text-gray-600 dark:text-gray-300">
+                    {setupRequirement?.kind === 'project'
+                        ? 'Projects organize your software variants, vulnerability data, scans, and assessments. Create one to get started.'
+                        : 'VulnScout needs a variant before it can display metrics for your project.'}
+                </p>
+                <div className="mt-5 flex justify-end">
+                    <button
+                        type="button"
+                        onClick={() => {
+                            setSettingsDestination({
+                                tab: 'projects',
+                                projectId: setupRequirement?.kind === 'variant'
+                                    ? setupRequirement.projectId
+                                    : undefined,
+                            });
+                            setTab('settings');
+                        }}
+                        className="rounded-md bg-sky-700 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-400"
+                    >
+                        Go to settings
+                    </button>
+                </div>
+            </Popup>
 
             <main id="main-content" aria-label={tabLabels[tab] ?? 'Content'} className="flex-1 flex flex-col overflow-hidden">
             <div className="px-8 pt-4">
@@ -481,12 +536,13 @@ function Explorer() {
                 {tab === 'scans' && <ScanHistory variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onScanComplete={handleScanComplete} />}
                 {tab === 'review' && <Review variantId={currentVariantId} projectId={currentVariantId ? undefined : currentProjectId} onAssessmentChanged={handleAssessmentChanged} />}
                 {tab === 'exports' && <Exports variantId={currentVariantId} projectId={currentProjectId} variantIds={currentVariantIds} />}
-                {tab === 'settings' && <Settings onDataChanged={(message) => {
+                {tab === 'settings' && <Settings initialTab={settingsDestination?.tab} onDataChanged={(message) => {
                     if (message) setLoadingMessage(message);
                     Config.get().then(config => setDefaultConfig(config)).catch(() => {});
+                    loadSetupRequirement();
                     setSelectorKey(k => k + 1);
                     loadData(currentVariantId, currentVariantId ? undefined : currentProjectId, undefined, undefined, currentVariantIds, currentMultiOperation);
-                }} projectId={currentProjectId} onLoadingMessage={(msg) => {
+                }} projectId={settingsDestination ? settingsDestination.projectId : currentProjectId} onLoadingMessage={(msg) => {
                     if (msg) {
                         setLoadingMessage(msg);
                         setIsLoadingData(true);

--- a/frontend/src/pages/Explorer.tsx
+++ b/frontend/src/pages/Explorer.tsx
@@ -75,12 +75,13 @@ function Explorer() {
     const [currentMultiOperation, setCurrentMultiOperation] = useState<string | undefined>(undefined);
     const [operationQueueOpen, setOperationQueueOpen] = useState(false);
     const [setupRequirement, setSetupRequirement] = useState<
-        { kind: 'project' } | { kind: 'variant'; projectId: string } | null
+        { kind: 'project' } | { kind: 'variant'; projectId: string } | { kind: 'error' } | null
     >(null);
     const [settingsDestination, setSettingsDestination] = useState<
         { tab: 'projects'; projectId?: string } | null
     >(null);
     const hadActiveScans = useRef(false);
+    const setupCheckGeneration = useRef(0);
     const grypeScanEntries = useSyncExternalStore(grypeSubscribe, grypeGetSnapshot);
     const nvdScanEntries = useSyncExternalStore(nvdSubscribe, nvdGetSnapshot);
     const osvScanEntries = useSyncExternalStore(osvSubscribe, osvGetSnapshot);
@@ -117,8 +118,10 @@ function Explorer() {
     }, []);
 
     const loadSetupRequirement = useCallback(() => {
+        const generation = ++setupCheckGeneration.current;
         return Promise.all([Projects.list(), Variants.listAll()])
             .then(([projects, variants]) => {
+                if (generation !== setupCheckGeneration.current) return;
                 if (projects.length === 0) {
                     setSetupRequirement({ kind: 'project' });
                 } else if (variants.length === 0) {
@@ -127,7 +130,11 @@ function Explorer() {
                     setSetupRequirement(null);
                 }
             })
-            .catch(() => undefined);
+            .catch(() => {
+                if (generation === setupCheckGeneration.current) {
+                    setSetupRequirement({ kind: 'error' });
+                }
+            });
     }, []);
 
     useEffect(() => {
@@ -442,19 +449,29 @@ function Explorer() {
             <OperationQueueModal isOpen={operationQueueOpen} onClose={() => setOperationQueueOpen(false)} />
             <Popup
                 isOpen={tab === 'metrics' && setupRequirement !== null}
-                title={setupRequirement?.kind === 'project' ? 'Add your first project' : 'Add a project variant'}
+                title={setupRequirement?.kind === 'project'
+                    ? 'Add your first project'
+                    : setupRequirement?.kind === 'variant'
+                        ? 'Add a project variant'
+                        : 'Unable to check setup'}
                 onClose={() => setSetupRequirement(null)}
                 testId="setup-required-popup"
             >
                 <p className="text-sm text-gray-600 dark:text-gray-300">
                     {setupRequirement?.kind === 'project'
                         ? 'Projects organize your software variants, vulnerability data, scans, and assessments. Create one to get started.'
-                        : 'VulnScout needs a variant before it can display metrics for your project.'}
+                        : setupRequirement?.kind === 'variant'
+                            ? 'VulnScout needs a variant before it can display metrics for your project.'
+                            : 'VulnScout could not load the project list. Check the connection and try again.'}
                 </p>
                 <div className="mt-5 flex justify-end">
                     <button
                         type="button"
                         onClick={() => {
+                            if (setupRequirement?.kind === 'error') {
+                                void loadSetupRequirement();
+                                return;
+                            }
                             setSettingsDestination({
                                 tab: 'projects',
                                 projectId: setupRequirement?.kind === 'variant'
@@ -465,7 +482,7 @@ function Explorer() {
                         }}
                         className="rounded-md bg-sky-700 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-400"
                     >
-                        Go to settings
+                        {setupRequirement?.kind === 'error' ? 'Retry' : 'Go to settings'}
                     </button>
                 </div>
             </Popup>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -43,6 +43,7 @@ type Props = {
   onDataChanged?: (message?: string) => void;
   onLoadingMessage?: (message: string | null) => void;
   projectId?: string;
+  initialTab?: SettingsTab;
 };
 
 type SettingsTab = "general" | "transfer" | "projects" | "variants";
@@ -51,9 +52,9 @@ type AdditionalCleanup =
   | { kind: "empty-scans"; scans: EmptyScanPreview[] }
   | { kind: "orphaned-vulnerabilities"; vulnerabilities: OrphanedVulnerabilityPreview[] };
 
-function Settings({ onDataChanged, onLoadingMessage, projectId }: Readonly<Props>) {
+function Settings({ onDataChanged, onLoadingMessage, projectId, initialTab }: Readonly<Props>) {
   // ---- Active category tab ----
-  const [activeTab, setActiveTab] = useState<SettingsTab>("general");
+  const [activeTab, setActiveTab] = useState<SettingsTab>(initialTab ?? "general");
 
   // ---- Unmount guard for async operations ----
   const unmountedRef = useRef(false);
@@ -453,6 +454,16 @@ function Settings({ onDataChanged, onLoadingMessage, projectId }: Readonly<Props
   const [confirmDeleteProject, setConfirmDeleteProject] = useState(false);
   const [deleteProjectBusy, setDeleteProjectBusy] = useState(false);
   const [deleteProjectMsg, setDeleteProjectMsg] = useState<FeedbackMsg>(null);
+  const initialProjectAppliedRef = useRef(false);
+
+  useEffect(() => {
+    if (initialProjectAppliedRef.current || initialTab !== "projects" || !projectId) return;
+    const project = projects.find((item) => item.id === projectId);
+    if (!project) return;
+    setRenameProjectId(project.id);
+    setRenameProjectName(project.name);
+    initialProjectAppliedRef.current = true;
+  }, [initialTab, projectId, projects]);
 
   const handleRenameProject = async () => {
     if (!renameProjectId || !renameProjectName.trim()) return;

--- a/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
+++ b/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
@@ -396,6 +396,7 @@ describe('Explorer saved-scope validation', () => {
             .mockReturnValueOnce(older)
             .mockResolvedValueOnce([{ id: 'project-1', name: 'Project 1' }]);
         mockVariantsListAll
+            .mockResolvedValueOnce([])
             .mockResolvedValueOnce([{ id: 'variant-1', name: 'Variant 1', project_id: 'project-1' }])
             .mockResolvedValueOnce([])
             .mockResolvedValueOnce([{ id: 'variant-1', name: 'Variant 1', project_id: 'project-1' }]);

--- a/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
+++ b/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
@@ -371,6 +371,46 @@ describe('Explorer saved-scope validation', () => {
         expect(screen.getByRole('button', { name: 'filter vulnerabilities' })).toBeInTheDocument();
     });
 
+    test('shows a retryable setup error when projects cannot be loaded', async () => {
+        mockGetFrontendScope.mockReturnValue(null);
+        mockProjectsList
+            .mockRejectedValueOnce(new Error('Temporary network failure'))
+            .mockResolvedValue([{ id: 'project-1', name: 'Project 1' }]);
+        mockVariantsListAll.mockResolvedValue([
+            { id: 'variant-1', name: 'Variant 1', project_id: 'project-1' },
+        ]);
+
+        render(<Explorer />);
+
+        expect(await screen.findByText('Unable to check setup')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+        await waitFor(() => expect(screen.queryByTestId('setup-required-popup')).not.toBeInTheDocument());
+    });
+
+    test('ignores an older setup response that resolves after a newer check', async () => {
+        mockGetFrontendScope.mockReturnValue(null);
+        let resolveOlder: (projects: Array<{ id: string; name: string }>) => void = () => undefined;
+        const older = new Promise<Array<{ id: string; name: string }>>(resolve => { resolveOlder = resolve; });
+        mockProjectsList
+            .mockResolvedValueOnce([{ id: 'project-1', name: 'Project 1' }])
+            .mockReturnValueOnce(older)
+            .mockResolvedValueOnce([{ id: 'project-1', name: 'Project 1' }]);
+        mockVariantsListAll
+            .mockResolvedValueOnce([{ id: 'variant-1', name: 'Variant 1', project_id: 'project-1' }])
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([{ id: 'variant-1', name: 'Variant 1', project_id: 'project-1' }]);
+
+        render(<Explorer />);
+        await waitFor(() => expect(mockProjectsList).toHaveBeenCalled());
+        fireEvent.click(screen.getByRole('button', { name: 'settings' }));
+        fireEvent.click(screen.getByRole('button', { name: 'settings changed' }));
+        fireEvent.click(screen.getByRole('button', { name: 'settings changed' }));
+        await waitFor(() => expect(mockProjectsList).toHaveBeenCalledTimes(3));
+        resolveOlder([{ id: 'project-1', name: 'Project 1' }]);
+
+        await waitFor(() => expect(screen.queryByTestId('setup-required-popup')).not.toBeInTheDocument());
+    });
+
     test('wires navigation and data update callbacks', async () => {
         mockGetFrontendScope.mockReturnValue(null);
         mockProjectsList.mockResolvedValue([]);

--- a/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
+++ b/frontend/tests/unit_tests/test_explorer_scope_restore.tsx
@@ -161,7 +161,14 @@ jest.mock('../../src/pages/Review', () => ({
 }));
 jest.mock('../../src/pages/Settings', () => ({
     __esModule: true,
-    default: ({ onDataChanged, onLoadingMessage }: { onDataChanged: (message: string) => void; onLoadingMessage: (message: string) => void }) => <div>
+    default: ({ onDataChanged, onLoadingMessage, initialTab, projectId }: {
+        onDataChanged: (message: string) => void;
+        onLoadingMessage: (message: string) => void;
+        initialTab?: string;
+        projectId?: string;
+    }) => <div>
+        <span data-testid="settings-initial-tab">{initialTab}</span>
+        <span data-testid="settings-project-id">{projectId}</span>
         <button onClick={() => onDataChanged('Saving')}>settings changed</button>
         <button onClick={() => onLoadingMessage('Loading settings')}>settings loading</button>
         <button onClick={() => onLoadingMessage('')}>settings loaded</button>
@@ -318,6 +325,50 @@ describe('Explorer saved-scope validation', () => {
                 status: { variant_id: 'variant-1', status: 'running' },
             },
         ]));
+    });
+
+    test('opens the add project settings view when no projects exist', async () => {
+        mockGetFrontendScope.mockReturnValue(null);
+        mockProjectsList.mockResolvedValue([]);
+        mockVariantsListAll.mockResolvedValue([]);
+
+        render(<Explorer />);
+
+        expect(await screen.findByTestId('setup-required-popup')).toBeInTheDocument();
+        expect(screen.getByText('Add your first project')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Go to settings' }));
+
+        expect(screen.getByTestId('settings-initial-tab')).toHaveTextContent('projects');
+        expect(screen.getByTestId('settings-project-id')).toBeEmptyDOMElement();
+    });
+
+    test('opens the existing project in settings when it has no variants', async () => {
+        mockGetFrontendScope.mockReturnValue(null);
+        mockProjectsList.mockResolvedValue([{ id: 'project-1', name: 'Project 1' }]);
+        mockVariantsListAll.mockResolvedValue([]);
+
+        render(<Explorer />);
+
+        expect(await screen.findByTestId('setup-required-popup')).toBeInTheDocument();
+        expect(screen.getByText('Add a project variant')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Go to settings' }));
+
+        expect(screen.getByTestId('settings-initial-tab')).toHaveTextContent('projects');
+        expect(screen.getByTestId('settings-project-id')).toHaveTextContent('project-1');
+    });
+
+    test('keeps metrics visible when projects and variants exist', async () => {
+        mockGetFrontendScope.mockReturnValue(null);
+        mockProjectsList.mockResolvedValue([{ id: 'project-1', name: 'Project 1' }]);
+        mockVariantsListAll.mockResolvedValue([
+            { id: 'variant-1', name: 'Variant 1', project_id: 'project-1' },
+        ]);
+
+        render(<Explorer />);
+
+        await waitFor(() => expect(mockProjectsList).toHaveBeenCalled());
+        expect(screen.queryByTestId('setup-required-popup')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'filter vulnerabilities' })).toBeInTheDocument();
     });
 
     test('wires navigation and data update callbacks', async () => {

--- a/frontend/tests/unit_tests/test_project_variant_handlers.ts
+++ b/frontend/tests/unit_tests/test_project_variant_handlers.ts
@@ -113,6 +113,12 @@ describe('Projects', () => {
         expect(projects).toEqual([]);
     });
 
+    test('rejects when the project list request fails', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ error: 'unavailable' }), { status: 503 });
+
+        await expect(Projects.list()).rejects.toThrow('Failed to list projects (503)');
+    });
+
     test('filters out items missing id or name', async () => {
         const mockData = [
             { id: 'p1', name: 'Valid' },

--- a/frontend/tests/unit_tests/test_settings_page.tsx
+++ b/frontend/tests/unit_tests/test_settings_page.tsx
@@ -115,6 +115,14 @@ describe("Settings scoped project and variant views", () => {
     expect(screen.queryByRole("heading", { name: "Add Project" })).not.toBeInTheDocument();
   });
 
+  test("opens an initial project from the project list", async () => {
+    render(<Settings initialTab="projects" projectId={project.id} />);
+
+    expect(await screen.findByDisplayValue("Apollo")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Rename Project" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Add Project" })).not.toBeInTheDocument();
+  });
+
   test("the project add-variant action opens an add form scoped to that project", async () => {
     render(<Settings />);
 


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

When the user first launches Vulnscout we tell them how to work with adding project / variant to their instance.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Launch Vulnscout with a fresh database (e.g change vulnscout.db to vulnscout.db.old) then open the web dashboard, you should be presented with a popup instructing you how to start your first project / variant.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


