### PR TITLE
Add CLI vulnerability data refresh option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -195,6 +195,26 @@ You can combine inputs with a match condition in a single invocation:
   --match-condition "((cvss >= 9.0) and (pending or affected)) "
 ----
 
+===  Refreshing Vulnerability Data
+
+Use `--refresh-vulnerability-data` with an input command to enrich vulnerabilities imported by that run with current EPSS, NVD, ENISA EUVD, and GitHub Advisory data:
+
+[source,shell]
+----
+./vulnscout --add-spdx /path/to/sbom.spdx.json --refresh-vulnerability-data
+----
+
+The option can also refresh vulnerabilities already in the database. Without a project it refreshes all vulnerabilities; project and variant options restrict the scope:
+
+[source,shell]
+----
+./vulnscout --refresh-vulnerability-data
+./vulnscout --project demo --refresh-vulnerability-data
+./vulnscout --project demo --variant x86 --refresh-vulnerability-data
+----
+
+The refresh enriches existing CVE and GHSA records; it does not discover new findings. A variant requires its project because variant names are project-local.
+
 ===  Performing a Grype Scan
 
 VulnScout can run Grype on the current database contents. This exports the current state as a CycloneDX SBOM, runs Grype against it, and merges the results back:

--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -128,6 +128,42 @@ Example:
 
 VulnScout accepts multiple input file types. Commands can be chained and will automatically trigger a scan.
 
+### Refresh Vulnerability Data
+
+Use `--refresh-vulnerability-data` with an input command to enrich the vulnerabilities
+imported by that run with current EPSS, NVD, ENISA EUVD, and GitHub Advisory data:
+
+```bash
+./vulnscout \
+  --add-spdx $(pwd)/example/spdx3/core-image-minimal-qemux86-64.rootfs.spdx.json \
+  --refresh-vulnerability-data
+```
+
+Inside the container, the equivalent Flask command is:
+
+```bash
+flask --app src.bin.webapp process --refresh-vulnerability-data
+```
+
+The option can also refresh vulnerability data already in the database. Omit
+`--project` to refresh every vulnerability, or supply it to restrict the refresh to
+that project's active vulnerabilities:
+
+```bash
+./vulnscout --refresh-vulnerability-data
+./vulnscout --project demo --refresh-vulnerability-data
+./vulnscout --project demo --variant x86 --refresh-vulnerability-data
+```
+
+Inside the container, use `flask --app src.bin.webapp refresh-vulnerability-data`
+with optional `--project` and `--variant` arguments. A variant requires its project
+because variant names are project-local.
+
+The refresh enriches existing imported CVE and GHSA records; it does not discover new
+findings. Providers with no applicable vulnerability identifiers are skipped. If any
+applicable provider fails, processing continues through the remaining providers and the
+command exits with an error listing the failed sources.
+
 ### SPDX SBOM
 
 ```

--- a/src/bin/cmd_process.py
+++ b/src/bin/cmd_process.py
@@ -25,10 +25,12 @@ from ..extensions import batch_session, db as _db
 import click
 import json
 import os
-from typing import TYPE_CHECKING
+from typing import Callable, Iterable, TYPE_CHECKING
 from flask.cli import with_appcontext
 from sqlalchemy import and_, exists
 from ._common import DEFAULT_VARIANT_NAME, resolve_project_variant
+from ..controllers.projects import ProjectController
+from ..helpers.export_scope import compute_export_scope
 
 if TYPE_CHECKING:
     from ..controllers.packages import PackagesController
@@ -68,6 +70,63 @@ def _ts_key(ts) -> str:
 def post_treatment(controllers: ControllersCache, documents=None):
     """Enrich vulnerabilities with EPSS scores."""
     return controllers.vulnerabilities.fetch_epss_scores()
+
+
+REFRESH_SOURCES = ("epss", "nvd", "euvd", "ghsa")
+
+
+def _refresh_source(controllers: ControllersCache, source: str) -> bool:
+    if source == "epss":
+        result = post_treatment(controllers)
+    elif source in {"nvd", "ghsa"}:
+        result = controllers.vulnerabilities.fetch_nvd_data()
+    else:
+        result = controllers.vulnerabilities.fetch_euvd_data()
+    return result is None or result.completed
+
+
+def refresh_vulnerability_sources(
+    controllers: ControllersCache,
+    vulnerability_ids: Iterable[str],
+    refresh_sources: Iterable[str] = REFRESH_SOURCES,
+    on_source_start: Callable[[str, int, int], None] | None = None,
+) -> list[str]:
+    """Refresh selected providers for the supplied vulnerabilities."""
+    vuln_ctrl = controllers.vulnerabilities
+    all_vulnerabilities = vuln_ctrl.vulnerabilities
+    selected_vulnerability_ids = tuple(vulnerability_ids)
+    selected_sources = set(refresh_sources)
+    applicable_sources = [
+        source
+        for source in REFRESH_SOURCES
+        if source in selected_sources
+        and any(
+            vuln_id.startswith("GHSA-" if source == "ghsa" else "CVE-")
+            and vuln_id in all_vulnerabilities
+            for vuln_id in selected_vulnerability_ids
+        )
+    ]
+    failed_sources: list[str] = []
+    try:
+        for step, source in enumerate(applicable_sources, start=1):
+            prefix = "GHSA-" if source == "ghsa" else "CVE-"
+            vuln_ctrl.vulnerabilities = {
+                vuln_id: all_vulnerabilities[vuln_id]
+                for vuln_id in selected_vulnerability_ids
+                if vuln_id.startswith(prefix) and vuln_id in all_vulnerabilities
+            }
+            label = source.upper()
+            if on_source_start is not None:
+                on_source_start(label, step, len(applicable_sources))
+            try:
+                if not _refresh_source(controllers, source):
+                    failed_sources.append(label)
+            except Exception as exc:
+                failed_sources.append(label)
+                verbose(f"{label} enrichment failed: {exc}")
+    finally:
+        vuln_ctrl.vulnerabilities = all_vulnerabilities
+    return failed_sources
 
 
 def evaluate_condition(
@@ -264,10 +323,50 @@ def create_project_context(
 
 
 @click.command("process")
+@click.option(
+    "--refresh-vulnerability-data",
+    is_flag=True,
+    help="Refresh EPSS, NVD, EUVD, and GHSA data for imported vulnerabilities.",
+)
 @with_appcontext
-def process_command() -> None:
+def process_command(refresh_vulnerability_data: bool) -> None:
     """Parse all SBOM inputs, persist results to the DB and generate output files."""
-    _run_main()
+    _run_main(refresh_vulnerability_data=refresh_vulnerability_data)
+
+
+@click.command("refresh-vulnerability-data")
+@click.option("--project", "project_name", default=None, help="Refresh vulnerabilities in this project only.")
+@click.option("--variant", "variant_name", default=None, help="Refresh vulnerabilities in this project variant only.")
+@with_appcontext
+def refresh_vulnerability_data_command(project_name: str | None, variant_name: str | None) -> None:
+    """Refresh vulnerability data already stored in the database."""
+    scope = None
+    if variant_name and not project_name:
+        raise click.UsageError("--variant requires --project.")
+    if project_name:
+        project = ProjectController.get_by_name(project_name)
+        if project is None:
+            raise click.ClickException(f"project not found: {project_name}")
+        if variant_name:
+            _, variant = resolve_project_variant(project_name, variant_name)
+            scope = compute_export_scope(variant_id=variant.id)
+        else:
+            scope = compute_export_scope(project_id=project.id)
+
+    controllers = ControllersCache(scope=scope)
+    failed_sources = refresh_vulnerability_sources(
+        controllers,
+        controllers.vulnerabilities.vulnerabilities,
+        on_source_start=lambda label, step, total: click.echo(
+            f"Refreshing {label} data (step {step} of {total})..."
+        ),
+    )
+    if failed_sources:
+        unique_failed = list(dict.fromkeys(failed_sources))
+        raise click.ClickException(
+            f"{', '.join(unique_failed)} vulnerability-data refresh failed."
+        )
+    click.echo("Vulnerability data refresh complete.")
 
 
 def populate_observations(scan, vulnCtrl, log_prefix: str = "merger_ci") -> None:
@@ -334,7 +433,7 @@ def populate_observations(scan, vulnCtrl, log_prefix: str = "merger_ci") -> None
         print(f"Warning: could not populate observations table: {e}")
 
 
-def _run_main() -> ControllersCache:
+def _run_main(refresh_vulnerability_data: bool = False) -> ControllersCache:
     """Core processing logic (usable both from the CLI command and directly)."""
     controllers = ControllersCache()
     vulnCtrl: VulnerabilitiesController = controllers.vulnerabilities
@@ -366,7 +465,24 @@ def _run_main() -> ControllersCache:
     # In batch / CI mode (INTERACTIVE_MODE != "true") we run it here so that
     # EPSS scores are available for --match-condition evaluation.
     interactive_mode = get_bool_env("INTERACTIVE_MODE", False)
-    if not interactive_mode:
+    observations_populated = False
+    if refresh_vulnerability_data:
+        populate_observations(latest_scan, vulnCtrl)
+        observations_populated = True
+        failed_sources = refresh_vulnerability_sources(
+            controllers,
+            vulnCtrl._encountered_this_run,
+            on_source_start=lambda label, step, total: click.echo(
+                f"Refreshing {label} data (step {step} of {total})..."
+            ),
+        )
+        if failed_sources:
+            unique_failed = list(dict.fromkeys(failed_sources))
+            raise click.ClickException(
+                f"{', '.join(unique_failed)} vulnerability-data refresh failed."
+            )
+        click.echo("Vulnerability data refresh complete.")
+    elif not interactive_mode:
         verbose("merger_ci: Starting post-treatment (EPSS enrichment)")
         post_treatment(controllers)
         verbose("merger_ci: Post-treatment done")
@@ -389,8 +505,9 @@ def _run_main() -> ControllersCache:
     verbose("merger_ci: Start exporting results")
     verbose("merger_ci: Finished exporting results")
 
-    latest_scan = ScanModel.get_latest()
-    populate_observations(latest_scan, vulnCtrl)
+    if not observations_populated:
+        latest_scan = ScanModel.get_latest()
+        populate_observations(latest_scan, vulnCtrl)
 
     verbose("merger_ci: Processing complete")
 

--- a/src/bin/merger_ci.py
+++ b/src/bin/merger_ci.py
@@ -20,6 +20,7 @@ from ._common import DEFAULT_VARIANT_NAME  # noqa: F401 — intentional re-expor
 from .cmd_process import (  # noqa: F401 — intentional re-exports for callers
     create_project_context,
     process_command,
+    refresh_vulnerability_data_command,
     _run_main,
     post_treatment,
     populate_observations,
@@ -53,6 +54,7 @@ def init_app(app) -> None:
     """Register all Flask CLI commands with *app*."""
     app.cli.add_command(create_project_context)
     app.cli.add_command(process_command)
+    app.cli.add_command(refresh_vulnerability_data_command)
     app.cli.add_command(report_command)
     app.cli.add_command(export_command)
     app.cli.add_command(export_custom_vulnscout_data_command)

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -8,7 +8,9 @@ set -m # enable job control to allow `fg` command
 CONFIG_FILE="${VULNSCOUT_CONFIG:-/etc/vulnscout/config.env}"
 INPUTS_DIR="/scan/inputs"
 PROJECT_NAME="default"
+PROJECT_SPECIFIED=false
 VARIANT_NAME=""
+VARIANT_SPECIFIED=false
 
 readonly BASE_DIR="/scan"
 INTERACTIVE_MODE="${INTERACTIVE_MODE:-false}"
@@ -98,7 +100,7 @@ Usage: docker exec <container> /scan/src/entrypoint.sh [COMMAND] [OPTIONS]
 
 Setting:
   --project <name>          Project name for the next input command (default: 'default')
-  --variant <name>          Variant name for the next input command (default: 'default')
+    --variant <name>          Variant name for the next input command or standalone refresh (requires --project)
 
 Input commands:
   --add-spdx <path>         Add an SPDX 2/3 SBOM file or archive
@@ -111,6 +113,7 @@ Input commands:
   --perform-nvd-scan        Run an NVD CPE-based vulnerability scan
   --perform-osv-scan        Run an OSV PURL-based vulnerability scan
   --perform-sbom-cve-check-scan  Run a sbom-cve-check vulnerability scan
+    --refresh-vulnerability-data  Refresh EPSS, NVD, EUVD, and GHSA data; with no inputs, refreshes all vulnerabilities
   --add-asset <path>        Stage an image asset for use in report templates
 
 Scan & output commands:
@@ -472,7 +475,9 @@ cmd_scan() {
         # passed through to stdout unchanged.
         # With set -o pipefail the non-zero exit code from flask (e.g. 2 for a
         # triggered fail condition) is still propagated through the pipeline.
-        (cd "$BASE_DIR" && flask --app src.bin.webapp process) | \
+        local -a process_args=()
+        [[ "${REFRESH_VULNERABILITY_DATA:-false}" == "true" ]] && process_args+=(--refresh-vulnerability-data)
+        (cd "$BASE_DIR" && flask --app src.bin.webapp process "${process_args[@]}") | \
             while IFS= read -r _line; do
                 if [[ "$_line" =~ ^::STATUS::([0-9]+)::(.*)$ ]]; then
                     set_status "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
@@ -488,6 +493,11 @@ cmd_scan() {
             # Also clean up any staged temp files
             rm -f /tmp/vulnscout_stage_*
         fi
+    elif [[ "${REFRESH_VULNERABILITY_DATA:-false}" == "true" ]]; then
+        local -a refresh_args=()
+        [[ "$PROJECT_SPECIFIED" == "true" ]] && refresh_args+=(--project "$PROJECT_NAME")
+        [[ "$VARIANT_SPECIFIED" == "true" ]] && refresh_args+=(--variant "$VARIANT_NAME")
+        (cd "$BASE_DIR" && flask --app src.bin.webapp refresh-vulnerability-data "${refresh_args[@]}") || _cmd_scan_exit=$?
     elif [[ "${INTERACTIVE_MODE}" == "true" ]] && [[ "$has_inputs" == "false" ]]; then
         set_status "1" "No new input files to merge, skipping"
     fi
@@ -775,6 +785,7 @@ GRYPE_SCAN_REQUESTED=false
 NVD_SCAN_REQUESTED=false
 OSV_SCAN_REQUESTED=false
 SBOM_CVE_CHECK_SCAN_REQUESTED=false
+REFRESH_VULNERABILITY_DATA=false
 REPORT_TEMPLATES=()
 EXPORT_FORMATS=()
 SCAN_REQUIRED=false
@@ -794,9 +805,9 @@ while [[ $# -gt 0 ]]; do
         --version)
             echo "${VULNSCOUT_VERSION:-unknown}"; exit 0 ;;
         --project)
-            PROJECT_NAME="$2"; shift 2 ;;
+            PROJECT_NAME="$2"; PROJECT_SPECIFIED=true; shift 2 ;;
         --variant)
-            VARIANT_NAME="$2"; shift 2 ;;
+            VARIANT_NAME="$2"; VARIANT_SPECIFIED=true; shift 2 ;;
         --json)
             JSON_OUTPUT=true; shift ;;
         --match-condition)
@@ -826,6 +837,8 @@ while [[ $# -gt 0 ]]; do
             OSV_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
         --perform-sbom-cve-check-scan)
             SBOM_CVE_CHECK_SCAN_REQUESTED=true; SCAN_REQUIRED=true; shift ;;
+        --refresh-vulnerability-data)
+            REFRESH_VULNERABILITY_DATA=true; SCAN_REQUIRED=true; shift ;;
         --delete-scan)
             cmd_delete_scan "$2"; shift 2 ;;
         --delete-outdated)

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -29,6 +29,7 @@ from ..models.scan import Scan as ScanModel
 from ..models.project import Project
 from ..models.variant import Variant
 from ..helpers.verbose import verbose
+from ..bin.cmd_process import REFRESH_SOURCES, refresh_vulnerability_sources
 from ._scan_helpers import parse_uuid_or_400, ErrorResponse
 
 if TYPE_CHECKING:
@@ -51,7 +52,7 @@ class _CrudController(Protocol[_C]):
 # Tracks in-progress SBOM uploads: upload_id → {status, message, ts}
 _upload_status: dict[str, dict] = {}
 _UPLOAD_STATUS_TTL = 3600  # seconds – entries older than this are pruned
-_REFRESH_SOURCES = {"epss", "nvd", "euvd", "ghsa"}
+_REFRESH_SOURCES = set(REFRESH_SOURCES)
 
 
 def _prune_upload_status() -> None:
@@ -177,7 +178,7 @@ def _process_sbom_background(
         try:
             _upload_status[upload_id] = {"status": "processing", "message": "Parsing SBOM file(s)..."}
 
-            from ..bin.cmd_process import read_inputs, post_treatment, populate_observations
+            from ..bin.cmd_process import read_inputs, populate_observations
 
             controllers = ControllersCache()
             vulnCtrl = controllers.vulnerabilities
@@ -197,41 +198,18 @@ def _process_sbom_background(
                 else ScanModel.get_by_id(uuid.UUID(str(scan_id)))
             populate_observations(scan, vulnCtrl, log_prefix="settings/upload")
 
-            encountered = vulnCtrl._encountered_this_run
-            all_vulnerabilities = vulnCtrl.vulnerabilities
-            failed_sources: list[str] = []
-            try:
-                for source in ("epss", "nvd", "euvd", "ghsa"):
-                    if source not in refresh_sources:
-                        continue
-                    prefix = "GHSA-" if source == "ghsa" else "CVE-"
-                    vulnCtrl.vulnerabilities = {
-                        vuln_id: all_vulnerabilities[vuln_id]
-                        for vuln_id in encountered
-                        if vuln_id.startswith(prefix) and vuln_id in all_vulnerabilities
-                    }
-                    if not vulnCtrl.vulnerabilities:
-                        continue
-                    label = source.upper()
-                    _upload_status[upload_id] = {
-                        "status": "processing",
-                        "message": f"Refreshing {label} data...",
-                    }
-                    # Each source is isolated so one failure doesn't skip the rest.
-                    try:
-                        if source == "epss":
-                            result = post_treatment(controllers)
-                        elif source in {"nvd", "ghsa"}:
-                            result = vulnCtrl.fetch_nvd_data()
-                        else:
-                            result = vulnCtrl.fetch_euvd_data()
-                        if result is not None and not result.completed:
-                            failed_sources.append(label)
-                    except Exception as e:
-                        failed_sources.append(label)
-                        verbose(f"settings/upload: {label} enrichment failed: {e}")
-            finally:
-                vulnCtrl.vulnerabilities = all_vulnerabilities
+            def update_refresh_status(label: str, _step: int, _total: int) -> None:
+                _upload_status[upload_id] = {
+                    "status": "processing",
+                    "message": f"Refreshing {label} data...",
+                }
+
+            failed_sources = refresh_vulnerability_sources(
+                controllers,
+                vulnCtrl._encountered_this_run,
+                refresh_sources,
+                update_refresh_status,
+            )
 
             done_message = "SBOM imported successfully."
             if failed_sources:

--- a/tests/CI_tests/vulnscout_wrapper_test.sh
+++ b/tests/CI_tests/vulnscout_wrapper_test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR=$(readlink -f "$(dirname "$0")/../..")
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+mkdir -p "$TEST_DIR/bin"
+cat > "$TEST_DIR/bin/podman" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+case "$1" in
+    ps)
+        echo "vulnscout"
+        ;;
+    cp)
+        ;;
+    exec)
+        printf '%q ' "$@" >> "$VULNSCOUT_TEST_LOG"
+        printf '\n' >> "$VULNSCOUT_TEST_LOG"
+        exit "${VULNSCOUT_TEST_EXEC_EXIT:-0}"
+        ;;
+    *)
+        echo "Unexpected podman command: $*" >&2
+        exit 99
+        ;;
+esac
+EOF
+chmod +x "$TEST_DIR/bin/podman"
+
+SBOM="$TEST_DIR/input.spdx.json"
+printf '{}\n' > "$SBOM"
+export PATH="$TEST_DIR/bin:/usr/bin:/bin"
+export VULNSCOUT_BUILD_DIR="$TEST_DIR/build"
+export VULNSCOUT_TEST_LOG="$TEST_DIR/container.log"
+
+"$ROOT_DIR/vulnscout" --help | grep -q -- '--refresh-vulnerability-data'
+
+"$ROOT_DIR/vulnscout" --refresh-vulnerability-data
+grep -q -- '/scan/src/entrypoint.sh --refresh-vulnerability-data' "$VULNSCOUT_TEST_LOG"
+
+: > "$VULNSCOUT_TEST_LOG"
+"$ROOT_DIR/vulnscout" --project cli --refresh-vulnerability-data
+grep -q -- '/scan/src/entrypoint.sh --project cli --refresh-vulnerability-data' "$VULNSCOUT_TEST_LOG"
+
+: > "$VULNSCOUT_TEST_LOG"
+"$ROOT_DIR/vulnscout" --project cli --variant default --refresh-vulnerability-data
+grep -q -- '/scan/src/entrypoint.sh --variant default --project cli --refresh-vulnerability-data' "$VULNSCOUT_TEST_LOG"
+
+: > "$VULNSCOUT_TEST_LOG"
+"$ROOT_DIR/vulnscout" --project cli --variant default \
+    --add-spdx "$SBOM" --refresh-vulnerability-data
+grep -q -- \
+    '--project cli --variant default --add-spdx /tmp/vulnscout_stage_input.spdx.json --refresh-vulnerability-data' \
+    "$VULNSCOUT_TEST_LOG"
+
+: > "$VULNSCOUT_TEST_LOG"
+"$ROOT_DIR/vulnscout" --add-spdx "$SBOM"
+if grep -q -- '--refresh-vulnerability-data' "$VULNSCOUT_TEST_LOG"; then
+    echo "Refresh flag was propagated when absent." >&2
+    exit 1
+fi
+
+export VULNSCOUT_TEST_EXEC_EXIT=7
+if "$ROOT_DIR/vulnscout" --add-spdx "$SBOM" --refresh-vulnerability-data; then
+    echo "Container execution failure was not propagated." >&2
+    exit 1
+else
+    status=$?
+fi
+if [[ "$status" -ne 7 ]]; then
+    echo "Expected exit 7, got $status." >&2
+    exit 1
+fi
+
+echo "Host wrapper refresh tests passed."

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,9 +22,10 @@ test_frontend:
 	fi
 
 test_ci:
-	shellcheck $(SRC_DIR)/../vulnscout $(SRC_DIR)/entrypoint.sh
+	shellcheck $(SRC_DIR)/../vulnscout $(SRC_DIR)/entrypoint.sh $(CI_DIR)/vulnscout_wrapper_test.sh
 	cd $(CI_DIR) && \
-	bash ./vulnscout_CI_test.sh
+	bash ./vulnscout_CI_test.sh && \
+	bash ./vulnscout_wrapper_test.sh
 
 validate_sbom:
 	bash $(MAKEFILE_DIR)/validate_sbom.sh

--- a/tests/cli_tests/test_cmd_process.py
+++ b/tests/cli_tests/test_cmd_process.py
@@ -8,6 +8,7 @@ Targets uncovered branches reported by the CI coverage run:
 
 import json
 import pytest
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from src.bin.webapp import create_app
@@ -58,7 +59,207 @@ class TestCmdProcessCoverage:
             mock_main.return_value = {}
             runner = app.test_cli_runner()
             result = runner.invoke(args=["process"])
-        mock_main.assert_called_once()
+        assert result.exit_code == 0
+        mock_main.assert_called_once_with(refresh_vulnerability_data=False)
+
+    def test_process_command_propagates_refresh_flag(self, app):
+        with patch("src.bin.cmd_process._run_main") as run_main:
+            runner = app.test_cli_runner()
+            result = runner.invoke(args=["process", "--refresh-vulnerability-data"])
+
+        assert result.exit_code == 0
+        run_main.assert_called_once_with(refresh_vulnerability_data=True)
+
+    def test_standalone_refresh_uses_all_vulnerabilities(self, app):
+        with patch("src.bin.cmd_process.refresh_vulnerability_sources", return_value=[]) as refresh:
+            result = app.test_cli_runner().invoke(args=["refresh-vulnerability-data"])
+
+        assert result.exit_code == 0
+        assert set(refresh.call_args.args[1]) == set(refresh.call_args.args[0].vulnerabilities.vulnerabilities)
+        assert "Vulnerability data refresh complete." in result.output
+
+    def test_standalone_refresh_scopes_to_project(self, app):
+        with patch("src.bin.cmd_process.refresh_vulnerability_sources", return_value=[]) as refresh:
+            result = app.test_cli_runner().invoke(
+                args=["refresh-vulnerability-data", "--project", "ProcessProject"]
+            )
+
+        assert result.exit_code == 0
+        assert refresh.call_args.args[0]._scope is not None
+
+    def test_standalone_refresh_scopes_to_variant(self, app):
+        with patch("src.bin.cmd_process.refresh_vulnerability_sources", return_value=[]) as refresh:
+            result = app.test_cli_runner().invoke(
+                args=[
+                    "refresh-vulnerability-data", "--project", "ProcessProject",
+                    "--variant", "ProcessVariant",
+                ]
+            )
+
+        assert result.exit_code == 0
+        assert len(refresh.call_args.args[0]._scope.variant_ids) == 1
+
+    def test_standalone_refresh_rejects_variant_without_project(self, app):
+        result = app.test_cli_runner().invoke(
+            args=["refresh-vulnerability-data", "--variant", "ProcessVariant"]
+        )
+
+        assert result.exit_code == 2
+        assert "--variant requires --project" in result.output
+
+    def test_process_refresh_failure_exits_one(self, app):
+        with patch("src.bin.cmd_process.read_inputs"), \
+                patch("src.bin.cmd_process.populate_observations"):
+            with patch(
+                    "src.bin.cmd_process.refresh_vulnerability_sources",
+                    return_value=["NVD", "GHSA"],
+            ):
+                runner = app.test_cli_runner()
+                result = runner.invoke(args=["process", "--refresh-vulnerability-data"])
+
+        assert result.exit_code == 1
+        assert "NVD, GHSA vulnerability-data refresh failed" in result.output
+
+    def test_process_refresh_reports_source_steps(self, app):
+        def report_all_sources(*args, on_source_start, **kwargs):
+            labels = ("EPSS", "NVD", "EUVD", "GHSA")
+            for step, label in enumerate(labels, start=1):
+                on_source_start(label, step, len(labels))
+            return []
+
+        with patch("src.bin.cmd_process.read_inputs"), \
+                patch("src.bin.cmd_process.populate_observations"), \
+                patch(
+                    "src.bin.cmd_process.refresh_vulnerability_sources",
+                    side_effect=report_all_sources,
+                ):
+            runner = app.test_cli_runner()
+            result = runner.invoke(args=["process", "--refresh-vulnerability-data"])
+
+        assert result.exit_code == 0
+        assert "Refreshing EPSS data (step 1 of 4)..." in result.output
+        assert "Refreshing NVD data (step 2 of 4)..." in result.output
+        assert "Refreshing EUVD data (step 3 of 4)..." in result.output
+        assert "Refreshing GHSA data (step 4 of 4)..." in result.output
+        assert "Vulnerability data refresh complete." in result.output
+
+    def test_refresh_vulnerability_sources_uses_settings_order_and_scope(self):
+        from src.bin.cmd_process import refresh_vulnerability_sources
+        from src.controllers.vulnerabilities import EnrichmentResult
+
+        events = []
+
+        class Vulnerabilities:
+            def __init__(self):
+                self.vulnerabilities = {
+                    "CVE-2026-0001": object(),
+                    "CVE-OLD-0001": object(),
+                    "GHSA-aaaa-bbbb-cccc": object(),
+                }
+
+            def fetch_nvd_data(self):
+                events.append(("fetch-nvd", tuple(self.vulnerabilities)))
+                return EnrichmentResult(successful=1)
+
+            def fetch_euvd_data(self):
+                events.append(("fetch-euvd", tuple(self.vulnerabilities)))
+                return EnrichmentResult(successful=1)
+
+        vulnerabilities = Vulnerabilities()
+        original_vulnerabilities = vulnerabilities.vulnerabilities
+        controllers = SimpleNamespace(vulnerabilities=vulnerabilities)
+
+        with patch(
+            "src.bin.cmd_process.post_treatment",
+            side_effect=lambda _: events.append(
+                ("fetch-epss", tuple(vulnerabilities.vulnerabilities))
+            ) or EnrichmentResult(successful=1),
+        ):
+            failed = refresh_vulnerability_sources(
+                controllers,
+                {"CVE-2026-0001", "GHSA-aaaa-bbbb-cccc"},
+                on_source_start=lambda label, step, total: events.append(
+                    ("start", label, step, total)
+                ),
+            )
+
+        assert failed == []
+        assert events == [
+            ("start", "EPSS", 1, 4),
+            ("fetch-epss", ("CVE-2026-0001",)),
+            ("start", "NVD", 2, 4),
+            ("fetch-nvd", ("CVE-2026-0001",)),
+            ("start", "EUVD", 3, 4),
+            ("fetch-euvd", ("CVE-2026-0001",)),
+            ("start", "GHSA", 4, 4),
+            ("fetch-nvd", ("GHSA-aaaa-bbbb-cccc",)),
+        ]
+        assert vulnerabilities.vulnerabilities is original_vulnerabilities
+
+    def test_refresh_progress_excludes_inapplicable_ghsa_source(self):
+        from src.bin.cmd_process import refresh_vulnerability_sources
+        from src.controllers.vulnerabilities import EnrichmentResult
+
+        class Vulnerabilities:
+            vulnerabilities = {"CVE-2026-0001": object()}
+
+            def fetch_nvd_data(self):
+                return EnrichmentResult(successful=1)
+
+            def fetch_euvd_data(self):
+                return EnrichmentResult(successful=1)
+
+        events = []
+        controllers = SimpleNamespace(vulnerabilities=Vulnerabilities())
+        with patch(
+            "src.bin.cmd_process.post_treatment",
+            return_value=EnrichmentResult(successful=1),
+        ):
+            failed = refresh_vulnerability_sources(
+                controllers,
+                ["CVE-2026-0001"],
+                on_source_start=lambda label, step, total: events.append(
+                    (label, step, total)
+                ),
+            )
+
+        assert failed == []
+        assert events == [
+            ("EPSS", 1, 3),
+            ("NVD", 2, 3),
+            ("EUVD", 3, 3),
+        ]
+
+    def test_refresh_vulnerability_sources_continues_after_failure(self):
+        from src.bin.cmd_process import refresh_vulnerability_sources
+        from src.controllers.vulnerabilities import EnrichmentResult
+
+        calls = []
+
+        class Vulnerabilities:
+            vulnerabilities = {"CVE-2026-0001": object()}
+
+            def fetch_nvd_data(self):
+                calls.append("nvd")
+                return EnrichmentResult(successful=1)
+
+            def fetch_euvd_data(self):
+                calls.append("euvd")
+                return EnrichmentResult(successful=1)
+
+        controllers = SimpleNamespace(vulnerabilities=Vulnerabilities())
+        with patch(
+            "src.bin.cmd_process.post_treatment",
+            side_effect=RuntimeError("EPSS unavailable"),
+        ):
+            failed = refresh_vulnerability_sources(
+                controllers,
+                ["CVE-2026-0001"],
+                {"epss", "nvd", "euvd"},
+            )
+
+        assert failed == ["EPSS"]
+        assert calls == ["nvd", "euvd"]
 
     def test_populate_observations_no_scan_prints_warning(self, app, capsys):
         """populate_observations(None, …) prints warning and returns early (lines 255-256)."""

--- a/vulnscout
+++ b/vulnscout
@@ -32,7 +32,9 @@ call_container_engine() {
 }
 
 PROJECT="default"
+PROJECT_SPECIFIED=false
 VARIANT=""
+VARIANT_SPECIFIED=false
 MATCH_CONDITION=""
 PENDING_ARGS=()
 DEV_MODE=false
@@ -54,8 +56,8 @@ Note: The container runs as a daemon. All commands auto-start it if needed and
 leave it running afterward (including --serve). Use 'stop' or '--stop' to remove it.
 
 Global flags:
-  --project <name>                Set project name (default: 'default')
-  --variant <name>                Set variant name (default: 'default')
+  --project <name>                Set project name (scopes standalone refresh)
+  --variant <name>                Set variant name (scopes standalone refresh; requires --project)
 
 Input commands (can be chained, triggers scan automatically):
   --add-spdx <path>               Add an SPDX 2/3 SBOM file or archive
@@ -64,6 +66,7 @@ Input commands (can be chained, triggers scan automatically):
   --add-openvex <path>            Add an OpenVEX JSON file
   --add-cdx <path>                Add a CycloneDX file
   --add-grype <path>              Add a Grype results file
+  --refresh-vulnerability-data    Refresh EPSS, NVD, EUVD, and GHSA data; without inputs refreshes all vulnerabilities
   --perform-grype-scan            Run Grype on the current DB content (after merging any added inputs)
   --perform-nvd-scan              Run an NVD CPE-based vulnerability scan
   --perform-osv-scan              Run an OSV PURL-based vulnerability scan
@@ -126,9 +129,19 @@ exec_container() {
     call_container_engine exec "$CONTAINER_NAME" /scan/src/entrypoint.sh "$@"
 }
 
+container_has_dev_mount() {
+    call_container_engine inspect "$CONTAINER_NAME" \
+        --format '{{range .Mounts}}{{.Destination}}{{println}}{{end}}' 2>/dev/null \
+        | grep -qx '/scan/src'
+}
+
 ensure_running() {
     if ! call_container_engine ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
         echo "Container not running, starting..."
+        do_start
+    elif [ "$DEV_MODE" = true ] && [ -d "$SCRIPT_DIR/src" ] && ! container_has_dev_mount; then
+        # Otherwise the container keeps serving the image's src/, ignoring local changes
+        echo "Container running without dev mode, restarting..."
         do_start
     fi
 }
@@ -321,13 +334,15 @@ parse_and_run() {
             --dev)
                 DEV_MODE=true; shift ;;
             --project)
-                PROJECT="$2"; shift 2 ;;
+                PROJECT="$2"; PROJECT_SPECIFIED=true; shift 2 ;;
             --variant)
-                VARIANT="$2"; shift 2 ;;
+                VARIANT="$2"; VARIANT_SPECIFIED=true; shift 2 ;;
             --match-condition)
                 MATCH_CONDITION="$2"; shift 2 ;;
             add-spdx|--add-spdx|add-cve-check|--add-cve-check|add-yocto-vex|--add-yocto-vex|add-openvex|--add-openvex|add-cdx|--add-cdx|add-grype|--add-grype)
                 ensure_running; add_input "${1#--}" "$2"; shift 2 ;;
+            --refresh-vulnerability-data)
+                ensure_running; REFRESH_VULNERABILITY_DATA=true; shift ;;
             add-asset|--add-asset)
                 ensure_running; add_input add-asset "$2"; shift 2 ;;
             perform-grype-scan|--perform-grype-scan)
@@ -502,7 +517,13 @@ parse_and_run() {
     elif [ ${#PENDING_ARGS[@]} -gt 0 ]; then
         local -a scan_args=()
         [ -n "$MATCH_CONDITION" ] && scan_args+=(--match-condition "$MATCH_CONDITION")
+        [ "${REFRESH_VULNERABILITY_DATA:-false}" = true ] && scan_args+=(--refresh-vulnerability-data)
         exec_container --project "$PROJECT" --variant "$VARIANT" "${PENDING_ARGS[@]}" "${scan_args[@]}" "${REPORT_ARGS[@]}" "${EXPORT_ARGS[@]}" || _exit=$?
+    elif [ "${REFRESH_VULNERABILITY_DATA:-false}" = true ]; then
+        local -a refresh_args=(--refresh-vulnerability-data)
+        [ "$PROJECT_SPECIFIED" = true ] && refresh_args=(--project "$PROJECT" "${refresh_args[@]}")
+        [ "$VARIANT_SPECIFIED" = true ] && refresh_args=(--variant "$VARIANT" "${refresh_args[@]}")
+        exec_container "${refresh_args[@]}" || _exit=$?
     elif [[ "$DATA_REQUESTED" != "" ]]; then
         exec_container "--$DATA_REQUESTED" "${DATA_ARGS[@]}"
     elif [ -n "$MATCH_CONDITION" ] || [ ${#REPORT_ARGS[@]} -gt 0 ] || [ ${#EXPORT_ARGS[@]} -gt 0 ]; then


### PR DESCRIPTION
## Fixes # by supporting vulnerability refresh during CLI import

### Changes proposed in this pull request:

* Add `--refresh-vulnerability-data` to the host wrapper and container entrypoint.
* Run the same complete EPSS, NVD, EUVD, and GHSA refresh sequence used by Settings after SBOM import.
* Preserve absent-flag behavior, refresh ordering, failure isolation, and exit status propagation.
* Add focused Python and shell coverage for argument handling and wrapper propagation.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Run `pytest tests/cli_tests/test_cmd_process.py`.
* Run `tests/CI_tests/vulnscout_wrapper_test.sh`.
* Run `./vulnscout --help` and confirm `--refresh-vulnerability-data` is documented; import an SBOM with the flag and confirm the complete refresh runs afterward.

### Additional notes

Live external provider requests are not required by the automated tests; refresh orchestration and failure behavior are covered locally.

### Related Issue

No linked issue.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [X] The code compiles and passes all tests
- [X] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers