### PR TITLE
Add refresh modes to SBOM import

### DIFF
--- a/frontend/src/components/RefreshVulnerabilityData.tsx
+++ b/frontend/src/components/RefreshVulnerabilityData.tsx
@@ -10,6 +10,8 @@ import type { GHSAProgress } from "../handlers/ghsa_progress";
 import type { EUVDProgress } from "../handlers/euvd_progress";
 import { queueVulnerabilityRefresh } from "../handlers/activeScanQueue";
 import type { RefreshType } from "../handlers/activeScanQueue";
+import { resolveRefreshSources, vulnerabilityRefreshSources } from "../helpers/refreshSources";
+import type { RefreshMode } from "../helpers/refreshSources";
 
 
 type Props = {
@@ -26,7 +28,7 @@ type Props = {
 
 function RefreshVulnerabilityData({ vulnerabilities, getRefreshVulnerabilities, triggerBanner, hideBanner, nvdProgress, epssProgress, ghsaProgress, euvdProgress, onRefreshComplete }: Readonly<Props>) {
     const [refreshMenuOpen, setRefreshMenuOpen] = useState(false);
-    const [refreshMode, setRefreshMode] = useState<'complete' | 'custom'>('complete');
+    const [refreshMode, setRefreshMode] = useState<RefreshMode>('complete');
     const [selectedRefreshTypes, setSelectedRefreshTypes] = useState<Set<RefreshType>>(new Set(['nvd', 'epss', 'ghsa', 'euvd']));
     const [cancelling, setCancelling] = useState<Set<RefreshType>>(new Set());
     const refreshMenuRef = useRef<HTMLDivElement>(null);
@@ -44,15 +46,13 @@ function RefreshVulnerabilityData({ vulnerabilities, getRefreshVulnerabilities, 
         ghsa: ghsaInProgress,
         euvd: euvdInProgress,
     };
-    const sources: { source: RefreshType; label: string; available: boolean }[] = [
-        { source: 'nvd', label: 'NVD', available: hasCveIds },
-        { source: 'epss', label: 'EPSS', available: hasCveIds },
-        { source: 'ghsa', label: 'GHSA', available: hasGhsaIds },
-        { source: 'euvd', label: 'ENISA EUVD', available: hasCveIds },
-    ];
-    const refreshTypes = refreshMode === 'complete'
-        ? new Set(sources.filter(({ available }) => available).map(({ source }) => source))
-        : selectedRefreshTypes;
+    const sources = vulnerabilityRefreshSources.map(({ source, label }) => ({
+        source,
+        label,
+        available: source === 'ghsa' ? hasGhsaIds : hasCveIds,
+    }));
+    const availableRefreshTypes = new Set(sources.filter(({ available }) => available).map(({ source }) => source));
+    const refreshTypes = resolveRefreshSources(refreshMode, selectedRefreshTypes, availableRefreshTypes);
     const anyInProgress = Object.values(inProgress).some(Boolean);
     const actionableRefreshCount = (refreshTypes.has('nvd') && !inProgress.nvd && hasCveIds ? 1 : 0)
         + (refreshTypes.has('epss') && !inProgress.epss && hasCveIds ? 1 : 0)

--- a/frontend/src/handlers/variant.ts
+++ b/frontend/src/handlers/variant.ts
@@ -1,3 +1,5 @@
+import type { RefreshType } from "./activeScanQueue";
+
 type Variant = {
     id: string;
     name: string;
@@ -188,7 +190,7 @@ class Variants {
         projectId: string,
         variantId: string,
         files: File[],
-        refreshSources: string[] = ["epss"],
+        refreshSources: RefreshType[] = ["epss"],
     ): Promise<{ upload_id: string; scan_id: string; message: string }> {
         const formData = new FormData();
         for (const file of files) {

--- a/frontend/src/helpers/refreshSources.ts
+++ b/frontend/src/helpers/refreshSources.ts
@@ -1,5 +1,27 @@
 import type { RefreshType } from "../handlers/activeScanQueue";
 
+export type RefreshMode = "complete" | "custom";
+
+export const vulnerabilityRefreshSources: ReadonlyArray<{ source: RefreshType; label: string }> = [
+    { source: "nvd", label: "NVD" },
+    { source: "epss", label: "EPSS" },
+    { source: "ghsa", label: "GHSA" },
+    { source: "euvd", label: "ENISA EUVD" },
+];
+
+export const allVulnerabilityRefreshTypes = new Set<RefreshType>(
+    vulnerabilityRefreshSources.map(({ source }) => source),
+);
+
+export function resolveRefreshSources(
+    mode: RefreshMode,
+    customSources: ReadonlySet<RefreshType>,
+    availableSources: ReadonlySet<RefreshType> = allVulnerabilityRefreshTypes,
+): Set<RefreshType> {
+    const requestedSources = mode === "complete" ? availableSources : customSources;
+    return new Set([...requestedSources].filter(source => availableSources.has(source)));
+}
+
 // Refresh sources that can be applied to the vulnerabilities a given set of scans produces.
 export function refreshSourcesForScans(selectedScans: Set<string>): Set<RefreshType> {
     const sources = new Set<RefreshType>();

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -31,6 +31,13 @@ import ConfirmationModal from "../components/ConfirmationModal";
 import MessageBanner from "../components/MessageBanner";
 import Popup from "../components/Popup";
 import Transfer from "./Transfer";
+import type { RefreshType } from "../handlers/activeScanQueue";
+import {
+  allVulnerabilityRefreshTypes,
+  resolveRefreshSources,
+  vulnerabilityRefreshSources,
+} from "../helpers/refreshSources";
+import type { RefreshMode } from "../helpers/refreshSources";
 
 type Props = {
   onDataChanged?: (message?: string) => void;
@@ -621,7 +628,11 @@ function Settings({ onDataChanged, onLoadingMessage, projectId }: Readonly<Props
   const [importFiles, setImportFiles] = useState<File[]>([]);
   const [importBusy, setImportBusy] = useState(false);
   const [importMsg, setImportMsg] = useState<string | null>(null);
-  const [importRefreshSources, setImportRefreshSources] = useState<Set<string>>(new Set(["epss"]));
+  const [importRefreshMode, setImportRefreshMode] = useState<RefreshMode>("complete");
+  const [importCustomRefreshSources, setImportCustomRefreshSources] = useState<Set<RefreshType>>(
+    () => new Set(allVulnerabilityRefreshTypes),
+  );
+  const importRefreshSources = resolveRefreshSources(importRefreshMode, importCustomRefreshSources);
 
   const clearImportState = () => {
     setImportFiles([]);
@@ -1499,27 +1510,62 @@ function Settings({ onDataChanged, onLoadingMessage, projectId }: Readonly<Props
               </p>
             </div>
 
-            <fieldset className="space-y-2">
+            <fieldset className="space-y-3" disabled={importBusy}>
               <legend className="block text-sm text-zinc-300 mb-1">Refresh vulnerability data</legend>
-              <div className="flex flex-wrap gap-x-5 gap-y-2">
-                {(["epss", "nvd", "euvd", "ghsa"] as const).map((source) => (
-                  <label key={source} className="flex items-center gap-2 text-sm text-zinc-200 cursor-pointer">
+              <p className="text-xs text-zinc-400">Optionally fetch current vulnerability data after the SBOM is imported.</p>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {([
+                  ["complete", "Complete refresh", "Refresh every supported data source."],
+                  ["custom", "Custom refresh", "Choose which data sources to refresh."],
+                ] as const).map(([mode, label, description]) => (
+                  <label key={mode} className={[
+                    "flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-3 text-sm transition-colors",
+                    importRefreshMode === mode
+                      ? "border-cyan-500 bg-cyan-950/40 text-white"
+                      : "border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500",
+                  ].join(" ")}>
                     <input
-                      type="checkbox"
-                      aria-label={source.toUpperCase()}
-                      checked={importRefreshSources.has(source)}
-                      disabled={importBusy}
-                      onChange={() => setImportRefreshSources((previous) => {
+                      type="radio"
+                      name="import-refresh-mode"
+                      checked={importRefreshMode === mode}
+                      onChange={() => setImportRefreshMode(mode)}
+                      className="mt-0.5 accent-cyan-500"
+                    />
+                    <span className="flex flex-col">
+                      <span className="font-medium">{label}</span>
+                      <span className="mt-1 text-xs text-zinc-400">{description}</span>
+                    </span>
+                  </label>
+                ))}
+              </div>
+              {importRefreshMode === "custom" && (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {vulnerabilityRefreshSources.map(({ source, label }) => (
+                    <label key={source} className={[
+                      "flex cursor-pointer items-center gap-2 rounded border px-3 py-2 text-sm transition-colors",
+                      importCustomRefreshSources.has(source)
+                        ? "border-cyan-600 bg-cyan-950/30 text-zinc-100"
+                        : "border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500",
+                    ].join(" ")}>
+                      <input
+                        type="checkbox"
+                        aria-label={label}
+                        checked={importCustomRefreshSources.has(source)}
+                        onChange={() => setImportCustomRefreshSources((previous) => {
                         const next = new Set(previous);
                         if (next.has(source)) next.delete(source); else next.add(source);
                         return next;
                       })}
                       className="rounded accent-cyan-500"
                     />
-                    {source.toUpperCase()}
-                  </label>
-                ))}
-              </div>
+                      {label}
+                    </label>
+                  ))}
+                </div>
+              )}
+              {importRefreshMode === "custom" && importRefreshSources.size === 0 && (
+                <p className="text-xs text-zinc-400">The SBOM will be imported without refreshing vulnerability data.</p>
+              )}
             </fieldset>
 
             {/* ---- Submit ---- */}

--- a/frontend/tests/unit_tests/test_settings_page.tsx
+++ b/frontend/tests/unit_tests/test_settings_page.tsx
@@ -137,6 +137,9 @@ describe("Settings scoped project and variant views", () => {
     expect(screen.getByRole("heading", { name: "Rename Variant" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Delete Variant" })).toBeInTheDocument();
     expect(screen.getByLabelText("SBOM Files")).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Complete refresh/ })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /Custom refresh/ })).not.toBeChecked();
+    expect(screen.queryByRole("checkbox", { name: "NVD" })).not.toBeInTheDocument();
   });
 
   test("saves report metadata and Grype memory settings", async () => {
@@ -268,19 +271,71 @@ describe("Settings scoped project and variant views", () => {
     fireEvent.click(screen.getByRole("button", { name: "Import" }));
 
     expect(await screen.findByText("Upload rejected")).toBeInTheDocument();
-    expect(variantsUploadSBOM).toHaveBeenCalledWith(project.id, variant.id, [file], ["epss"]);
+    expect(variantsUploadSBOM).toHaveBeenCalledWith(
+      project.id,
+      variant.id,
+      [file],
+      ["nvd", "epss", "ghsa", "euvd"],
+    );
   });
 
-  test("updates import refresh sources, removes selected files, and navigates settings sections", async () => {
+  test("custom import refresh submits only selected sources", async () => {
+    render(<Settings />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Expand Apollo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Release" }));
+    fireEvent.click(await screen.findByRole("radio", { name: /Custom refresh/ }));
+    expect(screen.getByRole("checkbox", { name: "NVD" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "EPSS" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "GHSA" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "ENISA EUVD" })).toBeChecked();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "NVD" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "GHSA" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "ENISA EUVD" }));
+    const file = new File(["{}"], "sbom.json", { type: "application/json" });
+    fireEvent.change(screen.getByLabelText("SBOM Files"), { target: { files: [file] } });
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    await waitFor(() => expect(variantsUploadSBOM).toHaveBeenCalledWith(
+      project.id,
+      variant.id,
+      [file],
+      ["epss"],
+    ));
+  });
+
+  test("custom import refresh can be disabled without disabling import", async () => {
+    render(<Settings />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Expand Apollo" }));
+    fireEvent.click(screen.getByRole("button", { name: "Release" }));
+    fireEvent.click(await screen.findByRole("radio", { name: /Custom refresh/ }));
+    for (const source of ["NVD", "EPSS", "GHSA", "ENISA EUVD"]) {
+      fireEvent.click(screen.getByRole("checkbox", { name: source }));
+    }
+    expect(screen.getByText("The SBOM will be imported without refreshing vulnerability data.")).toBeInTheDocument();
+
+    const file = new File(["{}"], "sbom.json", { type: "application/json" });
+    fireEvent.change(screen.getByLabelText("SBOM Files"), { target: { files: [file] } });
+    expect(screen.getByRole("button", { name: "Import" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    await waitFor(() => expect(variantsUploadSBOM).toHaveBeenCalledWith(
+      project.id,
+      variant.id,
+      [file],
+      [],
+    ));
+  });
+
+  test("removes selected import files and navigates settings sections", async () => {
     render(<Settings />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Expand Apollo" }));
     fireEvent.click(screen.getByRole("button", { name: "Release" }));
     const file = new File(["{}"], "sbom.json", { type: "application/json" });
     fireEvent.change(await screen.findByLabelText("SBOM Files"), { target: { files: [file] } });
-    fireEvent.click(screen.getByLabelText("NVD"));
-    fireEvent.click(screen.getByLabelText("EUVD"));
-    fireEvent.click(screen.getByLabelText("GHSA"));
     fireEvent.click(screen.getByRole("button", { name: "Remove file sbom.json" }));
     expect(screen.queryByText("sbom.json")).not.toBeInTheDocument();
 


### PR DESCRIPTION
## Fixes # by aligning SBOM import refresh options

### Changes proposed in this pull request:

* Add Complete and Custom vulnerability-data refresh modes to Settings SBOM import.
* Reuse shared refresh source types, labels, ordering, and backend payload resolution.
* Preserve SBOM import without refresh and add focused UI and submission tests.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Run `cd frontend && npm test -- --runInBand tests/unit_tests/test_settings_page.tsx`.
* Run `cd frontend && npx tsc --noEmit`.
* Import an SBOM from Settings with no refresh, Complete mode, and a Custom source selection; confirm each request uses the selected refresh configuration.

### Additional notes

The UI shares refresh source definitions with the existing Refresh Data popup to keep both workflows consistent.

### Related Issue

No linked issue.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [X] The code compiles and passes all tests
- [X] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers