### PR TITLE
Add amend option for review exports

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -324,7 +324,12 @@ The `--export-custom-vulnscout-data` flag exports custom assessments, CVSS score
 
 # Export one variant
 ./vulnscout --project demo --variant x86 --export-custom-vulnscout-data
+
+# Update the existing export with current review data
+./vulnscout --project demo --export-custom-vulnscout-data --amend
 ----
+
+Add `--amend` to reconcile current review data with the existing file in the output directory. The file must already exist at the path produced by the same export scope. Existing records retain stable ordering and extension fields while updated and new records are incorporated.
 
 The `--import-custom-vulnscout-data` command restores entries according to the variant metadata in the file. Imported assessments use the current system time by default. Add `--use-original-timestamps` to preserve assessment timestamps from the file.
 `--use-current-timestamps` is also accepted to select the default explicitly.
@@ -345,12 +350,17 @@ The OpenVEX custom-assessment commands operate on one JSON document and require 
 # Export a variant
 ./vulnscout --project demo --variant x86 --export-custom-openvex-assessments
 
+# Update the existing OpenVEX export
+./vulnscout --project demo --variant x86 --export-custom-openvex-assessments --amend
+
 # Import into a variant
 ./vulnscout --project demo --variant x86 --import-custom-openvex-assessments /path/to/custom_openvex_x86.json
 
 # Ignore OpenVEX statement timestamps and use the current system time
 ./vulnscout --project demo --variant x86 --import-custom-openvex-assessments /path/to/custom_openvex_x86.json --use-current-timestamps
 ----
+
+For OpenVEX exports, `--amend` preserves the document ID and statement ordering from the existing output file and increments its version.
 
 OpenVEX imports preserve statement timestamps by default. Add `--use-current-timestamps` to use the current system time, or use `--use-original-timestamps` to select the default explicitly.
 

--- a/frontend/src/pages/Review.tsx
+++ b/frontend/src/pages/Review.tsx
@@ -459,10 +459,10 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
         setShowOnlyOutdated(false);
     };
 
-    const transferVariants = useMemo(() => {
-        const scopedProjectId = projectId ?? allVariants.find(v => v.id === variantId)?.project_id;
-        return scopedProjectId ? allVariants.filter(v => v.project_id === scopedProjectId) : allVariants;
-    }, [allVariants, projectId, variantId]);
+    const transferProjectId = projectId ?? allVariants.find(v => v.id === variantId)?.project_id;
+    const transferVariants = useMemo(() => (
+        transferProjectId ? allVariants.filter(v => v.project_id === transferProjectId) : allVariants
+    ), [allVariants, transferProjectId]);
 
     const openTransfer = useCallback((mode: 'import' | 'export') => {
         setTransferFormat('custom');
@@ -539,6 +539,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             if (exportMode === 'update' && existingExportFile) {
                 const formData = new FormData();
                 formData.append('file', existingExportFile);
+                if (transferProjectId) formData.append('project_id', transferProjectId);
                 transferVariantIds.forEach(variantId => formData.append('variant_id', variantId));
                 res = await fetch(new URL(
                     import.meta.env.VITE_API_URL + '/api/assessments/review/export-update',
@@ -566,7 +567,7 @@ function Review({ variantId, projectId, onAssessmentChanged }: Readonly<Props>) 
             console.error('Export error:', err);
             showMessage('Failed to export review data.', 'error');
         }
-    }, [existingExportFile, exportMode, showMessage, variantNames, transferVariantIds, transferFormat]);
+    }, [existingExportFile, exportMode, showMessage, transferProjectId, variantNames, transferVariantIds, transferFormat]);
 
     const handleImportReview = useCallback(() => {
         setTransferMode(null);

--- a/frontend/tests/unit_tests/test_review.tsx
+++ b/frontend/tests/unit_tests/test_review.tsx
@@ -1560,6 +1560,7 @@ describe('Review — import and export', () => {
         const updateCall = fetchMock.mock.calls.find(call => String(call[0]).includes('/api/assessments/review/export-update'));
         const body = (updateCall?.[1] as RequestInit).body as FormData;
         expect(updateCall?.[1]).toMatchObject({ method: 'POST' });
+        expect(body.get('project_id')).toBe('proj1');
         expect(body.getAll('variant_id')).toEqual(['v1']);
         expect((body.get('file') as File).name).toBe('tracked-review.json');
     });

--- a/src/bin/cmd_assessments.py
+++ b/src/bin/cmd_assessments.py
@@ -14,6 +14,7 @@ from ..helpers.assessment_io import (
     import_statements,
     build_custom_data_export,
     import_custom_data,
+    reconcile_review_export,
 )
 from ..models.assessment import Assessment as DBAssessment
 from ..models.variant import Variant as DBVariant
@@ -61,8 +62,10 @@ def _print_custom_data_import_result(result: dict) -> None:
 @click.option("--project", "-p", required=True, help="Project name.")
 @click.option("--variant", "-v", default=None,
               help="Variant name. If empty, all project variants are exported.")
+@click.option("--amend", is_flag=True,
+              help="Update the existing output file while preserving stable review ordering.")
 @with_appcontext
-def export_custom_vulnscout_data_command(output_dir: str, project: str, variant: str | None) -> None:
+def export_custom_vulnscout_data_command(output_dir: str, project: str, variant: str | None, amend: bool) -> None:
     """Export custom VulnScout JSON data for one or all project variants."""
     project_obj = resolve_project(project)
     if variant:
@@ -83,6 +86,8 @@ def export_custom_vulnscout_data_command(output_dir: str, project: str, variant:
         raise click.ClickException("No custom VulnScout data to export.")
     os.makedirs(output_dir, exist_ok=True)
     output_path = os.path.join(output_dir, f"custom_vulnscout_data_{filename_label}{_JSON_SUFFIX}")
+    if amend:
+        data = reconcile_review_export(_load_json_file(output_path), data)
     with open(output_path, "w") as file:
         _json.dump(data, file, indent=2)
     click.echo(f"Custom VulnScout data exported: {output_path}")
@@ -121,8 +126,10 @@ def import_custom_vulnscout_data_command(
               help="Directory where the exported file is written.")
 @click.option("--project", "-p", default="default", show_default=True, help="Project name.")
 @click.option("--variant", "-v", default="default", show_default=True, help="Variant name to export.")
+@click.option("--amend", is_flag=True,
+              help="Update the existing output file while preserving stable review ordering.")
 @with_appcontext
-def export_custom_openvex_assessments_command(output_dir: str, project: str, variant: str) -> None:
+def export_custom_openvex_assessments_command(output_dir: str, project: str, variant: str, amend: bool) -> None:
     """Export custom assessments for one variant as an OpenVEX JSON file."""
     _, variant_obj = resolve_project_variant(project, variant, create=False)
     handmade = DBAssessment.get_by_origin([variant_obj.id])
@@ -136,6 +143,8 @@ def export_custom_openvex_assessments_command(output_dir: str, project: str, var
         output_dir,
         f"custom_openvex_{sanitize_variant_name(variant_obj.name)}{_JSON_SUFFIX}",
     )
+    if amend:
+        document = reconcile_review_export(_load_json_file(output_path), document)
     with open(output_path, "w") as file:
         _json.dump(document, file, indent=2)
     click.echo(f"Custom OpenVEX assessments exported: {output_path}")

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -178,6 +178,10 @@ Timestamp options for custom data imports:
         --use-current-timestamps        Set imported assessment timestamps to the current time
         Default: current time for VulnScout JSON; original timestamps for OpenVEX.
 
+Custom review export options:
+        Applies to --export-custom-vulnscout-data and --export-custom-openvex-assessments.
+        --amend                         Update the existing output file while preserving stable review ordering
+
 Examples:
   /scan/src/entrypoint.sh --project test --variant x86 --add-cve-check ./cve.json --add-spdx ./sbom.json
   /scan/src/entrypoint.sh --project test --match-condition "cvss >= 9.0"
@@ -582,6 +586,7 @@ cmd_export_custom_vulnscout_data() {
     cd "$BASE_DIR"
     local output_dir="${OUTPUTS_DIR:-/scan/outputs}"
     export_args+=(--output-dir "$output_dir")
+    [[ "${AMEND_REVIEW_EXPORT:-false}" == "true" ]] && export_args+=(--amend)
 
     flask --app src.bin.webapp db upgrade
     flask --app src.bin.webapp export-custom-vulnscout-data "${export_args[@]}"
@@ -618,9 +623,12 @@ cmd_export_custom_openvex_assessments() {
 
     cd "$BASE_DIR"
     local output_dir="${OUTPUTS_DIR:-/scan/outputs}"
+    local -a amend_args=()
+    [[ "${AMEND_REVIEW_EXPORT:-false}" == "true" ]] && amend_args+=(--amend)
     flask --app src.bin.webapp db upgrade
     flask --app src.bin.webapp export-custom-openvex-assessments \
-        --project "$PROJECT_NAME" --variant "$variant_name" --output-dir "$output_dir"
+        --project "$PROJECT_NAME" --variant "$variant_name" --output-dir "$output_dir" \
+        "${amend_args[@]}"
     setup_user
 }
 
@@ -892,6 +900,8 @@ while [[ $# -gt 0 ]]; do
             IMPORT_CUSTOM_VULNSCOUT_DATA_FILE="$2"; shift 2 ;;
         --export-custom-openvex-assessments)
             EXPORT_CUSTOM_OPENVEX_ASSESSMENTS=true; shift ;;
+        --amend)
+            AMEND_REVIEW_EXPORT=true; shift ;;
         --import-custom-openvex-assessments)
             IMPORT_CUSTOM_OPENVEX_ASSESSMENTS_FILE="$2"; shift 2 ;;
         --export-context)

--- a/src/helpers/assessment_io.py
+++ b/src/helpers/assessment_io.py
@@ -370,8 +370,12 @@ def reconcile_review_export(existing: object, current: dict[str, Any]) -> dict[s
     result = dict(existing)
     if export_format == "openvex":
         for key, value in current.items():
-            if key != "@id":
+            if key not in {"@id", "version"}:
                 result[key] = value
+            if type(existing["version"]) is int:
+                result["version"] = existing["version"] + 1
+            else:
+                raise ValueError("Version must be an integer")
         result["statements"] = _reconcile_records(
             existing["statements"],
             current["statements"],

--- a/src/routes/assessments.py
+++ b/src/routes/assessments.py
@@ -819,7 +819,7 @@ def init_app(app: Flask) -> None:
         are appended.
 
         OpenAPI:
-        body multipart required Existing JSON export and repeated variant_id fields.
+        body multipart required Existing JSON export, project_id and repeated variant_id fields.
         response 200 binary Updated JSON download.
         response 400 Error Unsupported input or invalid variant selection.
         response 404 Error No review data available.
@@ -844,6 +844,14 @@ def init_app(app: Flask) -> None:
         raw_variant_ids = request.form.getlist('variant_id')
         if not raw_variant_ids:
             return {"error": "At least one variant_id is required"}, 400
+        raw_project_id = request.form.get('project_id')
+        if not raw_project_id:
+            return {"error": "project_id is required"}, 400
+        project_id, err = parse_uuid_or_400(raw_project_id, "project_id")
+        if err:
+            return err
+        if project_id is None:
+            return {"error": "Internal error"}, 500
         variant_ids: list[UUID] = []
         for raw_variant_id in raw_variant_ids:
             variant_id, err = parse_uuid_or_400(raw_variant_id, "variant_id")
@@ -854,6 +862,8 @@ def init_app(app: Flask) -> None:
             variant = DBVariant.get_by_id(variant_id)
             if variant is None:
                 return {"error": f"Variant not found: {raw_variant_id}"}, 404
+            if variant.project_id != project_id:
+                return {"error": f"Variant does not belong to project: {raw_variant_id}"}, 400
             variant_ids.append(variant_id)
 
         if export_format == 'openvex':

--- a/tests/unit_tests/test_assessment_io_coverage.py
+++ b/tests/unit_tests/test_assessment_io_coverage.py
@@ -242,8 +242,22 @@ class TestReconcileReviewExport:
 
         assert result["@id"] == "stable-id"
         assert result["author"] == "new"
+        assert result["version"] == 2
         assert [item["vulnerability"]["name"] for item in result["statements"]] == ["CVE-2", "CVE-1"]
         assert result["statements"][1]["status"] == "fixed"
+
+    def test_openvex_requires_an_integer_version(self):
+        document = {
+            "@context": "https://openvex.dev/ns/v0.2.0",
+            "@id": "stable-id",
+            "author": "author",
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "version": True,
+            "statements": [],
+        }
+
+        with pytest.raises(ValueError):
+            reconcile_review_export(document, {**document, "version": 1})
 
     def test_duplicate_records_match_exact_values_before_timestamp_updates(self):
         first = {

--- a/tests/webapp_tests/test_review_endpoints.py
+++ b/tests/webapp_tests/test_review_endpoints.py
@@ -1126,6 +1126,7 @@ def test_update_custom_export_preserves_matching_content_and_removes_unselected(
         "/api/assessments/review/export-update",
         data={
             "file": (io.BytesIO(json.dumps(existing).encode()), "custom_data.json"),
+            "project_id": str(PROJECT_UUID),
             "variant_id": str(VARIANT_UUID),
         },
         content_type="multipart/form-data",
@@ -1145,11 +1146,13 @@ def test_update_openvex_auto_detects_format_and_preserves_document_id(client):
     existing = json.loads(exported.data)
     existing["@id"] = "https://example.com/stable-review-id"
     existing["author"] = "Existing review author"
+    existing["version"] = 3
 
     response = client.post(
         "/api/assessments/review/export-update",
         data={
             "file": (io.BytesIO(json.dumps(existing).encode()), "review.json"),
+            "project_id": str(PROJECT_UUID),
             "variant_id": str(VARIANT_UUID),
         },
         content_type="multipart/form-data",
@@ -1159,6 +1162,7 @@ def test_update_openvex_auto_detects_format_and_preserves_document_id(client):
     updated = json.loads(response.data)
     assert updated["@id"] == "https://example.com/stable-review-id"
     assert updated["author"] == "Existing review author"
+    assert updated["version"] == 4
     assert "openvex" in updated["@context"]
 
 
@@ -1178,6 +1182,7 @@ def test_update_export_can_remove_all_selected_data(client):
         "/api/assessments/review/export-update",
         data={
             "file": (io.BytesIO(json.dumps(existing).encode()), "custom_data.json"),
+            "project_id": str(PROJECT_UUID),
             "variant_id": str(VARIANT_UUID),
         },
         content_type="multipart/form-data",
@@ -1197,6 +1202,7 @@ def test_update_export_rejects_malformed_or_unsupported_input(client, body, expe
         "/api/assessments/review/export-update",
         data={
             "file": (io.BytesIO(body), "review.json"),
+            "project_id": str(PROJECT_UUID),
             "variant_id": str(VARIANT_UUID),
         },
         content_type="multipart/form-data",
@@ -1204,6 +1210,36 @@ def test_update_export_rejects_malformed_or_unsupported_input(client, body, expe
 
     assert response.status_code == 400
     assert expected_error in json.loads(response.data)["error"]
+
+
+def test_update_export_rejects_variant_from_another_project(client, app):
+    from src.models.project import Project
+    from src.models.variant import Variant
+
+    with app.app_context():
+        foreign_project = Project.create("foreign-review-project")
+        foreign_variant = Variant.create("foreign-review-variant", foreign_project.id)
+        foreign_variant_id = str(foreign_variant.id)
+
+    existing = {
+        "version": 1,
+        "assessments": [],
+        "ai_assessments": [],
+        "cvss": [],
+        "time_estimates": [],
+    }
+    response = client.post(
+        "/api/assessments/review/export-update",
+        data={
+            "file": (io.BytesIO(json.dumps(existing).encode()), "custom_data.json"),
+            "project_id": str(PROJECT_UUID),
+            "variant_id": [str(VARIANT_UUID), foreign_variant_id],
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    assert "does not belong to project" in json.loads(response.data)["error"]
 
 
 # ── POST /api/assessments/review/import-custom-data ──────────────────────

--- a/vulnscout
+++ b/vulnscout
@@ -127,6 +127,10 @@ Timestamp options for custom data imports:
     --use-current-timestamps        Set imported assessment timestamps to the current time
     Default: current time for VulnScout JSON; original timestamps for OpenVEX.
 
+Custom review export options:
+    Applies to --export-custom-vulnscout-data and --export-custom-openvex-assessments.
+    --amend                         Update the existing output file while preserving stable review ordering
+
 Environment variables:
     VULNSCOUT_CONTAINER     Container name (default: vulnscout)
     VULNSCOUT_IMAGE         Docker image (default: docker.io/sflinux/vulnscout:v0.20)
@@ -386,6 +390,8 @@ parse_and_run() {
                 ensure_running; EXPORT_ARGS+=(--export-custom-vulnscout-data); shift ;;
             export-custom-openvex-assessments|--export-custom-openvex-assessments)
                 ensure_running; EXPORT_ARGS+=(--export-custom-openvex-assessments); shift ;;
+            amend|--amend)
+                EXPORT_ARGS+=(--amend); shift ;;
             import-custom-vulnscout-data|--import-custom-vulnscout-data)
                 ensure_running
                 local import_file


### PR DESCRIPTION
## Description

Add `--amend` to custom VulnScout JSON and OpenVEX review exports. It reconciles the generated export with the existing file in `.vulnscout/outputs` to preserve stable ordering and reduce Git diff churn.

## Checklist

- [x] READY
- [x] Tests added or updated
- [ ] Documentation updated

## Related issue

No linked issue.
