### PR TITLE
Show Git progress during SCC database sync

### DIFF
--- a/src/bin/cmd_vuln_scan.py
+++ b/src/bin/cmd_vuln_scan.py
@@ -192,7 +192,7 @@ def _nvd_scan_api(variant_uuid, packages) -> None:
 def _nvd_scan_local(variant_uuid, packages) -> None:
     """NVD scan using the local NVD-FKIE advisory database."""
     click.echo("Loading local NVD advisory database…")
-    engine = get_engine()
+    engine = get_engine(progress=click.echo)
 
     scan = _create_tool_scan(variant_uuid, "nvd")
     total = len(packages)
@@ -673,7 +673,7 @@ def sbom_cve_check_scan_command(project: str, variant: str | None) -> None:
     click.echo(f"Resolved {len(packages)} active packages")
 
     click.echo("Loading local CVE databases (NVD-FKIE + CVEList) and building index…")
-    engine = get_engine()
+    engine = get_engine(progress=click.echo)
     click.echo("Index ready — scanning packages")
 
     scan = _create_tool_scan(variant_uuid, "scc")

--- a/src/controllers/scc_engine.py
+++ b/src/controllers/scc_engine.py
@@ -29,11 +29,13 @@ import fcntl
 import logging
 import os
 import pathlib
+import re
+import subprocess
 import tempfile
 import threading
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from typing import cast
+from typing import Any, cast
 
 from sbom_cve_check.database.db_git import GitDatabase
 from sbom_cve_check.database.locking import init_global_databases_lock
@@ -57,6 +59,132 @@ _PURE_CACHES_INSTALLED = False
 # Sentinel distinguishing "attribute genuinely absent" (upstream rename) from a
 # legitimate ``None`` value when reaching into sbom-cve-check internals.
 _MISSING = object()
