### PR TITLE
Add scan history import support

### DIFF
--- a/doc/source/interactive-mode.md
+++ b/doc/source/interactive-mode.md
@@ -233,6 +233,22 @@ Every scan and vulnerability-data refresh is also tracked in the **Operation que
 
 Three coloured toggle buttons in the toolbar (Grype, NVD, OSV) let you show or hide scan entries by source. This is useful when you only want to see SBOM imports or a specific scanner's results without the others cluttering the timeline.
 
+### Importing and Exporting Scan Data
+
+The **Export** menu downloads scan history as VulnScout JSON. A single timeline entry can be exported either as its diff or as its full scan result. The toolbar export applies the same formats to every scan visible in the current project or variant scope.
+
+Use **Import** to restore exported scan data. You can select one or more files, and each file may hold a single export or the array produced by the toolbar's Export All — every scan in the selection is imported together.
+
+VulnScout matches the `project_name` and `variant_name` recorded in each export to an existing project and variant, then persists its packages, findings and assessments as a new scan entry. The destination project and variant must already exist; nothing is created implicitly.
+
+A few properties are worth knowing:
+
+- **Both export formats import.** A scan diff carries the scan's complete package and finding state at the top level, so a diff taken from any point in the timeline can be imported, not just the first one. The `diff` section itself describes the *source* instance's history and is ignored — the destination recomputes badges against its own timeline.
+- **Imports are idempotent.** A scan is recognised by its variant, its kind (SBOM, or a tool plus that tool's name) and its timestamp, so importing the same scan into a variant that already has it is rejected as a duplicate instead of creating a second copy. This also catches an export whose scan the destination already holds natively — re-importing a file into the instance it came from changes nothing. Assessments that already exist on the destination are likewise left alone rather than duplicated.
+- **Imports are all-or-nothing.** The entire selection is validated before anything is written and applied in one transaction. If any export is malformed, references a missing project or variant, or has already been imported, the request is rejected and the database is left untouched — the error names the offending entry so you can drop it and retry.
+- **Existing data is reused.** Packages, vulnerabilities and findings already present in the destination are linked to rather than duplicated, so importing overlapping scans does not inflate the database. A supplier recorded in SPDX form is matched against the plain name the export carries, so no second copy of the package appears.
+- **Assessments keep their finding.** An assessment applies to one package/vulnerability pair, and exports record that pair, so an imported assessment attaches to the same finding it had on the source rather than to every package sharing the vulnerability.
+
 ### Timeline Layout
 
 Scans are displayed in a vertical timeline, most recent first. Each entry shows the timestamp of the import, the project and variant it belongs to, and a set of colour-coded badges summarising the delta:

--- a/frontend/src/handlers/scans.ts
+++ b/frontend/src/handlers/scans.ts
@@ -166,6 +166,38 @@ type RunningScans = {
 
 export type { ScanStatusResponse, RunningScanEntry, RunningScans };
 
+type ScanImportEntry = {
+    scan_id: string;
+    source_scan_id: string;
+    format: 'diff' | 'full';
+    project_name: string;
+    variant_name: string;
+    package_count: number;
+    finding_count: number;
+    vulnerability_count: number;
+    assessment_count: number;
+    is_first: boolean;
+};
+
+type ScanImportResult = {
+    scan_id: string | null;
+    format: 'diff' | 'full' | null;
+    imported_count: number;
+    skipped_count: number;
+    package_count: number;
+    finding_count: number;
+    vulnerability_count: number;
+    assessment_count: number;
+    is_first: boolean;
+    scans: ScanImportEntry[];
+};
+
+type ScanImportResponse =
+    | { ok: true; result: ScanImportResult }
+    | { ok: false; error: string };
+
+export type { ScanImportEntry, ScanImportResult, ScanImportResponse };
+
 type OutdatedDataPreview = {
     candidate_ids: {
         observations: string[];
@@ -198,6 +230,35 @@ type OrphanedVulnerabilityPreview = {
 export type { OutdatedDataPreview, EmptyScanPreview, OrphanedVulnerabilityPreview };
 
 class ScansHandler {
+    /**
+     * Send one or more exported scans to the import endpoint.
+     *
+     * The whole payload is imported atomically by the server, so a rejected
+     * request leaves nothing behind. Network failures are reported through the
+     * same result shape as API errors rather than thrown, so callers do not
+     * have to distinguish "could not reach the server" from "could not read
+     * the file".
+     */
+    static async importExport(payload: unknown): Promise<ScanImportResponse> {
+        let response: Response;
+        try {
+            response = await fetch(import.meta.env.VITE_API_URL + '/api/scans/import', {
+                method: 'POST',
+                mode: 'cors',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+        } catch (err) {
+            const detail = err instanceof Error ? err.message : String(err);
+            return { ok: false, error: `Import failed: could not reach the server (${detail}).` };
+        }
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            return { ok: false, error: data?.error ?? `Import failed (${response.status})` };
+        }
+        return { ok: true, result: data as ScanImportResult };
+    }
+
     static async list(variantId?: string, projectId?: string): Promise<Scan[]> {
         let url: string;
         if (variantId) {

--- a/frontend/src/pages/ScanHistory.tsx
+++ b/frontend/src/pages/ScanHistory.tsx
@@ -35,9 +35,10 @@ import { extractSupplierName } from "../helpers/pkgId";
 import { formatSourceName } from "../helpers/sourceNames";
 import { downloadJson } from "../helpers/exportJson";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faCrosshairs, faTrash, faPlay, faBook, faDownload, faMagnifyingGlass, faBox, faClipboardCheck } from "@fortawesome/free-solid-svg-icons";
+import { faPencil, faCheck, faXmark, faBug, faFilter, faShieldHalved, faLeaf, faFile, faFileImport, faCrosshairs, faTrash, faPlay, faBook, faDownload, faMagnifyingGlass, faBox, faClipboardCheck } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import ConfirmationModal from "../components/ConfirmationModal";
+import MessageBanner from "../components/MessageBanner";
 import RunScansWizard from "../components/RunScansWizard";
 import { refreshSourcesForScans } from "../helpers/refreshSources";
 import Variants from "../handlers/variant";
@@ -1112,13 +1113,16 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     const [showNvd, setShowNvd] = useState(true);
     const [showScc, setShowScc] = useState(true);
 
+    // Import state
+    const [importing, setImporting] = useState(false);
+    const [importNotice, setImportNotice] = useState<{ tone: 'success' | 'error'; text: string } | null>(null);
+    const importInputRef = useRef<HTMLInputElement>(null);
+
     // Export state
     const [exportMenuScanId, setExportMenuScanId] = useState<string | null>(null);
     const [exportingScanId, setExportingScanId] = useState<string | null>(null);
-    const [exportAllMenuOpen, setExportAllMenuOpen] = useState(false);
     const [exportingAll, setExportingAll] = useState(false);
     const exportMenuRef = useRef<HTMLDivElement>(null);
-    const exportAllMenuRef = useRef<HTMLDivElement>(null);
 
     // Scan wizard state
     const [scanWizardOpen, setScanWizardOpen] = useState(false);
@@ -1195,6 +1199,82 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
         }
     }
 
+    /**
+     * Read the selected export files and import them in a single request.
+     *
+     * Each file holds either one export object or an array of them (as the
+     * Export All download does). They are flattened into one payload so the
+     * server imports the whole selection atomically: either every scan lands
+     * or none does, which is what makes a failed import safe to retry.
+     */
+    async function handleImportFile(event: React.ChangeEvent<HTMLInputElement>) {
+        const files = Array.from(event.target.files ?? []);
+        if (files.length === 0) return;
+        setImporting(true);
+        setImportNotice(null);
+        try {
+            const exports: unknown[] = [];
+            for (const file of files) {
+                let parsed: unknown;
+                try {
+                    parsed = JSON.parse(await file.text());
+                } catch (err) {
+                    const reason = err instanceof SyntaxError
+                        ? 'it is not valid JSON'
+                        : 'it could not be read';
+                    setImportNotice({
+                        tone: 'error',
+                        text: `Import failed: "${file.name}" was skipped because ${reason}.`,
+                    });
+                    return;
+                }
+                if (Array.isArray(parsed)) exports.push(...parsed);
+                else exports.push(parsed);
+            }
+            if (exports.length === 0) {
+                setImportNotice({
+                    tone: 'error',
+                    text: 'Import failed: the selected file contains no scan exports.',
+                });
+                return;
+            }
+
+            const response = await ScansHandler.importExport(exports);
+            if (!response.ok) {
+                setImportNotice({ tone: 'error', text: response.error });
+                return;
+            }
+            const { result } = response;
+            const scanLabel = result.imported_count === 1
+                ? (result.format === 'diff' ? '1 scan diff' : '1 full scan result')
+                : `${result.imported_count.toLocaleString()} scans`;
+            const parts = [
+                `${result.package_count.toLocaleString()} packages`,
+                `${result.finding_count.toLocaleString()} findings`,
+            ];
+            if (result.assessment_count > 0) {
+                parts.push(`${result.assessment_count.toLocaleString()} assessments`);
+            }
+            const skipped = result.skipped_count > 0
+                ? ` Skipped ${result.skipped_count.toLocaleString()} already imported scan${result.skipped_count === 1 ? '' : 's'}.`
+                : '';
+            setImportNotice({
+                tone: 'success',
+                text: `Imported ${scanLabel} with ${parts.join(', ')}.${skipped}`,
+            });
+            refreshScans();
+            onScanComplete?.();
+        } catch {
+            setImportNotice({
+                tone: 'error',
+                text: 'Import failed while reading the selected files.',
+            });
+        } finally {
+            event.target.value = '';
+            setImporting(false);
+        }
+    }
+
     // Derive the effective variant IDs to scan: explicit prop or unique IDs from loaded scans
     const effectiveVariantIds: string[] = variantId
         ? [variantId]
@@ -1262,18 +1342,6 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
             return () => document.removeEventListener('mousedown', handleClickOutside);
         }
     }, [exportMenuScanId]);
-
-    useEffect(() => {
-        function handleClickOutside(e: MouseEvent) {
-            if (exportAllMenuRef.current && !exportAllMenuRef.current.contains(e.target as Node)) {
-                setExportAllMenuOpen(false);
-            }
-        }
-        if (exportAllMenuOpen) {
-            document.addEventListener('mousedown', handleClickOutside);
-            return () => document.removeEventListener('mousedown', handleClickOutside);
-        }
-    }, [exportAllMenuOpen]);
 
     function toggleVariant(vid: string) {
         setSelectedVariantIds(prev => {
@@ -1412,14 +1480,13 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     });
 
     // -- Export All (grouped by project/variant) --
-    async function handleExportAll(type: 'diff' | 'total') {
-        setExportAllMenuOpen(false);
+    async function handleExportAll() {
         setExportingAll(true);
         try {
-            const params = new URLSearchParams({ type });
+            const params = new URLSearchParams({ type: 'diff' });
             if (variantId) params.set('variant_id', variantId);
             else if (projectId) params.set('project_id', projectId);
-            await downloadFromEndpoint(`/api/scans/export?${params}`, `scans_${type}.json`);
+            await downloadFromEndpoint(`/api/scans/export?${params}`, 'scans_diff.json');
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to export scans.');
         } finally {
@@ -1440,6 +1507,17 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     // Column sizing — single lane
     const LANE_W = 36;            // px – timeline column
     const mainCX = LANE_W / 2;    // center-x of the lane
+
+    const importNoticeBanner = importNotice && (
+        <div className="sticky top-0 z-40">
+            <MessageBanner
+                type={importNotice.tone}
+                message={importNotice.text}
+                isVisible={true}
+                onClose={() => setImportNotice(null)}
+            />
+        </div>
+    );
 
     const menuBar = (
         <div className="rounded-md mb-4 p-2 bg-sky-800 text-white w-full flex flex-row items-center gap-2 flex-wrap">
@@ -1508,7 +1586,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                 sbom-cve-check
             </button>
 
-            {/* Right side: doc link + export + scan menu */}
+            {/* Right side: doc link + import/export + scan menu */}
             <div className="ml-auto flex items-center gap-3">
                 <a
                     href={docUrl}
@@ -1521,41 +1599,48 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
                     <FontAwesomeIcon icon={faBook} />
                 </a>
 
-                {/* Export All dropdown */}
-                {filteredScans.length > 0 && (
-                    <div className="relative" ref={exportAllMenuRef}>
-                        <button
-                            onClick={() => setExportAllMenuOpen(o => !o)}
-                            disabled={exportingAll}
-                            className={[
-                                "inline-flex items-center gap-2 px-3 py-1.5 rounded text-sm font-semibold transition-colors",
-                                exportingAll
-                                    ? "bg-sky-800/50 text-sky-300 cursor-wait"
-                                    : "bg-sky-900 hover:bg-sky-950 text-white",
-                            ].join(' ')}
-                            title="Export scan history"
-                        >
-                            <FontAwesomeIcon icon={faDownload} />
-                            {exportingAll ? 'Exporting…' : 'Export'}
-                        </button>
+                <button
+                    type="button"
+                    onClick={() => importInputRef.current?.click()}
+                    disabled={importing}
+                    className={[
+                        "flex items-center gap-1.5 px-3 py-1 rounded text-white border border-green-500",
+                        importing
+                            ? "bg-green-800/50 cursor-wait"
+                            : "bg-green-700 hover:bg-green-600",
+                    ].join(' ')}
+                    title="Import exported scan data (one or more VulnScout JSON exports)"
+                >
+                    <FontAwesomeIcon icon={faFileImport} />
+                    {importing ? 'Importing…' : 'Import'}
+                </button>
+                <input
+                    ref={importInputRef}
+                    type="file"
+                    multiple
+                    accept=".json,application/json"
+                    className="hidden"
+                    aria-label="Choose exported scan data"
+                    onChange={handleImportFile}
+                />
 
-                        {exportAllMenuOpen && (
-                            <div className="absolute right-0 top-full mt-1 z-50 w-52 rounded-lg border border-sky-700/60 bg-neutral-900 shadow-xl p-2">
-                                <button
-                                    onClick={() => handleExportAll('diff')}
-                                    className="w-full text-left px-3 py-2 text-sm text-neutral-200 hover:bg-sky-900/40 rounded transition-colors"
-                                >
-                                    Export All Diffs
-                                </button>
-                                <button
-                                    onClick={() => handleExportAll('total')}
-                                    className="w-full text-left px-3 py-2 text-sm text-neutral-200 hover:bg-sky-900/40 rounded transition-colors"
-                                >
-                                    Export All Scan Results
-                                </button>
-                            </div>
-                        )}
-                    </div>
+                {/* Export all scan diffs */}
+                {filteredScans.length > 0 && (
+                    <button
+                        type="button"
+                        onClick={handleExportAll}
+                        disabled={exportingAll}
+                        className={[
+                            "flex items-center gap-1.5 px-3 py-1 rounded text-white border border-green-500",
+                            exportingAll
+                                ? "bg-green-800/50 cursor-wait"
+                                : "bg-green-700 hover:bg-green-600",
+                        ].join(' ')}
+                        title="Export all scan diffs"
+                    >
+                        <FontAwesomeIcon icon={faDownload} />
+                        {exportingAll ? 'Exporting…' : 'Export'}
+                    </button>
                 )}
 
                 {/* Run scans wizard */}
@@ -1611,6 +1696,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     if (error) {
         return (
             <div className="w-full px-6 py-6">
+                {importNoticeBanner}
                 {menuBar}
                 <div className="flex items-center justify-center h-32 text-red-400">
                     {error}
@@ -1621,6 +1707,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
     if (scans.length === 0) {
         return (
             <div className="w-full px-6 py-6">
+                {importNoticeBanner}
                 {menuBar}
                 <div className="flex items-center justify-center h-32 text-gray-400 dark:text-neutral-400">
                     No scans found.
@@ -1657,6 +1744,7 @@ function ScanHistory({ variantId, projectId, onScanComplete }: Readonly<Props>) 
             />
 
             <div className="w-full px-6 py-6">
+                {importNoticeBanner}
                 {menuBar}
 
                 {/* Timeline rows */}

--- a/frontend/tests/handlers/scans.test.ts
+++ b/frontend/tests/handlers/scans.test.ts
@@ -14,6 +14,56 @@ beforeEach(() => {
 });
 
 describe("ScansHandler request contracts", () => {
+  test("imports exported scan JSON and preserves API errors", async () => {
+    const result = {
+      scan_id: "scan-1",
+      format: "diff",
+      imported_count: 1,
+      package_count: 2,
+      finding_count: 3,
+      vulnerability_count: 2,
+      assessment_count: 1,
+      is_first: false,
+      scans: [{
+        scan_id: "scan-1",
+        source_scan_id: "source-1",
+        format: "diff",
+        project_name: "Proj",
+        variant_name: "Var",
+        package_count: 2,
+        finding_count: 3,
+        vulnerability_count: 2,
+        assessment_count: 1,
+        is_first: false,
+      }],
+    };
+    fetchSpy.mockResolvedValueOnce(response(result, true, 201));
+    fetchSpy.mockResolvedValueOnce(response({ error: "This scan has already been imported" }, false, 409));
+
+    expect(await ScansHandler.importExport([{ scan_id: "scan-1" }])).toEqual({ ok: true, result });
+    expect(fetchSpy.mock.calls[0]).toEqual([
+      expect.stringContaining("/api/scans/import"),
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify([{ scan_id: "scan-1" }]),
+      }),
+    ]);
+    expect(await ScansHandler.importExport([{ scan_id: "scan-1" }])).toEqual({
+      ok: false,
+      error: "This scan has already been imported",
+    });
+  });
+
+  test("reports a network failure instead of throwing", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("Failed to fetch"));
+
+    const result = await ScansHandler.importExport([{ scan_id: "scan-1" }]);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toContain("could not reach the server");
+  });
+
   test("lists scans for global, project, and variant scopes", async () => {
     const scan = { id: "scan-1", timestamp: "2026-08-07", variant_id: "variant-1", finding_count: 1 };
     fetchSpy.mockResolvedValueOnce(response([scan]));

--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -23,6 +23,7 @@ MAX_SCRIPT_STEPS = 8
 SCAN_FILE = "/scan/status.txt"
 DEFAULT_DB_URI = "sqlite:////cache/vulnscout/vulnscout.db"
 MAX_UPLOAD_REQUEST_BYTES = MAX_ASSET_UPLOAD_BYTES + 64 * 1024
+MAX_SCAN_IMPORT_REQUEST_BYTES = 100 * 1024 * 1024
 DEFAULT_BACKGROUND_TASK_DELAY = 120.0
 
 
@@ -118,6 +119,7 @@ def create_app():
     # Allow multipart headers while ensuring Werkzeug rejects oversized bodies
     # before parsing and spooling uploaded files.
     app.config["MAX_CONTENT_LENGTH"] = MAX_UPLOAD_REQUEST_BYTES
+    app.config["MAX_SCAN_IMPORT_CONTENT_LENGTH"] = MAX_SCAN_IMPORT_REQUEST_BYTES
     app._INT_SCAN_FINISHED = False
     if "SCAN_FILE" not in app.config:
         app.config["SCAN_FILE"] = SCAN_FILE

--- a/src/helpers/add_middleware.py
+++ b/src/helpers/add_middleware.py
@@ -3,7 +3,7 @@
 
 from typing import Any, Callable, TypeVar, cast
 
-from flask import Flask
+from flask import Flask, Request, current_app
 from flask.typing import ResponseReturnValue
 from functools import wraps
 
@@ -15,7 +15,21 @@ MiddlewareCallable = Callable[..., ResponseReturnValue | None]
 RouteFunc = TypeVar("RouteFunc", bound=Callable[..., Any])
 
 
+class VulnScoutRequest(Request):
+    @property
+    def max_content_length(self) -> int | None:
+        if self.path == "/api/scans/import":
+            return current_app.config["MAX_SCAN_IMPORT_CONTENT_LENGTH"]
+        return super().max_content_length
+
+    @max_content_length.setter
+    def max_content_length(self, value: int | None) -> None:
+        self._max_content_length = value
+
+
 class FlaskWithMiddleware(Flask):
+    request_class = VulnScoutRequest
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
 
         self.middlewares: list[tuple[str, MiddlewareCallable]] = []

--- a/src/routes/_scan_diff.py
+++ b/src/routes/_scan_diff.py
@@ -687,6 +687,10 @@ def _global_result_full(
         if aid in seen_assess:
             continue
         seen_assess.add(aid)
+        # Carry the finding's package: an assessment applies to one
+        # (package, vulnerability) pair, and consumers that serialise the
+        # result need it to attach the assessment back to the right finding.
+        package = pkg_map.get(pkg_id, {})
         assessments.append({
             "vulnerability_id": vid,
             "status": status or "under_investigation",
@@ -694,6 +698,9 @@ def _global_result_full(
             "justification": justification or "",
             "impact_statement": impact or "",
             "status_notes": notes or "",
+            "package_name": package.get("package_name", ""),
+            "package_version": package.get("package_version", ""),
+            "package_supplier": package.get("package_supplier", ""),
         })
     assessments.sort(key=lambda a: a["vulnerability_id"])
 

--- a/src/routes/_scan_queries.py
+++ b/src/routes/_scan_queries.py
@@ -39,6 +39,9 @@ AssessmentRow: TypeAlias = Row[Tuple[
     Optional[str],      # status_notes
     str,                # vulnerability_id
     Optional[str],      # origin
+    Optional[str],      # package name
+    Optional[str],      # package version
+    Optional[str],      # package supplier
 ]]
 
 
@@ -218,13 +221,21 @@ def _assessment_rows_for_scans(scan_ids: List[uuid_module.UUID]) -> Sequence[Ass
     Returns a list of tuples:
         (scan_id, assessment_id, assessment_timestamp,
          status, simplified_status, justification, impact_statement,
-         status_notes, vulnerability_id, origin)
+         status_notes, vulnerability_id, origin,
+         package_name, package_version, package_supplier)
+
+    The package columns identify the finding the assessment is attached to.
+    An assessment applies to one (package, vulnerability) pair, not to a
+    vulnerability across every package, so consumers that serialise it — the
+    scan export in particular — need the package to round-trip it faithfully.
+    They are appended last so existing positional access stays valid.
 
     The query logic:
       - Start FROM observation
       - JOIN finding ON finding.id = observation.finding_id
       - JOIN assessment ON assessment.finding_id = finding.id
       - JOIN scan ON scan.id = observation.scan_id
+      - JOIN package ON package.id = finding.package_id
       - WHERE observation.scan_id IN (scan_ids)
             AND assessment.variant_id = scan.variant_id
     """
@@ -245,11 +256,15 @@ def _assessment_rows_for_scans(scan_ids: List[uuid_module.UUID]) -> Sequence[Ass
             Assessment.status_notes,
             Finding.vulnerability_id,
             Assessment.origin,
+            Package.name,
+            Package.version,
+            Package.supplier,
         )
         .select_from(Observation)
         .join(Finding, Finding.id == Observation.finding_id)
         .join(Assessment, Assessment.finding_id == Finding.id)
         .join(Scan, Scan.id == Observation.scan_id)
+        .join(Package, Package.id == Finding.package_id)
         .where(
             Observation.scan_id.in_(scan_ids),
             Assessment.variant_id == Scan.variant_id,
@@ -431,6 +446,11 @@ def _assessments_detail_for_scan(
             "justification": row[5] or "",
             "impact_statement": row[6] or "",
             "status_notes": row[7] or "",
+            # The finding this assessment belongs to, so consumers can tell it
+            # apart from an assessment of the same vulnerability elsewhere.
+            "package_name": row[10] or "",
+            "package_version": row[11] or "",
+            "package_supplier": row[12] or "",
         }
         # "Added" = created during this scan's window [scan_ts, next_scan_ts)
         is_added = False
@@ -482,6 +502,9 @@ def _assessments_detail_for_scan(
                     "justification": row[5] or "",
                     "impact_statement": row[6] or "",
                     "status_notes": row[7] or "",
+                    "package_name": row[10] or "",
+                    "package_version": row[11] or "",
+                    "package_supplier": row[12] or "",
                 })
         removed_list.sort(key=lambda e: e["vulnerability_id"])
 

--- a/src/routes/scans.py
+++ b/src/routes/scans.py
@@ -10,19 +10,27 @@ Computation helpers live in sibling modules:
 
 import re
 import uuid as uuid_module
-from collections.abc import Callable
+from collections.abc import Callable, Iterator, Sequence
 from datetime import datetime, timezone
-from typing import cast
+from typing import NamedTuple, TypedDict, TypeVar, cast
 
 from flask import Flask, jsonify, request as flask_request
 from flask.typing import ResponseReturnValue
+from werkzeug.exceptions import RequestEntityTooLarge
 
 from ..controllers.scans import ScanController
 from ..controllers.projects import ProjectController
 from ..controllers.variants import VariantController
 from ..models.observation import Observation
+from ..models.assessment import Assessment
 from ..models.finding import Finding
+from ..models.package import Package, _normalize_supplier
+from ..models.project import Project
 from ..models.scan import Scan
+from ..models.sbom_document import SBOMDocument
+from ..models.sbom_package import SBOMPackage
+from ..models.variant import Variant
+from ..models.vulnerability import Vulnerability
 from ..extensions import db
 
 from ._scan_queries import (
@@ -42,6 +50,7 @@ from ._scan_diff import (
     _global_result_id_sets,
     _global_assessment_ids_for,
     _global_result_full,
+    invalidate_scan_list_cache,
     serialize_list_with_diff_cached,
 )
 
@@ -111,6 +120,7 @@ def _scan_meta(scan: Scan, variant_name: str | None = None, project_name: str | 
     if isinstance(ts, datetime):
         ts = ts.isoformat()
     return {
+        "export_version": 1,
         "scan_id": str(scan.id),
         "timestamp": ts,
         "scan_type": "vulnerability_scan" if scan_type == "tool" else "import_sbom",
@@ -170,7 +180,7 @@ def _strip_finding_upgrade(entry: dict) -> dict:
 
 
 def _strip_assessment(entry: dict) -> dict:
-    return {
+    result = {
         "vulnerability_id": entry.get("vulnerability_id", ""),
         "status": entry.get("status", ""),
         "simplified_status": entry.get("simplified_status", ""),
@@ -178,6 +188,17 @@ def _strip_assessment(entry: dict) -> dict:
         "impact_statement": entry.get("impact_statement", ""),
         "status_notes": entry.get("status_notes", ""),
     }
+    # Identify the finding the assessment belongs to. Without it an importer
+    # can only guess, and would attach the assessment to every package sharing
+    # the vulnerability — asserting things the source never said.
+    package_name = entry.get("package_name", "")
+    if package_name:
+        result["package_name"] = package_name
+        result["package_version"] = entry.get("package_version", "")
+        supplier = _extract_supplier_name(entry.get("package_supplier", "") or "")
+        if supplier:
+            result["supplier"] = supplier
+    return result
 
 
 def _build_diff_export(
@@ -188,6 +209,7 @@ def _build_diff_export(
 ) -> dict[str, object]:
     """Build the export-ready dict from a scan and its diff response."""
     meta = _scan_meta(scan, variant_name, project_name)
+    meta["export_format"] = "scan-diff"
     is_tool = (scan.scan_type or "sbom") == "tool"
 
     if is_tool:
@@ -262,6 +284,7 @@ def _build_global_result_export(
 ) -> dict[str, object]:
     """Build the export-ready dict from a scan and its global result."""
     meta = _scan_meta(scan, variant_name, project_name)
+    meta["export_format"] = "full-result"
     return {
         **meta,
         "packages": [
@@ -313,7 +336,743 @@ def _format_timestamp_for_filename(dt: datetime | str | None = None) -> str:
     return d.strftime('%Y%m%d_%H%M%S')
 
 
+# ---------------------------------------------------------------------------
+# Scan import — validation
+# ---------------------------------------------------------------------------
+#
+# Importing is a two-phase operation:
+#
+#   1. every export in the request is parsed and validated against the
+#      destination database *without writing anything*, and
+#   2. only once all of them are known to be importable are they persisted,
+#      inside the single transaction the request handler commits.
+#
+# Splitting the phases keeps a bad entry halfway through a bulk import from
+# doing any work at all, and lets validation errors name the offending entry.
+
+#: ``source`` recorded on rows created by an import.
+_IMPORT_SOURCE_LABEL = "Imported VulnScout scan"
+#: The only ``export_version`` this importer understands.
+_SUPPORTED_EXPORT_VERSION = 1
+#: Upper bound on exports accepted in one request, mirroring MAX_EXPORT_SCANS.
+_MAX_IMPORT_EXPORTS = 200
+#: Batch size for ``IN`` lookups, kept well under SQLite's parameter limit.
+_IMPORT_QUERY_CHUNK = 400
+
+#: (name, version, supplier) identity of a package within an export.
+PackageKey = tuple[str, str, str]
+#: (package identity, vulnerability id) identity of a finding within an export.
+FindingKey = tuple[PackageKey, str]
+
+_T = TypeVar("_T")
+
+
+class _ImportSummary(TypedDict):
+    """What importing one export created, as reported back to the caller."""
+
+    scan_id: str
+    source_scan_id: str
+    format: str                 # 'diff' | 'full'
+    project_name: str
+    variant_name: str
+    package_count: int
+    finding_count: int
+    vulnerability_count: int
+    assessment_count: int
+    is_first: bool
+
+
+class _ScanImport(NamedTuple):
+    """One validated export, resolved against the destination database."""
+
+    source_scan_id: uuid_module.UUID
+    export_format: str          # 'scan-diff' | 'full-result'
+    variant: Variant
+    project_name: str
+    variant_name: str
+    scan_type: str              # 'sbom' | 'tool'
+    scan_source: str | None
+    timestamp: datetime
+    package_keys: list[PackageKey]
+    findings: list[FindingKey]
+    assessments: list["_ImportAssessment"]
+
+
+def _chunked(items: Sequence[_T], size: int) -> Iterator[Sequence[_T]]:
+    """Yield *items* in slices of at most *size* elements."""
+    for start in range(0, len(items), size):
+        yield items[start:start + size]
+
+
+def _required_import_string(payload: dict, key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"'{key}' must be a non-empty string")
+    return value.strip()
+
+
+def _optional_import_string(payload: dict, key: str) -> str:
+    """Return a string field that may be absent or null, defaulting to ''."""
+    value = payload.get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"'{key}' must be a string")
+    return value
+
+
+def _import_array(payload: dict, key: str, required: bool) -> list:
+    value = payload.get(key)
+    if value is None and not required:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"'{key}' must be an array")
+    return value
+
+
+def _import_destination(project_name: str, variant_name: str) -> Variant:
+    project = db.session.execute(
+        db.select(Project).where(Project.name == project_name)
+    ).scalar_one_or_none()
+    if project is None:
+        raise LookupError(f"Project '{project_name}' was not found")
+    variant = Variant.get_by_name_and_project(variant_name, project.id)
+    if variant is None:
+        raise LookupError(
+            f"Variant '{variant_name}' was not found in project '{project_name}'"
+        )
+    return variant
+
+
+def _import_scan_metadata(
+    payload: dict,
+) -> tuple[uuid_module.UUID, str, str | None, datetime]:
+    """Validate and extract scan metadata from an import payload.
+
+    The exported ``scan_id`` identifies the source scan. It is recorded on the
+    destination Scan as ``source_scan_id`` so the same export cannot be
+    imported twice, but it is never reused as the destination primary key.
+    """
+    scan_id_text = _required_import_string(payload, "scan_id")
+    try:
+        source_scan_id = uuid_module.UUID(scan_id_text)
+    except ValueError as exc:
+        raise ValueError("'scan_id' must be a UUID") from exc
+
+    exported_scan_type = _required_import_string(payload, "scan_type")
+    if exported_scan_type not in {"import_sbom", "vulnerability_scan"}:
+        raise ValueError(
+            "'scan_type' must be 'import_sbom' or 'vulnerability_scan'"
+        )
+
+    scan_type = "sbom" if exported_scan_type == "import_sbom" else "tool"
+    scan_source = _optional_import_string(payload, "scan_source")
+
+    timestamp_text = _required_import_string(payload, "timestamp")
+    try:
+        timestamp = datetime.fromisoformat(
+            timestamp_text.replace("Z", "+00:00")
+        )
+    except ValueError as exc:
+        raise ValueError("'timestamp' must be an ISO 8601 datetime") from exc
+
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+
+    return source_scan_id, scan_type, scan_source or None, timestamp
+
+
+def _import_package_key(entry: object) -> PackageKey:
+    """Return the package identity carried by a package or finding entry."""
+    if not isinstance(entry, dict):
+        raise ValueError("Package and finding entries must be JSON objects")
+    return (
+        _required_import_string(entry, "package_name"),
+        _optional_import_string(entry, "package_version"),
+        # Match the normalisation Package applies on write, so a lookup for an
+        # already-known package finds it instead of inserting a duplicate.
+        _normalize_supplier(_optional_import_string(entry, "supplier")),
+    )
+
+
+class _ImportAssessment(NamedTuple):
+    """One assessment from an export, with the finding it belongs to."""
+
+    vulnerability_id: str
+    #: The assessed package, when the export records one.  Exports written
+    #: before assessments carried their package leave this ``None``, and the
+    #: assessment then applies to every finding for its vulnerability.
+    package_key: PackageKey | None
+    values: dict[str, str]
+
+
+def _import_assessment_entry(entry: object) -> _ImportAssessment:
+    if not isinstance(entry, dict):
+        raise ValueError("Assessment entries must be JSON objects")
+    package_key = _import_package_key(entry) if entry.get("package_name") else None
+    return _ImportAssessment(
+        vulnerability_id=_required_import_string(entry, "vulnerability_id").upper(),
+        package_key=package_key,
+        values={
+            "status": _required_import_string(entry, "status"),
+            "simplified_status": _optional_import_string(entry, "simplified_status"),
+            "status_notes": _optional_import_string(entry, "status_notes"),
+            "justification": _optional_import_string(entry, "justification"),
+            "impact_statement": _optional_import_string(entry, "impact_statement"),
+        },
+    )
+
+
+def _parse_scan_export(payload: object) -> _ScanImport:
+    """Validate one export against the destination DB without writing to it."""
+    if not isinstance(payload, dict):
+        raise ValueError("Scan export must be a JSON object")
+
+    # Exports predating the versioned format carry neither marker but are
+    # recognisable by their full-result field set.
+    is_legacy_full_result = (
+        "export_version" not in payload
+        and "export_format" not in payload
+        and {
+            "scan_id",
+            "scan_type",
+            "timestamp",
+            "project_name",
+            "variant_name",
+            "packages",
+            "findings",
+        }.issubset(payload)
+    )
+
+    if (
+        not is_legacy_full_result
+        and payload.get("export_version") != _SUPPORTED_EXPORT_VERSION
+    ):
+        raise ValueError(
+            f"'export_version' must be {_SUPPORTED_EXPORT_VERSION}"
+        )
+
+    export_format = (
+        "full-result" if is_legacy_full_result else payload.get("export_format")
+    )
+    if export_format not in {"scan-diff", "full-result"}:
+        raise ValueError("'export_format' must be 'scan-diff' or 'full-result'")
+
+    project_name = _required_import_string(payload, "project_name")
+    variant_name = _required_import_string(payload, "variant_name")
+    variant = _import_destination(project_name, variant_name)
+
+    source_scan_id, scan_type, scan_source, timestamp = _import_scan_metadata(payload)
+
+    # Both export formats carry the scan's complete state in the top-level
+    # ``packages`` / ``findings`` arrays.  A ``diff`` block, when present, is
+    # derived from the source variant's history and is deliberately ignored:
+    # the destination recomputes its own diff from its own timeline.
+    findings_raw = _import_array(payload, "findings", required=True)
+    packages_raw = _import_array(payload, "packages", required=(scan_type == "sbom"))
+
+    package_keys: list[PackageKey] = []
+    seen_packages: set[PackageKey] = set()
+    for entry in packages_raw:
+        key = _import_package_key(entry)
+        if key not in seen_packages:
+            seen_packages.add(key)
+            package_keys.append(key)
+
+    findings: list[FindingKey] = []
+    seen_findings: set[FindingKey] = set()
+    for entry in findings_raw:
+        key = _import_package_key(entry)
+        if key not in seen_packages:
+            seen_packages.add(key)
+            package_keys.append(key)
+        pair = (key, _required_import_string(entry, "vulnerability_id").upper())
+        if pair not in seen_findings:
+            seen_findings.add(pair)
+            findings.append(pair)
+
+    # Full-result exports list assessments under ``assessments``; tool diff
+    # exports list them under ``newly_detected_assessments``.
+    assessments = [
+        _import_assessment_entry(entry)
+        for key in ("assessments", "newly_detected_assessments")
+        for entry in _import_array(payload, key, required=False)
+    ]
+    known_vulns = {vulnerability_id for _key, vulnerability_id in findings}
+    unmatched = sorted({a.vulnerability_id for a in assessments} - known_vulns)
+    if unmatched:
+        raise ValueError(
+            "Assessments reference vulnerabilities with no matching finding: "
+            + ", ".join(unmatched[:5])
+            + (f" (+{len(unmatched) - 5} more)" if len(unmatched) > 5 else "")
+        )
+
+    return _ScanImport(
+        source_scan_id=source_scan_id,
+        export_format=export_format,
+        variant=variant,
+        project_name=project_name,
+        variant_name=variant_name,
+        scan_type=scan_type,
+        scan_source=scan_source,
+        timestamp=timestamp,
+        package_keys=package_keys,
+        findings=findings,
+        assessments=assessments,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scan import — persistence
+# ---------------------------------------------------------------------------
+
+def _resolve_import_packages(
+    keys: Sequence[PackageKey],
+) -> dict[PackageKey, Package]:
+    """Map every package identity to a persisted Package, creating misses.
+
+    Existing packages are fetched in a handful of batched queries rather than
+    one round-trip per entry, which is what makes a large import finish.
+    """
+    if not keys:
+        return {}
+
+    names = sorted({name for name, _version, _supplier in keys})
+    known: dict[PackageKey, Package] = {}
+    for chunk in _chunked(names, _IMPORT_QUERY_CHUNK):
+        for package in db.session.execute(
+            db.select(Package).where(Package.name.in_(chunk))
+        ).scalars().all():
+            stored = (package.name or "", package.version or "", package.supplier or "")
+            known.setdefault(stored, package)
+            # Export reduces a supplier to its bare name, dropping any SPDX
+            # prefix and contact address, so an export of "Organization: PNG
+            # Group (png@example.com)" comes back as "PNG Group". Index that
+            # form too, or re-importing would create a second row for a
+            # package the destination already has.
+            as_exported = (stored[0], stored[1], _extract_supplier_name(stored[2]))
+            if as_exported != stored:
+                known.setdefault(as_exported, package)
+
+    created = False
+    for key in keys:
+        if key in known:
+            continue
+        name, version, supplier = key
+        package = Package(
+            name=name, version=version, cpe=[], purl=[],
+            licences="", supplier=supplier,
+        )
+        db.session.add(package)
+        known[key] = package
+        created = True
+
+    if created:
+        db.session.flush()  # assign primary keys before findings reference them
+    return {key: known[key] for key in keys}
+
+
+def _ensure_import_vulnerabilities(vulnerability_ids: set[str]) -> None:
+    """Create placeholder Vulnerability rows for ids not yet in the database."""
+    if not vulnerability_ids:
+        return
+    ordered = sorted(vulnerability_ids)
+    existing: set[str] = set()
+    for chunk in _chunked(ordered, _IMPORT_QUERY_CHUNK):
+        existing.update(db.session.execute(
+            db.select(Vulnerability.id).where(Vulnerability.id.in_(chunk))
+        ).scalars().all())
+
+    missing = [vuln_id for vuln_id in ordered if vuln_id not in existing]
+    for vulnerability_id in missing:
+        db.session.add(Vulnerability(id=vulnerability_id))
+    if missing:
+        db.session.flush()
+
+
+def _resolve_import_findings(
+    pairs: Sequence[tuple[uuid_module.UUID, str]],
+) -> dict[tuple[uuid_module.UUID, str], Finding]:
+    """Map every (package, vulnerability) pair to a Finding, creating misses."""
+    if not pairs:
+        return {}
+
+    package_ids = sorted({package_id for package_id, _vuln in pairs}, key=str)
+    known: dict[tuple[uuid_module.UUID, str], Finding] = {}
+    for chunk in _chunked(package_ids, _IMPORT_QUERY_CHUNK):
+        for finding in db.session.execute(
+            db.select(Finding).where(Finding.package_id.in_(chunk))
+        ).scalars().all():
+            known[(finding.package_id, finding.vulnerability_id)] = finding
+
+    created = False
+    for pair in pairs:
+        if pair in known:
+            continue
+        package_id, vulnerability_id = pair
+        finding = Finding(package_id=package_id, vulnerability_id=vulnerability_id)
+        db.session.add(finding)
+        known[pair] = finding
+        created = True
+
+    if created:
+        db.session.flush()  # assign primary keys before observations reference them
+    return {pair: known[pair] for pair in pairs}
+
+
+def _assessment_identity(
+    finding_id: uuid_module.UUID, entry: dict[str, str]
+) -> tuple:
+    return (
+        finding_id,
+        entry["status"],
+        entry["simplified_status"],
+        entry["status_notes"],
+        entry["justification"],
+        entry["impact_statement"],
+    )
+
+
+def _existing_assessment_identities(
+    variant_id: uuid_module.UUID,
+    finding_ids: Sequence[uuid_module.UUID],
+) -> set[tuple]:
+    """Return identities of assessments already attached to these findings."""
+    identities: set[tuple] = set()
+    for chunk in _chunked(finding_ids, _IMPORT_QUERY_CHUNK):
+        for assessment in db.session.execute(
+            db.select(Assessment).where(
+                Assessment.variant_id == variant_id,
+                Assessment.finding_id.in_(chunk),
+            )
+        ).scalars().all():
+            identities.add((
+                assessment.finding_id,
+                assessment.status or "",
+                assessment.simplified_status or "",
+                assessment.status_notes or "",
+                assessment.justification or "",
+                assessment.impact_statement or "",
+            ))
+    return identities
+
+
+def _utc_key(value: datetime) -> str:
+    """Normalise a timestamp to a UTC string that compares reliably.
+
+    Comparing datetimes through the database would depend on how each backend
+    stores time zones, so identity comparisons are made in Python instead.
+    """
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _is_first_scan_of_its_kind(scan: Scan) -> bool:
+    """Whether *scan* is the earliest of its type/source in its variant.
+
+    Mirrors the previous-scan selection in ``_compute_diff_dict`` without
+    paying for a full diff computation.
+    """
+    scan_type = scan.scan_type or "sbom"
+    same_kind = [
+        sibling for sibling in ScanController.get_by_variant(scan.variant_id)
+        if (sibling.scan_type or "sbom") == scan_type
+        and (sibling.scan_source == scan.scan_source if scan_type == "tool" else True)
+    ]
+    return bool(same_kind) and same_kind[0].id == scan.id
+
+
+def _persist_scan_import(item: _ScanImport) -> _ImportSummary:
+    """Persist one validated export and return a summary of what it created."""
+    # The id in the export belongs to the source scan and is not reused: Scan.id
+    # keeps its uuid4 default so the destination gets its own identity. The scan
+    # is instead recognised on a later import by its variant, kind and timestamp.
+    scan = Scan(
+        description=(
+            f"Imported scan from {item.project_name} / {item.variant_name}"
+        ),
+        scan_type=item.scan_type,
+        scan_source=item.scan_source,
+        timestamp=item.timestamp,
+        variant_id=item.variant.id,
+    )
+    db.session.add(scan)
+    db.session.flush()
+
+    packages = _resolve_import_packages(item.package_keys)
+
+    if item.scan_type == "sbom":
+        # SBOM scans expose their package set through an SBOM document; tool
+        # scans reach theirs through their findings and need none.
+        document = SBOMDocument(
+            path=f"imported-scan://{scan.id}",
+            source_name=_IMPORT_SOURCE_LABEL,
+            format="vulnscout_json",
+            scan_id=scan.id,
+        )
+        db.session.add(document)
+        db.session.flush()
+        # Two export entries can resolve to one row (e.g. suppliers that
+        # normalise to the same value), so link each package only once.
+        for package_id in {package.id for package in packages.values()}:
+            db.session.add(SBOMPackage(
+                sbom_document_id=document.id,
+                package_id=package_id,
+            ))
+
+    vulnerability_ids = {vulnerability_id for _key, vulnerability_id in item.findings}
+    _ensure_import_vulnerabilities(vulnerability_ids)
+
+    finding_pairs = [
+        (packages[package_key].id, vulnerability_id)
+        for package_key, vulnerability_id in item.findings
+    ]
+    findings = _resolve_import_findings(finding_pairs)
+
+    findings_by_vulnerability: dict[str, list[Finding]] = {}
+    findings_by_pair: dict[FindingKey, Finding] = {}
+    observed: set[uuid_module.UUID] = set()
+    for package_key, vulnerability_id in item.findings:
+        finding = findings[(packages[package_key].id, vulnerability_id)]
+        findings_by_pair[(package_key, vulnerability_id)] = finding
+        if finding.id in observed:
+            continue
+        observed.add(finding.id)
+        findings_by_vulnerability.setdefault(vulnerability_id, []).append(finding)
+        db.session.add(Observation(finding_id=finding.id, scan_id=scan.id))
+
+    assessment_count = _persist_import_assessments(
+        item, findings_by_vulnerability, findings_by_pair
+    )
+
+    db.session.flush()
+    return _ImportSummary(
+        scan_id=str(scan.id),
+        source_scan_id=str(item.source_scan_id),
+        format="diff" if item.export_format == "scan-diff" else "full",
+        project_name=item.project_name,
+        variant_name=item.variant_name,
+        package_count=len(item.package_keys),
+        finding_count=len(item.findings),
+        vulnerability_count=len(vulnerability_ids),
+        assessment_count=assessment_count,
+        is_first=_is_first_scan_of_its_kind(scan),
+    )
+
+
+def _persist_import_assessments(
+    item: _ScanImport,
+    findings_by_vulnerability: dict[str, list[Finding]],
+    findings_by_pair: dict[FindingKey, Finding],
+) -> int:
+    """Create the export's assessments, skipping ones already present.
+
+    An assessment belongs to one (package, vulnerability) finding.  When the
+    export names the package the assessment is attached to exactly that
+    finding; only for older exports that omit it does it fall back to every
+    finding sharing the vulnerability.  Re-importing a file — or importing two
+    exports that share an assessment — must not duplicate it, so identical
+    assessments already on the destination variant are left alone.
+    """
+    if not item.assessments:
+        return 0
+
+    # Assessments whose origin is unset are filtered out of every export and
+    # scan diff (SQL ``NOT IN`` drops NULLs), so an imported assessment must
+    # carry the origin a natively-produced one of the same kind would have —
+    # otherwise it silently disappears the next time the data is exported.
+    origin = item.scan_source if item.scan_type == "tool" else "sbom"
+
+    finding_ids = sorted(
+        {finding.id for findings in findings_by_vulnerability.values() for finding in findings},
+        key=str,
+    )
+    seen = _existing_assessment_identities(item.variant.id, finding_ids)
+
+    created = 0
+    for entry in item.assessments:
+        if entry.package_key is not None:
+            finding = findings_by_pair.get((entry.package_key, entry.vulnerability_id))
+            targets = [finding] if finding is not None else []
+        else:
+            targets = findings_by_vulnerability.get(entry.vulnerability_id, [])
+        for target in targets:
+            identity = _assessment_identity(target.id, entry.values)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            Assessment.create(
+                status=entry.values["status"],
+                finding_id=target.id,
+                variant_id=item.variant.id,
+                source=_IMPORT_SOURCE_LABEL,
+                origin=origin or "sbom",
+                simplified_status=entry.values["simplified_status"],
+                status_notes=entry.values["status_notes"],
+                justification=entry.values["justification"],
+                impact_statement=entry.values["impact_statement"],
+                commit=False,
+            )
+            created += 1
+    return created
+
+
+def _import_scan_exports(exports: Sequence[object]) -> tuple[list[_ImportSummary], int]:
+    """Validate exports and persist only scans absent from their destination."""
+    parsed: list[_ScanImport] = []
+    batch_keys: set[tuple[uuid_module.UUID, str, str | None, str]] = set()
+    skipped_count = 0
+
+    for index, export in enumerate(exports):
+        try:
+            item = _parse_scan_export(export)
+        except (TypeError, ValueError, LookupError) as exc:
+            raise type(exc)(_import_entry_error(index, len(exports), exc)) from exc
+
+        location = f"'{item.project_name}' / '{item.variant_name}'"
+        described = f"scan '{item.source_scan_id}' ({_utc_key(item.timestamp)})"
+
+        # Guard against the same scan arriving twice in one request as well as
+        # against one already present in the destination.
+        batch_key = (
+            item.variant.id, item.scan_type, item.scan_source,
+            _utc_key(item.timestamp),
+        )
+        if batch_key in batch_keys:
+            raise FileExistsError(_import_entry_error(
+                index, len(exports),
+                f"{described} appears more than once for {location} "
+                f"in this import",
+            ))
+        batch_keys.add(batch_key)
+
+        if _find_duplicate_scan(item) is not None:
+            skipped_count += 1
+            continue
+        parsed.append(item)
+
+    try:
+        return ([_persist_scan_import(item) for item in parsed], skipped_count)
+    except LookupError as exc:
+        # Every destination lookup already succeeded during validation, so a
+        # LookupError here is an internal fault. Re-raise it as one rather than
+        # letting the route report it to the client as a missing destination.
+        raise RuntimeError("Failed to persist a validated scan import") from exc
+
+
+def _find_duplicate_scan(item: _ScanImport) -> Scan | None:
+    """Return the destination scan *item* would duplicate, if there is one.
+
+    A scan is identified by what it is rather than by a recorded provenance
+    id: its variant, its kind (type plus tool source) and the instant it ran.
+    Scan timestamps carry microsecond precision, so two distinct scans of the
+    same kind in one variant never collide in practice, while a re-import of
+    the same export always does.  Identifying it this way keeps the importer
+    self-contained — no extra column, and no dependence on rows written by an
+    earlier version — and it also catches an export whose scan the destination
+    already has natively, which a provenance marker would miss.
+    """
+    target = _utc_key(item.timestamp)
+    for sibling in ScanController.get_by_variant(item.variant.id):
+        if (sibling.scan_type or "sbom") != item.scan_type:
+            continue
+        if (sibling.scan_source or None) != item.scan_source:
+            continue
+        if _utc_key(sibling.timestamp) == target:
+            return sibling
+    return None
+
+
+def _import_entry_error(index: int, total: int, detail: object) -> str:
+    """Prefix an error with its position, so bulk imports name the bad entry."""
+    if total <= 1:
+        return str(detail)
+    return f"Export #{index + 1} of {total}: {detail}"
+
+
+def _format_byte_size(num_bytes: float) -> str:
+    """Render a byte count using the largest unit that keeps it >= 1."""
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if num_bytes < 1024 or unit == "GiB":
+            return f"{num_bytes:g} {unit}"
+        num_bytes /= 1024
+    return f"{num_bytes:g} GiB"
+
+
 def init_app(app: Flask) -> None:
+
+    @app.route('/api/scans/import', methods=['POST'])
+    def import_scan() -> ResponseReturnValue:
+        """Import VulnScout scan diff or full-result exports.
+
+        Accepts a single export object or an array of them (as produced by
+        ``GET /api/scans/export``).  The whole request is validated before any
+        of it is written, and persisted in one transaction, so a rejected
+        import leaves the database untouched.
+
+        OpenAPI:
+        response 201 JsonObject Import summary, with one entry per newly imported scan.
+        response 400 Error Malformed or unsupported export payload.
+        response 404 Error Destination project or variant not found.
+        response 413 Error Request body exceeds the scan import size limit.
+        """
+        try:
+            payload = flask_request.get_json(force=True, silent=True)
+            if payload is None:
+                raise ValueError(
+                    "Request body must be valid JSON: a scan export object "
+                    "or an array of them"
+                )
+            exports = payload if isinstance(payload, list) else [payload]
+            if not exports:
+                raise ValueError("Scan import array must not be empty")
+            if len(exports) > _MAX_IMPORT_EXPORTS:
+                raise ValueError(
+                    f"Too many exports ({len(exports)}). "
+                    f"Maximum is {_MAX_IMPORT_EXPORTS} per request."
+                )
+            results, skipped_count = _import_scan_exports(exports)
+            db.session.commit()
+        except RequestEntityTooLarge:
+            db.session.rollback()
+            limit = _format_byte_size(app.config["MAX_SCAN_IMPORT_CONTENT_LENGTH"])
+            return jsonify({
+                "error": f"Scan import exceeds the {limit} size limit",
+            }), 413
+        except FileExistsError as exc:
+            db.session.rollback()
+            return jsonify({"error": str(exc)}), 409
+        except LookupError as exc:
+            db.session.rollback()
+            return jsonify({"error": str(exc)}), 404
+        except (TypeError, ValueError) as exc:
+            db.session.rollback()
+            return jsonify({"error": str(exc)}), 400
+        except Exception:
+            db.session.rollback()
+            app.logger.exception("Failed to import scan export")
+            return jsonify({"error": "Failed to import scan data"}), 500
+
+        # New scans change every cached scan-history list and their diff badges.
+        if results:
+            invalidate_scan_list_cache()
+
+        last = results[-1] if results else None
+        return jsonify({
+            "imported_count": len(results),
+            "skipped_count": skipped_count,
+            "scans": results,
+            # Summary of the request as a whole; the singular fields describe
+            # the last scan imported, for single-file imports the only one.
+            "scan_id": last["scan_id"] if last else None,
+            "format": last["format"] if last else None,
+            "is_first": last["is_first"] if last else None,
+            "package_count": sum(r["package_count"] for r in results),
+            "finding_count": sum(r["finding_count"] for r in results),
+            "vulnerability_count": sum(r["vulnerability_count"] for r in results),
+            "assessment_count": sum(r["assessment_count"] for r in results),
+        }), 201
 
     @app.route('/api/scans')
     def list_all_scans() -> ResponseReturnValue:

--- a/tests/webapp_tests/test_scan_export.py
+++ b/tests/webapp_tests/test_scan_export.py
@@ -176,6 +176,8 @@ class TestExportScanDiff:
         assert r.status_code == 200
         data = json.loads(r.data)
         assert data["scan_id"] == ids["scan_a_id"]
+        assert data["export_format"] == "scan-diff"
+        assert data["export_version"] == 1
         assert data["scan_type"] == "import_sbom"
         assert data["project_name"] == "ExportProject"
         assert data["variant_name"] == "ExportVariant"
@@ -243,6 +245,8 @@ class TestExportScanResult:
         assert r.status_code == 200
         data = json.loads(r.data)
         assert data["scan_id"] == ids["scan_b_id"]
+        assert data["export_format"] == "full-result"
+        assert data["export_version"] == 1
         assert data["scan_type"] == "import_sbom"
         assert "packages" in data
         assert "findings" in data
@@ -290,6 +294,363 @@ class TestExportScanResult:
         data = json.loads(r.data)
         assert data["project_name"] == "ExportProject"
         assert data["variant_name"] == "ExportVariant"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/scans/import
+# ---------------------------------------------------------------------------
+
+class TestImportScan:
+    @staticmethod
+    def _set_fresh_destination(app, *payloads):
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        project_name = f"DestinationProject-{uuid.uuid4()}"
+        variant_name = "DestinationVariant"
+        with app.app_context():
+            project = Project.create(project_name)
+            Variant.create(variant_name, project.id)
+        for payload in payloads:
+            payload.update({
+                "project_name": project_name,
+                "variant_name": variant_name,
+            })
+
+    def test_imports_full_result(self, app, client, ids):
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_b_id']}/export-result"
+        ).data)
+        payload.update({
+            "scan_id": str(uuid.uuid4()),
+            "project_name": "DestinationProject",
+            "variant_name": "DestinationVariant",
+        })
+        with app.app_context():
+            project = Project.create("DestinationProject")
+            Variant.create("DestinationVariant", project.id)
+
+        response = client.post("/api/scans/import", json=payload)
+
+        assert response.status_code == 201
+        assert response.get_json()["format"] == "full"
+
+    def test_imports_legacy_full_result(self, app, client, ids):
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_b_id']}/export-result"
+        ).data)
+        payload.pop("export_version")
+        payload.pop("export_format")
+        payload["scan_id"] = str(uuid.uuid4())
+        self._set_fresh_destination(app, payload)
+
+        response = client.post("/api/scans/import", json=payload)
+
+        assert response.status_code == 201
+        assert response.get_json()["format"] == "full"
+
+    def test_imports_non_first_diff_from_its_top_level_state(self, app, client, ids):
+        """A later scan's diff export carries its full state and imports fine.
+
+        The ``diff`` block describes the *source* variant's history and is
+        ignored: the destination recomputes its own diff.
+        """
+        from src.models.scan import Scan
+
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_b_id']}/export-diff"
+        ).data)
+        assert "diff" in payload  # precondition: this is not a first-scan export
+        self._set_fresh_destination(app, payload)
+
+        response = client.post("/api/scans/import", json=payload)
+
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["format"] == "diff"
+        # scan_b holds cairo + libpng, both of which must land in the copy.
+        assert body["package_count"] == 2
+        assert body["finding_count"] == 2
+        assert body["is_first"] is True  # first scan in the empty destination
+        with app.app_context():
+            imported = _db.session.get(Scan, uuid.UUID(body["scan_id"]))
+            assert {o.finding.package.name for o in imported.observations} == {
+                "cairo", "libpng",
+            }
+
+    def test_imports_export_all_diffs(self, app, client, ids):
+        """The Export All (diff) file round-trips through import as a whole."""
+        payload = json.loads(client.get("/api/scans/export?type=diff").data)
+        assert len(payload) >= 2
+        self._set_fresh_destination(app, *payload)
+
+        response = client.post("/api/scans/import", json=payload)
+
+        assert response.status_code == 201
+        assert response.get_json()["imported_count"] == len(payload)
+
+    def test_import_diff_uses_current_state_and_skips_duplicate(self, app, client, ids):
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_a_id']}/export-diff"
+        ).data)
+        payload["scan_id"] = str(uuid.uuid4())
+        self._set_fresh_destination(app, payload)
+
+        response = client.post("/api/scans/import", json=payload)
+        duplicate = client.post("/api/scans/import", json=payload)
+
+        assert response.status_code == 201
+        assert json.loads(response.data)["format"] == "diff"
+        assert duplicate.status_code == 201
+        assert json.loads(duplicate.data)["imported_count"] == 0
+        assert json.loads(duplicate.data)["skipped_count"] == 1
+
+    def test_imports_export_all_results(self, app, client, ids):
+        payload = json.loads(client.get("/api/scans/export?type=total").data)
+        for export in payload:
+            export["scan_id"] = str(uuid.uuid4())
+            export["assessments"] = []
+        self._set_fresh_destination(app, *payload)
+
+        response = client.post("/api/scans/import", json=payload)
+
+        assert response.status_code == 201
+        assert response.get_json()["imported_count"] == len(payload)
+
+    def test_import_allows_json_larger_than_default_request_limit(self, app, client, ids):
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_a_id']}/export-diff"
+        ).data)
+        payload["scan_id"] = str(uuid.uuid4())
+        payload["padding"] = "x" * app.config["MAX_CONTENT_LENGTH"]
+        self._set_fresh_destination(app, payload)
+
+        response = client.post("/api/scans/import", json=payload)
+
+        assert response.status_code == 201
+
+    def test_import_rejects_request_larger_than_import_limit(self, app, client):
+        app.config["MAX_SCAN_IMPORT_CONTENT_LENGTH"] = 1
+
+        response = client.post("/api/scans/import", json={})
+
+        assert response.status_code == 413
+        # The message reports the limit actually configured, not a constant.
+        assert response.get_json() == {
+            "error": "Scan import exceeds the 1 B size limit",
+        }
+
+    def test_import_needs_no_schema_change(self, app):
+        """Import works against the schema as it already exists on disk.
+
+        The importer identifies scans by their own content, so it must not
+        depend on any column added for its benefit.
+        """
+        from src.models.scan import Scan
+
+        with app.app_context():
+            columns = set(Scan.__table__.columns.keys())
+        assert columns == {
+            "id", "description", "scan_type", "scan_source", "timestamp",
+            "variant_id",
+        }
+
+    def test_import_rejects_malformed_json_body(self, client):
+        response = client.post(
+            "/api/scans/import",
+            data="{not json",
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert "valid JSON" in response.get_json()["error"]
+
+    def test_import_rolls_back_when_persistence_fails(
+        self, app, client, ids, monkeypatch
+    ):
+        from src.models.scan import Scan
+
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_a_id']}/export-diff"
+        ).data)
+        self._set_fresh_destination(app, payload)
+
+        def fail_persist(_item):
+            raise RuntimeError("persistence failure")
+
+        monkeypatch.setattr("src.routes.scans._persist_scan_import", fail_persist)
+
+        with app.app_context():
+            before = len(Scan.get_all())
+
+        response = client.post("/api/scans/import", json=payload)
+
+        assert response.status_code == 500
+        assert response.get_json() == {"error": "Failed to import scan data"}
+        with app.app_context():
+            assert len(Scan.get_all()) == before
+
+    def test_import_rejects_whole_batch_when_one_entry_is_invalid(self, app, client, ids):
+        """A bad entry aborts the request and names its position."""
+        from src.models.scan import Scan
+
+        good = json.loads(client.get(
+            f"/api/scans/{ids['scan_a_id']}/export-diff"
+        ).data)
+        other = json.loads(client.get(
+            f"/api/scans/{ids['scan_b_id']}/export-diff"
+        ).data)
+        self._set_fresh_destination(app, good, other)
+        broken = dict(other, timestamp="not-a-timestamp")
+
+        with app.app_context():
+            before = len(Scan.get_all())
+
+        response = client.post("/api/scans/import", json=[good, broken])
+
+        assert response.status_code == 400
+        assert "Export #2 of 2" in response.get_json()["error"]
+        with app.app_context():
+            assert len(Scan.get_all()) == before
+
+    def test_import_rejects_duplicate_entries_within_one_request(self, app, client, ids):
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_a_id']}/export-diff"
+        ).data)
+        self._set_fresh_destination(app, payload)
+
+        response = client.post("/api/scans/import", json=[payload, payload])
+
+        assert response.status_code == 409
+        assert "appears more than once" in response.get_json()["error"]
+
+    def test_import_rejects_too_many_exports(self, app, client, ids):
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_a_id']}/export-diff"
+        ).data)
+        self._set_fresh_destination(app, payload)
+
+        response = client.post("/api/scans/import", json=[payload] * 201)
+
+        assert response.status_code == 400
+        assert "Too many exports" in response.get_json()["error"]
+
+    def test_import_persists_assessments_without_duplicating_them(
+        self, app, client, ids
+    ):
+        """Assessments are imported, and re-importing them adds no copies."""
+        from src.models.assessment import Assessment
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_b_id']}/export-result"
+        ).data)
+        payload["assessments"] = [{
+            "vulnerability_id": "CVE-2020-35492",
+            "status": "fixed",
+            "simplified_status": "fixed",
+            "justification": "patched upstream",
+            "impact_statement": "",
+            "status_notes": "",
+        }]
+        self._set_fresh_destination(app, payload)
+
+        first = client.post("/api/scans/import", json=payload)
+        assert first.status_code == 201
+        assert first.get_json()["assessment_count"] == 1
+
+        def variant_assessments():
+            with app.app_context():
+                project = Project.get_by_name(payload["project_name"])
+                variant = Variant.get_by_name_and_project(
+                    payload["variant_name"], project.id
+                )
+                return _db.session.execute(
+                    _db.select(Assessment).where(Assessment.variant_id == variant.id)
+                ).scalars().all()
+
+        assert len(variant_assessments()) == 1
+
+        # A genuinely different scan that re-states the same assessment: the
+        # scan is new, the assessment is not, so only the scan is stored.
+        second_payload = dict(
+            payload, scan_id=str(uuid.uuid4()), timestamp="2027-03-04T05:06:07+00:00",
+        )
+        second = client.post("/api/scans/import", json=second_payload)
+
+        assert second.status_code == 201
+        assert second.get_json()["assessment_count"] == 0
+        assert len(variant_assessments()) == 1
+
+    def test_import_reuses_existing_packages_and_findings(self, app, client, ids):
+        """Importing into a populated DB links to existing rows, not copies."""
+        from src.models.finding import Finding
+        from src.models.package import Package
+
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_b_id']}/export-result"
+        ).data)
+        self._set_fresh_destination(app, payload)
+        with app.app_context():
+            packages_before = len(Package.get_all())
+            findings_before = len(Finding.get_all())
+
+        assert client.post("/api/scans/import", json=payload).status_code == 201
+
+        with app.app_context():
+            assert len(Package.get_all()) == packages_before
+            assert len(Finding.get_all()) == findings_before
+
+    @pytest.mark.parametrize("payload, status", [
+        ({}, 400),
+        ({"scan_id": "not-a-uuid"}, 400),
+        ({
+            "export_format": "scan-diff",
+            "export_version": 1,
+            "scan_id": "00000000-0000-0000-0000-000000000001",
+            "project_name": "Missing",
+            "variant_name": "Missing",
+            "scan_type": "import_sbom",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "packages": [],
+            "findings": [],
+        }, 404),
+    ])
+    def test_import_rejects_invalid_payloads(self, client, payload, status):
+        response = client.post("/api/scans/import", json=payload)
+
+        assert response.status_code == status
+        assert json.loads(response.data)["error"]
+
+    def test_import_rejects_malformed_state_arrays_and_assessments(
+        self, app, client, ids
+    ):
+        payload = json.loads(client.get(
+            f"/api/scans/{ids['scan_a_id']}/export-diff"
+        ).data)
+        self._set_fresh_destination(app, payload)
+
+        # An assessment missing its status, and one whose vulnerability has no
+        # finding in this scan, are both rejected.
+        no_status = dict(payload, assessments=[{"vulnerability_id": "CVE-1"}])
+        unmatched = dict(payload, assessments=[
+            {"vulnerability_id": "CVE-1", "status": "fixed"},
+        ])
+        missing_findings = dict(payload)
+        del missing_findings["findings"]
+        missing_packages = dict(payload)
+        del missing_packages["packages"]
+
+        assert client.post("/api/scans/import", json=no_status).status_code == 400
+        unmatched_response = client.post("/api/scans/import", json=unmatched)
+        assert unmatched_response.status_code == 400
+        assert "no matching finding" in unmatched_response.get_json()["error"]
+        assert client.post("/api/scans/import", json=missing_findings).status_code == 400
+        assert client.post("/api/scans/import", json=missing_packages).status_code == 400
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webapp_tests/test_scan_import_matrix.py
+++ b/tests/webapp_tests/test_scan_import_matrix.py
@@ -1,0 +1,810 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Round-trip matrix for scan export -> import.
+
+Every scenario below exports real data through the export endpoints, imports
+the result back through ``POST /api/scans/import``, and asserts that what
+landed in the destination matches what the source held.  The source fixture
+deliberately mixes the awkward cases — SBOM and tool scans, several scan
+sources, suppliers in three shapes, an empty scan, unicode and assessments —
+so a regression in any one of them fails a named scenario rather than
+silently degrading fidelity.
+"""
+
+import json
+import os
+import uuid
+
+import pytest
+
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+
+
+# ---------------------------------------------------------------------------
+# Source fixture
+# ---------------------------------------------------------------------------
+
+def _build_source_db(app):
+    """Populate one project with variants covering the interesting shapes.
+
+    Layout
+    ------
+    MatrixSource
+      v-sbom   S1 sbom  : cairo@1.16.0 (no supplier)         -> CVE-A
+               S2 sbom  : cairo@1.16.0, libpng@1.6.37 (SPDX  -> CVE-A, CVE-B
+                          supplier), zlib@1.2.13 (plain)        + assessments
+      v-tool   T1 sbom  : openssl@3.0.0                      -> (no findings)
+               T2 tool  : grype                              -> CVE-C
+               T3 tool  : nvd                                -> CVE-C, CVE-D
+      v-empty  E1 sbom  : no packages, no findings
+      v-uni    U1 sbom  : 'café-lib@1.0' unicode name        -> CVE-É
+    """
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.package import Package
+    from src.models.vulnerability import Vulnerability
+    from src.models.finding import Finding
+    from src.models.observation import Observation
+    from src.models.assessment import Assessment
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("MatrixSource")
+        v_sbom = Variant.create("v-sbom", project.id)
+        v_tool = Variant.create("v-tool", project.id)
+        v_empty = Variant.create("v-empty", project.id)
+        v_uni = Variant.create("v-uni", project.id)
+
+        cairo = Package.find_or_create("cairo", "1.16.0")
+        libpng = Package.find_or_create(
+            "libpng", "1.6.37", supplier="Organization: PNG Group (png@example.com)"
+        )
+        zlib = Package.find_or_create("zlib", "1.2.13", supplier="Zlib Project")
+        openssl = Package.find_or_create("openssl", "3.0.0")
+        cafe = Package.find_or_create("café-lib", "1.0")
+
+        vulns = {
+            key: Vulnerability.create_record(id=vid, description=f"{key} vuln")
+            for key, vid in {
+                "A": "CVE-2020-35492", "B": "CVE-2019-7317",
+                "C": "CVE-2022-0778", "D": "CVE-2023-0464",
+                "E": "GHSA-jfh8-c2jp-5v3q",
+            }.items()
+        }
+        f_cairo_a = Finding.get_or_create(cairo.id, vulns["A"].id)
+        f_libpng_b = Finding.get_or_create(libpng.id, vulns["B"].id)
+        f_zlib_a = Finding.get_or_create(zlib.id, vulns["A"].id)
+        f_ssl_c = Finding.get_or_create(openssl.id, vulns["C"].id)
+        f_ssl_d = Finding.get_or_create(openssl.id, vulns["D"].id)
+        f_cafe_e = Finding.get_or_create(cafe.id, vulns["E"].id)
+        _db.session.commit()
+
+        ids = {}
+
+        # -- v-sbom: two SBOM scans, the second adding packages -------------
+        s1 = Scan.create("S1", v_sbom.id)
+        doc = SBOMDocument.create("/s1/sbom.json", "spdx", s1.id)
+        SBOMPackage.create(doc.id, cairo.id)
+        Observation.create(finding_id=f_cairo_a.id, scan_id=s1.id)
+
+        s2 = Scan.create("S2", v_sbom.id)
+        doc = SBOMDocument.create("/s2/sbom.json", "spdx", s2.id)
+        for pkg in (cairo, libpng, zlib):
+            SBOMPackage.create(doc.id, pkg.id)
+        for finding in (f_cairo_a, f_libpng_b, f_zlib_a):
+            Observation.create(finding_id=finding.id, scan_id=s2.id)
+
+        # origin mirrors what a native SBOM scan records; assessments without
+        # one are filtered out of every export.
+        Assessment.create(
+            status="fixed", finding_id=f_cairo_a.id, variant_id=v_sbom.id,
+            origin="sbom", simplified_status="fixed",
+            justification="patched upstream", status_notes="verified",
+            impact_statement="", commit=False,
+        )
+        Assessment.create(
+            status="not_affected", finding_id=f_libpng_b.id, variant_id=v_sbom.id,
+            origin="sbom", simplified_status="not affected",
+            justification="component not built", status_notes="",
+            impact_statement="not reachable", commit=False,
+        )
+        ids["sbom_first"] = str(s1.id)
+        ids["sbom_second"] = str(s2.id)
+        ids["v_sbom"] = str(v_sbom.id)
+
+        # -- v-tool: an SBOM base plus two tool scans from two sources ------
+        t1 = Scan.create("T1", v_tool.id)
+        doc = SBOMDocument.create("/t1/sbom.json", "spdx", t1.id)
+        SBOMPackage.create(doc.id, openssl.id)
+
+        t2 = Scan.create("T2", v_tool.id, scan_type="tool", scan_source="grype")
+        Observation.create(finding_id=f_ssl_c.id, scan_id=t2.id)
+
+        t3 = Scan.create("T3", v_tool.id, scan_type="tool", scan_source="nvd")
+        Observation.create(finding_id=f_ssl_c.id, scan_id=t3.id)
+        Observation.create(finding_id=f_ssl_d.id, scan_id=t3.id)
+        ids["tool_sbom_base"] = str(t1.id)
+        ids["tool_grype"] = str(t2.id)
+        ids["tool_nvd"] = str(t3.id)
+        ids["v_tool"] = str(v_tool.id)
+
+        # -- v-empty: a scan that observed nothing --------------------------
+        e1 = Scan.create("E1", v_empty.id)
+        SBOMDocument.create("/e1/sbom.json", "spdx", e1.id)
+        ids["empty"] = str(e1.id)
+        ids["v_empty"] = str(v_empty.id)
+
+        # -- v-uni: unicode package name, GHSA-style vulnerability id -------
+        u1 = Scan.create("U1", v_uni.id)
+        doc = SBOMDocument.create("/u1/sbom.json", "spdx", u1.id)
+        SBOMPackage.create(doc.id, cafe.id)
+        Observation.create(finding_id=f_cafe_e.id, scan_id=u1.id)
+        ids["unicode"] = str(u1.id)
+        ids["v_uni"] = str(v_uni.id)
+
+        _db.session.commit()
+        ids["project_id"] = str(project.id)
+        return ids
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        application._test_ids = _build_source_db(application)
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_destination(app, name_hint="dest"):
+    """Create an empty project/variant and return its (project, variant) names."""
+    from src.models.project import Project
+    from src.models.variant import Variant
+
+    project_name = f"MatrixDest-{name_hint}-{uuid.uuid4().hex[:8]}"
+    with app.app_context():
+        project = Project.create(project_name)
+        Variant.create("dest-variant", project.id)
+    return project_name, "dest-variant"
+
+
+def _retarget(payload, project_name, variant_name):
+    """Point one export, or a list of them, at a destination."""
+    entries = payload if isinstance(payload, list) else [payload]
+    for entry in entries:
+        entry["project_name"] = project_name
+        entry["variant_name"] = variant_name
+    return payload
+
+
+def _scan_state(app, scan_id):
+    """Return the (package, vulnerability) pairs a scan observed."""
+    from src.models.scan import Scan
+
+    with app.app_context():
+        scan = _db.session.get(Scan, uuid.UUID(str(scan_id)))
+        return {
+            (
+                obs.finding.package.name,
+                obs.finding.package.version,
+                obs.finding.vulnerability_id,
+            )
+            for obs in scan.observations
+        }
+
+
+def _scan_packages(app, scan_id):
+    """Return the packages an SBOM scan declares through its documents."""
+    from src.models.scan import Scan
+
+    with app.app_context():
+        scan = _db.session.get(Scan, uuid.UUID(str(scan_id)))
+        return {
+            (link.package.name, link.package.version)
+            for document in scan.sbom_documents
+            for link in document.sbom_packages
+        }
+
+
+def _variant_assessments(app, project_name, variant_name):
+    """Return the assessment content attached to a variant."""
+    from src.models.assessment import Assessment
+    from src.models.project import Project
+    from src.models.variant import Variant
+
+    with app.app_context():
+        project = Project.get_by_name(project_name)
+        variant = Variant.get_by_name_and_project(variant_name, project.id)
+        rows = _db.session.execute(
+            _db.select(Assessment).where(Assessment.variant_id == variant.id)
+        ).scalars().all()
+        return {
+            (
+                a.finding.vulnerability_id,
+                a.status,
+                a.simplified_status,
+                a.justification or "",
+                a.impact_statement or "",
+            )
+            for a in rows
+        }
+
+
+def _export(client, path):
+    response = client.get(path)
+    assert response.status_code == 200, f"{path} -> {response.status_code}"
+    return json.loads(response.data)
+
+
+def _import(client, payload):
+    return client.post("/api/scans/import", json=payload)
+
+
+# ---------------------------------------------------------------------------
+# Matrix — single-scan exports round-tripped into an empty destination
+# ---------------------------------------------------------------------------
+
+#: (scenario id, source scan key, export endpoint suffix)
+SINGLE_SCAN_MATRIX = [
+    ("sbom-first/diff", "sbom_first", "export-diff"),
+    ("sbom-first/full", "sbom_first", "export-result"),
+    ("sbom-later/diff", "sbom_second", "export-diff"),
+    ("sbom-later/full", "sbom_second", "export-result"),
+    ("tool-sbom-base/diff", "tool_sbom_base", "export-diff"),
+    ("tool-sbom-base/full", "tool_sbom_base", "export-result"),
+    ("tool-grype/diff", "tool_grype", "export-diff"),
+    ("tool-grype/full", "tool_grype", "export-result"),
+    ("tool-nvd/diff", "tool_nvd", "export-diff"),
+    ("tool-nvd/full", "tool_nvd", "export-result"),
+    ("empty-scan/diff", "empty", "export-diff"),
+    ("empty-scan/full", "empty", "export-result"),
+    ("unicode-ghsa/diff", "unicode", "export-diff"),
+    ("unicode-ghsa/full", "unicode", "export-result"),
+]
+
+
+class TestSingleScanRoundTrip:
+    """Each export format, for each kind of scan, imports into a clean variant."""
+
+    @pytest.mark.parametrize(
+        "scenario, scan_key, endpoint",
+        SINGLE_SCAN_MATRIX,
+        ids=[row[0] for row in SINGLE_SCAN_MATRIX],
+    )
+    def test_round_trip(self, app, client, ids, scenario, scan_key, endpoint):
+        payload = _export(client, f"/api/scans/{ids[scan_key]}/{endpoint}")
+        project_name, variant_name = _fresh_destination(app, scan_key)
+        _retarget(payload, project_name, variant_name)
+
+        response = _import(client, payload)
+
+        assert response.status_code == 201, response.get_json()
+        body = response.get_json()
+        assert body["imported_count"] == 1
+        assert body["format"] == ("diff" if endpoint == "export-diff" else "full")
+
+        source_state = _scan_state(app, ids[scan_key])
+        imported_state = _scan_state(app, body["scan_id"])
+
+        if endpoint == "export-diff":
+            # A diff export carries the scan's own state, so it must survive
+            # the round trip exactly.
+            assert imported_state == source_state, scenario
+        else:
+            # A full-result export carries the cumulative state at that scan,
+            # which is a superset of what the scan itself observed.
+            assert imported_state >= source_state, scenario
+
+        # Counts reported back must match what actually landed.
+        assert body["finding_count"] == len(imported_state)
+        assert body["vulnerability_count"] == len({v for _n, _ver, v in imported_state})
+
+
+# ---------------------------------------------------------------------------
+# Matrix — supplier shapes survive the round trip
+# ---------------------------------------------------------------------------
+
+class TestSupplierFidelity:
+    def test_supplier_shapes_round_trip(self, app, client, ids):
+        """SPDX-prefixed, plain and absent suppliers all land correctly."""
+        from src.models.package import Package
+        from src.models.scan import Scan
+
+        payload = _export(client, f"/api/scans/{ids['sbom_second']}/export-diff")
+        project_name, variant_name = _fresh_destination(app, "supplier")
+        _retarget(payload, project_name, variant_name)
+
+        response = _import(client, payload)
+        assert response.status_code == 201
+
+        with app.app_context():
+            scan = _db.session.get(Scan, uuid.UUID(response.get_json()["scan_id"]))
+            by_name = {
+                obs.finding.package.name: obs.finding.package
+                for obs in scan.observations
+            }
+            # Export strips the SPDX prefix and contact address, so the import
+            # sees a bare "PNG Group". It must still resolve to the package the
+            # destination already has, keeping the richer stored supplier
+            # rather than creating a second row.
+            assert by_name["libpng"].supplier == "Organization: PNG Group (png@example.com)"
+            assert by_name["zlib"].supplier == "Zlib Project"
+            assert by_name["cairo"].supplier == ""
+            assert len(Package.get_all()) == 5, "import created duplicate packages"
+
+    def test_supplier_shapes_land_intact_in_an_empty_database(self, app, client, ids):
+        """Into a destination with no packages, exported suppliers are kept."""
+        from src.models.package import Package
+        from src.models.scan import Scan
+
+        payload = _export(client, f"/api/scans/{ids['sbom_second']}/export-diff")
+        project_name, variant_name = _fresh_destination(app, "supplier-new")
+        _retarget(payload, project_name, variant_name)
+        # Rename the packages so none of them already exists.
+        for group in ("packages", "findings"):
+            for row in payload[group]:
+                row["package_name"] = f"new-{row['package_name']}"
+
+        response = _import(client, payload)
+        assert response.status_code == 201
+
+        with app.app_context():
+            scan = _db.session.get(Scan, uuid.UUID(response.get_json()["scan_id"]))
+            suppliers = {
+                obs.finding.package.name: obs.finding.package.supplier
+                for obs in scan.observations
+            }
+            assert suppliers == {
+                "new-cairo": "", "new-libpng": "PNG Group", "new-zlib": "Zlib Project",
+            }
+            assert len(Package.get_all()) == 8
+
+
+# ---------------------------------------------------------------------------
+# Matrix — batch exports (Export All) at each scope
+# ---------------------------------------------------------------------------
+
+BATCH_MATRIX = [
+    ("all-scans/diff", "", "diff"),
+    ("all-scans/total", "", "total"),
+    ("by-project/diff", "project", "diff"),
+    ("by-project/total", "project", "total"),
+    ("by-variant-sbom/diff", "v_sbom", "diff"),
+    ("by-variant-sbom/total", "v_sbom", "total"),
+    ("by-variant-tool/diff", "v_tool", "diff"),
+    ("by-variant-tool/total", "v_tool", "total"),
+    ("by-variant-empty/diff", "v_empty", "diff"),
+    ("by-variant-empty/total", "v_empty", "total"),
+]
+
+
+class TestBatchRoundTrip:
+    """The Export All download imports as one atomic batch at every scope."""
+
+    @pytest.mark.parametrize(
+        "scenario, scope, export_type",
+        BATCH_MATRIX,
+        ids=[row[0] for row in BATCH_MATRIX],
+    )
+    def test_batch_round_trip(self, app, client, ids, scenario, scope, export_type):
+        if scope == "":
+            query = f"type={export_type}"
+        elif scope == "project":
+            query = f"type={export_type}&project_id={ids['project_id']}"
+        else:
+            query = f"type={export_type}&variant_id={ids[scope]}"
+
+        payload = _export(client, f"/api/scans/export?{query}")
+        assert isinstance(payload, list) and payload, scenario
+
+        project_name, variant_name = _fresh_destination(app, scenario[:12])
+        _retarget(payload, project_name, variant_name)
+
+        response = _import(client, payload)
+
+        assert response.status_code == 201, response.get_json()
+        body = response.get_json()
+        assert body["imported_count"] == len(payload)
+        assert len(body["scans"]) == len(payload)
+        # Each entry keeps the source scan it came from, so the destination can
+        # tell the copies apart.
+        assert len({s["source_scan_id"] for s in body["scans"]}) == len(payload)
+
+
+# ---------------------------------------------------------------------------
+# Matrix — assessments
+# ---------------------------------------------------------------------------
+
+class TestAssessmentRoundTrip:
+    def test_full_result_carries_assessments(self, app, client, ids):
+        payload = _export(client, f"/api/scans/{ids['sbom_second']}/export-result")
+        assert payload["assessments"], "fixture should export assessments"
+        project_name, variant_name = _fresh_destination(app, "assess")
+        _retarget(payload, project_name, variant_name)
+
+        response = _import(client, payload)
+
+        assert response.status_code == 201
+        assert response.get_json()["assessment_count"] == len(payload["assessments"])
+        imported = _variant_assessments(app, project_name, variant_name)
+        expected = {
+            (
+                a["vulnerability_id"], a["status"], a["simplified_status"],
+                a["justification"], a["impact_statement"],
+            )
+            for a in payload["assessments"]
+        }
+        assert imported == expected
+
+    def test_imported_data_can_be_exported_again(self, app, client, ids):
+        """Import -> export -> import keeps packages, findings and assessments.
+
+        An imported row that the export layer filters out (an assessment with
+        no origin, say) would leave this second export thinner than the first.
+        """
+        first = _export(client, f"/api/scans/{ids['sbom_second']}/export-result")
+        hop1 = _fresh_destination(app, "hop1")
+        _retarget(first, *hop1)
+        response = _import(client, first)
+        assert response.status_code == 201
+        imported_scan_id = response.get_json()["scan_id"]
+
+        # Export the copy straight back out again.
+        second = _export(client, f"/api/scans/{imported_scan_id}/export-result")
+
+        assert {(p["package_name"], p["package_version"]) for p in second["packages"]} \
+            == {(p["package_name"], p["package_version"]) for p in first["packages"]}
+        assert {(f["vulnerability_id"], f["package_name"]) for f in second["findings"]} \
+            == {(f["vulnerability_id"], f["package_name"]) for f in first["findings"]}
+        assert {a["vulnerability_id"] for a in second["assessments"]} \
+            == {a["vulnerability_id"] for a in first["assessments"]}
+
+        # And that re-export imports once more, unchanged.
+        hop2 = _fresh_destination(app, "hop2")
+        _retarget(second, *hop2)
+        third = _import(client, second)
+        assert third.status_code == 201
+        assert third.get_json()["assessment_count"] == len(first["assessments"])
+        assert _variant_assessments(app, *hop2) == _variant_assessments(app, *hop1)
+
+    def test_tool_scan_assessments_keep_their_source_as_origin(self, app, client, ids):
+        """An imported tool-scan assessment is labelled with that tool."""
+        from src.models.assessment import Assessment
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        payload = _export(client, f"/api/scans/{ids['tool_nvd']}/export-result")
+        payload["assessments"] = [{
+            "vulnerability_id": "CVE-2022-0778", "status": "fixed",
+            "simplified_status": "fixed", "justification": "",
+            "impact_statement": "", "status_notes": "",
+        }]
+        project_name, variant_name = _fresh_destination(app, "origin")
+        _retarget(payload, project_name, variant_name)
+
+        assert _import(client, payload).status_code == 201
+
+        with app.app_context():
+            project = Project.get_by_name(project_name)
+            variant = Variant.get_by_name_and_project(variant_name, project.id)
+            origins = {
+                a.origin for a in _db.session.execute(
+                    _db.select(Assessment).where(Assessment.variant_id == variant.id)
+                ).scalars().all()
+            }
+        assert origins == {"nvd"}
+
+    def test_reimport_does_not_duplicate_assessments(self, app, client, ids):
+        payload = _export(client, f"/api/scans/{ids['sbom_second']}/export-result")
+        project_name, variant_name = _fresh_destination(app, "assess-dup")
+        _retarget(payload, project_name, variant_name)
+
+        assert _import(client, payload).status_code == 201
+        before = _variant_assessments(app, project_name, variant_name)
+
+        # A genuinely different scan restating the same assessments: the scan
+        # is new, the assessments are not.
+        again = dict(
+            payload, scan_id=str(uuid.uuid4()),
+            timestamp="2027-03-04T05:06:07+00:00",
+        )
+        second = _import(client, again)
+
+        assert second.status_code == 201
+        assert second.get_json()["assessment_count"] == 0
+        assert _variant_assessments(app, project_name, variant_name) == before
+
+
+# ---------------------------------------------------------------------------
+# Matrix — destination states
+# ---------------------------------------------------------------------------
+
+class TestDestinationStates:
+    def test_import_into_populated_variant_appends(self, app, client, ids):
+        """Importing beside existing scans adds to the timeline, not over it."""
+        from src.models.scan import Scan
+        from src.models.project import Project
+        from src.models.variant import Variant
+
+        first = _export(client, f"/api/scans/{ids['sbom_first']}/export-diff")
+        second = _export(client, f"/api/scans/{ids['sbom_second']}/export-diff")
+        project_name, variant_name = _fresh_destination(app, "populated")
+        _retarget(first, project_name, variant_name)
+        _retarget(second, project_name, variant_name)
+
+        assert _import(client, first).status_code == 201
+        response = _import(client, second)
+        assert response.status_code == 201
+        assert response.get_json()["is_first"] is False
+
+        with app.app_context():
+            project = Project.get_by_name(project_name)
+            variant = Variant.get_by_name_and_project(variant_name, project.id)
+            assert len(Scan.get_by_variant_id(variant.id)) == 2
+
+    def test_reimport_into_same_variant_is_skipped(self, app, client, ids):
+        payload = _export(client, f"/api/scans/{ids['sbom_first']}/export-diff")
+        project_name, variant_name = _fresh_destination(app, "dup")
+        _retarget(payload, project_name, variant_name)
+
+        assert _import(client, payload).status_code == 201
+        duplicate = _import(client, payload)
+
+        assert duplicate.status_code == 201
+        assert duplicate.get_json()["imported_count"] == 0
+        assert duplicate.get_json()["skipped_count"] == 1
+
+    def test_import_skips_existing_scans_and_adds_new_ones(self, app, client, ids):
+        from src.models.project import Project
+        from src.models.scan import Scan
+        from src.models.variant import Variant
+
+        payload = _export(client, f"/api/scans/export?type=diff&variant_id={ids['v_tool']}")
+        project_name, variant_name = _fresh_destination(app, "overlap")
+        _retarget(payload, project_name, variant_name)
+
+        assert _import(client, payload[:2]).status_code == 201
+        response = _import(client, payload)
+
+        assert response.status_code == 201
+        assert response.get_json()["imported_count"] == 1
+        assert response.get_json()["skipped_count"] == 2
+        with app.app_context():
+            project = Project.get_by_name(project_name)
+            variant = Variant.get_by_name_and_project(variant_name, project.id)
+            assert len(Scan.get_by_variant_id(variant.id)) == 3
+
+    def test_same_export_into_two_variants_is_allowed(self, app, client, ids):
+        """The duplicate guard is per destination variant, not global."""
+        payload = _export(client, f"/api/scans/{ids['sbom_first']}/export-diff")
+        first_project, first_variant = _fresh_destination(app, "vA")
+        second_project, second_variant = _fresh_destination(app, "vB")
+
+        assert _import(
+            client, _retarget(dict(payload), first_project, first_variant)
+        ).status_code == 201
+        assert _import(
+            client, _retarget(dict(payload), second_project, second_variant)
+        ).status_code == 201
+
+    def test_import_back_into_the_source_variant_is_skipped(self, app, client, ids):
+        """Re-importing an export where it came from does not add a scan."""
+        payload = _export(client, f"/api/scans/{ids['sbom_first']}/export-diff")
+
+        response = _import(client, payload)
+
+        assert response.status_code == 201
+        assert response.get_json()["imported_count"] == 0
+        assert response.get_json()["skipped_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Matrix — rejection cases, none of which may write anything
+# ---------------------------------------------------------------------------
+
+class TestRejectionsLeaveNothingBehind:
+    @pytest.mark.parametrize("scenario, mutate, status", [
+        ("missing-project", lambda p: p.update({"project_name": "Nope"}), 404),
+        ("missing-variant", lambda p: p.update({"variant_name": "Nope"}), 404),
+        ("bad-scan-id", lambda p: p.update({"scan_id": "not-a-uuid"}), 400),
+        ("bad-timestamp", lambda p: p.update({"timestamp": "yesterday"}), 400),
+        ("bad-version", lambda p: p.update({"export_version": 99}), 400),
+        ("bad-format", lambda p: p.update({"export_format": "something"}), 400),
+        ("findings-not-array", lambda p: p.update({"findings": {}}), 400),
+        ("packages-not-array", lambda p: p.update({"packages": "no"}), 400),
+        ("finding-not-object", lambda p: p.update({"findings": ["x"]}), 400),
+        ("finding-missing-name",
+         lambda p: p.update({"findings": [{"vulnerability_id": "CVE-1"}]}), 400),
+        ("assessment-unmatched",
+         lambda p: p.update({"assessments": [
+             {"vulnerability_id": "CVE-9999-1", "status": "fixed"}]}), 400),
+        ("assessment-missing-status",
+         lambda p: p.update({"assessments": [{"vulnerability_id": "CVE-1"}]}), 400),
+    ], ids=lambda v: v if isinstance(v, str) else "")
+    def test_rejection(self, app, client, ids, scenario, mutate, status):
+        from src.models.scan import Scan
+
+        payload = _export(client, f"/api/scans/{ids['sbom_second']}/export-diff")
+        project_name, variant_name = _fresh_destination(app, "reject")
+        _retarget(payload, project_name, variant_name)
+        mutate(payload)
+
+        with app.app_context():
+            before = len(Scan.get_all())
+
+        response = _import(client, payload)
+
+        assert response.status_code == status, (scenario, response.get_json())
+        assert response.get_json()["error"]
+        with app.app_context():
+            assert len(Scan.get_all()) == before, f"{scenario} wrote to the database"
+
+    def test_bad_entry_in_batch_rolls_the_whole_batch_back(self, app, client, ids):
+        from src.models.scan import Scan
+
+        payload = _export(client, f"/api/scans/export?type=diff&variant_id={ids['v_sbom']}")
+        project_name, variant_name = _fresh_destination(app, "batchfail")
+        _retarget(payload, project_name, variant_name)
+        payload[-1]["timestamp"] = "not-a-timestamp"
+
+        with app.app_context():
+            before = len(Scan.get_all())
+
+        response = _import(client, payload)
+
+        assert response.status_code == 400
+        assert f"Export #{len(payload)} of {len(payload)}" in response.get_json()["error"]
+        with app.app_context():
+            assert len(Scan.get_all()) == before
+
+
+# ---------------------------------------------------------------------------
+# Matrix — format compatibility
+# ---------------------------------------------------------------------------
+
+class TestFormatCompatibility:
+    def test_legacy_full_result_without_version_markers(self, app, client, ids):
+        payload = _export(client, f"/api/scans/{ids['sbom_second']}/export-result")
+        payload.pop("export_version")
+        payload.pop("export_format")
+        project_name, variant_name = _fresh_destination(app, "legacy")
+        _retarget(payload, project_name, variant_name)
+
+        response = _import(client, payload)
+
+        assert response.status_code == 201
+        assert response.get_json()["format"] == "full"
+
+    def test_single_object_and_single_element_array_agree(self, app, client, ids):
+        payload = _export(client, f"/api/scans/{ids['sbom_first']}/export-diff")
+        as_object_dest = _fresh_destination(app, "obj")
+        as_array_dest = _fresh_destination(app, "arr")
+
+        object_response = _import(
+            client, _retarget(dict(payload), *as_object_dest)
+        )
+        array_response = _import(
+            client, [_retarget(dict(payload), *as_array_dest)]
+        )
+
+        assert object_response.status_code == array_response.status_code == 201
+        for key in ("format", "imported_count", "package_count", "finding_count"):
+            assert object_response.get_json()[key] == array_response.get_json()[key]
+
+    def test_scan_type_and_source_survive_the_round_trip(self, app, client, ids):
+        """A tool scan stays a tool scan of the same source after import."""
+        from src.models.scan import Scan
+
+        payload = _export(client, f"/api/scans/{ids['tool_nvd']}/export-diff")
+        project_name, variant_name = _fresh_destination(app, "kind")
+        _retarget(payload, project_name, variant_name)
+
+        response = _import(client, payload)
+
+        assert response.status_code == 201
+        with app.app_context():
+            scan = _db.session.get(Scan, uuid.UUID(response.get_json()["scan_id"]))
+            assert scan.scan_type == "tool"
+            assert scan.scan_source == "nvd"
+            assert scan.timestamp.isoformat().startswith(payload["timestamp"][:19])
+
+    def test_sbom_import_registers_its_packages_as_a_document(self, app, client, ids):
+        """SBOM scans expose packages through a document; tool scans do not."""
+        from src.models.scan import Scan
+
+        sbom = _export(client, f"/api/scans/{ids['sbom_second']}/export-diff")
+        tool = _export(client, f"/api/scans/{ids['tool_grype']}/export-diff")
+        sbom_dest = _fresh_destination(app, "doc-sbom")
+        tool_dest = _fresh_destination(app, "doc-tool")
+
+        sbom_response = _import(client, _retarget(sbom, *sbom_dest))
+        tool_response = _import(client, _retarget(tool, *tool_dest))
+
+        assert sbom_response.status_code == tool_response.status_code == 201
+        assert _scan_packages(app, sbom_response.get_json()["scan_id"]) == {
+            ("cairo", "1.16.0"), ("libpng", "1.6.37"), ("zlib", "1.2.13"),
+        }
+        with app.app_context():
+            scan = _db.session.get(Scan, uuid.UUID(tool_response.get_json()["scan_id"]))
+            assert scan.sbom_documents == []
+
+
+# ---------------------------------------------------------------------------
+# Matrix — full instance migration, the flow the feature exists for
+# ---------------------------------------------------------------------------
+
+class TestWholeInstanceMigration:
+    @pytest.mark.parametrize("export_type", ["diff", "total"])
+    def test_export_everything_then_import_into_a_new_instance(
+        self, app, client, ids, export_type
+    ):
+        """Export every scan, import each variant's slice into a fresh copy."""
+        from src.models.project import Project
+        from src.models.variant import Variant
+        from src.models.scan import Scan
+
+        payload = _export(client, f"/api/scans/export?type={export_type}")
+        source_variants = {
+            (entry["project_name"], entry["variant_name"]) for entry in payload
+        }
+        assert len(source_variants) == 4  # v-sbom, v-tool, v-empty, v-uni
+
+        # Recreate the source layout under a new project name.
+        destination = f"MatrixMigrated-{export_type}-{uuid.uuid4().hex[:6]}"
+        with app.app_context():
+            project = Project.create(destination)
+            for _project_name, variant_name in sorted(source_variants):
+                Variant.create(variant_name, project.id)
+        for entry in payload:
+            entry["project_name"] = destination
+
+        response = _import(client, payload)
+
+        assert response.status_code == 201, response.get_json()
+        assert response.get_json()["imported_count"] == len(payload)
+
+        with app.app_context():
+            project = Project.get_by_name(destination)
+            migrated = [
+                scan
+                for variant in Variant.get_by_project(project.id)
+                for scan in Scan.get_by_variant_id(variant.id)
+            ]
+            assert len(migrated) == len(payload)
+            # Every scan kept its type and source.
+            assert (
+                sorted((s.scan_type, s.scan_source) for s in migrated)
+                == sorted(
+                    (
+                        "tool" if e["scan_type"] == "vulnerability_scan" else "sbom",
+                        e.get("scan_source"),
+                    )
+                    for e in payload
+                )
+            )


### PR DESCRIPTION
## Fixes # by importing exported scan context

### Changes proposed in this pull request:

* Add an Import control to the Scan history toolbar using the established transfer interaction.
* Accept exported diffs and full scans, deriving the relevant diff before persistence.
* Persist imported scan context atomically with destination-aware derivation, progress states, errors, tests, and documentation.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Run `python -m pytest tests/webapp_tests/test_scan_export.py -q`.
* Run `npm --prefix frontend test -- --runInBand tests/handlers/scans.test.ts`.
* Run `npm --prefix frontend run build`.
* In Scan history, select Import and upload first an exported diff and then a full scan; confirm each adds the derived context to the selected destination and reports invalid input without partial persistence.

### Additional notes

Full-scan imports calculate the diff against the destination context, and persistence rolls back atomically on failure.

### Related Issue

No linked issue.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [X] The code compiles and passes all tests
- [X] All new and existing tests are passing
- [X] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers
