### PR TITLE
feat(operations): expose the queue API and the SSE event stream

### DIFF
--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -8,8 +8,10 @@
 from ..helpers.add_middleware import FlaskWithMiddleware as Flask
 from ..helpers.env_vars import get_bool_env
 from ..extensions import db, migrate, setup_write_serialization
+from ..controllers.operation_queue import queue as operation_queue
 from ..routes import init_app
 from ..routes.documents import MAX_ASSET_UPLOAD_BYTES
+from ..routes.events import STREAM_PATH
 from .. import models  # noqa: F401
 from .merger_ci import init_app as init_merger_cli, post_treatment
 import sys
@@ -28,26 +30,34 @@ DEFAULT_BACKGROUND_TASK_DELAY = 120.0
 
 
 def _launch_enrichment(app):
-    """Spawn background thread for EPSS enrichment.
+    """Queue boot EPSS enrichment so its progress reaches the event stream."""
+    from ..controllers.job_context import JobContext
+    from ..controllers.operation_queue import queue
+    from ..controllers.operation_registry import (
+        KIND_ENRICHMENT, LANE_PIPELINE, registry,
+    )
 
-    Runs in its own thread so it doesn't block Flask request handlers
-    (WAL journal mode allows concurrent reads).
-    """
-    def _enrich_epss():
-        with app.app_context():
-            # Disable autoflush: without this, every SELECT triggers a flush
-            # which acquires the write-lock and holds it across the slow HTTP
-            # calls until the next explicit commit().  With autoflush=False
-            # the lock is only held during commit() itself (milliseconds).
-            db.session.autoflush = False
-            try:
-                from ..controllers import ControllersCache
-                controllers = ControllersCache()
-                post_treatment(controllers)
-            except Exception as e:
-                print(f"[enrichment/epss] {e}", flush=True)
+    op_id = "enrichment:boot"
+    if registry.has_active(op_id):
+        return
 
-    threading.Thread(target=_enrich_epss, name="enrichment-epss", daemon=True).start()
+    def _enrich_epss(ctx):
+        # Disable autoflush: without this, every SELECT triggers a flush which
+        # acquires the write-lock and holds it across the slow HTTP calls until
+        # the next explicit commit(). With autoflush=False the lock is only
+        # held during commit() itself (milliseconds).
+        db.session.autoflush = False
+        from ..controllers import ControllersCache
+        post_treatment(ControllersCache(), reporter=ctx)
+
+    registry.create(
+        op_id=op_id,
+        kind=KIND_ENRICHMENT,
+        source="epss",
+        label="EPSS enrichment",
+        lane=LANE_PIPELINE,
+    )
+    queue.submit(op_id, LANE_PIPELINE, _enrich_epss, JobContext(op_id))
 
 
 def _warm_scan_list_cache(app):
@@ -238,12 +248,18 @@ def create_app():
 
     @app.middleware("/api")
     def fail_scan_not_finished(*args, **kw):
-        if request.path in {"/api", "/api/openapi", "/api/openapi.json", "/api/openapi/ui"}:
+        # The event stream is exempt like /api/scan/status: the UI opens it
+        # during boot import so it can render enrichment progress live.
+        if request.path in {
+            "/api", "/api/openapi", "/api/openapi.json", "/api/openapi/ui",
+            STREAM_PATH,
+        }:
             return None
         if not is_scan_finished():
             return {"error": "Scan not finished"}, 503
 
     init_app(app)
+    operation_queue.init_app(app)
     init_merger_cli(app)
     return app
 

--- a/src/helpers/openapi.py
+++ b/src/helpers/openapi.py
@@ -22,6 +22,7 @@ _SCAN_EXEMPT_PATHS = {
     "/api/openapi/ui",
     "/api/scan/status",
     "/api/version",
+    "/api/events/stream",
 }
 
 

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,19 +1,15 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
-from .bulk_refresh import init_app as init_bulk_refresh_app
 from .packages import init_app as init_pkg_app
 from .vulnerabilities import init_app as init_vuln_app
 from .assessments import init_app as init_assess_app
 from .documents import init_app as init_doc_app
-from .nvd_progress import init_app as init_nvd_progress_app
-from .epss_progress import init_app as init_epss_progress_app
-from .ghsa_progress import init_app as init_ghsa_progress_app
-from .euvd_progress import init_app as init_euvd_progress_app
+from .events import init_app as init_events_app
+from .operations import init_app as init_operations_app
 from .project import init_app as init_project_app
 from .variant import init_app as init_variant_app
 from .scans import init_app as init_scans_app
-from .scan_triggers import init_app as init_scan_triggers_app
 from .config import init_app as init_config_app
 from .settings import init_app as init_settings_app
 from .openapi import init_app as init_openapi_app
@@ -26,15 +22,11 @@ def init_app(app):
     init_vuln_app(app)
     init_assess_app(app)
     init_doc_app(app)
-    init_nvd_progress_app(app)
-    init_epss_progress_app(app)
-    init_ghsa_progress_app(app)
-    init_euvd_progress_app(app)
+    init_events_app(app)
+    init_operations_app(app)
     init_project_app(app)
     init_variant_app(app)
     init_scans_app(app)
-    init_scan_triggers_app(app)
-    init_bulk_refresh_app(app)
     init_config_app(app)
     init_settings_app(app)
     init_context_app(app)

--- a/src/routes/events.py
+++ b/src/routes/events.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Server-sent event stream carrying every operation update.
+
+One connection replaces the per-scan, per-refresh, upload and export polling
+loops the frontend used to run. A new connection starts with a full snapshot;
+a reconnecting client that sends a usable ``Last-Event-ID`` receives the
+buffered deltas it missed instead, and falls back to a fresh snapshot when the
+gap is too wide to replay.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Iterator, Optional
+
+from flask import Flask, Response, jsonify, request, stream_with_context
+from flask.typing import ResponseReturnValue
+
+from ..controllers.event_bus import operation_events
+from ..controllers.operation_registry import registry
+
+STREAM_PATH = "/api/events/stream"
+
+# Long enough to stay cheap, short enough that proxies and load balancers do
+# not treat an idle stream as dead.
+HEARTBEAT_SECONDS = 15.0
+
+DEFAULT_MAX_STREAMS = 32
+
+_active_streams = 0
+_streams_lock = threading.Lock()
+
+
+def _max_streams() -> int:
+    """Cap concurrent streams; each one occupies a server thread."""
+    try:
+        return max(1, int(os.environ.get("VULNSCOUT_SSE_MAX_STREAMS", DEFAULT_MAX_STREAMS)))
+    except ValueError:
+        return DEFAULT_MAX_STREAMS
+
+
+def _acquire_slot() -> bool:
+    global _active_streams
+    with _streams_lock:
+        if _active_streams >= _max_streams():
+            return False
+        _active_streams += 1
+        return True
+
+
+def _release_slot() -> None:
+    global _active_streams
+    with _streams_lock:
+        _active_streams = max(0, _active_streams - 1)
+
+
+def _frame(event_type: str, data: dict, seq: Optional[int] = None) -> str:
+    lines = []
+    if seq is not None:
+        lines.append(f"id: {seq}")
+    lines.append(f"event: {event_type}")
+    lines.append(f"data: {json.dumps(data, default=str)}")
+    return "\n".join(lines) + "\n\n"
+
+
+def _snapshot_frame() -> tuple[str, int]:
+    seq = operation_events.seq
+    return _frame("snapshot", {"seq": seq, "operations": registry.snapshot()}), seq
+
+
+def _parse_last_event_id() -> Optional[int]:
+    raw = request.headers.get("Last-Event-ID") or request.args.get("last_event_id")
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _stream(last_event_id: Optional[int]) -> Iterator[str]:
+    # Subscribe before snapshotting so nothing published in between is lost;
+    # overlapping events are filtered by sequence below.
+    subscription = operation_events.subscribe()
+    try:
+        highest_sent = 0
+        replay = (
+            operation_events.replay_since(last_event_id)
+            if last_event_id is not None else None
+        )
+        if replay is not None:
+            highest_sent = last_event_id or 0
+            for event in replay:
+                yield _frame(event["event"], event["data"], event["seq"])
+                highest_sent = max(highest_sent, event["seq"])
+        else:
+            # No usable history: the client rebuilds from a full snapshot.
+            frame, highest_sent = _snapshot_frame()
+            yield frame
+
+        while True:
+            events = subscription.drain(HEARTBEAT_SECONDS)
+            if subscription.closed:
+                yield _frame("bye", {"reason": "server shutdown"})
+                return
+            if subscription.overflowed:
+                subscription.overflowed = False
+                frame, highest_sent = _snapshot_frame()
+                yield frame
+                continue
+            if not events:
+                yield _frame("heartbeat", {"seq": highest_sent})
+                continue
+            for event in events:
+                if event["seq"] <= highest_sent:
+                    continue
+                yield _frame(event["event"], event["data"], event["seq"])
+                highest_sent = event["seq"]
+    finally:
+        subscription.close()
+        _release_slot()
+
+
+def init_app(app: Flask) -> None:
+
+    @app.route(STREAM_PATH)
+    def operation_event_stream() -> ResponseReturnValue:
+        """Stream every operation update over a single connection.
+
+        Frames are ``snapshot`` (full state, sent first), ``operation`` and
+        ``operation_removed`` deltas, ``heartbeat`` every 15 seconds, and
+        ``bye`` on shutdown. Reconnecting clients that send ``Last-Event-ID``
+        are replayed from the buffer, or resnapshotted when the gap is too wide.
+
+        OpenAPI:
+        header Last-Event-ID string optional Resume from this sequence number.
+        response 200 string Server-sent event stream.
+        response 503 Error Too many concurrent streams.
+        """
+        if not _acquire_slot():
+            return jsonify({"error": "Too many concurrent event streams"}), 503
+
+        response = Response(
+            stream_with_context(_stream(_parse_last_event_id())),
+            mimetype="text/event-stream",
+        )
+        response.headers["Cache-Control"] = "no-cache, no-transform"
+        response.headers["Connection"] = "keep-alive"
+        # Tells nginx and friends to forward frames instead of buffering them.
+        response.headers["X-Accel-Buffering"] = "no"
+        return response

--- a/src/routes/operations.py
+++ b/src/routes/operations.py
@@ -1,0 +1,412 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unified operation queue API.
+
+One endpoint enqueues any mix of scans and vulnerability refreshes; progress is
+delivered exclusively through ``/api/events/stream``.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid as uuid_module
+from typing import Dict, List, Tuple
+
+from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
+
+from ..controllers.job_context import JobContext
+from ..controllers.operation_queue import queue
+from ..controllers.operation_registry import (
+    KIND_REFRESH,
+    KIND_SCAN,
+    LANE_PIPELINE,
+    new_queue_id,
+    registry,
+)
+from ..controllers.refresh_jobs import (
+    MAX_CVE_IDS,
+    MAX_GHSA_IDS,
+    REFRESH_JOBS,
+    known_cve_ids,
+    normalise_cve_ids,
+    normalise_ghsa_ids,
+    run_deferred_refresh,
+)
+from ..controllers.scan_jobs import SCAN_JOBS
+from ..controllers.variants import VariantController
+
+SCAN_LABELS = {
+    "grype": "Grype",
+    "nvd": "NVD CPE",
+    "osv": "OSV PURL",
+    "scc": "sbom-cve-check",
+}
+
+REFRESH_LABELS = {
+    "nvd": "NVD",
+    "epss": "EPSS",
+    "ghsa": "GHSA",
+    "euvd": "ENISA EUVD",
+}
+
+# The order the frontend used to enforce by awaiting each manager in turn.
+SCAN_ORDER = ["grype", "nvd", "osv", "scc"]
+REFRESH_ORDER = ["nvd", "epss", "ghsa", "euvd"]
+
+VALID_MODES = ("local", "api")
+
+# Serialises the conflict check and the registry writes so two simultaneous
+# requests cannot both pass the check and double-submit the same operation.
+_enqueue_lock = threading.Lock()
+
+
+def scan_op_id(source: str, variant_id: str) -> str:
+    return f"scan:{source}:{variant_id}"
+
+
+def refresh_op_id(source: str) -> str:
+    return f"refresh:{source}"
+
+
+class _PlanError(Exception):
+    """Rejects a batch before anything is queued."""
+
+    def __init__(self, message: str, status: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status = status
+
+
+def _job_options(job: dict) -> dict:
+    options = job.get("options")
+    if options is None:
+        return {}
+    if not isinstance(options, dict):
+        raise _PlanError("options must be an object")
+    return options
+
+
+def _mode_option(options: dict) -> str:
+    mode = options.get("mode", "local")
+    if mode not in VALID_MODES:
+        raise _PlanError(f"Unsupported mode: {mode}")
+    return mode
+
+
+def _bool_option(options: dict, key: str, default: bool) -> bool:
+    value = options.get(key, default)
+    if not isinstance(value, bool):
+        raise _PlanError(f"{key} must be a boolean")
+    return value
+
+
+def _plan_scan_job(job: dict) -> List[dict]:
+    source = job.get("source")
+    if source not in SCAN_JOBS:
+        raise _PlanError(f"Unknown scan source: {source}")
+
+    variant_ids = job.get("variant_ids") or []
+    if not isinstance(variant_ids, list) or not variant_ids:
+        raise _PlanError(f"{source} scan requires a non-empty variant_ids list")
+
+    options = _job_options(job)
+    mode = _mode_option(options)
+    exclude_kernel = _bool_option(options, "exclude_kernel", True)
+    planned: List[dict] = []
+    for raw_id in variant_ids:
+        try:
+            variant_uuid = uuid_module.UUID(str(raw_id))
+        except (ValueError, AttributeError):
+            raise _PlanError(f"Invalid variant id: {raw_id}")
+        variant = VariantController.get(variant_uuid)
+        if variant is None:
+            raise _PlanError(f"Variant not found: {raw_id}", status=404)
+
+        planned.append({
+            "op_id": scan_op_id(source, str(variant_uuid)),
+            "kind": KIND_SCAN,
+            "source": source,
+            "label": SCAN_LABELS[source],
+            "lane": LANE_PIPELINE,
+            "scope": {
+                "variant_id": str(variant_uuid),
+                "variant_name": variant.name,
+                "project_id": str(variant.project_id),
+            },
+            "options": {
+                "variant_id": str(variant_uuid),
+                "exclude_kernel": exclude_kernel,
+                "mode": mode,
+            },
+            "runner": SCAN_JOBS[source],
+        })
+    return planned
+
+
+def _deferred_refresh_options(source: str, job: dict, mode: str) -> dict:
+    if job.get("ids") is not None:
+        raise _PlanError("refresh jobs cannot specify both ids and variant_ids")
+    raw_variant_ids = job.get("variant_ids")
+    if not isinstance(raw_variant_ids, list) or not raw_variant_ids:
+        raise _PlanError(f"{source} deferred refresh requires variant_ids")
+
+    variant_ids: List[str] = []
+    for raw_id in raw_variant_ids:
+        try:
+            variant_uuid = uuid_module.UUID(str(raw_id))
+        except (ValueError, AttributeError):
+            raise _PlanError(f"Invalid variant id: {raw_id}")
+        if VariantController.get(variant_uuid) is None:
+            raise _PlanError(f"Variant not found: {raw_id}", status=404)
+        variant_ids.append(str(variant_uuid))
+
+    exclude_ids = (
+        normalise_ghsa_ids(job.get("exclude_ids", []))
+        if source == "ghsa"
+        else normalise_cve_ids(job.get("exclude_ids", []))
+    )
+    return {
+        "ids": [],
+        "mode": mode,
+        "source": source,
+        "variant_ids": variant_ids,
+        "exclude_ids": exclude_ids,
+    }
+
+
+def _explicit_refresh_options(source: str, job: dict, mode: str) -> dict:
+    if source == "ghsa":
+        ids = normalise_ghsa_ids(job.get("ids"))
+        if not ids:
+            raise _PlanError("ghsa refresh requires valid GHSA identifiers")
+        if len(ids) > MAX_GHSA_IDS:
+            raise _PlanError(f"ghsa refresh accepts at most {MAX_GHSA_IDS} identifiers")
+        return {"ids": ids, "mode": mode}
+
+    ids = normalise_cve_ids(job.get("ids"))
+    if not ids:
+        raise _PlanError(f"{source} refresh requires valid CVE identifiers")
+    if source == "nvd" and mode == "api" and len(ids) > MAX_CVE_IDS:
+        raise _PlanError(
+            f"nvd refresh accepts at most {MAX_CVE_IDS} identifiers in api mode"
+        )
+    if source == "epss":
+        ids = known_cve_ids(ids)
+        if not ids:
+            raise _PlanError("epss refresh requires at least one known CVE identifier")
+    return {"ids": ids, "mode": mode}
+
+
+def _plan_refresh_job(job: dict) -> List[dict]:
+    source = job.get("source")
+    if source not in REFRESH_JOBS:
+        raise _PlanError(f"Unknown refresh source: {source}")
+
+    options = _job_options(job)
+    mode = _mode_option(options)
+    deferred = job.get("variant_ids") is not None
+    job_options = (
+        _deferred_refresh_options(source, job, mode)
+        if deferred
+        else _explicit_refresh_options(source, job, mode)
+    )
+
+    return [{
+        "op_id": refresh_op_id(source),
+        "kind": KIND_REFRESH,
+        "source": source,
+        "label": REFRESH_LABELS[source],
+        "lane": LANE_PIPELINE,
+        "scope": None,
+        "options": job_options,
+        "runner": run_deferred_refresh if deferred else REFRESH_JOBS[source],
+    }]
+
+
+def _plan(jobs: List[dict]) -> List[dict]:
+    """Expand the requested jobs into individual operations, in execution order."""
+    scans: Dict[str, List[dict]] = {}
+    refreshes: Dict[str, List[dict]] = {}
+
+    for job in jobs:
+        if not isinstance(job, dict):
+            raise _PlanError("Each job must be an object")
+        kind = job.get("kind")
+        if kind == KIND_SCAN:
+            scans.setdefault(str(job.get("source")), []).extend(_plan_scan_job(job))
+        elif kind == KIND_REFRESH:
+            refreshes.setdefault(str(job.get("source")), []).extend(_plan_refresh_job(job))
+        else:
+            raise _PlanError(f"Unsupported job kind: {kind}")
+
+    planned: List[dict] = []
+    for source in SCAN_ORDER:
+        planned.extend(scans.get(source, []))
+    for source in REFRESH_ORDER:
+        planned.extend(refreshes.get(source, []))
+    return planned
+
+
+def _conflicts(planned: List[dict]) -> List[str]:
+    return [item["op_id"] for item in planned if registry.has_active(item["op_id"])]
+
+
+def _duplicates(planned: List[dict]) -> List[str]:
+    seen: set = set()
+    duplicated: List[str] = []
+    for item in planned:
+        if item["op_id"] in seen:
+            duplicated.append(item["op_id"])
+        seen.add(item["op_id"])
+    return duplicated
+
+
+class _ConflictError(Exception):
+    """Raised when a requested operation is already queued or running."""
+
+    def __init__(self, operations: List[str]) -> None:
+        super().__init__("conflicting operations")
+        self.operations = operations
+
+
+def _enqueue(planned: List[dict]) -> Tuple[str, List[dict]]:
+    queue_id = new_queue_id()
+    created: List[dict] = []
+    for position, item in enumerate(planned, 1):
+        operation = registry.create(
+            op_id=item["op_id"],
+            kind=item["kind"],
+            source=item["source"],
+            label=item["label"],
+            lane=item["lane"],
+            scope=item["scope"],
+            queue_id=queue_id,
+            position=position,
+            options=item["options"],
+            cancellable=True,
+        )
+        created.append(operation)
+        queue.submit(
+            op_id=item["op_id"],
+            lane=item["lane"],
+            runner=item["runner"],
+            ctx=JobContext(item["op_id"], item["options"]),
+        )
+    return queue_id, created
+
+
+def _enqueue_exclusively(planned: List[dict]) -> Tuple[str, List[dict]]:
+    """Conflict check and registry writes under one lock, so concurrent
+    requests cannot both pass the check and double-submit an operation."""
+    with _enqueue_lock:
+        conflicting = _conflicts(planned)
+        if conflicting:
+            raise _ConflictError(conflicting)
+        return _enqueue(planned)
+
+
+def _cancel_operation_response(op_id: str) -> ResponseReturnValue:
+    operation = registry.get(op_id)
+    if operation is not None and not operation.get("cancellable", False):
+        return jsonify({"error": "This operation does not support cancellation"}), 409
+    if queue.cancel(op_id):
+        return jsonify({"status": "cancelling", "op_id": op_id}), 200
+    return jsonify({"error": "No active operation with that id"}), 404
+
+
+def init_app(app: Flask) -> None:
+
+    @app.route('/api/operations', methods=['POST'])
+    def enqueue_operations() -> ResponseReturnValue:
+        """Queue a batch of scans and vulnerability refreshes.
+
+        Body: ``{"jobs": [{"kind": "scan", "source": "grype",
+        "variant_ids": [...], "options": {...}}, ...]}``
+
+        Scans run before refreshes and each family keeps its canonical order, so
+        one request reproduces the whole pipeline. Progress is published on
+        ``/api/events/stream``; there is no status endpoint to poll.
+
+        OpenAPI:
+        body JsonObject optional Batch of jobs to queue.
+        response 202 JsonObject Queue accepted with the created operations.
+        response 400 Error Invalid job specification.
+        response 404 Error Referenced variant not found.
+        response 409 Error One of the requested operations is already active.
+        """
+        body = request.get_json(force=True, silent=True) or {}
+        jobs = body.get("jobs")
+        if not isinstance(jobs, list) or not jobs:
+            return jsonify({"error": "jobs must be a non-empty list"}), 400
+
+        try:
+            planned = _plan(jobs)
+        except _PlanError as error:
+            return jsonify({"error": error.message}), error.status
+
+        if not planned:
+            return jsonify({"error": "jobs produced no operations"}), 400
+
+        duplicated = _duplicates(planned)
+        if duplicated:
+            return jsonify({
+                "error": "jobs contain duplicate operations",
+                "operations": duplicated,
+            }), 400
+
+        try:
+            queue_id, created = _enqueue_exclusively(planned)
+        except _ConflictError as conflict:
+            return jsonify({
+                "error": "Some requested operations are already queued or running",
+                "operations": conflict.operations,
+            }), 409
+        return jsonify({"queue_id": queue_id, "operations": created}), 202
+
+    @app.route('/api/operations', methods=['GET'])
+    def list_operations() -> ResponseReturnValue:
+        """Return every tracked operation.
+
+        The SSE stream sends the same payload as its first frame; this endpoint
+        exists for clients that cannot hold a stream open and for diagnostics.
+
+        OpenAPI:
+        response 200 JsonObject Current operation snapshot.
+        """
+        return jsonify({"operations": registry.snapshot()})
+
+    @app.route('/api/operations/<path:op_id>/cancel', methods=['POST'])
+    def cancel_operation(op_id: str) -> ResponseReturnValue:
+        """Cancel a queued or running operation.
+
+        Queued work is dropped without starting; running work receives a
+        cooperative stop signal that its job body honours at the next checkpoint.
+
+        OpenAPI:
+        response 200 JsonObject Cancellation accepted.
+        response 404 Error No such active operation.
+        """
+        return _cancel_operation_response(op_id)
+
+    @app.route('/api/operations/queue/<queue_id>/cancel', methods=['POST'])
+    def cancel_operation_queue(queue_id: str) -> ResponseReturnValue:
+        """Cancel every still-active operation in a batch.
+
+        OpenAPI:
+        response 200 JsonObject Number of operations cancelled.
+        """
+        return jsonify({"cancelled": queue.cancel_queue(queue_id)}), 200
+
+    @app.route('/api/operations/<path:op_id>', methods=['DELETE'])
+    def dismiss_operation(op_id: str) -> ResponseReturnValue:
+        """Forget a finished operation so it disappears from every client.
+
+        OpenAPI:
+        response 200 JsonObject Operation dismissed.
+        response 409 Error Operation is still active.
+        """
+        if registry.remove(op_id):
+            return jsonify({"status": "dismissed", "op_id": op_id}), 200
+        return jsonify({"error": "Operation is unknown or still active"}), 409

--- a/tests/unit_tests/test_webapp_coverage_boost.py
+++ b/tests/unit_tests/test_webapp_coverage_boost.py
@@ -9,6 +9,10 @@ import pytest
 from flask import Flask
 
 from src.bin import webapp as webapp_mod
+from src.controllers import operation_queue as operation_queue_mod
+from src.controllers.operation_registry import (
+    KIND_ENRICHMENT, LANE_PIPELINE, registry,
+)
 
 
 class _InlineThread:
@@ -23,42 +27,85 @@ class _InlineThread:
         self._target()
 
 
-def test_launch_enrichment_executes_epss(monkeypatch):
-    calls: list[str] = []
+@pytest.fixture()
+def captured_submissions(monkeypatch):
+    """Record what ``_launch_enrichment`` hands to the operation queue."""
+    registry.clear()
+    submissions: list[dict] = []
 
-    fake_session = SimpleNamespace(autoflush=True)
-    fake_db = SimpleNamespace(session=fake_session)
+    def _submit(op_id, lane, runner, ctx):
+        submissions.append(
+            {"op_id": op_id, "lane": lane, "runner": runner, "ctx": ctx}
+        )
 
-    def _record_post_treatment(_controllers):
-        calls.append("epss")
+    monkeypatch.setattr(operation_queue_mod.queue, "submit", _submit)
+    yield submissions
+    registry.clear()
 
-    monkeypatch.setattr(webapp_mod, "db", fake_db)
-    monkeypatch.setattr(webapp_mod.threading, "Thread", _InlineThread)
-    monkeypatch.setattr(webapp_mod, "post_treatment", _record_post_treatment)
 
+def test_boot_enrichment_is_registered_as_a_pipeline_operation(
+    captured_submissions,
+):
+    webapp_mod._launch_enrichment(Flask(__name__))
+
+    operation = registry.get("enrichment:boot")
+    assert operation is not None
+    assert operation["kind"] == KIND_ENRICHMENT
+    assert operation["source"] == "epss"
+    assert operation["lane"] == LANE_PIPELINE
+
+    assert len(captured_submissions) == 1
+    submission = captured_submissions[0]
+    assert submission["op_id"] == "enrichment:boot"
+    assert submission["lane"] == LANE_PIPELINE
+    assert submission["ctx"].op_id == "enrichment:boot"
+
+
+def test_boot_enrichment_is_not_queued_twice(captured_submissions):
     app = Flask(__name__)
     webapp_mod._launch_enrichment(app)
+    webapp_mod._launch_enrichment(app)
+
+    assert len(captured_submissions) == 1
+
+
+def test_boot_enrichment_runs_post_treatment_with_a_reporter(
+    captured_submissions, monkeypatch
+):
+    fake_session = SimpleNamespace(autoflush=True)
+    monkeypatch.setattr(webapp_mod, "db", SimpleNamespace(session=fake_session))
+
+    reporters: list[object] = []
+    monkeypatch.setattr(
+        webapp_mod, "post_treatment",
+        lambda _controllers, reporter=None: reporters.append(reporter),
+    )
+
+    webapp_mod._launch_enrichment(Flask(__name__))
+    submission = captured_submissions[0]
+    submission["runner"](submission["ctx"])
 
     assert fake_session.autoflush is False
-    assert "epss" in calls
+    assert reporters == [submission["ctx"]]
 
 
-def test_launch_enrichment_catches_and_logs_failures(monkeypatch, capsys):
-    fake_session = SimpleNamespace(autoflush=True)
-    fake_db = SimpleNamespace(session=fake_session)
+def test_boot_enrichment_failure_reaches_the_queue(
+    captured_submissions, monkeypatch
+):
+    """The runner raises so the queue can mark the operation as failed."""
+    monkeypatch.setattr(
+        webapp_mod, "db", SimpleNamespace(session=SimpleNamespace(autoflush=True))
+    )
 
-    def _raise_in_post_treatment(_controllers):
+    def _raise(_controllers, reporter=None):
         raise RuntimeError("epss failure")
 
-    monkeypatch.setattr(webapp_mod, "db", fake_db)
-    monkeypatch.setattr(webapp_mod.threading, "Thread", _InlineThread)
-    monkeypatch.setattr(webapp_mod, "post_treatment", _raise_in_post_treatment)
+    monkeypatch.setattr(webapp_mod, "post_treatment", _raise)
 
-    app = Flask(__name__)
-    webapp_mod._launch_enrichment(app)
-
-    out = capsys.readouterr().out
-    assert "[enrichment/epss]" in out
+    webapp_mod._launch_enrichment(Flask(__name__))
+    submission = captured_submissions[0]
+    with pytest.raises(RuntimeError, match="epss failure"):
+        submission["runner"](submission["ctx"])
 
 
 def test_create_app_schedules_background_tasks_when_scan_finished(monkeypatch, tmp_path):

--- a/tests/webapp_tests/test_event_stream.py
+++ b/tests/webapp_tests/test_event_stream.py
@@ -1,0 +1,277 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""The single SSE stream that replaced every status and progress endpoint."""
+
+import json
+import os
+
+import pytest
+
+from src.bin.webapp import create_app
+from src.controllers.event_bus import operation_events
+from src.controllers.operation_registry import (
+    LANE_PIPELINE,
+    STATUS_DONE,
+    registry,
+)
+from src.routes import events as events_module
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    registry.clear()
+    yield
+    registry.clear()
+
+
+@pytest.fixture(autouse=True)
+def fast_heartbeat(monkeypatch):
+    """Keep the idle timeout short so tests never wait 15 seconds."""
+    monkeypatch.setattr(events_module, "HEARTBEAT_SECONDS", 0.05)
+
+
+@pytest.fixture()
+def open_stream(client):
+    """Open streams and guarantee they are closed, freeing their slot."""
+    readers = []
+
+    def _open(**kwargs):
+        response = client.get("/api/events/stream", **kwargs)
+        reader = _Reader(response)
+        readers.append(reader)
+        return reader
+
+    yield _open
+    for reader in readers:
+        reader.close()
+
+
+class _Reader:
+    """Pulls SSE frames off a streaming response.
+
+    Reading is synchronous: the shortened heartbeat guarantees the generator
+    yields something within milliseconds, so no worker thread is needed.
+    """
+
+    def __init__(self, response):
+        self.response = response
+        self._iterator = iter(response.response)
+
+    def next_frame(self):
+        chunk = next(self._iterator)
+        return parse_frame(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+    def next_frame_of(self, event_type, max_skips=50):
+        for _ in range(max_skips):
+            frame = self.next_frame()
+            if frame["event"] == event_type:
+                return frame
+        raise AssertionError(f"no {event_type!r} frame arrived")
+
+    def close(self):
+        self.response.close()
+
+
+def parse_frame(raw):
+    parsed = {"id": None, "event": None, "data": None}
+    for line in raw.strip().splitlines():
+        key, _, value = line.partition(": ")
+        if key == "id":
+            parsed["id"] = int(value)
+        elif key == "event":
+            parsed["event"] = value
+        elif key == "data":
+            parsed["data"] = json.loads(value)
+    return parsed
+
+
+def _create(op_id, status=None):
+    operation = registry.create(
+        op_id=op_id, kind="scan", source="grype", label="Grype", lane=LANE_PIPELINE
+    )
+    if status is not None:
+        operation = registry.update(op_id, status=status)
+    return operation
+
+
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+def test_stream_declares_the_sse_content_type_and_disables_buffering(client):
+    response = client.get("/api/events/stream")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("text/event-stream")
+    assert response.headers["X-Accel-Buffering"] == "no"
+    assert "no-cache" in response.headers["Cache-Control"]
+    response.close()
+
+
+def test_stream_is_reachable_before_the_boot_import_finishes(app, tmp_path):
+    """The UI opens the stream while /api is still gated, like /api/scan/status."""
+    unfinished = tmp_path / "unfinished.txt"
+    unfinished.write_text("3 still importing")
+    app.config["SCAN_FILE"] = str(unfinished)
+    app._INT_SCAN_FINISHED = False
+
+    client = app.test_client()
+    assert client.get("/api/packages").status_code == 503
+
+    response = client.get("/api/events/stream")
+    assert response.status_code == 200
+    response.close()
+
+
+# ---------------------------------------------------------------------------
+# Snapshot first
+# ---------------------------------------------------------------------------
+
+def test_first_frame_is_a_full_snapshot(open_stream):
+    _create("scan:grype:v1")
+    _create("refresh:epss")
+
+    frame = open_stream().next_frame()
+
+    assert frame["event"] == "snapshot"
+    assert sorted(op["op_id"] for op in frame["data"]["operations"]) == [
+        "refresh:epss", "scan:grype:v1",
+    ]
+
+
+def test_snapshot_carries_progress_and_logs_so_a_reload_restores_everything(open_stream):
+    _create("scan:grype:v1")
+    registry.update(
+        "scan:grype:v1",
+        status="running",
+        progress={"current": 7, "total": 20, "message": "7/20 packages"},
+        append_logs=["Resolving active packages…"],
+    )
+
+    operations = open_stream().next_frame_of("snapshot")["data"]["operations"]
+
+    assert operations[0]["progress"] == {
+        "current": 7, "total": 20, "message": "7/20 packages",
+    }
+    assert operations[0]["logs"] == ["Resolving active packages…"]
+
+
+def test_queued_operations_survive_a_reload(open_stream):
+    """The old per-variant status endpoints could only restore running scans."""
+    _create("scan:grype:v1")
+
+    operations = open_stream().next_frame_of("snapshot")["data"]["operations"]
+
+    assert [op["status"] for op in operations] == ["queued"]
+
+
+# ---------------------------------------------------------------------------
+# Deltas
+# ---------------------------------------------------------------------------
+
+def test_updates_arrive_as_operation_deltas(open_stream):
+    reader = open_stream()
+    reader.next_frame_of("snapshot")
+
+    _create("scan:grype:v1")
+    frame = reader.next_frame_of("operation")
+
+    assert frame["data"]["op_id"] == "scan:grype:v1"
+    assert frame["id"] is not None
+
+
+def test_dismissal_is_broadcast_so_every_client_forgets_the_operation(open_stream):
+    _create("scan:grype:v1", status=STATUS_DONE)
+
+    reader = open_stream()
+    reader.next_frame_of("snapshot")
+
+    registry.remove("scan:grype:v1")
+    frame = reader.next_frame_of("operation_removed")
+
+    assert frame["data"] == {"op_id": "scan:grype:v1"}
+
+
+def test_idle_stream_emits_heartbeats(open_stream):
+    reader = open_stream()
+    reader.next_frame_of("snapshot")
+
+    assert reader.next_frame_of("heartbeat")["event"] == "heartbeat"
+
+
+# ---------------------------------------------------------------------------
+# Reconnection
+# ---------------------------------------------------------------------------
+
+def test_reconnect_with_last_event_id_replays_instead_of_resnapshotting(open_stream):
+    _create("scan:grype:v1")
+    baseline = operation_events.seq
+    registry.update("scan:grype:v1", status=STATUS_DONE)
+
+    frame = open_stream(headers={"Last-Event-ID": str(baseline)}).next_frame()
+
+    assert frame["event"] == "operation"
+    assert frame["data"]["status"] == STATUS_DONE
+
+
+def test_reconnect_resnapshots_when_the_gap_is_too_wide(open_stream):
+    _create("scan:grype:v1")
+
+    # A sequence far beyond anything published cannot be bridged from the buffer.
+    frame = open_stream(headers={"Last-Event-ID": "999999999"}).next_frame()
+
+    assert frame["event"] == "snapshot"
+
+
+def test_unparsable_last_event_id_falls_back_to_a_snapshot(open_stream):
+    frame = open_stream(headers={"Last-Event-ID": "garbage"}).next_frame()
+
+    assert frame["event"] == "snapshot"
+
+
+# ---------------------------------------------------------------------------
+# Capacity
+# ---------------------------------------------------------------------------
+
+def test_stream_count_is_capped_because_each_one_holds_a_thread(client, open_stream, monkeypatch):
+    monkeypatch.setenv("VULNSCOUT_SSE_MAX_STREAMS", "1")
+
+    assert open_stream().response.status_code == 200
+
+    refused = client.get("/api/events/stream")
+    assert refused.status_code == 503
+    assert "Too many concurrent event streams" in refused.get_json()["error"]
+
+
+def test_client_disconnect_releases_the_subscription_and_the_stream_slot(open_stream):
+    subscribers_before = operation_events.subscriber_count()
+    streams_before = events_module._active_streams
+
+    reader = open_stream()
+    reader.next_frame_of("snapshot")
+    assert operation_events.subscriber_count() == subscribers_before + 1
+    assert events_module._active_streams == streams_before + 1
+
+    # Closing the response finalizes the generator, as a client abort does.
+    reader.close()
+
+    assert operation_events.subscriber_count() == subscribers_before
+    assert events_module._active_streams == streams_before

--- a/tests/webapp_tests/test_operation_queue.py
+++ b/tests/webapp_tests/test_operation_queue.py
@@ -1,0 +1,342 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Operation registry, queue lanes and cancellation semantics."""
+
+import os
+import threading
+import time
+
+import pytest
+
+from src.bin.webapp import create_app
+from src.controllers.event_bus import EventBus
+from src.controllers.job_context import CancelledError, JobContext
+from src.controllers.operation_queue import OperationQueue
+from src.controllers.operation_registry import (
+    LANE_EXPORT,
+    LANE_PIPELINE,
+    STATUS_CANCELLED,
+    STATUS_DONE,
+    STATUS_ERROR,
+    STATUS_QUEUED,
+    STATUS_RUNNING,
+    registry,
+)
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    registry.clear()
+    yield
+    registry.clear()
+
+
+@pytest.fixture
+def op_queue(app):
+    queue = OperationQueue()
+    queue.init_app(app)
+    return queue
+
+
+def _create(op_id, lane=LANE_PIPELINE, queue_id=None, position=None):
+    return registry.create(
+        op_id=op_id, kind="scan", source="grype", label="Grype",
+        lane=lane, queue_id=queue_id, position=position, cancellable=True,
+    )
+
+
+def _wait_for(op_id, status, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        operation = registry.get(op_id)
+        if operation is not None and operation["status"] == status:
+            return operation
+        time.sleep(0.01)
+    actual = registry.get(op_id)
+    raise AssertionError(
+        f"{op_id} never reached {status}; last state="
+        f"{actual['status'] if actual else 'missing'}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+def test_create_publishes_queued_operation():
+    operation = _create("scan:grype:v1")
+    assert operation["status"] == STATUS_QUEUED
+    assert registry.has_active("scan:grype:v1")
+    assert [op["op_id"] for op in registry.snapshot()] == ["scan:grype:v1"]
+
+
+def test_update_appends_logs_without_replacing_them():
+    _create("scan:grype:v1")
+    registry.update("scan:grype:v1", append_logs=["first"])
+    registry.update("scan:grype:v1", append_logs=["second", "third"])
+    assert registry.get("scan:grype:v1")["logs"] == ["first", "second", "third"]
+
+
+def test_terminal_status_stamps_finished_at_once():
+    _create("scan:grype:v1")
+    registry.update("scan:grype:v1", status=STATUS_DONE)
+    first = registry.get("scan:grype:v1")["finished_at"]
+    registry.update("scan:grype:v1", append_logs=["late"])
+    assert registry.get("scan:grype:v1")["finished_at"] == first
+
+
+def test_remove_only_drops_terminal_operations():
+    _create("scan:grype:v1")
+    assert registry.remove("scan:grype:v1") is False
+    registry.update("scan:grype:v1", status=STATUS_DONE)
+    assert registry.remove("scan:grype:v1") is True
+    assert registry.get("scan:grype:v1") is None
+
+
+# ---------------------------------------------------------------------------
+# Queue lanes
+# ---------------------------------------------------------------------------
+
+def test_pipeline_lane_runs_operations_serially_in_submission_order(op_queue):
+    order = []
+    running = []
+    overlap = threading.Event()
+
+    def make_runner(name):
+        def runner(ctx):
+            running.append(name)
+            if len(running) > 1:
+                overlap.set()
+            order.append(name)
+            time.sleep(0.05)
+            running.remove(name)
+        return runner
+
+    for name in ("a", "b", "c"):
+        _create(f"scan:grype:{name}")
+        op_queue.submit(
+            f"scan:grype:{name}", LANE_PIPELINE, make_runner(name),
+            JobContext(f"scan:grype:{name}"),
+        )
+
+    for name in ("a", "b", "c"):
+        _wait_for(f"scan:grype:{name}", STATUS_DONE)
+
+    assert order == ["a", "b", "c"]
+    assert not overlap.is_set(), "pipeline lane ran two operations at once"
+
+
+def test_export_lane_runs_two_operations_concurrently(op_queue):
+    both_started = threading.Barrier(2, timeout=5)
+
+    def runner(ctx):
+        both_started.wait()
+
+    for name in ("x", "y"):
+        _create(f"export:{name}", lane=LANE_EXPORT)
+        op_queue.submit(
+            f"export:{name}", LANE_EXPORT, runner, JobContext(f"export:{name}")
+        )
+
+    # The barrier only releases if both operations are in flight together.
+    for name in ("x", "y"):
+        _wait_for(f"export:{name}", STATUS_DONE)
+
+
+def test_failing_job_records_the_error(op_queue):
+    def runner(ctx):
+        raise RuntimeError("grype binary not found on this system")
+
+    _create("scan:grype:v1")
+    op_queue.submit("scan:grype:v1", LANE_PIPELINE, runner, JobContext("scan:grype:v1"))
+
+    operation = _wait_for("scan:grype:v1", STATUS_ERROR)
+    assert operation["error"] == "grype binary not found on this system"
+    assert operation["logs"][-1].startswith("ERROR:")
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+def test_cancelling_a_queued_operation_prevents_it_from_running(op_queue):
+    release = threading.Event()
+    ran = []
+
+    def blocker(ctx):
+        release.wait(timeout=5)
+
+    def should_not_run(ctx):
+        ran.append(True)
+
+    _create("scan:grype:first")
+    op_queue.submit("scan:grype:first", LANE_PIPELINE, blocker, JobContext("scan:grype:first"))
+    _wait_for("scan:grype:first", STATUS_RUNNING)
+
+    _create("scan:grype:second")
+    op_queue.submit(
+        "scan:grype:second", LANE_PIPELINE, should_not_run, JobContext("scan:grype:second")
+    )
+
+    assert op_queue.cancel("scan:grype:second") is True
+    assert registry.get("scan:grype:second")["status"] == STATUS_CANCELLED
+
+    release.set()
+    _wait_for("scan:grype:first", STATUS_DONE)
+    assert ran == [], "a cancelled queued operation still executed"
+
+
+def test_cancelling_a_running_operation_reaches_cancelled(op_queue):
+    started = threading.Event()
+
+    def runner(ctx):
+        started.set()
+        for _ in range(500):
+            ctx.check_cancelled()
+            time.sleep(0.01)
+
+    _create("scan:grype:v1")
+    op_queue.submit("scan:grype:v1", LANE_PIPELINE, runner, JobContext("scan:grype:v1"))
+    assert started.wait(timeout=5)
+
+    assert op_queue.cancel("scan:grype:v1") is True
+    _wait_for("scan:grype:v1", STATUS_CANCELLED)
+
+
+def test_cancel_queue_stops_every_operation_in_the_batch(op_queue):
+    release = threading.Event()
+
+    def blocker(ctx):
+        release.wait(timeout=5)
+
+    _create("scan:grype:a", queue_id="q-1", position=1)
+    op_queue.submit("scan:grype:a", LANE_PIPELINE, blocker, JobContext("scan:grype:a"))
+    _wait_for("scan:grype:a", STATUS_RUNNING)
+
+    for index, name in enumerate(("b", "c"), 2):
+        _create(f"scan:grype:{name}", queue_id="q-1", position=index)
+        op_queue.submit(
+            f"scan:grype:{name}", LANE_PIPELINE, blocker, JobContext(f"scan:grype:{name}")
+        )
+
+    assert op_queue.cancel_queue("q-1") == 3
+    release.set()
+    for name in ("b", "c"):
+        assert registry.get(f"scan:grype:{name}")["status"] == STATUS_CANCELLED
+
+
+def test_cancel_returns_false_for_unknown_operation(op_queue):
+    assert op_queue.cancel("scan:grype:missing") is False
+
+
+# ---------------------------------------------------------------------------
+# Job context
+# ---------------------------------------------------------------------------
+
+def test_check_cancelled_raises_after_request():
+    ctx = JobContext("scan:grype:v1")
+    ctx.check_cancelled()
+    ctx.request_cancel()
+    with pytest.raises(CancelledError):
+        ctx.check_cancelled()
+
+
+def test_cancel_hook_fires_so_blocking_work_can_abort():
+    ctx = JobContext("scan:grype:v1")
+    aborted = threading.Event()
+    ctx.set_cancel_hook(aborted.set)
+    ctx.request_cancel()
+    assert aborted.is_set()
+
+
+def test_flush_publishes_buffered_progress_and_logs():
+    _create("scan:grype:v1")
+    ctx = JobContext("scan:grype:v1")
+    ctx.report(3, 10, "3/10 packages")
+    ctx.log("scanning")
+    ctx.flush()
+
+    operation = registry.get("scan:grype:v1")
+    assert operation["progress"] == {"current": 3, "total": 10, "message": "3/10 packages"}
+    assert operation["logs"] == ["scanning"]
+
+
+def test_message_keeps_the_last_reported_counters():
+    _create("scan:grype:v1")
+    ctx = JobContext("scan:grype:v1")
+    ctx.report(4, 9, "4/9 packages")
+    ctx.flush()
+    ctx.message("Syncing advisory database")
+    ctx.flush()
+
+    progress = registry.get("scan:grype:v1")["progress"]
+    assert progress == {
+        "current": 4, "total": 9, "message": "Syncing advisory database",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Event bus
+# ---------------------------------------------------------------------------
+
+def test_publish_assigns_monotonic_sequence_numbers():
+    bus = EventBus()
+    first = bus.publish("operation", {"op_id": "a"})
+    second = bus.publish("operation", {"op_id": "b"})
+    assert (first["seq"], second["seq"]) == (1, 2)
+    assert bus.seq == 2
+
+
+def test_subscriber_receives_events_published_after_subscribing():
+    bus = EventBus()
+    subscription = bus.subscribe()
+    bus.publish("operation", {"op_id": "a"})
+    events = subscription.drain(timeout=1)
+    assert [event["data"]["op_id"] for event in events] == ["a"]
+    subscription.close()
+
+
+def test_replay_returns_events_after_the_given_sequence():
+    bus = EventBus()
+    for name in ("a", "b", "c"):
+        bus.publish("operation", {"op_id": name})
+    replayed = list(bus.replay_since(1))
+    assert [event["data"]["op_id"] for event in replayed] == ["b", "c"]
+
+
+def test_replay_returns_none_when_the_gap_is_too_wide():
+    bus = EventBus(replay_size=2)
+    for name in ("a", "b", "c", "d"):
+        bus.publish("operation", {"op_id": name})
+    assert bus.replay_since(1) is None
+
+
+def test_slow_subscriber_overflows_instead_of_blocking_the_publisher():
+    bus = EventBus(client_backlog=2)
+    subscription = bus.subscribe()
+    for index in range(5):
+        bus.publish("operation", {"op_id": str(index)})
+    assert subscription.overflowed is True
+    subscription.close()
+
+
+def test_close_all_signals_every_subscriber():
+    bus = EventBus()
+    subscription = bus.subscribe()
+    bus.close_all()
+    subscription.drain(timeout=1)
+    assert subscription.closed is True

--- a/tests/webapp_tests/test_operations_api.py
+++ b/tests/webapp_tests/test_operations_api.py
@@ -1,0 +1,380 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""The unified enqueue API that replaced the eight trigger endpoints."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+from src.controllers.operation_registry import STATUS_DONE, registry
+
+
+def _build_db(app):
+    from src.models.package import Package
+    from src.models.project import Project
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.scan import Scan
+    from src.models.variant import Variant
+    from src.models.vulnerability import Vulnerability
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("OpsProject")
+        first = Variant.create("alpha", project.id)
+        second = Variant.create("beta", project.id)
+
+        scan = Scan.create("initial scan", first.id, scan_type="sbom")
+        package = Package.find_or_create(
+            "openssl", "1.1.1",
+            cpe=["cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"],
+            purl=["pkg:generic/openssl/openssl@1.1.1"],
+        )
+        Vulnerability.create_record(id="CVE-2024-1111", description="known")
+        _db.session.commit()
+
+        sbom = SBOMDocument.create("/test/sbom.json", "spdx", scan.id)
+        SBOMPackage.create(sbom.id, package.id)
+        _db.session.commit()
+
+        return {
+            "project_id": str(project.id),
+            "variant_a": str(first.id),
+            "variant_b": str(second.id),
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        application._test_ids = _build_db(application)
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    registry.clear()
+    yield
+    registry.clear()
+
+
+@pytest.fixture(autouse=True)
+def never_execute():
+    """Keep enqueue tests about planning, not about running real scanners."""
+    with patch("src.controllers.operation_queue.OperationQueue.submit"):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Planning and ordering
+# ---------------------------------------------------------------------------
+
+def test_one_request_queues_scans_then_refreshes_in_canonical_order(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "refresh", "source": "epss", "ids": ["CVE-2024-1111"]},
+        {"kind": "scan", "source": "scc", "variant_ids": [ids["variant_a"]]},
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+        {"kind": "refresh", "source": "nvd", "ids": ["CVE-2024-1111"]},
+    ]})
+
+    assert response.status_code == 202
+    assert [op["op_id"] for op in response.get_json()["operations"]] == [
+        f"scan:grype:{ids['variant_a']}",
+        f"scan:scc:{ids['variant_a']}",
+        "refresh:nvd",
+        "refresh:epss",
+    ]
+
+
+def test_a_scan_expands_to_one_operation_per_variant(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype",
+         "variant_ids": [ids["variant_a"], ids["variant_b"]]},
+    ]})
+
+    operations = response.get_json()["operations"]
+    assert [op["position"] for op in operations] == [1, 2]
+    assert [op["scope"]["variant_name"] for op in operations] == ["alpha", "beta"]
+
+
+def test_every_operation_in_a_batch_shares_one_queue_id(client, ids):
+    payload = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+        {"kind": "refresh", "source": "epss", "ids": ["CVE-2024-1111"]},
+    ]}).get_json()
+
+    queue_ids = {op["queue_id"] for op in payload["operations"]}
+    assert queue_ids == {payload["queue_id"]}
+
+
+def test_deferred_refresh_is_reserved_with_its_scan_batch(client, ids):
+    payload = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+        {"kind": "refresh", "source": "epss", "variant_ids": [ids["variant_a"]],
+         "exclude_ids": ["CVE-2024-1111"]},
+    ]}).get_json()
+
+    assert [operation["op_id"] for operation in payload["operations"]] == [
+        f"scan:grype:{ids['variant_a']}",
+        "refresh:epss",
+    ]
+    refresh = payload["operations"][1]
+    assert refresh["queue_id"] == payload["queue_id"]
+    assert refresh["options"]["variant_ids"] == [ids["variant_a"]]
+    assert refresh["options"]["exclude_ids"] == ["CVE-2024-1111"]
+    assert refresh["cancellable"] is True
+
+
+def test_scan_options_are_carried_onto_the_operation(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "nvd", "variant_ids": [ids["variant_a"]],
+         "options": {"exclude_kernel": False, "mode": "api"}},
+    ]})
+
+    options = response.get_json()["operations"][0]["options"]
+    assert options["exclude_kernel"] is False
+    assert options["mode"] == "api"
+
+
+def test_operations_start_queued_so_the_ui_can_show_the_whole_batch(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype",
+         "variant_ids": [ids["variant_a"], ids["variant_b"]]},
+    ]})
+
+    assert {op["status"] for op in response.get_json()["operations"]} == {"queued"}
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_empty_job_list_is_rejected(client):
+    assert client.post("/api/operations", json={"jobs": []}).status_code == 400
+
+
+def test_unknown_scan_source_is_rejected(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "nessus", "variant_ids": [ids["variant_a"]]},
+    ]})
+    assert response.status_code == 400
+    assert "nessus" in response.get_json()["error"]
+
+
+def test_malformed_variant_id_is_rejected(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": ["not-a-uuid"]},
+    ]})
+    assert response.status_code == 400
+
+
+def test_unknown_variant_returns_404(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype",
+         "variant_ids": ["11111111-1111-1111-1111-111111111111"]},
+    ]})
+    assert response.status_code == 404
+
+
+def test_refresh_without_valid_identifiers_is_rejected(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "refresh", "source": "nvd", "ids": ["not-a-cve"]},
+    ]})
+    assert response.status_code == 400
+
+
+def test_epss_refresh_requires_at_least_one_known_cve(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "refresh", "source": "epss", "ids": ["CVE-2000-9999"]},
+    ]})
+    assert response.status_code == 400
+
+
+def test_ghsa_refresh_rejects_cve_identifiers(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "refresh", "source": "ghsa", "ids": ["CVE-2024-1111"]},
+    ]})
+    assert response.status_code == 400
+
+
+def test_nothing_is_queued_when_planning_fails(client, ids):
+    client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+        {"kind": "scan", "source": "grype", "variant_ids": ["not-a-uuid"]},
+    ]})
+    assert registry.snapshot() == []
+
+
+def test_the_same_operation_twice_in_one_batch_is_rejected(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+    ]})
+    assert response.status_code == 400
+    assert response.get_json()["operations"] == [f"scan:grype:{ids['variant_a']}"]
+
+
+def test_relaunching_an_active_operation_conflicts(client, ids):
+    job = {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]}
+    assert client.post("/api/operations", json={"jobs": [job]}).status_code == 202
+
+    response = client.post("/api/operations", json={"jobs": [job]})
+    assert response.status_code == 409
+    assert response.get_json()["operations"] == [f"scan:grype:{ids['variant_a']}"]
+
+
+def test_a_finished_operation_can_be_relaunched(client, ids):
+    job = {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]}
+    client.post("/api/operations", json={"jobs": [job]})
+    registry.update(f"scan:grype:{ids['variant_a']}", status=STATUS_DONE)
+
+    assert client.post("/api/operations", json={"jobs": [job]}).status_code == 202
+
+
+def test_non_object_options_are_rejected(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]],
+         "options": "exclude_kernel"},
+    ]})
+    assert response.status_code == 400
+    assert "options must be an object" in response.get_json()["error"]
+
+
+def test_unknown_mode_is_rejected(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "nvd", "variant_ids": [ids["variant_a"]],
+         "options": {"mode": "turbo"}},
+    ]})
+    assert response.status_code == 400
+    assert "Unsupported mode" in response.get_json()["error"]
+
+
+def test_string_exclude_kernel_is_rejected_instead_of_truthy_coerced(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]],
+         "options": {"exclude_kernel": "false"}},
+    ]})
+    assert response.status_code == 400
+    assert "exclude_kernel must be a boolean" in response.get_json()["error"]
+
+
+def test_refresh_with_unknown_mode_is_rejected(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "refresh", "source": "nvd", "ids": ["CVE-2024-1111"],
+         "options": {"mode": "remote"}},
+    ]})
+    assert response.status_code == 400
+    assert "Unsupported mode" in response.get_json()["error"]
+
+
+def test_concurrent_requests_for_the_same_operation_yield_one_winner(app):
+    """The conflict check and the registry writes happen under one lock."""
+    import threading
+
+    # An nvd refresh plans without touching the database, so every thread
+    # reaches the enqueue step and the race is purely about the lock.
+    job = {"kind": "refresh", "source": "nvd", "ids": ["CVE-2024-1111"]}
+    attempts = 8
+    barrier = threading.Barrier(attempts)
+    statuses = []
+    statuses_lock = threading.Lock()
+
+    def submit():
+        thread_client = app.test_client()
+        barrier.wait()
+        response = thread_client.post("/api/operations", json={"jobs": [job]})
+        with statuses_lock:
+            statuses.append(response.status_code)
+
+    threads = [threading.Thread(target=submit) for _ in range(attempts)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(statuses) == [202] + [409] * (attempts - 1)
+    assert len(registry.snapshot()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Snapshot, cancel, dismiss
+# ---------------------------------------------------------------------------
+
+def test_snapshot_endpoint_mirrors_the_stream(client, ids):
+    client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+    ]})
+
+    payload = client.get("/api/operations").get_json()
+    assert [op["op_id"] for op in payload["operations"]] == [
+        f"scan:grype:{ids['variant_a']}"
+    ]
+
+
+def test_cancelling_an_unknown_operation_returns_404(client):
+    assert client.post("/api/operations/scan:grype:nope/cancel").status_code == 404
+
+
+def test_cancelling_an_unsupported_operation_returns_409(client):
+    registry.create(
+        op_id="upload:active", kind="upload", source="sbom", label="SBOM import",
+        lane="upload",
+    )
+
+    response = client.post("/api/operations/upload:active/cancel")
+
+    assert response.status_code == 409
+    assert "does not support cancellation" in response.get_json()["error"]
+
+
+def test_cancelling_a_batch_reports_how_many_stopped(client, ids):
+    payload = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype",
+         "variant_ids": [ids["variant_a"], ids["variant_b"]]},
+    ]}).get_json()
+
+    response = client.post(f"/api/operations/queue/{payload['queue_id']}/cancel")
+    assert response.status_code == 200
+
+
+def test_dismiss_removes_a_finished_operation(client, ids):
+    client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+    ]})
+    op_id = f"scan:grype:{ids['variant_a']}"
+    registry.update(op_id, status=STATUS_DONE)
+
+    assert client.delete(f"/api/operations/{op_id}").status_code == 200
+    assert registry.get(op_id) is None
+
+
+def test_dismiss_refuses_while_the_operation_is_active(client, ids):
+    client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+    ]})
+
+    response = client.delete(f"/api/operations/scan:grype:{ids['variant_a']}")
+    assert response.status_code == 409


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR 2 of 6 — split out of #529.** Review and merge in order; each PR targets the one before it.
>
> 1. #548 — operation queue core, scan/refresh jobs extracted → base `staging`
> 2. **#549 — queue REST API and SSE event stream → base `#548` ← you are here**
> 3. #550 — delete the 21 legacy polling endpoints → base `#549`
> 4. #551 — route exports and uploads through the queue → base `#550`
> 5. #552 — frontend SSE operation store, queue rendered from it → base `#551`
> 6. #553 — migrate remaining frontend workflows, delete the polling client → base `#552`
>
> The tip of the stack (#553) is commit-identical to #529, which stays open untouched as the integration reference.

---

## Fixes # by putting one batch-submit endpoint and one event stream in front of the queue

### Changes proposed in this pull request:

* Add `GET /api/events/stream`, a single Server-Sent Events connection carrying every operation update: a full `snapshot` first, then `operation` / `operation_removed` deltas, a `heartbeat` every 15 s, and `bye` on shutdown. `Last-Event-ID` replays from a bounded buffer, or triggers a fresh snapshot when the gap is too wide.
* Add `POST /api/operations`, which accepts a whole batch of scans and refreshes in one request and expands it into individually tracked operations. Scans run before refreshes; each family keeps its canonical order (`grype → nvd → osv → scc`, then `nvd → epss → ghsa → euvd`).
* Add cooperative cancellation for scans, which previously had none — only the four bulk refreshes could be cancelled. A cancel request also terminates the Grype subprocess.
* Run three lanes reproducing the concurrency the frontend used to enforce by hand: `pipeline` (all scans and refreshes, strictly serial), `export` (two at a time), and `upload` (one thread each).
* Register the queue on the app in `bin/webapp.py` and surface the boot enrichment thread as a tracked operation — it previously reported nothing at all.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

The legacy polling endpoints are all still present and untouched in this layer, so the running app is unaffected. `curl -N http://localhost:7275/api/events/stream` should emit a `snapshot` immediately and a `heartbeat` every 15 s. `POST /api/operations` with a multi-scan batch should return one operation id per expanded operation, and those should appear on the stream in canonical order.

### Additional notes

Adding the new surface before removing the old one keeps this PR and the next one independently reviewable, and means the stack is never in a state where neither mechanism works.

### Related Issue

No linked issue.

## Pull Request Checklist

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers
