### PR TITLE
vulnscout: update the helper for consistency

### DIFF
--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -90,7 +90,7 @@ The same global cleanup is available to automation and CI:
 ```bash
 ./vulnscout --delete-outdated
 ./vulnscout --delete-empty-scans
-./vulnscout --delete-orphaned-vulnerabilities
+./vulnscout --delete-orphaned-vulns
 ```
 
 The cleanup removes outdated package observations, SBOM links, and custom assessments.

--- a/src/bin/cmd_assessments.py
+++ b/src/bin/cmd_assessments.py
@@ -119,8 +119,8 @@ def import_custom_vulnscout_data_command(
 @click.command("export-custom-openvex-assessments")
 @click.option("--output-dir", default="/scan/outputs", show_default=True,
               help="Directory where the exported file is written.")
-@click.option("--project", "-p", required=True, help="Project name.")
-@click.option("--variant", "-v", required=True, help="Variant name to export.")
+@click.option("--project", "-p", default="default", show_default=True, help="Project name.")
+@click.option("--variant", "-v", default="default", show_default=True, help="Variant name to export.")
 @with_appcontext
 def export_custom_openvex_assessments_command(output_dir: str, project: str, variant: str) -> None:
     """Export custom assessments for one variant as an OpenVEX JSON file."""
@@ -143,8 +143,8 @@ def export_custom_openvex_assessments_command(output_dir: str, project: str, var
 
 @click.command("import-custom-openvex-assessments")
 @click.argument("file_path")
-@click.option("--project", "-p", required=True, help="Project name.")
-@click.option("--variant", "-v", required=True, help="Variant name to import into.")
+@click.option("--project", "-p", default="default", show_default=True, help="Project name.")
+@click.option("--variant", "-v", default="default", show_default=True, help="Variant name to import into.")
 @click.option(
     "--use-original-timestamps/--use-current-timestamps",
     default=True,

--- a/src/bin/cmd_scans.py
+++ b/src/bin/cmd_scans.py
@@ -100,7 +100,7 @@ def delete_empty_scans_command():
     click.echo(f"Deleted {summary['scans_deleted']} empty scans")
 
 
-@click.command("delete-orphaned-vulnerabilities")
+@click.command("delete-orphaned-vulns")
 @with_appcontext
 def delete_orphaned_vulnerabilities_command():
     """Permanently remove CVEs absent from every project and variant."""

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -95,60 +95,88 @@ export SBOM_CVE_CHECK_AUTO_UPDATE="${SBOM_CVE_CHECK_AUTO_UPDATE:-1}"
 
 show_help() {
     cat <<EOF
-VulnScout Entrypoint
-Usage: docker exec <container> /scan/src/entrypoint.sh [COMMAND] [OPTIONS]
+VulnScout - Vulnerability Scanner
+Usage: /scan/src/entrypoint.sh [--project <name>] [--variant <name>] <command> [options]
 
-Setting:
-  --project <name>          Project name for the next input command (default: 'default')
-    --variant <name>          Variant name for the next input command or standalone refresh (requires --project)
+Project and variant options:
+        --project <name>                Select a project
+        --variant <name>                Select a variant within --project
 
-Input commands:
-  --add-spdx <path>         Add an SPDX 2/3 SBOM file or archive
-  --add-cve-check <path>    Add a Yocto CVE check JSON file
-  --add-yocto-vex <path>    Add a Yocto VEX JSON file
-  --add-openvex <path>      Add an OpenVEX JSON file
-  --add-cdx <path>          Add a CycloneDX file
-  --add-grype <path>        Add a Grype results file
-  --perform-grype-scan      Perform a Grype scan on the added inputs
-  --perform-nvd-scan        Run an NVD CPE-based vulnerability scan
-  --perform-osv-scan        Run an OSV PURL-based vulnerability scan
-  --perform-sbom-cve-check-scan  Run a sbom-cve-check vulnerability scan
-    --refresh-vulnerability-data  Refresh EPSS, NVD, EUVD, and GHSA data; with no inputs, refreshes all vulnerabilities
-  --add-asset <path>        Stage an image asset for use in report templates
+Commands without --project or --variant:
 
-Scan & output commands:
-  --serve                   Run scan then start interactive web UI (port 7275)
-  --report <template>       Generate a report from a template in /cache/vulnscout/templates/
-  --report <path>           Stage a local report template file and generate a report from it
-  --export-spdx             Export project as SPDX 3.0 SBOM to /scan/outputs/
-  --export-cdx              Export project as CycloneDX 1.6 SBOM to /scan/outputs/
-  --export-openvex          Export project as OpenVEX document to /scan/outputs/
-    --export-custom-vulnscout-data  Export custom VulnScout JSON data to /scan/outputs/
-        --import-custom-vulnscout-data <path>  Import custom VulnScout JSON data
-            --use-original-timestamps    Preserve file timestamps instead of using system time
-            --use-current-timestamps     Use current system time instead of file timestamps
-    --export-custom-openvex-assessments  Export custom OpenVEX assessments for --variant
-    --import-custom-openvex-assessments <path>  Import custom OpenVEX assessments into --variant
-    --export-context          Export AI assessment context (project/variant description, threat model, etc.) to /scan/outputs/context-export.json
-    --import-context <path>   Import AI assessment context from a JSON file (overwrites matching project/variant)
-  --match-condition <expr>  Exit code 2 if condition met (e.g. "cvss >= 9.0")
-  --delete-scan <id>        Delete a past scan by its ID
-    --delete-outdated         Permanently delete outdated packages and assessments
-    --delete-empty-scans      Permanently delete scans with no recorded changes
-    --delete-orphaned-vulnerabilities  Delete CVEs absent from every project and variant
+        Container lifecycle:
+        daemon                          Keep the container running
+        --version                       Show current version
+        --help, -h                      Show this help message
 
-Data retrieval commands:
-  --list-projects           List all projects and their variants
-  --list-scans              List all past scans
-  --json                    Output objects in JSON format
+        Development and web interface:
+        --serve                         Run scan then start web UI (port 7275)
 
-Configuration commands:
-  --config <key> <value>    Set a persistent config value
-  --config-list             Show current configuration
-  --config-clear <key>      Remove a config key
+        Reports and assets:
+        --report <template|path>        Generate a report from a template
+        --add-asset <path>              Stage an image asset for report templates
 
-Container lifecycle:
-  --help, -h                Show this help message
+        Data maintenance:
+        --delete-scan <id>              Delete a past scan by ID
+        --delete-outdated               Delete outdated packages and assessments
+        --delete-empty-scans            Delete scans with no recorded changes
+        --delete-orphaned-vulns         Delete CVEs absent from every project and variant
+
+        Refresh vulnerability data:
+        --refresh-vulnerability-data    Refresh all projects (optionally limited by --project and --variant)
+
+        Data listing:
+        --list-projects                 List all projects and their variants (optionally in JSON format with --json)
+        --list-scans                    List all past scans (optionally in JSON format with --json)
+
+        Configuration:
+        --config <key> <value>          Set a config value
+        --config-list                   Show current configuration
+        --config-clear <key>            Remove a config key
+
+        Import or export AI assessment context for a project:
+        --export-context                Export AI assessment context
+        --import-context <path>         Import AI assessment context
+
+Commands with optional --project and --variant (uses "default" project and variant if not specified):
+
+        Import a SBOM or vulnerability data file into the selected project/variant:
+        --add-spdx <path>               Add an SPDX 2/3 SBOM file or archive
+        --add-cve-check <path>          Add a Yocto CVE check JSON file
+        --add-yocto-vex <path>          Add a Yocto VEX JSON file
+        --add-openvex <path>            Add an OpenVEX JSON file
+        --add-cdx <path>                Add a CycloneDX file
+        --add-grype <path>              Add a Grype results file
+
+        Trigger scanning to detect new vulnerabilities in the selected project/variant:
+        --perform-grype-scan            Run Grype after merging any inputs
+        --perform-nvd-scan              Run an NVD CPE-based scan
+        --perform-osv-scan              Run an OSV PURL-based scan
+        --perform-sbom-cve-check-scan   Run an sbom-cve-check scan
+
+        Export the selected project/variant's vulnerability data to a SBOM file:
+        --export-spdx                   Export as SPDX 3.0 SBOM
+        --export-cdx                    Export as CycloneDX 1.6 SBOM
+        --export-openvex                Export as OpenVEX
+
+        Import or export custom OpenVEX custom assessments for a project/variant:
+        --export-custom-openvex-assessments Export custom OpenVEX assessments
+        --import-custom-openvex-assessments <path> Import custom OpenVEX assessments
+
+        Test for vulnerabilities matching a condition in the selected project/variant:
+        --match-condition <expr>        Test for vulnerabilities matching a condition
+
+Commands only requiring --project (uses default project if not specified):
+
+        Import or export custom VulnScout data for a project:
+        --export-custom-vulnscout-data  Export custom VulnScout JSON data
+        --import-custom-vulnscout-data <path> Import custom VulnScout JSON data
+
+Timestamp options for custom data imports:
+        Applies to --import-custom-vulnscout-data and --import-custom-openvex-assessments.
+        --use-original-timestamps       Preserve assessment timestamps from the imported file
+        --use-current-timestamps        Set imported assessment timestamps to the current time
+        Default: current time for VulnScout JSON; original timestamps for OpenVEX.
 
 Examples:
   /scan/src/entrypoint.sh --project test --variant x86 --add-cve-check ./cve.json --add-spdx ./sbom.json
@@ -586,25 +614,19 @@ cmd_import_custom_vulnscout_data() {
 }
 
 cmd_export_custom_openvex_assessments() {
-    if [[ -z "$VARIANT_NAME" ]]; then
-        echo "Error: --variant is required to export custom OpenVEX assessments." >&2
-        exit 1
-    fi
+    local variant_name="${VARIANT_NAME:-default}"
 
     cd "$BASE_DIR"
     local output_dir="${OUTPUTS_DIR:-/scan/outputs}"
     flask --app src.bin.webapp db upgrade
     flask --app src.bin.webapp export-custom-openvex-assessments \
-        --project "$PROJECT_NAME" --variant "$VARIANT_NAME" --output-dir "$output_dir"
+        --project "$PROJECT_NAME" --variant "$variant_name" --output-dir "$output_dir"
     setup_user
 }
 
 cmd_import_custom_openvex_assessments() {
     local file="$1"
-    if [[ -z "$VARIANT_NAME" ]]; then
-        echo "Error: --variant is required to import custom OpenVEX assessments." >&2
-        exit 1
-    fi
+    local variant_name="${VARIANT_NAME:-default}"
 
     cd "$BASE_DIR"
     local raw_basename dest_name dest_file
@@ -618,7 +640,7 @@ cmd_import_custom_openvex_assessments() {
     fi
 
     flask --app src.bin.webapp db upgrade
-    local -a import_args=(--project "$PROJECT_NAME" --variant "$VARIANT_NAME")
+    local -a import_args=(--project "$PROJECT_NAME" --variant "$variant_name")
     if [[ "${IMPORT_CUSTOM_TIMESTAMP_POLICY:-original}" == "current" ]]; then
         import_args+=(--use-current-timestamps)
     fi
@@ -726,7 +748,7 @@ cmd_delete_empty_scans() {
 }
 
 cmd_delete_orphaned_vulnerabilities() {
-    flask --app src.bin.webapp delete-orphaned-vulnerabilities
+    flask --app src.bin.webapp delete-orphaned-vulns
 }
 
 #######################################
@@ -845,7 +867,7 @@ while [[ $# -gt 0 ]]; do
             cmd_delete_outdated; shift ;;
         --delete-empty-scans)
             cmd_delete_empty_scans; shift ;;
-        --delete-orphaned-vulnerabilities)
+        --delete-orphaned-vulns)
             cmd_delete_orphaned_vulnerabilities; shift ;;
         --serve)
             if [[ -n "$MATCH_CONDITION" ]]; then

--- a/tests/end_to_end_tests/test_merger_ci.py
+++ b/tests/end_to_end_tests/test_merger_ci.py
@@ -613,23 +613,29 @@ def test_import_custom_openvex_assessments_unsupported_type(app, tmp_path):
     assert "unsupported file type" in result.output.lower()
 
 
-def test_import_custom_openvex_assessments_requires_variant(app, tmp_path):
-    """OpenVEX import requires an explicit target variant."""
+def test_import_custom_openvex_assessments_defaults_variant(app, tmp_path):
+    """OpenVEX import uses the default variant when --variant is omitted."""
+    from src.controllers.projects import ProjectController
+    from src.models.variant import Variant
+
     doc = {
         "@context": "https://openvex.dev/ns/v0.2.0",
         "statements": [],
     }
-    json_file = tmp_path / "nonexistent_variant.json"
+    json_file = tmp_path / "default_variant.json"
     json_file.write_text(json.dumps(doc))
     with app.app_context():
+        project = ProjectController.get_by_name(_PROJECT_NAME)
+        assert project is not None
+        Variant.create("default", project.id)
         runner = app.test_cli_runner()
         result = runner.invoke(args=[
             "import-custom-openvex-assessments",
             "--project", _PROJECT_NAME,
             str(json_file),
         ])
-    assert result.exit_code == 2
-    assert "missing option '--variant'" in result.output.lower()
+    assert result.exit_code == 0, result.output
+    assert "Imported 0 OpenVEX assessments" in result.output
 
 
 def test_import_custom_openvex_assessments_invalid_json(app, tmp_path):

--- a/tests/webapp_tests/test_assessment_outdated.py
+++ b/tests/webapp_tests/test_assessment_outdated.py
@@ -696,7 +696,7 @@ class TestOutdatedFlag:
         ("command", "expected"),
         [
             ("delete-empty-scans", "Deleted 0 empty scans"),
-            ("delete-orphaned-vulnerabilities", "Deleted 0 orphaned vulnerabilities"),
+            ("delete-orphaned-vulns", "Deleted 0 orphaned vulnerabilities"),
         ],
     )
     def test_additional_cleanup_cli_commands(self, command, expected):

--- a/vulnscout
+++ b/vulnscout
@@ -44,72 +44,95 @@ show_help() {
 VulnScout - Vulnerability Scanner
 Usage: vulnscout [--project <name>] [--variant <name>] <command> [options]
 
-Container lifecycle:
-  start|--start                   Start VulnScout container (auto-started by other commands)
-  stop|--stop                     Stop and remove VulnScout container
-  restart|--restart               Restart VulnScout container
-  --update                        Pull latest image and restart if a new version is available
-  --version                       Show current version
-  --dev                           Dev mode: mount local src/ into container and start frontend npm dev server
+Project and variant options:
+    --project <name>                Select a project
+    --variant <name>                Select a variant within --project
 
-Note: The container runs as a daemon. All commands auto-start it if needed and
-leave it running afterward (including --serve). Use 'stop' or '--stop' to remove it.
+Commands without --project or --variant:
 
-Global flags:
-  --project <name>                Set project name (scopes standalone refresh)
-  --variant <name>                Set variant name (scopes standalone refresh; requires --project)
+    Container lifecycle:
+    start|--start                   Start VulnScout container (auto-started by other commands)
+    stop|--stop                     Stop and remove VulnScout container
+    restart|--restart               Restart VulnScout container
+    --update                        Pull latest image and restart if a new version is available
+    --version                       Show current version
 
-Input commands (can be chained, triggers scan automatically):
-  --add-spdx <path>               Add an SPDX 2/3 SBOM file or archive
-  --add-cve-check <path>          Add a Yocto CVE check JSON file
-  --add-yocto-vex <path>          Add a Yocto VEX JSON file
-  --add-openvex <path>            Add an OpenVEX JSON file
-  --add-cdx <path>                Add a CycloneDX file
-  --add-grype <path>              Add a Grype results file
-  --refresh-vulnerability-data    Refresh EPSS, NVD, EUVD, and GHSA data; without inputs refreshes all vulnerabilities
-  --perform-grype-scan            Run Grype on the current DB content (after merging any added inputs)
-  --perform-nvd-scan              Run an NVD CPE-based vulnerability scan
-  --perform-osv-scan              Run an OSV PURL-based vulnerability scan
-  --perform-sbom-cve-check-scan          Run a sbom-cve-check vulnerability scan
+    Development and web interface:
+    --dev                           Mount local src/ and start the frontend dev server
+    --serve                         Run scan then start web UI (port 7275)
 
-Scan & output commands:
-  --match-condition <expr>        Run vulnerability scan
-  --serve                         Run scan then start web UI (port 7275)
-  --report <template>             Generate a report from a template
-  --report <path>                 Stage a local report template file and generate a report from it
-  --add-asset <path>              Stage a local image asset for use in report templates
-  --export-spdx                   Export project as SPDX 3.0 SBOM
-  --export-cdx                    Export project as CycloneDX 1.6 SBOM
-  --export-openvex                Export project as OpenVEX document
+    Reports and assets:
+    --report <template|path>        Generate a report from a template
+    --add-asset <path>              Stage an image asset for report templates
+
+    Data maintenance:
+    --delete-scan <id>              Delete a past scan by ID
+    --delete-outdated               Delete outdated packages and assessments
+    --delete-empty-scans            Delete scans with no recorded changes
+    --delete-orphaned-vulns         Delete CVEs absent from every project and variant
+
+    Refresh vulnerability data:
+    --refresh-vulnerability-data    Refresh all projects (optionally limited by --project and --variant)
+
+    Data listing:
+    --list-projects                 List all projects and their variants (optionally in JSON format with --json)
+    --list-scans                    List all past scans (optionally in JSON format with --json)
+
+    Import or export AI assessment context for a project:
+    --export-context                Export AI assessment context
+    --import-context <path>         Import AI assessment context
+    
+    Configuration:
+    --config <key> <value>          Set a config value
+    --config-list                   Show current configuration
+    --config-clear <key>            Remove a config key
+
+Commands with optional --project and --variant (uses "default" project and variant if not specified):
+
+    Import a SBOM or vulnerability data file into the selected project/variant:
+    --add-spdx <path>               Add an SPDX 2/3 SBOM file or archive
+    --add-cve-check <path>          Add a Yocto CVE check JSON file
+    --add-yocto-vex <path>          Add a Yocto VEX JSON file
+    --add-openvex <path>            Add an OpenVEX JSON file
+    --add-cdx <path>                Add a CycloneDX file
+    --add-grype <path>              Add a Grype results file
+
+    Trigger scanning to detect new vulnerabilities in the selected project/variant:
+    --perform-grype-scan            Run Grype after merging any inputs
+    --perform-nvd-scan              Run an NVD CPE-based scan
+    --perform-osv-scan              Run an OSV PURL-based scan
+    --perform-sbom-cve-check-scan   Run an sbom-cve-check scan
+
+    Export the selected project/variant's vulnerability data to a SBOM file:
+    --export-spdx                   Export as SPDX 3.0 SBOM
+    --export-cdx                    Export as CycloneDX 1.6 SBOM
+    --export-openvex                Export as OpenVEX
+
+    Import or export custom OpenVEX custom assessments for a project/variant:
+    --export-custom-openvex-assessments Export custom OpenVEX assessments
+    --import-custom-openvex-assessments <path> Import custom OpenVEX assessments
+
+    Test for vulnerabilities matching a condition in the selected project/variant:
+    --match-condition <expr>        Test for vulnerabilities matching a condition
+
+Commands only requiring --project (uses default project if not specified):
+
+    Import or export custom VulnScout data for a project:
     --export-custom-vulnscout-data  Export custom VulnScout JSON data
-        --import-custom-vulnscout-data <path>  Import custom VulnScout JSON data
-            --use-original-timestamps    Preserve file timestamps instead of using system time
-            --use-current-timestamps     Use current system time instead of file timestamps
-    --export-custom-openvex-assessments  Export custom OpenVEX assessments for --variant
-    --import-custom-openvex-assessments <path>  Import custom OpenVEX assessments into --variant
-    --export-context                 Export AI assessment context to /scan/outputs/context-export.json
-    --import-context <path>          Import AI assessment context from a JSON file (overwrites matching project/variant)
-  --delete-scan <id>                Delete a past scan by its ID
-    --delete-outdated                 Permanently delete outdated packages and assessments
-    --delete-empty-scans              Permanently delete scans with no recorded changes
-    --delete-orphaned-vulnerabilities Delete CVEs absent from every project and variant
+    --import-custom-vulnscout-data <path> Import custom VulnScout JSON data
 
-Data retrieval commands:
-  --list-projects                 List all projects and their variants
-  --list-scans                    List all past scans
-  --json                          Output objects in JSON format
-
-Configuration:
-  --config <key> <value>          Set a config value
-  --config-list                   Show current configuration
-  --config-clear <key>            Remove a config key
+Timestamp options for custom data imports:
+    Applies to --import-custom-vulnscout-data and --import-custom-openvex-assessments.
+    --use-original-timestamps       Preserve assessment timestamps from the imported file
+    --use-current-timestamps        Set imported assessment timestamps to the current time
+    Default: current time for VulnScout JSON; original timestamps for OpenVEX.
 
 Environment variables:
-  VULNSCOUT_CONTAINER   Container name (default: vulnscout)
-    VULNSCOUT_IMAGE       Docker image (default: docker.io/sflinux/vulnscout:v0.20)
-  VULNSCOUT_BUILD_DIR   Build base dir (default: ./.vulnscout)
-  VULNSCOUT_CACHE_DIR   Cache dir (default: VULNSCOUT_BUILD_DIR/cache)
-  VULNSCOUT_OUTPUTS_DIR Output directory (default: VULNSCOUT_BUILD_DIR/outputs)
+    VULNSCOUT_CONTAINER     Container name (default: vulnscout)
+    VULNSCOUT_IMAGE         Docker image (default: docker.io/sflinux/vulnscout:v0.20)
+    VULNSCOUT_BUILD_DIR     Build base dir (default: ./.vulnscout)
+    VULNSCOUT_CACHE_DIR     Cache dir (default: VULNSCOUT_BUILD_DIR/cache)
+    VULNSCOUT_OUTPUTS_DIR   Output directory (default: VULNSCOUT_BUILD_DIR/outputs)
 
 Examples:
   vulnscout --project test --variant x86 --add-cve-check ./cve.json --add-spdx ./sbom.json
@@ -408,9 +431,9 @@ parse_and_run() {
                 ensure_running
                 exec_container --delete-empty-scans
                 shift ;;
-            delete-orphaned-vulnerabilities|--delete-orphaned-vulnerabilities)
+            delete-orphaned-vulns|--delete-orphaned-vulns|delete-orphaned-vulnerabilities|--delete-orphaned-vulnerabilities)
                 ensure_running
-                exec_container --delete-orphaned-vulnerabilities
+                exec_container --delete-orphaned-vulns
                 shift ;;
             serve|--serve)
                 SERVE_REQUESTED=true; shift ;;
@@ -529,7 +552,8 @@ parse_and_run() {
     elif [ -n "$MATCH_CONDITION" ] || [ ${#REPORT_ARGS[@]} -gt 0 ] || [ ${#EXPORT_ARGS[@]} -gt 0 ]; then
         # No new inputs but a match-condition, report, or export was given: run against existing DB data
         ensure_running
-        local -a mc_args=(--project "$PROJECT" --variant "$VARIANT")
+        local -a mc_args=(--project "$PROJECT")
+        [ "$VARIANT_SPECIFIED" = true ] && mc_args+=(--variant "$VARIANT")
         [ -n "$MATCH_CONDITION" ] && mc_args+=(--match-condition "$MATCH_CONDITION")
         exec_container "${mc_args[@]}" "${REPORT_ARGS[@]}" "${EXPORT_ARGS[@]}" || _exit=$?
     fi


### PR DESCRIPTION
## Fixes # by Valentin Boudevin

### Changes proposed in this pull request:

VulnScout CLI and entrypoints helper needed some clarification. 

Now, all commands are described to be link with --project, --project and --variants, or none.

Also updated the commands `--export-custom-openvex-assessments  ` Export custom OpenVEX assessments and `--import-custom-openvex-assessments` to use `default` project if not specified

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

```
./vulnscout --help
```