+
+ProgressCallback = Callable[[str], None]
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_GIT_PERCENT_RE = re.compile(r"^(?P<stage>[^:]+):\s+(?P<percent>\d{1,3})%")
+
+
+class _GitProgressReporter:
+    """Normalize and rate-limit progress emitted by a Git subprocess."""
+
+    def __init__(self, database: str, callback: ProgressCallback) -> None:
+        self._database = database
+        self._callback: ProgressCallback | None = callback
+        self._last_message = ""
+        self._last_percent: dict[str, int] = {}
+
+    def emit(self, raw_message: str) -> None:
+        message = _ANSI_ESCAPE_RE.sub("", raw_message).strip()
+        if message.startswith("remote: "):
+            message = message.removeprefix("remote: ").strip()
+        if not message or message == self._last_message:
+            return
+
+        match = _GIT_PERCENT_RE.match(message)
+        if match:
+            stage = match.group("stage")
+            percent = int(match.group("percent"))
+            previous = self._last_percent.get(stage, -5)
+            if percent != 100 and percent < previous + 5:
+                return
+            self._last_percent[stage] = percent
+
+        self._last_message = message
+        callback = self._callback
+        if callback is None:
+            return
+        try:
+            callback(f"Synchronizing {self._database}: {message}")
+        except Exception:  # noqa: BLE001 - progress must never break synchronization
+            self._callback = None
+            _logger.warning(
+                "SCC Git progress callback failed; synchronization will continue",
+                exc_info=True,
+            )
+
+
+def _stream_git_command(
+    git_repo: Any, args: list[str], callback: ProgressCallback
+) -> subprocess.CompletedProcess[str]:
+    """Run an SCC Git transfer while streaming its normally-hidden progress."""
+    progress_args = list(args)
+    if progress_args[0] in {"clone", "fetch"} and "--progress" not in progress_args:
+        progress_args.insert(1, "--progress")
+
+    command = [git_repo._git_exe, *progress_args]
+    reporter = _GitProgressReporter(git_repo.path.name, callback)
+    process = subprocess.Popen(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=git_repo.path,
+        encoding="utf-8",
+        errors="replace",
+        text=True,
+        bufsize=1,
+    )
+    assert process.stdout is not None
+
+    output: list[str] = []
+    progress_line: list[str] = []
+    while chunk := process.stdout.read(1):
+        output.append(chunk)
+        if chunk in {"\r", "\n"}:
+            reporter.emit("".join(progress_line))
+            progress_line.clear()
+        else:
+            progress_line.append(chunk)
+    if progress_line:
+        reporter.emit("".join(progress_line))
+
+    return_code = process.wait()
+    stdout = "".join(output)
+    result = subprocess.CompletedProcess(command, return_code, stdout=stdout, stderr="")
+    if return_code:
+        raise subprocess.CalledProcessError(
+            return_code, command, output=stdout, stderr=""
+        )
+    return result
+
+
+@contextmanager
+def _git_progress(
+    git_databases: list[Any], callback: ProgressCallback | None
+) -> Generator[None, None, None]:
+    """Temporarily stream transfer progress from SCC's GitRepo instances."""
+    if callback is None:
+        yield
+        return
+
+    Executor = Callable[[list[str]], subprocess.CompletedProcess[str]]
+    originals: list[tuple[Any, Executor]] = []
+    for git_database in git_databases:
+        git_repo = getattr(git_database, "_git_repo", None)
+        original = getattr(git_repo, "_exec_git_cmd", None)
+        if git_repo is None or not callable(original):
+            continue
+        typed_original = cast(Executor, original)
+
+        def exec_with_progress(
+            args: list[str],
+            *,
+            _repo: Any = git_repo,
+            _original: Executor = typed_original,
+        ) -> subprocess.CompletedProcess[str]:
+            if args and args[0] in {"clone", "fetch"}:
+                return _stream_git_command(_repo, args, callback)
+            return _original(args)
+
+        originals.append((git_repo, typed_original))
+        git_repo._exec_git_cmd = exec_with_progress
+
+    try:
+        yield
+    finally:
+        for git_repo, original in originals:
+            git_repo._exec_git_cmd = original
 
 
 def _install_cpe_parse_caches() -> None:
@@ -186,7 +314,8 @@ class SccEngine:
     """Indexed sbom-cve-check engine ready to match VulnScout packages."""
 
     def __init__(self, databases_dir: pathlib.Path, fetch_depth: int,
-                 auto_update: bool) -> None:
+                 auto_update: bool,
+                 progress: ProgressCallback | None = None) -> None:
         self._databases_dir = databases_dir
         self._fetch_depth = fetch_depth
         self._auto_update = auto_update
@@ -254,7 +383,10 @@ class SccEngine:
         _install_cpe_parse_caches()
 
         # Build the in-memory index (parallel across databases).  Expensive.
-        self._manager.create_index()
+        # SCC captures Git stderr, so temporarily stream clone/fetch output to
+        # the caller while retaining SCC's locking and update decisions.
+        with _git_progress(self._git_databases(), progress):
+            self._manager.create_index()
 
         # Memoize per-CVE record reads so each advisory JSON file is opened and
         # parsed at most once per engine lifetime instead of once per
@@ -346,7 +478,7 @@ class SccEngine:
                     if callable(clear):
                         clear()
 
-    def refresh_databases(self) -> bool:
+    def refresh_databases(self, progress: ProgressCallback | None = None) -> bool:
         """Fetch fresh advisories for each git database before a scan.
 
         Called once per scan (see :func:`get_engine`).  The process-wide engine is
@@ -367,19 +499,21 @@ class SccEngine:
             return False
         with self._refresh_lock:
             changed = False
-            for git_db in self._git_databases():
-                before = git_db.get_date_last_commit()
-                try:
-                    git_db.update(force_update=True)
-                except Exception as exc:  # noqa: BLE001 - never abort a scan on fetch error
-                    _logger.warning(
-                        "sbom-cve-check database refresh failed (using existing clone): %s",
-                        exc,
-                    )
-                    continue
-                after = git_db.get_date_last_commit()
-                if before != after:
-                    changed = True
+            git_databases = self._git_databases()
+            with _git_progress(git_databases, progress):
+                for git_db in git_databases:
+                    before = git_db.get_date_last_commit()
+                    try:
+                        git_db.update(force_update=True)
+                    except Exception as exc:  # noqa: BLE001 - never abort a scan on fetch error
+                        _logger.warning(
+                            "sbom-cve-check database refresh failed (using existing clone): %s",
+                            exc,
+                        )
+                        continue
+                    after = git_db.get_date_last_commit()
+                    if before != after:
+                        changed = True
             if changed:
                 self._manager.create_index()
                 self._clear_caches()
@@ -508,7 +642,7 @@ class SccEngine:
         return None
 
 
-def _get_engine() -> SccEngine:
+def _get_engine(progress: ProgressCallback | None = None) -> SccEngine:
     """Build or reuse the process-wide engine and refresh its databases."""
     global _ENGINE
     with _ENGINE_LOCK:
@@ -522,12 +656,13 @@ def _get_engine() -> SccEngine:
                 databases_dir=_databases_dir(),
                 fetch_depth=fetch_depth,
                 auto_update=_truthy(os.getenv("SBOM_CVE_CHECK_AUTO_UPDATE")),
+                progress=progress,
             )
-    _ENGINE.refresh_databases()
+    _ENGINE.refresh_databases(progress=progress)
     return _ENGINE
 
 
-def get_engine() -> SccEngine:
+def get_engine(progress: ProgressCallback | None = None) -> SccEngine:
     """Return the process-wide indexed engine, building it on first use.
 
     The engine is expensive to build and is cached for the lifetime of the
@@ -538,7 +673,7 @@ def get_engine() -> SccEngine:
     triggering a refresh).
     """
     with _serialized_engine_operation():
-        return _get_engine()
+        return _get_engine(progress=progress)
 
 
 def serialized_engine_operation(func):

--- a/src/routes/bulk_refresh.py
+++ b/src/routes/bulk_refresh.py
@@ -139,7 +139,11 @@ def init_app(app: Flask) -> None:
                         # auto-update is on) so individual CVE lookups in the loop
                         # below reuse the cached engine without re-fetching.
                         try:
-                            _get_scc_engine()
+                            _get_scc_engine(
+                                progress=lambda message: NVDProgressTracker.update(
+                                    "database_sync", 0, total, message
+                                )
+                            )
                         except Exception as exc:
                             NVDProgressTracker.error(
                                 f"Failed to load local NVD database: {exc}"

--- a/src/routes/scan_triggers.py
+++ b/src/routes/scan_triggers.py
@@ -465,8 +465,13 @@ def init_app(app: Flask) -> None:
             _nvd_scans_in_progress[vid_str]["logs"].append(
                 "Loading local NVD advisory database…"
             )
+
+            def report_database_progress(message: str) -> None:
+                _nvd_scans_in_progress[vid_str]["progress"] = message
+                _nvd_scans_in_progress[vid_str]["logs"].append(message)
+
             try:
-                engine = get_engine()
+                engine = get_engine(progress=report_database_progress)
             except Exception as exc:
                 set_error(_nvd_scans_in_progress, vid_str,
                           f"Failed to load local NVD database: {exc}")
@@ -951,8 +956,14 @@ def init_app(app: Flask) -> None:
                 _sbom_cve_check_scans_in_progress[vid_str]["logs"].append(
                     "Loading CVE databases — this might take several minutes on first run…"
                 )
+
+                def report_database_progress(message: str) -> None:
+                    progress = _sbom_cve_check_scans_in_progress[vid_str]
+                    progress["progress"] = message
+                    progress["logs"].append(message)
+
                 try:
-                    engine = get_engine()
+                    engine = get_engine(progress=report_database_progress)
                 except Exception as e:
                     set_error(_sbom_cve_check_scans_in_progress, vid_str,
                               f"Failed to load CVE databases: {str(e)[:300]}")

--- a/tests/unit_tests/test_scc_engine_utils.py
+++ b/tests/unit_tests/test_scc_engine_utils.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 import pathlib
 import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, call
 
 import pytest
@@ -36,6 +37,64 @@ class TestTruthy:
         from src.controllers.scc_engine import _truthy
         for val in ("0", "false", "no", "off", "", None, "anything-else"):
             assert _truthy(val) is False, f"Expected False for {val!r}"
+
+
+class TestGitProgress:
+
+    def test_reporter_normalizes_and_throttles_percent_updates(self):
+        from src.controllers.scc_engine import _GitProgressReporter
+
+        messages = []
+        reporter = _GitProgressReporter("nvd-fkie", messages.append)
+        reporter.emit("remote: Counting objects: 1% (1/100)\x1b[K")
+        reporter.emit("remote: Counting objects: 3% (3/100)")
+        reporter.emit("remote: Counting objects: 6% (6/100)")
+        reporter.emit("remote: Counting objects: 100% (100/100)")
+
+        assert messages == [
+            "Synchronizing nvd-fkie: Counting objects: 1% (1/100)",
+            "Synchronizing nvd-fkie: Counting objects: 6% (6/100)",
+            "Synchronizing nvd-fkie: Counting objects: 100% (100/100)",
+        ]
+
+    def test_git_progress_intercepts_transfers_and_restores_executor(self, tmp_path):
+        from sbom_cve_check.utils.git import GitRepo
+        from src.controllers.scc_engine import _git_progress
+
+        source = self._create_git_repository(tmp_path / "source")
+        destination = tmp_path / "nvd-fkie"
+        destination.mkdir()
+        git_repo = GitRepo(destination)
+        original = git_repo._exec_git_cmd
+        messages = []
+        git_database = SimpleNamespace(_git_repo=git_repo)
+
+        with _git_progress([git_database], messages.append):
+            result = git_repo._exec_git_cmd(["clone", str(source), "."])
+            assert result.returncode == 0
+            assert git_repo._exec_git_cmd(["rev-parse", "HEAD"]).stdout.strip()
+
+        assert any(message.startswith("Synchronizing nvd-fkie:") for message in messages)
+        assert git_repo._exec_git_cmd == original
+
+    @staticmethod
+    def _create_git_repository(path):
+        import subprocess
+
+        path.mkdir()
+        subprocess.run(["git", "init", "-q", str(path)], check=True)
+        subprocess.run(
+            ["git", "-C", str(path), "config", "user.email", "test@example.com"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(path), "config", "user.name", "Test User"],
+            check=True,
+        )
+        path.joinpath("advisory.json").write_text("{}", encoding="utf-8")
+        subprocess.run(["git", "-C", str(path), "add", "advisory.json"], check=True)
+        subprocess.run(["git", "-C", str(path), "commit", "-qm", "Initial"], check=True)
+        return path
 
 
 class TestDatabasesDir:
@@ -593,7 +652,7 @@ class TestGetAndResetEngine:
 
         original_init = None
 
-        def fake_init(self, databases_dir, fetch_depth, auto_update):
+        def fake_init(self, databases_dir, fetch_depth, auto_update, progress=None):
             captured["fetch_depth"] = fetch_depth
             self._databases_dir = databases_dir
             self._manager = mock_mgr
@@ -627,7 +686,7 @@ class TestGetAndResetEngine:
         mock_mgr = MagicMock()
         mock_mgr._databases = {}
 
-        def fake_init(self, databases_dir, fetch_depth, auto_update):
+        def fake_init(self, databases_dir, fetch_depth, auto_update, progress=None):
             captured["fetch_depth"] = fetch_depth
             self._databases_dir = databases_dir
             self._manager = mock_mgr

--- a/tests/webapp_tests/test_bulk_refresh_routes.py
+++ b/tests/webapp_tests/test_bulk_refresh_routes.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import pytest
-from unittest.mock import patch, MagicMock, ANY
+from unittest.mock import patch, MagicMock, ANY, call
 from src.bin.webapp import create_app
 from tests.webapp_tests import write_demo_files, setup_demo_db
 
@@ -1639,15 +1639,24 @@ class TestBulkNvdRefreshMode:
 
         with patch("src.routes.bulk_refresh.get_cve_json") as mock_local, \
              patch("src.routes.bulk_refresh.NVD_DB") as MockNVD, \
-             patch("src.routes.bulk_refresh._get_scc_engine"), \
+             patch("src.routes.bulk_refresh._get_scc_engine") as mock_engine, \
              patch("src.routes.bulk_refresh.db"), \
              patch("src.routes.bulk_refresh.NVDProgressTracker") as MockTracker:
             MockTracker.is_cancelled.return_value = False
             mock_local.return_value = None
+            mock_engine.side_effect = lambda progress: progress(
+                "Synchronizing nvd-fkie: Receiving objects: 50%"
+            )
             captured["target"]()
 
         mock_local.assert_called_once_with(existing_cve_id)
         MockNVD.return_value.api_get_cve.assert_not_called()
+        assert call(
+            "database_sync",
+            0,
+            1,
+            "Synchronizing nvd-fkie: Receiving objects: 50%",
+        ) in MockTracker.update.call_args_list
 
     def test_api_mode_background_uses_nvd_db(self, client, existing_cve_id):
         """_run() uses NVD_DB (REST API) when mode is 'api'."""

--- a/tests/webapp_tests/test_sbom_cve_check_scan.py
+++ b/tests/webapp_tests/test_sbom_cve_check_scan.py
@@ -282,9 +282,10 @@ class TestTriggerSbomCveCheckScan:
         mock_engine = MagicMock()
         mock_engine.applicable_vulns.return_value = iter([])
 
-        def _engine_that_logs():
+        def _engine_that_logs(progress=None):
             import logging
             logging.getLogger("sbom_cve_check").info("test-forwarder-msg")
+            progress("Synchronizing nvd-fkie: Receiving objects: 50%")
             return mock_engine
 
         with patch("src.controllers.scc_engine.get_engine", side_effect=_engine_that_logs):
@@ -297,6 +298,7 @@ class TestTriggerSbomCveCheckScan:
         assert data["status"] == "done"
         all_logs = " ".join(data.get("logs", []))
         assert "test-forwarder-msg" in all_logs
+        assert "Synchronizing nvd-fkie: Receiving objects: 50%" in all_logs
 
     def test_scan_outer_exception_handler(self, client, ids):
         """Lines 889-891: outer except block when Scan.create raises unexpectedly."""


### PR DESCRIPTION
## Fixes # by improving SCC database synchronization feedback

### Changes proposed in this pull request:

* Stream Git clone and fetch progress through CLI output and frontend operation status.
* Preserve SCC locking, update decisions, and indexing while wrapping its pinned Git command execution.
* Add focused SCC engine and web route coverage, including real local Git transfers.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Run `pytest tests/unit_tests/test_scc_engine_utils.py tests/webapp_tests/test_bulk_refresh_routes.py tests/webapp_tests/test_sbom_cve_check_scan.py`.
* Trigger an SCC-backed scan or vulnerability refresh and confirm clone/fetch progress appears in CLI or frontend status output.

### Additional notes

SCC 1.3.1 does not expose a Git progress API. The implementation wraps its pinned private `GitRepo._exec_git_cmd` for clone and fetch while leaving SCC processing unchanged.

### Related Issue

No linked issue.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [X] The code compiles and passes all tests
- [X] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers