### PR TITLE
fix(podman): use IPv4 for scan readiness checks

### DIFF
--- a/tests/docker/test_1_normal_operation.sh
+++ b/tests/docker/test_1_normal_operation.sh
@@ -128,7 +128,9 @@ function wait_scan_finished() {
 
     if [[ $elapsed_time -ge $timeout_seconds ]]; then
         echo "Timeout reached"
+        return
     fi
+
     echo "OK"
 }
 

--- a/tests/podman/testPodman.sh
+++ b/tests/podman/testPodman.sh
@@ -44,7 +44,7 @@ function main() {
         --serve &
 
     chmod +x ./test_1_normal_operation.sh
-    ./test_1_normal_operation.sh "localhost:$flask_port"
+    ./test_1_normal_operation.sh "127.0.0.1:$flask_port"
 
     echo "[OK, FINAL] All tests passed"
 }


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

Probe the published Podman port through 127.0.0.1 rather than localhost. This avoids CI failures when localhost resolves to an IPv6 loopback address that the Podman port forward does not expose.

Also make the shared scan waiter return immediately after reporting a timeout. Previously it emitted both 'Timeout reached' and 'OK', producing an ambiguous command-substitution result and obscuring the actual readiness failure.

### Status

- [ ] READY
- [ ] HOLD
- [X] WIP (Work-In-Progress)

