### PR TITLE
fix: project description got  cleared when changing variant

### DIFF
--- a/frontend/src/pages/AIContext.tsx
+++ b/frontend/src/pages/AIContext.tsx
@@ -161,41 +161,50 @@ function AIContext() {
      
     }, [selectedProjectId]);
 
-    // Load context when selections change
-    const loadContext = useCallback(() => {
+    // The project description is project-bound, so it is loaded only when the project
+    // changes. Reloading it on every variant change would discard unsaved edits.
+    const loadProjectContext = useCallback(() => {
         if (!selectedProjectId) return;
-        if (selectedVariantId) {
-            Context.get(selectedProjectId, selectedVariantId)
-                .then(ctx => {
-                    if (unmountedRef.current) return;
-                    setDescription(ctx.description ?? '');
-                    setVariantDescription(ctx.variant_description ?? '');
-                    setCodebasePath(ctx.codebase_path ?? '');
-                    setEnvironment(ctx.environment ?? '');
-                    setThreatModel(ctx.threat_model ?? '');
-                    setRisks(ctx.risks ?? '');
-                    setOtherInfo(ctx.other_info ?? '');
-                }).catch((e: any) => {
-                    if (!unmountedRef.current)
-                        showBanner(e?.message || "Failed to load context.", "error");
-                });
-        } else {
+        Context.getProject(selectedProjectId)
+            .then(ctx => {
+                if (unmountedRef.current) return;
+                setDescription(ctx.description ?? '');
+            }).catch((e: any) => {
+                if (!unmountedRef.current)
+                    showBanner(e?.message || "Failed to load project context.", "error");
+            });
+    }, [selectedProjectId]);
+
+    useEffect(() => {
+        loadProjectContext();
+    }, [loadProjectContext]);
+
+    // Variant-bound fields only. The merged endpoint also returns the project
+    // description; it is deliberately ignored here.
+    const loadVariantContext = useCallback(() => {
+        if (!selectedProjectId || !selectedVariantId) {
             // Variant cleared or not yet selected — clear variant-bound fields
             clearVariantFields();
-            Context.getProject(selectedProjectId)
-                .then(ctx => {
-                    if (unmountedRef.current) return;
-                    setDescription(ctx.description ?? '');
-                }).catch((e: any) => {
-                    if (!unmountedRef.current)
-                        showBanner(e?.message || "Failed to load project context.", "error");
-                });
+            return;
         }
+        Context.get(selectedProjectId, selectedVariantId)
+            .then(ctx => {
+                if (unmountedRef.current) return;
+                setVariantDescription(ctx.variant_description ?? '');
+                setCodebasePath(ctx.codebase_path ?? '');
+                setEnvironment(ctx.environment ?? '');
+                setThreatModel(ctx.threat_model ?? '');
+                setRisks(ctx.risks ?? '');
+                setOtherInfo(ctx.other_info ?? '');
+            }).catch((e: any) => {
+                if (!unmountedRef.current)
+                    showBanner(e?.message || "Failed to load context.", "error");
+            });
     }, [selectedProjectId, selectedVariantId]);
 
     useEffect(() => {
-        loadContext();
-    }, [loadContext]);
+        loadVariantContext();
+    }, [loadVariantContext]);
 
     const validate = (): boolean => {
         const errors: Record<string, string> = {};
@@ -309,7 +318,9 @@ function AIContext() {
                 `Import complete: ${result.imported.length} of ${total} imported, ` +
                 `${result.ignored.length} ignored, ${result.failed.length} failed.`;
             showBanner(msg, result.failed.length > 0 ? "error" : "success");
-            loadContext();
+            // Import overwrites stored context, so both scopes are reloaded.
+            loadProjectContext();
+            loadVariantContext();
         } catch (err: any) {
             if (!unmountedRef.current) showBanner(err?.message || "Import failed.", "error");
         } finally {

--- a/frontend/tests/unit_tests/test_ai_context_page.tsx
+++ b/frontend/tests/unit_tests/test_ai_context_page.tsx
@@ -259,6 +259,50 @@ describe('AIContext page', () => {
         });
     });
 
+    test('keeps unsaved project description when variant changes', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
+        fetchMock.mockResponseOnce(JSON.stringify([
+            { id: 'v1', name: 'Variant 1', project_id: 'p1' },
+            { id: 'v2', name: 'Variant 2', project_id: 'p1' },
+        ]));
+        // getProject: nothing stored yet for the project description
+        fetchMock.mockResponseOnce(JSON.stringify({ project_id: 'p1', description: null }));
+        fetchMock.mockResponseOnce(JSON.stringify({
+            project_id: 'p1', description: null, variant_id: 'v1',
+            variant_description: null, environment: null, threat_model: 'TM1',
+            risks: null, other_info: null, files: [],
+        }));
+        fetchMock.mockResponseOnce(JSON.stringify({
+            project_id: 'p1', description: null, variant_id: 'v2',
+            variant_description: null, environment: null, threat_model: 'TM2',
+            risks: null, other_info: null, files: [],
+        }));
+
+        render(<AIContext />);
+        await screen.findByRole('option', { name: 'Project A' });
+        fireEvent.change(screen.getByLabelText("Project"), { target: { value: 'p1' } });
+        await screen.findByRole('option', { name: 'Variant 1' });
+        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v1' } });
+        await waitFor(() => {
+            const tm = screen.getByLabelText(/threat model/i) as HTMLTextAreaElement;
+            expect(tm.value).toBe('TM1');
+        });
+
+        // Type a project description without saving, then switch variant
+        fireEvent.change(screen.getByLabelText("Project Description"), {
+            target: { value: 'Unsaved description' },
+        });
+        fireEvent.change(screen.getByLabelText("Variant"), { target: { value: 'v2' } });
+
+        await waitFor(() => {
+            const tm = screen.getByLabelText(/threat model/i) as HTMLTextAreaElement;
+            expect(tm.value).toBe('TM2');
+        });
+        expect(
+            (screen.getByLabelText("Project Description") as HTMLTextAreaElement).value
+        ).toBe('Unsaved description');
+    });
+
     function setupWithVariant() {
         fetchMock.mockResponseOnce(JSON.stringify([{ id: 'p1', name: 'Project A' }]));
         fetchMock.mockResponseOnce(JSON.stringify([{ id: 'v1', name: 'Variant 1', project_id: 'p1' }]));


### PR DESCRIPTION
### Changes proposed in this pull request:

Changing the variant reloads all the context, including the project description. Now this PR splits the load, preventing the project context from being overwritten by the variant context reload.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

1. Enter anything in the project description on the AI context page.
2. Change the variant.
3. The text in the project description persists. (Before it gets cleared)

### Additional notes

*If applicable, explain the rationale behind your change.*

### Related Issue

*If this PR relates to an issue, please link it here.*

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [ ] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Code follows project style guidelines
- [ ] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers


