### PR TITLE
Support project-wide match conditions

### DIFF
--- a/doc/source/ci_conditions.md
+++ b/doc/source/ci_conditions.md
@@ -10,9 +10,16 @@ Evaluate and enforce conditions on vulnerabilities within a project.
 
 ## Description
 
-The `vulnscout` command can optionally accept a `--match-condition CONDITION` argument that causes the command to exit with code **2** if the specified condition is met by any vulnerability found in the project.
+The `vulnscout` command can optionally accept a `--match-condition CONDITION` argument that causes the command to exit with code **2** if the specified condition is met by any vulnerability in scope.
 
-The `CONDITION` is a boolean expression that is evaluated against each vulnerability identified. If the condition is met, the IDs of the matching vulnerabilities are displayed in the output. The command returns an exit code of **2** if at least one vulnerability meets the condition.
+The scope is selected as follows:
+
+- With no `--project` or `--variant`, the condition is evaluated for the `default/default` project and variant.
+- With `--project NAME` and no variant, the condition is evaluated across all variants in that project.
+- With `--project NAME --variant NAME`, the condition is evaluated only for that variant.
+- With `--variant NAME` alone, the variant is selected from the `default` project.
+
+The `CONDITION` is a boolean expression that is evaluated against each vulnerability identified. If the condition is met, the IDs of the matching vulnerabilities are displayed in the output. A vulnerability shared by multiple variants is displayed once for a project-wide evaluation. The command returns an exit code of **2** if at least one vulnerability meets the condition.
 
 Match conditions can be combined with input files in a single invocation:
 
@@ -39,7 +46,7 @@ If the `CONDITION` is invalid, the configuration is not found, or an error occur
 ./vulnscout --project demo --match-condition "cvss >= 7.0"
 ```
 
-This example will cause the command to exit with code **2** if any vulnerability with a CVSS score of 7.0 or higher is found.
+This example evaluates every variant in `demo` and exits with code **2** if any vulnerability has a CVSS score of 7.0 or higher. Add `--variant NAME` to limit evaluation to one variant. An unknown project or variant exits with code **1**.
 
 ---
 

--- a/doc/source/container-entrypoint.md
+++ b/doc/source/container-entrypoint.md
@@ -66,7 +66,7 @@ docker exec vulnscout /scan/src/entrypoint.sh --serve
 | `--export-custom-openvex-assessments` | Export custom assessments for the selected `--variant` as an OpenVEX `.json` file |
 | `--import-custom-openvex-assessments <path>` | Import an OpenVEX `.json` file into the selected `--variant` |
 | `--use-current-timestamps` | With either custom import, use the current system time |
-| `--match-condition <expr>` | Exit with code 2 if expression matches any vulnerability. Incompatible with `--serve` |
+| `--match-condition <expr>` | Exit with code 2 if expression matches any in-scope vulnerability. A project without a variant includes all its variants. Incompatible with `--serve` |
 | `--delete-scan <id>` | Delete a past scan by its ID |
 
 ### Data Retrieval Commands
@@ -160,10 +160,12 @@ docker exec vulnscout /scan/src/entrypoint.sh \
 **Run a CI scan with a match condition:**
 ```bash
 docker exec vulnscout /scan/src/entrypoint.sh \
-  --project demo --variant x86 \
+  --project demo \
   --add-spdx /scan/inputs/sbom.spdx.json \
   --match-condition "cvss >= 9.0 or (cvss >= 7.0 and epss >= 50%)"
 ```
+
+This evaluates all variants in `demo`. Add `--variant x86` to evaluate only that variant. With neither option, matching uses `default/default`.
 
 **Generate reports and export SBOMs without a new scan:**
 ```bash

--- a/doc/source/vulnscout-script.md
+++ b/doc/source/vulnscout-script.md
@@ -312,6 +312,8 @@ For CI pipelines or automated scans, use the `--match-condition` argument instea
 
 If vulnerabilities match the condition, the script exits with **code 2**, allowing CI systems to fail the pipeline.
 
+When `--project demo` is supplied without `--variant`, the condition is evaluated across all variants in `demo`. Supplying both options limits evaluation to one variant. Omitting both options evaluates `default/default`; supplying only `--variant` selects that variant from the `default` project. Unknown names exit with **code 1**.
+
 See the [Match Conditions](ci_conditions.md) page for the full syntax and token reference.
 
 ---

--- a/src/bin/cmd_process.py
+++ b/src/bin/cmd_process.py
@@ -28,7 +28,7 @@ import os
 from typing import Callable, Iterable, TYPE_CHECKING
 from flask.cli import with_appcontext
 from sqlalchemy import and_, exists
-from ._common import DEFAULT_VARIANT_NAME, resolve_project_variant
+from ._common import DEFAULT_VARIANT_NAME, resolve_project, resolve_project_variant
 from ..controllers.projects import ProjectController
 from ..helpers.export_scope import compute_export_scope
 
@@ -328,10 +328,20 @@ def create_project_context(
     is_flag=True,
     help="Refresh EPSS, NVD, EUVD, and GHSA data for imported vulnerabilities.",
 )
+@click.option("--project", "project_name", default=None, help="Evaluate conditions in this project.")
+@click.option("--variant", "variant_name", default=None, help="Evaluate conditions in this project variant.")
 @with_appcontext
-def process_command(refresh_vulnerability_data: bool) -> None:
+def process_command(
+    refresh_vulnerability_data: bool,
+    project_name: str | None,
+    variant_name: str | None,
+) -> None:
     """Parse all SBOM inputs, persist results to the DB and generate output files."""
-    _run_main(refresh_vulnerability_data=refresh_vulnerability_data)
+    _run_main(
+        refresh_vulnerability_data=refresh_vulnerability_data,
+        project_name=project_name,
+        variant_name=variant_name,
+    )
 
 
 @click.command("refresh-vulnerability-data")
@@ -433,7 +443,35 @@ def populate_observations(scan, vulnCtrl, log_prefix: str = "merger_ci") -> None
         print(f"Warning: could not populate observations table: {e}")
 
 
-def _run_main(refresh_vulnerability_data: bool = False) -> ControllersCache:
+def _condition_scope(project_name: str | None, variant_name: str | None):
+    project = project_name or "default"
+    if project_name is not None and variant_name is None:
+        project_obj = resolve_project(project)
+        return compute_export_scope(project_id=project_obj.id)
+
+    _, variant_obj = resolve_project_variant(project, variant_name)
+    return compute_export_scope(variant_id=variant_obj.id)
+
+
+def _evaluate_condition_in_scope(scope, condition: str) -> list[str]:
+    matched_vulns: list[str] = []
+    for variant_id in sorted(scope.variant_ids, key=str):
+        variant_controllers = ControllersCache(
+            scope=compute_export_scope(variant_id=variant_id)
+        )
+        matched_vulns.extend(evaluate_condition(
+            variant_controllers.vulnerabilities,
+            variant_controllers.assessments,
+            condition,
+        ))
+    return list(dict.fromkeys(matched_vulns))
+
+
+def _run_main(
+    refresh_vulnerability_data: bool = False,
+    project_name: str | None = None,
+    variant_name: str | None = None,
+) -> ControllersCache:
     """Core processing logic (usable both from the CLI command and directly)."""
     controllers = ControllersCache()
     vulnCtrl: VulnerabilitiesController = controllers.vulnerabilities
@@ -493,7 +531,10 @@ def _run_main(refresh_vulnerability_data: bool = False) -> ControllersCache:
     failed_vulns = []
     if match_condition:
         verbose("merger_ci: Start evaluating conditions")
-        failed_vulns = evaluate_condition(controllers.vulnerabilities, controllers.assessments, match_condition)
+        failed_vulns = _evaluate_condition_in_scope(
+            _condition_scope(project_name, variant_name),
+            match_condition,
+        )
         verbose("merger_ci: Finished evaluating conditions")
         # Cache result so flask report can reuse it without re-evaluating
         try:

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -163,8 +163,10 @@ Commands with optional --project and --variant (uses "default" project and varia
         --export-custom-openvex-assessments Export custom OpenVEX assessments
         --import-custom-openvex-assessments <path> Import custom OpenVEX assessments
 
-        Test for vulnerabilities matching a condition in the selected project/variant:
+        Test for vulnerabilities matching a condition:
         --match-condition <expr>        Test for vulnerabilities matching a condition
+                         --project without --variant tests all project variants
+                         No scope tests the default project/variant
 
 Commands only requiring --project (uses default project if not specified):
 
@@ -509,6 +511,10 @@ cmd_scan() {
         # triggered fail condition) is still propagated through the pipeline.
         local -a process_args=()
         [[ "${REFRESH_VULNERABILITY_DATA:-false}" == "true" ]] && process_args+=(--refresh-vulnerability-data)
+        if [[ -n "${MATCH_CONDITION:-}" ]]; then
+            [[ "$PROJECT_SPECIFIED" == "true" ]] && process_args+=(--project "$PROJECT_NAME")
+            [[ "$VARIANT_SPECIFIED" == "true" ]] && process_args+=(--variant "$VARIANT_NAME")
+        fi
         (cd "$BASE_DIR" && flask --app src.bin.webapp process "${process_args[@]}") | \
             while IFS= read -r _line; do
                 if [[ "$_line" =~ ^::STATUS::([0-9]+)::(.*)$ ]]; then

--- a/tests/CI_tests/vulnscout_CI_test.sh
+++ b/tests/CI_tests/vulnscout_CI_test.sh
@@ -23,7 +23,7 @@ run_scan() {
 
     export MATCH_CONDITION="$condition"
     local rc=0
-    flask --app src.bin.webapp process || rc=$?
+    flask --app src.bin.webapp process --project ci || rc=$?
 
     unset MATCH_CONDITION FLASK_SQLALCHEMY_DATABASE_URI IGNORE_PARSING_ERRORS
     rm -rf "$tmp_db"

--- a/tests/CI_tests/vulnscout_wrapper_test.sh
+++ b/tests/CI_tests/vulnscout_wrapper_test.sh
@@ -49,6 +49,31 @@ grep -q -- '/scan/src/entrypoint.sh --project cli --refresh-vulnerability-data' 
 grep -q -- '/scan/src/entrypoint.sh --variant default --project cli --refresh-vulnerability-data' "$VULNSCOUT_TEST_LOG"
 
 : > "$VULNSCOUT_TEST_LOG"
+"$ROOT_DIR/vulnscout" --match-condition affected
+grep -q -- '/scan/src/entrypoint.sh --match-condition affected' "$VULNSCOUT_TEST_LOG"
+if grep -q -- '--project\|--variant' "$VULNSCOUT_TEST_LOG"; then
+    echo "Default scope was forwarded as explicit scope." >&2
+    exit 1
+fi
+
+: > "$VULNSCOUT_TEST_LOG"
+"$ROOT_DIR/vulnscout" --project cli --match-condition affected
+grep -q -- '/scan/src/entrypoint.sh --project cli --match-condition affected' "$VULNSCOUT_TEST_LOG"
+
+: > "$VULNSCOUT_TEST_LOG"
+"$ROOT_DIR/vulnscout" --project cli --variant release --match-condition affected
+grep -q -- '/scan/src/entrypoint.sh --project cli --variant release --match-condition affected' "$VULNSCOUT_TEST_LOG"
+
+: > "$VULNSCOUT_TEST_LOG"
+"$ROOT_DIR/vulnscout" --project cli --add-spdx "$SBOM" --match-condition affected
+grep -q -- '--project cli --add-spdx /tmp/vulnscout_stage_input.spdx.json --match-condition affected' \
+    "$VULNSCOUT_TEST_LOG"
+if grep -q -- '--variant' "$VULNSCOUT_TEST_LOG"; then
+    echo "Default variant was forwarded as an explicit variant." >&2
+    exit 1
+fi
+
+: > "$VULNSCOUT_TEST_LOG"
 "$ROOT_DIR/vulnscout" --project cli --variant default \
     --add-spdx "$SBOM" --refresh-vulnerability-data
 grep -q -- \

--- a/tests/cli_tests/test_cmd_process.py
+++ b/tests/cli_tests/test_cmd_process.py
@@ -8,6 +8,7 @@ Targets uncovered branches reported by the CI coverage run:
 
 import json
 import pytest
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
@@ -29,8 +30,13 @@ def _build_db(app):
         _db.drop_all()
         _db.create_all()
 
+        default_project = Project.create("default")
+        Variant.create("default", default_project.id)
+        Variant.create("release", default_project.id)
+
         project = Project.create("ProcessProject")
         variant = Variant.create("ProcessVariant", project.id)
+        Variant.create("SecondVariant", project.id)
         Scan.create("scan", variant.id, scan_type="sbom")
         _db.session.commit()
 
@@ -60,7 +66,11 @@ class TestCmdProcessCoverage:
             runner = app.test_cli_runner()
             result = runner.invoke(args=["process"])
         assert result.exit_code == 0
-        mock_main.assert_called_once_with(refresh_vulnerability_data=False)
+        mock_main.assert_called_once_with(
+            refresh_vulnerability_data=False,
+            project_name=None,
+            variant_name=None,
+        )
 
     def test_process_command_propagates_refresh_flag(self, app):
         with patch("src.bin.cmd_process._run_main") as run_main:
@@ -68,7 +78,124 @@ class TestCmdProcessCoverage:
             result = runner.invoke(args=["process", "--refresh-vulnerability-data"])
 
         assert result.exit_code == 0
-        run_main.assert_called_once_with(refresh_vulnerability_data=True)
+        run_main.assert_called_once_with(
+            refresh_vulnerability_data=True,
+            project_name=None,
+            variant_name=None,
+        )
+
+    def test_process_command_propagates_condition_scope(self, app):
+        with patch("src.bin.cmd_process._run_main") as run_main:
+            result = app.test_cli_runner().invoke(
+                args=[
+                    "process", "--project", "ProcessProject",
+                    "--variant", "ProcessVariant",
+                ]
+            )
+
+        assert result.exit_code == 0
+        run_main.assert_called_once_with(
+            refresh_vulnerability_data=False,
+            project_name="ProcessProject",
+            variant_name="ProcessVariant",
+        )
+
+    def test_condition_scope_defaults_to_default_variant(self, app):
+        from src.bin.cmd_process import _condition_scope
+
+        with app.app_context():
+            scope = _condition_scope(None, None)
+
+        assert len(scope.variant_ids) == 1
+
+    def test_condition_scope_includes_all_project_variants(self, app):
+        from src.bin.cmd_process import _condition_scope
+
+        with app.app_context():
+            scope = _condition_scope("ProcessProject", None)
+
+        assert len(scope.variant_ids) == 2
+
+    def test_condition_scope_selects_one_variant(self, app):
+        from src.bin.cmd_process import _condition_scope
+
+        with app.app_context():
+            scope = _condition_scope("ProcessProject", "ProcessVariant")
+
+        assert len(scope.variant_ids) == 1
+
+    def test_condition_scope_uses_default_project_for_variant(self, app):
+        from src.bin.cmd_process import _condition_scope
+
+        with app.app_context():
+            scope = _condition_scope(None, "release")
+
+        assert len(scope.variant_ids) == 1
+
+    def test_project_condition_matches_each_variant_independently(self, app):
+        from src.bin.cmd_process import _condition_scope, _evaluate_condition_in_scope
+        from src.models.assessment import Assessment
+        from src.models.finding import Finding
+        from src.models.package import Package
+        from src.models.project import Project
+        from src.models.sbom_document import SBOMDocument
+        from src.models.sbom_package import SBOMPackage
+        from src.models.scan import Scan
+        from src.models.variant import Variant
+        from src.models.vulnerability import Vulnerability
+
+        with app.app_context():
+            project = Project.get_by_name("ProcessProject")
+            variants = {variant.name: variant for variant in Variant.get_by_project(project.id)}
+            first_variant = variants["ProcessVariant"]
+            second_variant = variants["SecondVariant"]
+            first_scan = Scan.get_by_variant_id(first_variant.id)[0]
+            second_scan = Scan.create("second-scan", second_variant.id, scan_type="sbom")
+            package = Package.create("shared-package", "1.0")
+            for scan in (first_scan, second_scan):
+                document = SBOMDocument.create(f"/{scan.id}.spdx", "spdx", scan.id)
+                SBOMPackage.create(document.id, package.id)
+
+            vulnerability = Vulnerability.get_or_create("CVE-2026-0001")
+            finding = Finding.get_or_create(package.id, vulnerability.id)
+            now = datetime.now(timezone.utc)
+            Assessment.create(
+                "affected",
+                finding_id=finding.id,
+                variant_id=first_variant.id,
+                timestamp=now - timedelta(days=1),
+            )
+            Assessment.create(
+                "not_affected",
+                finding_id=finding.id,
+                variant_id=second_variant.id,
+                timestamp=now,
+            )
+
+            matched = _evaluate_condition_in_scope(
+                _condition_scope("ProcessProject", None),
+                "affected",
+            )
+
+        assert matched == [vulnerability.id]
+
+    @pytest.mark.parametrize(
+        ("project_name", "variant_name", "message"),
+        [
+            ("MissingProject", None, "project not found: MissingProject"),
+            ("ProcessProject", "MissingVariant", "variant not found: MissingVariant"),
+        ],
+    )
+    def test_condition_scope_rejects_unknown_names(
+        self, app, capsys, project_name, variant_name, message
+    ):
+        from src.bin.cmd_process import _condition_scope
+
+        with app.app_context(), pytest.raises(SystemExit) as exc_info:
+            _condition_scope(project_name, variant_name)
+
+        assert exc_info.value.code == 1
+        assert message in capsys.readouterr().out
 
     def test_standalone_refresh_uses_all_vulnerabilities(self, app):
         with patch("src.bin.cmd_process.refresh_vulnerability_sources", return_value=[]) as refresh:

--- a/tests/end_to_end_tests/test_merger_ci.py
+++ b/tests/end_to_end_tests/test_merger_ci.py
@@ -140,24 +140,30 @@ def test_invalid_cdx(app, init_files, monkeypatch):
     _run_main()
 
 
-def test_ci_mode(app, monkeypatch):
+def test_ci_mode(app, monkeypatch, capsys):
     monkeypatch.setenv("MATCH_CONDITION", "false")
-    _run_main()
+    _run_main(project_name=_PROJECT_NAME)
 
     monkeypatch.setenv("MATCH_CONDITION", "true")
+    capsys.readouterr()
     with pytest.raises(SystemExit) as e:
-        _run_main()
+        _run_main(project_name=_PROJECT_NAME)
     assert e.type == SystemExit
     assert e.value.code == 2
+    matched_lines = [
+        line for line in capsys.readouterr().out.splitlines()
+        if line.startswith("Vulnerability triggered fail condition:")
+    ]
+    assert len(matched_lines) == len(set(matched_lines))
 
     monkeypatch.setenv("MATCH_CONDITION", "cvss >= 8")
     with pytest.raises(SystemExit) as e:
-        _run_main()
+        _run_main(project_name=_PROJECT_NAME)
     assert e.type == SystemExit
     assert e.value.code == 2
 
     monkeypatch.setenv("MATCH_CONDITION", "cvss >= 8 and epss == 1.23456%")
-    _run_main()
+    _run_main(project_name=_PROJECT_NAME)
 
 
 def test_spdx_output_completeness(app):

--- a/vulnscout
+++ b/vulnscout
@@ -112,8 +112,10 @@ Commands with optional --project and --variant (uses "default" project and varia
     --export-custom-openvex-assessments Export custom OpenVEX assessments
     --import-custom-openvex-assessments <path> Import custom OpenVEX assessments
 
-    Test for vulnerabilities matching a condition in the selected project/variant:
+    Test for vulnerabilities matching a condition:
     --match-condition <expr>        Test for vulnerabilities matching a condition
+                                     --project without --variant tests all project variants
+                                     No scope tests the default project/variant
 
 Commands only requiring --project (uses default project if not specified):
 
@@ -547,7 +549,10 @@ parse_and_run() {
         local -a scan_args=()
         [ -n "$MATCH_CONDITION" ] && scan_args+=(--match-condition "$MATCH_CONDITION")
         [ "${REFRESH_VULNERABILITY_DATA:-false}" = true ] && scan_args+=(--refresh-vulnerability-data)
-        exec_container --project "$PROJECT" --variant "$VARIANT" "${PENDING_ARGS[@]}" "${scan_args[@]}" "${REPORT_ARGS[@]}" "${EXPORT_ARGS[@]}" || _exit=$?
+        local -a scan_scope_args=()
+        [ "$PROJECT_SPECIFIED" = true ] && scan_scope_args+=(--project "$PROJECT")
+        [ "$VARIANT_SPECIFIED" = true ] && scan_scope_args+=(--variant "$VARIANT")
+        exec_container "${scan_scope_args[@]}" "${PENDING_ARGS[@]}" "${scan_args[@]}" "${REPORT_ARGS[@]}" "${EXPORT_ARGS[@]}" || _exit=$?
     elif [ "${REFRESH_VULNERABILITY_DATA:-false}" = true ]; then
         local -a refresh_args=(--refresh-vulnerability-data)
         [ "$PROJECT_SPECIFIED" = true ] && refresh_args=(--project "$PROJECT" "${refresh_args[@]}")
@@ -558,7 +563,12 @@ parse_and_run() {
     elif [ -n "$MATCH_CONDITION" ] || [ ${#REPORT_ARGS[@]} -gt 0 ] || [ ${#EXPORT_ARGS[@]} -gt 0 ]; then
         # No new inputs but a match-condition, report, or export was given: run against existing DB data
         ensure_running
-        local -a mc_args=(--project "$PROJECT")
+        local -a mc_args=()
+        if [ -n "$MATCH_CONDITION" ]; then
+            [ "$PROJECT_SPECIFIED" = true ] && mc_args+=(--project "$PROJECT")
+        else
+            mc_args+=(--project "$PROJECT")
+        fi
         [ "$VARIANT_SPECIFIED" = true ] && mc_args+=(--variant "$VARIANT")
         [ -n "$MATCH_CONDITION" ] && mc_args+=(--match-condition "$MATCH_CONDITION")
         exec_container "${mc_args[@]}" "${REPORT_ARGS[@]}" "${EXPORT_ARGS[@]}" || _exit=$?


### PR DESCRIPTION
## Fixes # by...

### Changes proposed in this pull request:

Change the match-conditions arguments so that:
* No project or variant: evaluate default/default.
* --project A: evaluate all variants in project A.
* --project A --variant V: evaluate only A/V.
* --variant V: evaluate V in the default project.
* Unknown scope: exit 1.
* Shared vulnerability IDs: report once.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Test the above configurations.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [x] Code follows project style guidelines
- [x] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers


