### PR TITLE
Hide unavailable assessment details

### DIFF
--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -50,6 +50,14 @@ type Props = {
 // How long the inline "Copied" confirmation stays next to a copy button.
 const COPIED_FEEDBACK_MS = 2000;
 
+const hasAvailableAssessmentText = (
+    value: string | null | undefined,
+    unavailableText: string
+): boolean => {
+    const normalizedValue = value?.trim().toLowerCase();
+    return Boolean(normalizedValue && normalizedValue !== unavailableText);
+};
+
 const dt_options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
@@ -1944,6 +1952,8 @@ type VariantScopedSnapshot = {
                                 {aiGroups.map(group => {
                                     const groupKey = group.group_id ?? group.assessment_ids[0];
                                     const firstTarget = group.targets[0];
+                                    const hasStatusNotes = hasAvailableAssessmentText(group.status_notes, 'no status notes');
+                                    const hasWorkaround = hasAvailableAssessmentText(group.workaround, 'no workaround available');
                                     return (
                                         <div
                                             key={`ai-${encodeURIComponent(groupKey)}`}
@@ -2019,11 +2029,13 @@ type VariantScopedSnapshot = {
                                                 {group.simplified_status}
                                                 {group.justification && <> - {group.justification}</>}
                                             </h3>
-                                            <p className="text-base font-normal text-gray-300 whitespace-pre-line">
-                                                {group.impact_statement && <>{group.impact_statement}<br/></>}
-                                                {group.status_notes || 'no status notes'}<br/>
-                                                {group.workaround || 'no workaround available'}
-                                            </p>
+                                            {(group.impact_statement || hasStatusNotes || hasWorkaround) && (
+                                                <p className="text-base font-normal text-gray-300 whitespace-pre-line">
+                                                    {group.impact_statement && <>{group.impact_statement}<br/></>}
+                                                    {hasStatusNotes && <>{group.status_notes}<br/></>}
+                                                    {hasWorkaround && group.workaround}
+                                                </p>
+                                            )}
                                         </div>
                                     );
                                 })}
@@ -2034,6 +2046,8 @@ type VariantScopedSnapshot = {
                                     const firstId = group.assessment_ids[0];
                                     const isNewlyAdded = group.assessment_ids.some(id => newAssessmentIds.has(id));
                                     const isBeingEdited = editingAssessmentId === firstId;
+                                    const hasStatusNotes = hasAvailableAssessmentText(group.status_notes, 'no status notes');
+                                    const hasWorkaround = hasAvailableAssessmentText(group.workaround, 'no workaround available');
                                     const groupPackages = [...new Set(group.targets.map(t => t.package))];
                                     // Build a synthetic Assessment for EditAssessment, which still expects
                                     // one Assessment object rather than a group.
@@ -2124,12 +2138,12 @@ type VariantScopedSnapshot = {
                                                             )}
                                                         </div>
                                                     </h3>
-                                                    {!isBeingEdited && (
+                                                    {!isBeingEdited && (group.impact_statement || group.status === 'not_affected' || hasStatusNotes || hasWorkaround) && (
                                                         <p className="text-base font-normal text-gray-300 whitespace-pre-line">
                                                             {group.impact_statement && <>{group.impact_statement}<br/></>}
                                                             {!group.impact_statement && group.status == 'not_affected' && <>no impact statement<br/></>}
-                                                            {group.status_notes || 'no status notes'}<br/>
-                                                            {group.workaround || 'no workaround available'}
+                                                            {hasStatusNotes && <>{group.status_notes}<br/></>}
+                                                            {hasWorkaround && group.workaround}
                                                         </p>
                                                     )}
                                                 </div>

--- a/frontend/src/components/VulnModal.tsx
+++ b/frontend/src/components/VulnModal.tsx
@@ -50,13 +50,7 @@ type Props = {
 // How long the inline "Copied" confirmation stays next to a copy button.
 const COPIED_FEEDBACK_MS = 2000;
 
-const hasAvailableAssessmentText = (
-    value: string | null | undefined,
-    unavailableText: string
-): boolean => {
-    const normalizedValue = value?.trim().toLowerCase();
-    return Boolean(normalizedValue && normalizedValue !== unavailableText);
-};
+const hasAssessmentText = (value: string | null | undefined): boolean => Boolean(value?.trim());
 
 const dt_options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
@@ -1952,8 +1946,8 @@ type VariantScopedSnapshot = {
                                 {aiGroups.map(group => {
                                     const groupKey = group.group_id ?? group.assessment_ids[0];
                                     const firstTarget = group.targets[0];
-                                    const hasStatusNotes = hasAvailableAssessmentText(group.status_notes, 'no status notes');
-                                    const hasWorkaround = hasAvailableAssessmentText(group.workaround, 'no workaround available');
+                                    const hasStatusNotes = hasAssessmentText(group.status_notes);
+                                    const hasWorkaround = hasAssessmentText(group.workaround);
                                     return (
                                         <div
                                             key={`ai-${encodeURIComponent(groupKey)}`}
@@ -2046,8 +2040,8 @@ type VariantScopedSnapshot = {
                                     const firstId = group.assessment_ids[0];
                                     const isNewlyAdded = group.assessment_ids.some(id => newAssessmentIds.has(id));
                                     const isBeingEdited = editingAssessmentId === firstId;
-                                    const hasStatusNotes = hasAvailableAssessmentText(group.status_notes, 'no status notes');
-                                    const hasWorkaround = hasAvailableAssessmentText(group.workaround, 'no workaround available');
+                                    const hasStatusNotes = hasAssessmentText(group.status_notes);
+                                    const hasWorkaround = hasAssessmentText(group.workaround);
                                     const groupPackages = [...new Set(group.targets.map(t => t.package))];
                                     // Build a synthetic Assessment for EditAssessment, which still expects
                                     // one Assessment object rather than a group.

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2063,32 +2063,6 @@ describe('Vulnerability Modal', () => {
         expect(screen.getByText(/some notes/i)).toBeInTheDocument();
     });
 
-    test('assessment sentinel notes and workaround are omitted', () => {
-        const vulnWithAssessment = {
-            ...vulnerability,
-            assessments: [{
-                id: 'sentinel-assessment',
-                vuln_id: vulnerability.id,
-                packages: vulnerability.packages,
-                status: 'affected',
-                simplified_status: 'Exploitable',
-                justification: '',
-                impact_statement: 'confirmed impact',
-                status_notes: 'No Status Notes',
-                workaround: ' no workaround available ',
-                timestamp: new Date().toISOString(),
-                origin: 'custom',
-                responses: [],
-            }]
-        };
-
-        render(<VulnModal vuln={vulnWithAssessment} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
-
-        expect(screen.getByText(/confirmed impact/i)).toBeInTheDocument();
-        expect(screen.queryByText(/no status notes/i)).not.toBeInTheDocument();
-        expect(screen.queryByText(/no workaround available/i)).not.toBeInTheDocument();
-    });
-
     test('renders empty CVSS array', async () => {
         const vulnWithoutCvss = {
             ...vulnerability,
@@ -2627,14 +2601,14 @@ describe('Vulnerability Modal', () => {
         expect(screen.queryByRole('button', { name: /Reject/i })).not.toBeInTheDocument();
     });
 
-    test('pending AI review omits sentinel status notes and workaround', async () => {
+    test('pending AI review omits empty status notes and workaround', async () => {
         fetchMock.resetMocks();
         fetchMock.mockResponse((req) => {
             if (req.url.includes(`/api/vulnerabilities/${encodeURIComponent(vulnerability.id)}/assessments`)) {
                 return Promise.resolve(JSON.stringify([{
                     ...pendingAiAssessment,
-                    status_notes: 'no status notes',
-                    workaround: 'no workaround available',
+                    status_notes: '',
+                    workaround: '   ',
                 }]));
             }
             return Promise.resolve(JSON.stringify([]));
@@ -2652,8 +2626,8 @@ describe('Vulnerability Modal', () => {
 
         expect(await screen.findByText(/AI-generated/i)).toBeInTheDocument();
         expect(screen.getByText('ai impact statement')).toBeInTheDocument();
-        expect(screen.queryByText(/no status notes/i)).not.toBeInTheDocument();
-        expect(screen.queryByText(/no workaround available/i)).not.toBeInTheDocument();
+        expect(screen.queryByText('ai notes')).not.toBeInTheDocument();
+        expect(screen.queryByText('ai workaround')).not.toBeInTheDocument();
     });
 
     test('approving an ungrouped pending AI review promotes it to a group, then calls approveAiGroup', async () => {

--- a/frontend/tests/unit_tests/test_vuln_modal.tsx
+++ b/frontend/tests/unit_tests/test_vuln_modal.tsx
@@ -2011,7 +2011,7 @@ describe('Vulnerability Modal', () => {
         expect(placeholder).toBeInTheDocument();
     });
 
-    test('assessment without status notes shows placeholder', async () => {
+    test('assessment without status notes omits the field', async () => {
         const vulnWithAssessment = {
             ...vulnerability,
             assessments: [{
@@ -2033,12 +2033,11 @@ describe('Vulnerability Modal', () => {
 
         render(<VulnModal vuln={vulnWithAssessment} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
-        // Should show placeholder for missing status notes
-        const placeholder = screen.getByText(/no status notes/i);
-        expect(placeholder).toBeInTheDocument();
+        expect(screen.queryByText(/no status notes/i)).not.toBeInTheDocument();
+        expect(screen.getByText(/update dependency/i)).toBeInTheDocument();
     });
 
-    test('assessment without workaround shows placeholder', async () => {
+    test('assessment without workaround omits the field', async () => {
         const vulnWithAssessment = {
             ...vulnerability,
             assessments: [{
@@ -2060,9 +2059,34 @@ describe('Vulnerability Modal', () => {
 
         render(<VulnModal vuln={vulnWithAssessment} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
 
-        // Should show placeholder for missing workaround
-        const placeholder = screen.getByText(/no workaround available/i);
-        expect(placeholder).toBeInTheDocument();
+        expect(screen.queryByText(/no workaround available/i)).not.toBeInTheDocument();
+        expect(screen.getByText(/some notes/i)).toBeInTheDocument();
+    });
+
+    test('assessment sentinel notes and workaround are omitted', () => {
+        const vulnWithAssessment = {
+            ...vulnerability,
+            assessments: [{
+                id: 'sentinel-assessment',
+                vuln_id: vulnerability.id,
+                packages: vulnerability.packages,
+                status: 'affected',
+                simplified_status: 'Exploitable',
+                justification: '',
+                impact_statement: 'confirmed impact',
+                status_notes: 'No Status Notes',
+                workaround: ' no workaround available ',
+                timestamp: new Date().toISOString(),
+                origin: 'custom',
+                responses: [],
+            }]
+        };
+
+        render(<VulnModal vuln={vulnWithAssessment} onClose={() => {}} appendAssessment={() => {}} appendCVSS={() => null} patchVuln={() => {}} />);
+
+        expect(screen.getByText(/confirmed impact/i)).toBeInTheDocument();
+        expect(screen.queryByText(/no status notes/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/no workaround available/i)).not.toBeInTheDocument();
     });
 
     test('renders empty CVSS array', async () => {
@@ -2594,10 +2618,42 @@ describe('Vulnerability Modal', () => {
     test('renders pending AI review panel at all times, with approve and reject actions only in edit mode', async () => {
         renderWithPendingAiAssessment();
 
-        expect(await screen.findByText(/AI-generated/i)).toBeInTheDocument();
+        const aiPanel = (await screen.findByText(/AI-generated/i)).closest('.mb-6');
+        expect(aiPanel).toBeInTheDocument();
         expect(screen.getByText(/Pending review/i)).toBeInTheDocument();
+        expect(aiPanel).toHaveTextContent('ai notes');
+        expect(aiPanel).toHaveTextContent('ai workaround');
         expect(screen.queryByRole('button', { name: /Approve/i })).not.toBeInTheDocument();
         expect(screen.queryByRole('button', { name: /Reject/i })).not.toBeInTheDocument();
+    });
+
+    test('pending AI review omits sentinel status notes and workaround', async () => {
+        fetchMock.resetMocks();
+        fetchMock.mockResponse((req) => {
+            if (req.url.includes(`/api/vulnerabilities/${encodeURIComponent(vulnerability.id)}/assessments`)) {
+                return Promise.resolve(JSON.stringify([{
+                    ...pendingAiAssessment,
+                    status_notes: 'no status notes',
+                    workaround: 'no workaround available',
+                }]));
+            }
+            return Promise.resolve(JSON.stringify([]));
+        });
+
+        render(
+            <VulnModal
+                vuln={{ ...vulnerability, assessments: [] }}
+                onClose={() => {}}
+                appendAssessment={() => {}}
+                appendCVSS={() => null}
+                patchVuln={() => {}}
+            />
+        );
+
+        expect(await screen.findByText(/AI-generated/i)).toBeInTheDocument();
+        expect(screen.getByText('ai impact statement')).toBeInTheDocument();
+        expect(screen.queryByText(/no status notes/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/no workaround available/i)).not.toBeInTheDocument();
     });
 
     test('approving an ungrouped pending AI review promotes it to a group, then calls approveAiGroup', async () => {


### PR DESCRIPTION
## Fixes # by hiding unavailable optional assessment details

### Changes proposed in this pull request:

* Omit empty and sentinel status notes and workarounds from assessment views.
* Apply the same behavior to pending AI assessment details.
* Preserve display of legitimate user-entered notes and workarounds.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

* Run `npm test -- --runInBand --coverage=false tests/unit_tests/test_vuln_modal.tsx` from `frontend`.
* Open vulnerabilities with absent, sentinel, and populated optional assessment details; confirm only populated values are displayed.

### Additional notes

Optional fields remain available when meaningful while placeholder sentinel text is treated as unavailable data.

### Related Issue

No linked issue.

## Pull Request Checklist

Please review and check all that apply before submitting your PR:

- [X] The code compiles and passes all tests
- [ ] All new and existing tests are passing
- [ ] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [ ] Linked relevant issues (if any)
- [ ] Added necessary reviewers
