### PR TITLE
Add stable review export updates

### DIFF
--- a/doc/source/interactive-mode.md
+++ b/doc/source/interactive-mode.md
@@ -306,4 +306,4 @@ The toolbar mirrors the vulnerability table's search bar. Filters are available 
 Two buttons in the toolbar handle review portability:
 
 - **Import Review**: choose either an OpenVEX JSON document or a VulnScout JSON file. OpenVEX imports assessments into one selected variant. VulnScout JSON restores all included assessments, custom CVSS scores, and time estimates using the variants recorded in the file.
-- **Export Review**: choose VulnScout JSON to export assessments, custom CVSS scores, and time estimates for selected variants, or OpenVEX to export assessments for one selected variant as a JSON document.
+- **Export Review**: choose **Normal export** to create a new file, or **Append/update existing file** to upload a previous export and preserve its stable ordering for smaller Git diffs. The existing file automatically selects VulnScout JSON or OpenVEX. VulnScout JSON exports assessments, custom CVSS scores, and time estimates for selected variants; OpenVEX exports assessments for one selected variant. Append/update replaces changed records, appends new records, and removes data for variants that are not currently selected.

--- a/frontend/src/components/ReviewTransferModal.tsx
+++ b/frontend/src/components/ReviewTransferModal.tsx
@@ -9,9 +9,14 @@ type Props = {
     selectedVariantIds: string[];
     transferFormat: 'custom' | 'openvex';
     timestampPolicy: 'original' | 'current';
+    exportMode: 'normal' | 'update';
+    existingFileName?: string;
+    existingFileError?: string;
     onSelectedVariantIdsChange: (ids: string[]) => void;
     onTransferFormatChange: (format: 'custom' | 'openvex') => void;
     onTimestampPolicyChange: (policy: 'original' | 'current') => void;
+    onExportModeChange: (mode: 'normal' | 'update') => void;
+    onExistingFileChange: (file?: File) => void;
     onConfirm: () => void;
     onCancel: () => void;
 };
@@ -22,9 +27,14 @@ function ReviewTransferModal({
     selectedVariantIds,
     transferFormat,
     timestampPolicy,
+    exportMode,
+    existingFileName,
+    existingFileError,
     onSelectedVariantIdsChange,
     onTransferFormatChange,
     onTimestampPolicyChange,
+    onExportModeChange,
+    onExistingFileChange,
     onConfirm,
     onCancel,
 }: Readonly<Props>) {
@@ -32,6 +42,7 @@ function ReviewTransferModal({
     const isOpenVex = transferFormat === 'openvex';
     const needsVariantSelection = isOpenVex || mode === 'export';
     const supportsMultipleVariants = !isOpenVex;
+    const isUpdateExport = mode === 'export' && exportMode === 'update';
 
     useEffect(() => {
         const onKeyDown = (event: KeyboardEvent) => {
@@ -60,19 +71,52 @@ function ReviewTransferModal({
                 </div>
 
                 <div className="space-y-5 p-5">
-                    <fieldset>
-                        <legend className="mb-2 text-sm font-semibold text-gray-200">Format</legend>
-                        <div className="grid grid-cols-2 gap-3">
-                            <label className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${transferFormat === 'custom' ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
-                                <input type="radio" name="review-transfer-format" checked={transferFormat === 'custom'} onChange={() => onTransferFormatChange('custom')} className="mt-0.5 accent-cyan-500" />
-                                <span className="flex flex-col"><span className="text-sm font-medium">VulnScout JSON</span><span className="text-xs text-zinc-400">{mode === 'export' ? 'Assessments, CVSS, and time estimates' : 'Uses the variants recorded in the file'}</span></span>
-                            </label>
-                            <label className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${isOpenVex ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
-                                <input type="radio" name="review-transfer-format" checked={isOpenVex} onChange={() => onTransferFormatChange('openvex')} className="mt-0.5 accent-cyan-500" />
-                                <span className="flex flex-col"><span className="text-sm font-medium">OpenVEX</span><span className="text-xs text-zinc-400">One variant in a JSON document</span></span>
-                            </label>
-                        </div>
-                    </fieldset>
+                    {mode === 'export' && (
+                        <fieldset>
+                            <legend className="mb-2 text-sm font-semibold text-gray-200">Export method</legend>
+                            <div className="grid grid-cols-2 gap-3">
+                                <label className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${exportMode === 'normal' ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
+                                    <input type="radio" name="review-export-mode" checked={exportMode === 'normal'} onChange={() => onExportModeChange('normal')} className="mt-0.5 accent-cyan-500" />
+                                    <span className="flex flex-col"><span className="text-sm font-medium">Normal export</span><span className="text-xs text-zinc-400">Create a new export file</span></span>
+                                </label>
+                                <label className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${isUpdateExport ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
+                                    <input type="radio" name="review-export-mode" checked={isUpdateExport} onChange={() => onExportModeChange('update')} className="mt-0.5 accent-cyan-500" />
+                                    <span className="flex flex-col"><span className="text-sm font-medium">Append/update existing file</span><span className="text-xs text-zinc-400">Preserve stable content for a minimal Git diff</span></span>
+                                </label>
+                            </div>
+                        </fieldset>
+                    )}
+
+                    {isUpdateExport && (
+                        <label className="block text-sm font-semibold text-gray-200">
+                            Existing export file
+                            <input
+                                type="file"
+                                aria-label="Existing export file"
+                                accept=".json,application/json"
+                                onChange={event => onExistingFileChange(event.target.files?.[0])}
+                                className="mt-2 block w-full rounded border border-slate-600 bg-slate-900 p-2 text-sm font-normal text-zinc-300 file:mr-3 file:rounded file:border-0 file:bg-slate-700 file:px-3 file:py-1 file:text-white"
+                            />
+                            {existingFileName && !existingFileError && <span className="mt-1 block font-normal text-cyan-300">Detected {isOpenVex ? 'OpenVEX' : 'VulnScout JSON'}: {existingFileName}</span>}
+                            {existingFileError && <span role="alert" className="mt-1 block font-normal text-red-300">{existingFileError}</span>}
+                        </label>
+                    )}
+
+                    {!isUpdateExport && (
+                        <fieldset>
+                            <legend className="mb-2 text-sm font-semibold text-gray-200">Format</legend>
+                            <div className="grid grid-cols-2 gap-3">
+                                <label className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${transferFormat === 'custom' ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
+                                    <input type="radio" name="review-transfer-format" checked={transferFormat === 'custom'} onChange={() => onTransferFormatChange('custom')} className="mt-0.5 accent-cyan-500" />
+                                    <span className="flex flex-col"><span className="text-sm font-medium">VulnScout JSON</span><span className="text-xs text-zinc-400">{mode === 'export' ? 'Assessments, CVSS, and time estimates' : 'Uses the variants recorded in the file'}</span></span>
+                                </label>
+                                <label className={`flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 transition-colors ${isOpenVex ? 'border-cyan-500 bg-cyan-950/40 text-white' : 'border-slate-600 bg-slate-900/40 text-zinc-300 hover:border-slate-500'}`}>
+                                    <input type="radio" name="review-transfer-format" checked={isOpenVex} onChange={() => onTransferFormatChange('openvex')} className="mt-0.5 accent-cyan-500" />
+                                    <span className="flex flex-col"><span className="text-sm font-medium">OpenVEX</span><span className="text-xs text-zinc-400">One variant in a JSON document</span></span>
+                                </label>
+                            </div>
+                        </fieldset>
+                    )}
 
                     {mode === 'import' && (
                         <fieldset>
@@ -117,8 +161,8 @@ function ReviewTransferModal({
 
                 <div className="flex justify-end gap-3 border-t border-gray-600 px-5 py-4">
                     <button type="button" onClick={onCancel} className="rounded border border-gray-500 px-4 py-2 text-sm text-gray-200 hover:bg-gray-700">Cancel</button>
-                    <button type="button" onClick={onConfirm} disabled={needsVariantSelection && (isOpenVex ? selectedVariantIds.length !== 1 : selectedVariantIds.length === 0)} className="rounded bg-green-700 px-4 py-2 text-sm font-medium text-white hover:bg-green-600 disabled:cursor-not-allowed disabled:opacity-50">
-                        {mode === 'export' ? 'Export' : 'Choose file'}
+                    <button type="button" onClick={onConfirm} disabled={(needsVariantSelection && (isOpenVex ? selectedVariantIds.length !== 1 : selectedVariantIds.length === 0)) || (isUpdateExport && (!existingFileName || Boolean(existingFileError)))} className="rounded bg-green-700 px-4 py-2 text-sm font-medium text-white hover:bg-green-600 disabled:cursor-not-allowed disabled:opacity-50">
+                        {mode === 'export' ? isUpdateExport ? 'Update export' : 'Export' : 'Choose file'}
                     </button>
                 </div>
             </div>

--- a/frontend/src/helpers/exportJson.ts
+++ b/frontend/src/helpers/exportJson.ts
@@ -19,6 +19,28 @@ export function formatTimestampForFilename(date?: Date | string): string {
     return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
 }
 
+export type ReviewExportFormat = 'custom' | 'openvex';
+
+/** Detect a supported Review export format from parsed JSON. */
+export function detectReviewExportFormat(data: unknown): ReviewExportFormat {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        throw new Error('Export file must contain a JSON object.');
+    }
+    const document = data as Record<string, unknown>;
+    if (String(document['@context'] ?? '').includes('openvex') && Array.isArray(document.statements)) {
+        return 'openvex';
+    }
+    if (document.version === 1 && Array.isArray(document.assessments)) {
+        for (const section of ['ai_assessments', 'cvss', 'time_estimates']) {
+            if (document[section] !== undefined && !Array.isArray(document[section])) {
+                throw new Error(`Invalid VulnScout JSON: '${section}' must be an array.`);
+            }
+        }
+        return 'custom';
+    }
+    throw new Error('Unsupported export format. Expected VulnScout JSON or OpenVEX.');
+}
+
 /**
  * Trigger a JSON file download in the browser.
  */

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -11,7 +11,7 @@ import FilterOption from "../components/FilterOption";
 import ToggleSwitch from "../components/ToggleSwitch";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleQuestion, faCircleInfo, faFileExport, faFileImport, faPenToSquare, faTrash, faBook, faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
-import { downloadJson, sanitizeFilename, formatTimestampForFilename } from '../helpers/exportJson';
+import { detectReviewExportFormat, downloadJson, sanitizeFilename, formatTimestampForFilename } from '../helpers/exportJson';
 import EditAssessment from '../components/EditAssessment';
 import type { EditAssessmentData } from '../components/EditAssessment';
 import type { Variant } from '../handlers/variant';
@@ -199,6 +199,9 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     const [transferVariantIds, setTransferVariantIds] = useState<string[]>([]);
     const [transferFormat, setTransferFormat] = useState<'custom' | 'openvex'>('custom');
     const [importTimestampPolicy, setImportTimestampPolicy] = useState<'original' | 'current'>('original');
+    const [exportMode, setExportMode] = useState<'normal' | 'update'>('normal');
+    const [existingExportFile, setExistingExportFile] = useState<File | undefined>();
+    const [existingExportError, setExistingExportError] = useState<string | undefined>();
 
     const showMessage = useCallback((message: string, type: "error" | "success") => {
         setBannerMessage(message);
@@ -464,6 +467,9 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
     const openTransfer = useCallback((mode: 'import' | 'export') => {
         setTransferFormat('custom');
         setImportTimestampPolicy('original');
+        setExportMode('normal');
+        setExistingExportFile(undefined);
+        setExistingExportError(undefined);
         setTransferVariantIds(mode === 'export'
             ? variantId ? [variantId] : transferVariants.map(variant => variant.id)
             : []);
@@ -484,8 +490,43 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         setTransferVariantIds(defaultVariantId ? [defaultVariantId] : []);
     }, [transferMode, transferVariants, variantId]);
 
+    const changeExportMode = useCallback((mode: 'normal' | 'update') => {
+        setExportMode(mode);
+        setExistingExportFile(undefined);
+        setExistingExportError(undefined);
+        if (mode === 'normal') changeTransferFormat('custom');
+    }, [changeTransferFormat]);
+
+    const existingExportSelection = useRef(0);
+    const handleExistingExportFile = useCallback(async (file?: File) => {
+        const selection = ++existingExportSelection.current;
+        setExistingExportFile(undefined);
+        setExistingExportError(undefined);
+        if (!file) return;
+        try {
+            const text = await new Promise<string>((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = () => resolve(String(reader.result ?? ''));
+                reader.onerror = () => reject(new Error('Unable to read export file.'));
+                reader.readAsText(file);
+            });
+            if (selection !== existingExportSelection.current) return;
+            const parsed = JSON.parse(text);
+            const detectedFormat = detectReviewExportFormat(parsed);
+            changeTransferFormat(detectedFormat);
+            setExistingExportFile(file);
+        } catch (error) {
+            if (selection !== existingExportSelection.current) return;
+            setExistingExportError(error instanceof Error ? error.message : 'Unable to read export file.');
+        }
+    }, [changeTransferFormat]);
+
     const handleExportReview = useCallback(async () => {
         try {
+            if (exportMode === 'update' && !existingExportFile) {
+                showMessage('Choose a supported existing export file.', 'error');
+                return;
+            }
             const params = new URLSearchParams();
             transferVariantIds.forEach(variantId => params.append('variant_id', variantId));
             const endpoint = transferFormat === 'openvex' ? 'export' : 'export-custom-data';
@@ -494,26 +535,38 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                 (params.toString() ? `?${params.toString()}` : ''),
                 window.location.href,
             );
-            const res = await fetch(url.toString(), { mode: 'cors' });
+            let res: Response;
+            if (exportMode === 'update' && existingExportFile) {
+                const formData = new FormData();
+                formData.append('file', existingExportFile);
+                transferVariantIds.forEach(variantId => formData.append('variant_id', variantId));
+                res = await fetch(new URL(
+                    import.meta.env.VITE_API_URL + '/api/assessments/review/export-update',
+                    window.location.href,
+                ).toString(), { method: 'POST', mode: 'cors', body: formData });
+            } else {
+                res = await fetch(url.toString(), { mode: 'cors' });
+            }
             if (!res.ok) {
                 const err = await res.json().catch(() => ({}));
                 showMessage(err.error || 'Failed to export review data.', 'error');
                 return;
             }
+            const exported = await res.json();
             const ts = formatTimestampForFilename();
             if (transferFormat === 'openvex') {
                 const label = variantNames[transferVariantIds[0]] ?? 'variant';
-                downloadJson(await res.json(), `review_openvex_${sanitizeFilename(label)}_${ts}.json`);
+                downloadJson(exported, `review_openvex_${sanitizeFilename(label)}_${ts}.json`);
             } else {
                 const label = transferVariantIds.length === 1 ? variantNames[transferVariantIds[0]] ?? 'variant' : 'all';
-                downloadJson(await res.json(), `custom_data_${sanitizeFilename(label)}_${ts}.json`);
+                downloadJson(exported, `custom_data_${sanitizeFilename(label)}_${ts}.json`);
             }
             setTransferMode(null);
         } catch (err) {
             console.error('Export error:', err);
             showMessage('Failed to export review data.', 'error');
         }
-    }, [showMessage, variantNames, transferVariantIds, transferFormat]);
+    }, [existingExportFile, exportMode, showMessage, variantNames, transferVariantIds, transferFormat]);
 
     const handleImportReview = useCallback(() => {
         setTransferMode(null);
@@ -1553,9 +1606,14 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
                     selectedVariantIds={transferVariantIds}
                     transferFormat={transferFormat}
                     timestampPolicy={importTimestampPolicy}
+                    exportMode={exportMode}
+                    existingFileName={existingExportFile?.name}
+                    existingFileError={existingExportError}
                     onSelectedVariantIdsChange={setTransferVariantIds}
                     onTransferFormatChange={changeTransferFormat}
                     onTimestampPolicyChange={setImportTimestampPolicy}
+                    onExportModeChange={changeExportMode}
+                    onExistingFileChange={handleExistingExportFile}
                     onConfirm={transferMode === 'export' ? handleExportReview : handleImportReview}
                     onCancel={() => setTransferMode(null)}
                 />

--- a/frontend/tests/unit_tests/test_export_json.ts
+++ b/frontend/tests/unit_tests/test_export_json.ts
@@ -1,6 +1,7 @@
 import {
     downloadBlob,
     downloadJson,
+    detectReviewExportFormat,
     formatTimestampForFilename,
     sanitizeFilename,
 } from '../../src/helpers/exportJson';
@@ -63,5 +64,12 @@ describe('exportJson helpers', () => {
 
         document.removeEventListener('click', captureDownload);
         expect(download).toBe('vulnerabilities.json');
+    });
+
+    test('detects supported review export formats and rejects unsupported JSON', () => {
+        expect(detectReviewExportFormat({ version: 1, assessments: [] })).toBe('custom');
+        expect(detectReviewExportFormat({ '@context': 'https://openvex.dev/ns/v0.2.0', statements: [] })).toBe('openvex');
+        expect(() => detectReviewExportFormat({ version: 1, assessments: [], cvss: {} })).toThrow(/cvss.*array/);
+        expect(() => detectReviewExportFormat({ foo: 'bar' })).toThrow(/Unsupported export format/);
     });
 });

--- a/frontend/tests/unit_tests/test_review.tsx
+++ b/frontend/tests/unit_tests/test_review.tsx
@@ -273,6 +273,7 @@ function mockNetwork(reviewList: unknown[] = [], opts: NetworkOpts = {}): void {
         // Mutations (PUT / DELETE / POST)
         if (url.includes('/api/assessments/review/import-custom-data')) return JSON.stringify(importResult);
         if (url.includes('/api/assessments/review/import')) return JSON.stringify({ status: 'success' });
+        if (url.includes('/api/assessments/review/export-update')) return JSON.stringify({ version: 1, assessments: [] });
         if (!mutationOk) return { status: 500, body: JSON.stringify({ status: 'error' }) };
         return JSON.stringify({ status: 'success' });
     });
@@ -1534,6 +1535,79 @@ describe('Review — import and export', () => {
         expect(String(exportCall?.[0])).not.toContain('variant_id=v1');
         expect(mockedDownloadJson.mock.calls[0][1]).toContain('review_openvex_Variant_Beta_');
         expect(mockedDownloadJson.mock.calls[0][1]).toContain('.json');
+    });
+
+    test('auto-detects and updates an existing export with a generated filename', async () => {
+        mockNetwork([makeAssessment('a1', 'v1')]);
+        render(<Review projectId="proj1" />);
+        const user = userEvent.setup();
+        await screen.findByTitle('Edit assessment');
+
+        await user.click(screen.getByText('Export'));
+        const dialog = screen.getByRole('dialog');
+        await user.click(within(dialog).getByRole('radio', { name: /^Append\/update existing file/ }));
+        const file = new File(
+            [JSON.stringify({ version: 1, assessments: [], ai_assessments: [], cvss: [], time_estimates: [] })],
+            'tracked-review.json',
+            { type: 'application/json' },
+        );
+        await user.upload(within(dialog).getByLabelText('Existing export file'), file);
+        await within(dialog).findByText(/Detected VulnScout JSON/);
+        await user.click(within(dialog).getByRole('checkbox', { name: 'Variant Beta' }));
+        await user.click(within(dialog).getByRole('button', { name: 'Update export' }));
+
+        await waitFor(() => expect(mockedDownloadJson).toHaveBeenCalledWith(expect.anything(), expect.stringMatching(/^custom_data_Variant_Alpha_\d{8}_\d{6}\.json$/)));
+        const updateCall = fetchMock.mock.calls.find(call => String(call[0]).includes('/api/assessments/review/export-update'));
+        const body = (updateCall?.[1] as RequestInit).body as FormData;
+        expect(updateCall?.[1]).toMatchObject({ method: 'POST' });
+        expect(body.getAll('variant_id')).toEqual(['v1']);
+        expect((body.get('file') as File).name).toBe('tracked-review.json');
+    });
+
+    test('reports unsupported existing export files before submission', async () => {
+        mockNetwork([makeAssessment('a1', 'v1')]);
+        render(<Review projectId="proj1" />);
+        const user = userEvent.setup();
+        await screen.findByTitle('Edit assessment');
+
+        await user.click(screen.getByText('Export'));
+        const dialog = screen.getByRole('dialog');
+        await user.click(within(dialog).getByRole('radio', { name: /^Append\/update existing file/ }));
+        await user.upload(
+            within(dialog).getByLabelText('Existing export file'),
+            new File([JSON.stringify({ foo: 'bar' })], 'unsupported.json', { type: 'application/json' }),
+        );
+
+        expect(await within(dialog).findByRole('alert')).toHaveTextContent('Unsupported export format');
+        expect(within(dialog).getByRole('button', { name: 'Update export' })).toBeDisabled();
+        expect(fetchMock.mock.calls.some(call => String(call[0]).includes('/export-update'))).toBe(false);
+    });
+
+    test('ignores an earlier existing export file that finishes reading last', async () => {
+        mockNetwork([makeAssessment('a1', 'v1')]);
+        const reads: Array<{ reader: FileReader; file: Blob }> = [];
+        const readSpy = jest.spyOn(FileReader.prototype, 'readAsText').mockImplementation(function (this: FileReader, file: Blob) {
+            reads.push({ reader: this, file });
+        });
+        render(<Review projectId="proj1" />);
+        const user = userEvent.setup();
+        await screen.findByTitle('Edit assessment');
+
+        await user.click(screen.getByText('Export'));
+        const dialog = screen.getByRole('dialog');
+        await user.click(within(dialog).getByRole('radio', { name: /^Append\/update existing file/ }));
+        const input = within(dialog).getByLabelText('Existing export file');
+        await user.upload(input, new File(['first'], 'first.json', { type: 'application/json' }));
+        await user.upload(input, new File(['second'], 'second.json', { type: 'application/json' }));
+
+        Object.defineProperty(reads[1].reader, 'result', { value: JSON.stringify({ version: 1, assessments: [] }) });
+        reads[1].reader.onload?.(new ProgressEvent('load') as ProgressEvent<FileReader>);
+        Object.defineProperty(reads[0].reader, 'result', { value: JSON.stringify({ '@context': 'https://openvex.dev/ns/v0.2.0', statements: [] }) });
+        reads[0].reader.onload?.(new ProgressEvent('load') as ProgressEvent<FileReader>);
+
+        expect(await within(dialog).findByText(/Detected VulnScout JSON/)).toBeInTheDocument();
+        expect(within(dialog).queryByText(/Detected OpenVEX/)).not.toBeInTheDocument();
+        readSpy.mockRestore();
     });
 
     test('reports an error when export fails', async () => {

--- a/frontend/tests/unit_tests/test_review_transfer_modal.tsx
+++ b/frontend/tests/unit_tests/test_review_transfer_modal.tsx
@@ -14,9 +14,12 @@ function renderModal(overrides = {}) {
         selectedVariantIds: [] as string[],
         transferFormat: 'custom' as const,
         timestampPolicy: 'original' as const,
+        exportMode: 'normal' as const,
         onSelectedVariantIdsChange: jest.fn(),
         onTransferFormatChange: jest.fn(),
         onTimestampPolicyChange: jest.fn(),
+        onExportModeChange: jest.fn(),
+        onExistingFileChange: jest.fn(),
         onConfirm: jest.fn(),
         onCancel: jest.fn(),
         ...overrides,
@@ -71,6 +74,13 @@ describe('ReviewTransferModal', () => {
         expect(selectedProps.onSelectedVariantIdsChange).toHaveBeenCalledWith([]);
     });
 
+    test('places Export method before Format and Variants', () => {
+        renderModal({ mode: 'export' as const });
+
+        const legends = Array.from(document.querySelectorAll('legend')).map(legend => legend.textContent);
+        expect(legends).toEqual(['Export method', 'Format', 'Variants']);
+    });
+
     test('toggles individual export variants and resets custom import settings', () => {
         const exportProps = renderModal({
             mode: 'export' as const,
@@ -93,5 +103,36 @@ describe('ReviewTransferModal', () => {
 
         expect(importProps.onTransferFormatChange).toHaveBeenCalledWith('custom');
         expect(importProps.onTimestampPolicyChange).toHaveBeenCalledWith('original');
+    });
+
+    test('requires a valid existing file for append/update export', () => {
+        const props = renderModal({ mode: 'export' as const, selectedVariantIds: ['variant-1'] });
+        fireEvent.click(screen.getByRole('radio', { name: /^Append\/update existing file/ }));
+        expect(props.onExportModeChange).toHaveBeenCalledWith('update');
+
+        cleanup();
+        renderModal({
+            mode: 'export' as const,
+            exportMode: 'update' as const,
+            selectedVariantIds: ['variant-1'],
+        });
+        expect(screen.queryByText('Format')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Update export' })).toBeDisabled();
+
+        cleanup();
+        const updateProps = renderModal({
+            mode: 'export' as const,
+            exportMode: 'update' as const,
+            selectedVariantIds: ['variant-1'],
+            existingFileName: 'review.json',
+        });
+        expect(screen.getByText('Detected VulnScout JSON: review.json')).toBeInTheDocument();
+        const file = new File(['{}'], 'review.json', { type: 'application/json' });
+        fireEvent.change(screen.getByLabelText('Existing export file'), { target: { files: [file] } });
+        fireEvent.click(screen.getByRole('button', { name: 'Update export' }));
+
+        expect(updateProps.onExistingFileChange).toHaveBeenCalledWith(file);
+        expect(updateProps.onConfirm).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('radio', { name: /^VulnScout JSON/ })).not.toBeInTheDocument();
     });
 });

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -11,6 +11,7 @@ neither caller needs to re-implement it.
 from __future__ import annotations
 
 import uuid as _uuid
+from collections import defaultdict, deque
 from datetime import datetime as _dt, timezone as _tz
 from typing import TYPE_CHECKING, Any
 
@@ -160,8 +161,234 @@ def is_openvex_doc(doc: object) -> bool:
     """Return ``True`` if *doc* looks like a valid OpenVEX document."""
     if not isinstance(doc, dict):
         return False
-    ctx = doc.get("@context", "")
-    return "openvex" in str(ctx) and isinstance(doc.get("statements"), list)
+    context = doc.get("@context", "")
+    return "openvex" in str(context) and isinstance(doc.get("statements"), list)
+
+
+def _is_review_openvex_export(doc: object) -> bool:
+    """Return whether *doc* has the stable identities needed for reconciliation."""
+    if not is_openvex_doc(doc):
+        return False
+    assert isinstance(doc, dict)
+    if not all(isinstance(doc.get(field), str) and doc[field] for field in ("@id", "author", "timestamp")):
+        return False
+    if not isinstance(doc.get("version"), int):
+        return False
+    return all(
+        isinstance(statement, dict)
+        and isinstance(statement.get("vulnerability"), dict)
+        and isinstance(statement["vulnerability"].get("name"), str)
+        and isinstance(statement.get("status"), str)
+        and isinstance(statement.get("products"), list)
+        and all(isinstance(product, dict) and isinstance(product.get("@id"), str) for product in statement["products"])
+        for statement in doc["statements"]
+    )
+
+
+_CUSTOM_EXPORT_SECTIONS = (
+    "assessments",
+    "ai_assessments",
+    "cvss",
+    "time_estimates",
+)
+
+
+def detect_review_export_format(doc: object) -> str:
+    """Return the supported Review export format represented by *doc*.
+
+    Raises ``ValueError`` with a user-facing explanation for malformed or
+    unsupported input.
+    """
+    if _is_review_openvex_export(doc):
+        return "openvex"
+    if not isinstance(doc, dict):
+        raise ValueError("Export file must contain a JSON object")
+    if doc.get("version") == 1 and isinstance(doc.get("assessments"), list):
+        for section in _CUSTOM_EXPORT_SECTIONS:
+            value = doc.get(section, [])
+            if not isinstance(value, list):
+                raise ValueError(f"Invalid VulnScout JSON: '{section}' must be an array")
+            if not all(
+                isinstance(record, dict)
+                and isinstance(record.get("variant_id"), str)
+                and isinstance(record.get("vuln_id"), str)
+                and (
+                    section not in {"assessments", "ai_assessments"}
+                    or isinstance(record.get("packages"), list)
+                    and all(isinstance(package, str) for package in record["packages"])
+                )
+                for record in value
+            ):
+                raise ValueError(f"Invalid VulnScout JSON: '{section}' contains an invalid record")
+        return "custom"
+    raise ValueError("Unsupported export format. Expected VulnScout JSON or OpenVEX")
+
+
+def _record_identity(section: str, record: dict[str, Any]) -> tuple[Any, ...]:
+    variant_id = record.get("variant_id")
+    vuln_id = record.get("vuln_id")
+    if section in {"assessments", "ai_assessments"}:
+        packages = record.get("packages", [])
+        package_key = tuple(sorted(str(package) for package in packages)) if isinstance(packages, list) else ()
+        return variant_id, vuln_id, package_key
+    return variant_id, vuln_id, None
+
+
+def _openvex_statement_identity(record: dict[str, Any]) -> tuple[Any, ...]:
+    vulnerability = record.get("vulnerability", {})
+    products = record.get("products", [])
+    vuln_name = vulnerability.get("name") if isinstance(vulnerability, dict) else None
+    product_ids = tuple(
+        str(product.get("@id", ""))
+        for product in products
+        if isinstance(product, dict)
+    ) if isinstance(products, list) else ()
+    return vuln_name, product_ids
+
+
+def _record_without_extensions(record: dict[str, Any]) -> dict[str, Any]:
+    """Return generated record content, excluding user-preserved extensions."""
+    return {
+        key: value for key, value in record.items()
+        if not (isinstance(key, str) and key.startswith("x-"))
+    }
+
+
+def _exact_current_index(
+    old_record: dict[str, Any],
+    candidates: deque[int],
+    current: list[Any],
+) -> int | None:
+    """Return an exact generated-content match among candidates."""
+    return next(
+        (index for index in candidates
+         if _record_without_extensions(current[index]) == _record_without_extensions(old_record)),
+        None,
+    )
+
+
+def _timestamp_current_index(
+    old_record: dict[str, Any],
+    candidates: deque[int],
+    current: list[Any],
+) -> int | None:
+    """Return the sole timestamp match among candidates, if one exists."""
+    timestamp_candidates = [
+        index for index in candidates
+        if current[index].get("timestamp") == old_record.get("timestamp")
+    ]
+    return timestamp_candidates[0] if len(timestamp_candidates) == 1 else None
+
+
+def _validate_records(records: list[Any], source: str) -> list[dict[str, Any]]:
+    """Validate records and return them with their dictionary type narrowed."""
+    validated_records: list[dict[str, Any]] = []
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError(f"{source} export contains an invalid record")
+        validated_records.append(record)
+    return validated_records
+
+
+def _current_record_indices(
+    current: list[dict[str, Any]], identity: Any,
+) -> dict[tuple[Any, ...], deque[int]]:
+    """Index current records by their non-unique reconciliation identity."""
+    indices: dict[tuple[Any, ...], deque[int]] = defaultdict(deque)
+    for index, record in enumerate(current):
+        indices[identity(record)].append(index)
+    return indices
+
+
+def _consume_matches(
+    existing: list[dict[str, Any]],
+    current: list[dict[str, Any]],
+    current_indices: dict[tuple[Any, ...], deque[int]],
+    matched_indices: list[int | None],
+    identity: Any,
+    match_index: Any,
+) -> None:
+    """Consume one match per still-unmatched existing record."""
+    for old_index, old_record in enumerate(existing):
+        if matched_indices[old_index] is not None:
+            continue
+        candidates = current_indices.get(identity(old_record))
+        if candidates is None:
+            continue
+        current_index = match_index(old_record, candidates, current)
+        if current_index is not None:
+            candidates.remove(current_index)
+            matched_indices[old_index] = current_index
+
+
+def _reconcile_records(
+    existing: list[Any],
+    current: list[Any],
+    identity: Any,
+) -> list[Any]:
+    """Retain existing order for matching records and append new records."""
+    current_records = _validate_records(current, "Generated")
+    existing_records = _validate_records(existing, "Existing")
+    current_indices = _current_record_indices(current_records, identity)
+    matched_indices: list[int | None] = [None] * len(existing_records)
+    _consume_matches(
+        existing_records, current_records, current_indices, matched_indices,
+        identity, _exact_current_index,
+    )
+    _consume_matches(
+        existing_records, current_records, current_indices, matched_indices,
+        identity, _timestamp_current_index,
+    )
+
+    reconciled: list[Any] = []
+    consumed: set[int] = set()
+    for old_record, current_index in zip(existing_records, matched_indices):
+        if current_index is None:
+            continue
+        consumed.add(current_index)
+        new_record = current_records[current_index]
+        extensions = {
+            key: value for key, value in old_record.items()
+            if isinstance(key, str) and key.startswith("x-")
+        }
+        reconciled.append(
+            old_record if old_record == new_record
+            else {**_record_without_extensions(new_record), **extensions}
+        )
+
+    reconciled.extend(record for index, record in enumerate(current_records) if index not in consumed)
+    return reconciled
+
+
+def reconcile_review_export(existing: object, current: dict[str, Any]) -> dict[str, Any]:
+    """Update a Review export while minimizing ordering and content churn."""
+    export_format = detect_review_export_format(existing)
+    if detect_review_export_format(current) != export_format:
+        raise ValueError("Existing file format does not match the generated export")
+    assert isinstance(existing, dict)
+
+    result = dict(existing)
+    if export_format == "openvex":
+        for key, value in current.items():
+            if key != "@id":
+                result[key] = value
+        result["statements"] = _reconcile_records(
+            existing["statements"],
+            current["statements"],
+            _openvex_statement_identity,
+        )
+        return result
+
+    for key, value in current.items():
+        if key not in _CUSTOM_EXPORT_SECTIONS:
+            result[key] = value
+    for section in _CUSTOM_EXPORT_SECTIONS:
+        result[section] = _reconcile_records(
+            existing.get(section, []),
+            current.get(section, []),
+            lambda record, section=section: _record_identity(section, record),
+        )
+    return result
 
 
 def parse_imported_timestamp(raw_ts: object, use_original_timestamps: bool) -> "_dt | None":

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -22,7 +22,9 @@ from ..helpers.assessment_io import (
     import_statements as _import_openvex_statements,
     build_variant_by_name_map,
     build_custom_data_export,
+    detect_review_export_format,
     import_custom_data,
+    reconcile_review_export,
 )
 from ..helpers.assessment_staleness import annotate_assessments_outdated
 
@@ -803,6 +805,75 @@ def init_app(app: Flask) -> None:
         safe_name = re.sub(r'[^\w\-.]', '_', project_name) if project_name else None
         filename = f"custom_data_{safe_name}.json" if safe_name else "custom_data.json"
         return json_bytes, 200, {
+            "Content-Type": "application/json",
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        }
+
+    @app.route('/api/assessments/review/export-update', methods=['POST'])
+    def update_review_export() -> ResponseReturnValue:
+        """Update an uploaded Review export using the currently selected variants.
+
+        The uploaded document determines whether VulnScout JSON or OpenVEX is
+        generated. Matching records retain their existing order, records for
+        variants outside the current selection are removed, and new records
+        are appended.
+
+        OpenAPI:
+        body multipart required Existing JSON export and repeated variant_id fields.
+        response 200 binary Updated JSON download.
+        response 400 Error Unsupported input or invalid variant selection.
+        response 404 Error No review data available.
+        """
+        if not (request.content_type and 'multipart/form-data' in request.content_type):
+            return {"error": "Expected multipart/form-data with a file upload"}, 400
+        uploaded = request.files.get('file')
+        if not uploaded or not uploaded.filename:
+            return {"error": "No file uploaded"}, 400
+        if not uploaded.filename.lower().endswith('.json'):
+            return {"error": "Unsupported file type. Please upload a .json file."}, 400
+
+        try:
+            existing = json.load(uploaded.stream)
+        except (TypeError, ValueError):
+            return {"error": "Invalid JSON file"}, 400
+        try:
+            export_format = detect_review_export_format(existing)
+        except ValueError as error:
+            return {"error": str(error)}, 400
+
+        raw_variant_ids = request.form.getlist('variant_id')
+        if not raw_variant_ids:
+            return {"error": "At least one variant_id is required"}, 400
+        variant_ids: list[UUID] = []
+        for raw_variant_id in raw_variant_ids:
+            variant_id, err = parse_uuid_or_400(raw_variant_id, "variant_id")
+            if err:
+                return err
+            if variant_id is None:
+                return {"error": "Internal error"}, 500
+            variant = DBVariant.get_by_id(variant_id)
+            if variant is None:
+                return {"error": f"Variant not found: {raw_variant_id}"}, 404
+            variant_ids.append(variant_id)
+
+        if export_format == 'openvex':
+            if len(variant_ids) != 1:
+                return {"error": "Exactly one variant_id is required for OpenVEX export"}, 400
+            handmade = DBAssessment.get_by_origin(variant_ids, origin="custom")
+            current = build_openvex_doc(
+                handmade,
+                request.form.get('author', existing.get('author', 'Savoir-faire Linux')),
+            )
+        else:
+            current = build_custom_data_export(variant_ids)
+
+        try:
+            updated = reconcile_review_export(existing, current)
+        except ValueError as error:
+            return {"error": str(error)}, 400
+
+        filename = re.sub(r'[^\w\-.]', '_', uploaded.filename) or 'review_export.json'
+        return json.dumps(updated, indent=2), 200, {
             "Content-Type": "application/json",
             "Content-Disposition": f'attachment; filename="{filename}"',
         }

--- a/tests/unit_tests/test_assessment_io_coverage.py
+++ b/tests/unit_tests/test_assessment_io_coverage.py
@@ -21,6 +21,8 @@ from src.helpers.assessment_io import (
     import_custom_data,
     import_statements,
     build_custom_data_export,
+    detect_review_export_format,
+    reconcile_review_export,
 )
 
 
@@ -166,6 +168,123 @@ class TestBuildCustomDataExport:
             "variant_id": str(var.id),
             "variant": "io-cov-var",
         }]
+
+
+class TestReconcileReviewExport:
+    def test_custom_export_preserves_order_updates_and_removes_variants(self):
+        unchanged = {
+            "vuln_id": "CVE-1", "variant_id": "variant-a",
+            "packages": ["a@1"], "status": "affected",
+        }
+        changed = {
+            "vuln_id": "CVE-2", "variant_id": "variant-a",
+            "packages": ["b@1"], "status": "affected",
+            "justification": "obsolete", "x-local-note": "keep",
+        }
+        removed = {
+            "vuln_id": "CVE-3", "variant_id": "variant-b",
+            "packages": ["c@1"], "status": "affected",
+        }
+        existing = {
+            "version": 1,
+            "exported_at": "old",
+            "custom_header": "preserved",
+            "assessments": [changed, removed, unchanged],
+            "ai_assessments": [], "cvss": [], "time_estimates": [],
+        }
+        current = {
+            "version": 1,
+            "exported_at": "new",
+            "assessments": [
+                unchanged,
+                {
+                    "vuln_id": "CVE-2", "variant_id": "variant-a",
+                    "packages": ["b@1"], "status": "fixed",
+                },
+                {"vuln_id": "CVE-4", "variant_id": "variant-a", "packages": [], "status": "affected"},
+            ],
+            "ai_assessments": [], "cvss": [], "time_estimates": [],
+        }
+
+        result = reconcile_review_export(existing, current)
+
+        assert result["custom_header"] == "preserved"
+        assert result["exported_at"] == "new"
+        assert [item["vuln_id"] for item in result["assessments"]] == ["CVE-2", "CVE-1", "CVE-4"]
+        assert result["assessments"][0]["status"] == "fixed"
+        assert result["assessments"][0]["x-local-note"] == "keep"
+        assert "justification" not in result["assessments"][0]
+
+    def test_openvex_preserves_document_id_and_statement_order(self):
+        existing = {
+            "@context": "https://openvex.dev/ns/v0.2.0",
+            "@id": "stable-id",
+            "author": "old",
+            "timestamp": "old",
+            "version": 1,
+            "statements": [
+                {"vulnerability": {"name": "CVE-2"}, "products": [], "status": "affected"},
+                {"vulnerability": {"name": "CVE-1"}, "products": [], "status": "affected"},
+            ],
+        }
+        current = {
+            **existing,
+            "@id": "generated-id",
+            "author": "new",
+            "timestamp": "new",
+            "statements": [
+                {"vulnerability": {"name": "CVE-1"}, "products": [], "status": "fixed"},
+                {"vulnerability": {"name": "CVE-2"}, "products": [], "status": "affected"},
+            ],
+        }
+
+        result = reconcile_review_export(existing, current)
+
+        assert result["@id"] == "stable-id"
+        assert result["author"] == "new"
+        assert [item["vulnerability"]["name"] for item in result["statements"]] == ["CVE-2", "CVE-1"]
+        assert result["statements"][1]["status"] == "fixed"
+
+    def test_duplicate_records_match_exact_values_before_timestamp_updates(self):
+        first = {
+            "vuln_id": "CVE-1", "variant_id": "variant-a", "packages": ["pkg@1"],
+            "status": "affected", "timestamp": "2026-01-01T00:00:00+00:00", "x-note": "first",
+        }
+        second = {
+            "vuln_id": "CVE-1", "variant_id": "variant-a", "packages": ["pkg@1"],
+            "status": "not_affected", "timestamp": "2026-01-02T00:00:00+00:00", "x-note": "second",
+        }
+        existing = {"version": 1, "assessments": [first, second], "ai_assessments": [], "cvss": [], "time_estimates": []}
+        current = {
+            "version": 1,
+            "assessments": [
+                {**second, "x-note": "ignored"},
+                {**first, "status": "fixed"},
+                {"vuln_id": "CVE-1", "variant_id": "variant-a", "packages": ["pkg@1"], "status": "affected", "timestamp": "2026-01-03T00:00:00+00:00"},
+            ],
+            "ai_assessments": [], "cvss": [], "time_estimates": [],
+        }
+
+        result = reconcile_review_export(existing, current)
+
+        assert result["assessments"][0]["x-note"] == "first"
+        assert result["assessments"][0]["status"] == "fixed"
+        assert result["assessments"][1] == second
+        assert "x-note" not in result["assessments"][2]
+
+    @pytest.mark.parametrize("payload", [[], {"version": 1}, {"foo": "bar"}])
+    def test_rejects_unsupported_or_malformed_exports(self, payload):
+        with pytest.raises(ValueError):
+            detect_review_export_format(payload)
+
+    @pytest.mark.parametrize("payload", [
+        {"@context": "openvex", "statements": []},
+        {"version": 1, "assessments": [{"variant_id": "variant-a"}]},
+        {"version": 1, "assessments": ["not-a-record"]},
+    ])
+    def test_rejects_malformed_review_record_identities(self, payload):
+        with pytest.raises(ValueError):
+            detect_review_export_format(payload)
 
 
 # ===========================================================================

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -1106,6 +1106,106 @@ def test_export_custom_data_filename_by_project(client):
     assert disposition.endswith('.json"')
 
 
+# ── POST /api/assessments/review/export-update ───────────────────────────
+
+def test_update_custom_export_preserves_matching_content_and_removes_unselected(client):
+    _create_handmade_assessment(client)
+    exported = client.get(f"/api/assessments/review/export-custom-data?variant_id={VARIANT_UUID}")
+    existing = json.loads(exported.data)
+    existing["custom_header"] = "preserved"
+    existing["assessments"][0]["x-local-note"] = "preserved"
+    existing["assessments"].insert(0, {
+        "vuln_id": "CVE-2099-REMOVED",
+        "variant_id": "33333333-3333-3333-3333-333333333333",
+        "variant": "not-selected",
+        "packages": [],
+        "status": "affected",
+    })
+
+    response = client.post(
+        "/api/assessments/review/export-update",
+        data={
+            "file": (io.BytesIO(json.dumps(existing).encode()), "custom_data.json"),
+            "variant_id": str(VARIANT_UUID),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    updated = json.loads(response.data)
+    assert updated["custom_header"] == "preserved"
+    assert updated["assessments"][0]["x-local-note"] == "preserved"
+    assert {item["variant_id"] for item in updated["assessments"]} == {str(VARIANT_UUID)}
+    assert 'filename="custom_data.json"' in response.headers["Content-Disposition"]
+
+
+def test_update_openvex_auto_detects_format_and_preserves_document_id(client):
+    _create_handmade_assessment(client)
+    exported = client.get(f"/api/assessments/review/export?variant_id={VARIANT_UUID}")
+    existing = json.loads(exported.data)
+    existing["@id"] = "https://example.com/stable-review-id"
+    existing["author"] = "Existing review author"
+
+    response = client.post(
+        "/api/assessments/review/export-update",
+        data={
+            "file": (io.BytesIO(json.dumps(existing).encode()), "review.json"),
+            "variant_id": str(VARIANT_UUID),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    updated = json.loads(response.data)
+    assert updated["@id"] == "https://example.com/stable-review-id"
+    assert updated["author"] == "Existing review author"
+    assert "openvex" in updated["@context"]
+
+
+def test_update_export_can_remove_all_selected_data(client):
+    existing = {
+        "version": 1,
+        "assessments": [{
+            "vuln_id": "CVE-2099-REMOVED",
+            "variant_id": str(VARIANT_UUID),
+            "packages": [],
+            "status": "affected",
+        }],
+        "ai_assessments": [], "cvss": [], "time_estimates": [],
+    }
+
+    response = client.post(
+        "/api/assessments/review/export-update",
+        data={
+            "file": (io.BytesIO(json.dumps(existing).encode()), "custom_data.json"),
+            "variant_id": str(VARIANT_UUID),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.data)["assessments"] == []
+
+
+@pytest.mark.parametrize("body, expected_error", [
+    (b"not-json", "Invalid JSON file"),
+    (json.dumps({"foo": "bar"}).encode(), "Unsupported export format"),
+    (json.dumps({"@context": "openvex", "statements": []}).encode(), "Unsupported export format"),
+])
+def test_update_export_rejects_malformed_or_unsupported_input(client, body, expected_error):
+    response = client.post(
+        "/api/assessments/review/export-update",
+        data={
+            "file": (io.BytesIO(body), "review.json"),
+            "variant_id": str(VARIANT_UUID),
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    assert expected_error in json.loads(response.data)["error"]
+
+
 # ── POST /api/assessments/review/import-custom-data ──────────────────────
 
 def _custom_data_payload(assessments=None, cvss=None, time_estimates=None):


### PR DESCRIPTION
## Fixes # by adding stable updates to existing Review exports

### Changes proposed in this pull request:

* Add Normal export and Append/update existing file modes to the Review export flow.
* Detect uploaded export formats and reconcile selected variants while preserving stable content for focused Git diffs.
* Remove variants that exist in the uploaded file but are no longer selected, with validation for malformed or unsupported files.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Run `python -m pytest tests/unit_tests/test_assessment_io_coverage.py tests/webapp_tests/test_review_endpoints.py -q`.
* Run `npm --prefix frontend test -- --runInBand tests/unit_tests/test_export_json.ts tests/unit_tests/test_review.tsx tests/unit_tests/test_review_transfer_modal.tsx --coverage=false`.
* Run `npm --prefix frontend run build`.
* In Review, export normally, then choose Append/update existing file, upload that export, change the variant selection, and confirm the downloaded file updates selected variants and removes unselected ones with a focused Git diff.

### Additional notes

The update path preserves stable OpenVEX identifiers, authors, ordering, and unchanged content where the format permits.

### Related Issue

No linked issue.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [X] The code compiles and passes all tests
- [X] All new and existing tests are passing
- [X] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers
