### PR TITLE
refactor(operations): route exports and uploads through the queue

### DIFF
--- a/src/routes/documents.py
+++ b/src/routes/documents.py
@@ -4,7 +4,6 @@
 from flask import Flask, Response, copy_current_request_context, request, make_response, send_file
 from flask.typing import ResponseReturnValue
 import atexit
-from concurrent.futures import ThreadPoolExecutor
 import io
 import json
 import os
@@ -12,13 +11,15 @@ import mimetypes
 import re
 import tempfile
 import threading
-import time
 import traceback
 import uuid
 import zipfile
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from PIL import Image
 from ..controllers import ControllersCache
+from ..controllers.job_context import JobContext
+from ..controllers.operation_queue import queue as operation_queue
+from ..controllers.operation_registry import KIND_EXPORT, LANE_EXPORT, STATUS_DONE, registry
 from ..models.project import Project
 from ..models.variant import Variant
 from ..views.templates import Templates, find_asset
@@ -28,23 +29,25 @@ from ..views.spdx3 import SPDX3
 from ..views.openvex import OpenVex
 from ..helpers.export_scope import ExportScope, compute_export_scope
 from ._scan_helpers import parse_uuid_or_400
-from typing import BinaryIO, Callable, cast, Dict, List, Optional
+from typing import BinaryIO, Callable, cast, Dict, List, Optional, Tuple
 
 
 # You can associate specific files to specific categories
 # "example.adoc": ["misc", "category_name"]
 CategoriesDictionary: Dict[str, List[str]] = {}
 ASCIIDOC_MIME = "text/asciidoc"
-_export_jobs: Dict[str, Dict[str, object]] = {}
-_export_jobs_lock = threading.Lock()
 EXPORT_JOB_TTL_SECONDS = 3600
 EXPORT_MAX_WORKERS = 2
 EXPORT_MAX_QUEUED_JOBS = 4
 EXPORT_MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
 EXPORT_MAX_RETAINED_ARCHIVE_BYTES = 512 * 1024 * 1024
-_export_executor = ThreadPoolExecutor(max_workers=EXPORT_MAX_WORKERS, thread_name_prefix="document-export")
-_export_capacity = threading.BoundedSemaphore(EXPORT_MAX_WORKERS + EXPORT_MAX_QUEUED_JOBS)
+# Async exports run on the shared "export" lane, which has EXPORT_MAX_WORKERS
+# workers; this bounds how many may additionally wait behind them.
+EXPORT_MAX_ACTIVE_JOBS = EXPORT_MAX_WORKERS + EXPORT_MAX_QUEUED_JOBS
+# Serialises archive accounting (retention budget, TTL pruning, download pop).
+_export_archive_lock = threading.Lock()
 _sync_export_capacity = threading.BoundedSemaphore(EXPORT_MAX_WORKERS)
+_EPOCH = datetime.fromtimestamp(0, timezone.utc)
 
 
 # Directories searched for user-provided templates, most-preferred first. This
@@ -436,8 +439,10 @@ class _SizeLimitedArchive:
         self.output.flush()
 
 
-def _delete_archive(job: Dict[str, object]) -> None:
-    archive_path = job.get("archive_path")
+def _delete_archive(result: object) -> None:
+    if not isinstance(result, dict):
+        return
+    archive_path = result.get("archive_path")
     if isinstance(archive_path, str):
         try:
             os.remove(archive_path)
@@ -445,40 +450,62 @@ def _delete_archive(job: Dict[str, object]) -> None:
             pass
 
 
-def _prune_export_jobs() -> None:
-    cutoff = time.monotonic() - EXPORT_JOB_TTL_SECONDS
-    expired = []
-    for job_id, job in _export_jobs.items():
-        finished_at = job.get("finished_at")
-        if isinstance(finished_at, float) and finished_at < cutoff:
-            expired.append(job_id)
-    for job_id in expired:
-        _delete_archive(_export_jobs.pop(job_id))
+def _parse_timestamp(value: object) -> Optional[datetime]:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _discard_export(op_id: str, result: object) -> None:
+    _delete_archive(result)
+    registry.remove(op_id)
+
+
+def _retained_archives() -> List[Tuple[str, Dict[str, object], Optional[datetime]]]:
+    """Export operations still owning an archive on disk, oldest first.
+
+    The operation registry is the archive table: the path lives in the
+    operation ``result``, so retention accounting reads straight from it.
+    """
+    entries: List[Tuple[str, Dict[str, object], Optional[datetime], datetime]] = []
+    for operation in registry.snapshot():
+        if operation.get("kind") != KIND_EXPORT:
+            continue
+        result = operation.get("result")
+        if not isinstance(result, dict) or not isinstance(result.get("archive_path"), str):
+            continue
+        finished_at = _parse_timestamp(operation.get("finished_at"))
+        ordering = finished_at or _parse_timestamp(operation.get("created_at")) or _EPOCH
+        entries.append((str(operation["op_id"]), result, finished_at, ordering))
+    entries.sort(key=lambda entry: entry[3])
+    return [(op_id, result, finished_at) for op_id, result, finished_at, _ in entries]
+
+
+def _prune_export_archives() -> None:
+    """Drop archives whose operation finished longer ago than the TTL."""
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=EXPORT_JOB_TTL_SECONDS)
+    for op_id, result, finished_at in _retained_archives():
+        if finished_at is not None and finished_at < cutoff:
+            _discard_export(op_id, result)
 
 
 def _reserve_retained_archive(archive_bytes: int) -> None:
-    retained = [
-        (job_id, job) for job_id, job in _export_jobs.items()
-        if isinstance(job.get("archive_path"), str)
-    ]
-
-    def finished_at(item: tuple[str, Dict[str, object]]) -> float:
-        value = item[1].get("finished_at")
-        return value if isinstance(value, float) else 0.0
-
-    retained.sort(key=finished_at)
+    retained = _retained_archives()
     retained_bytes = sum(
-        os.path.getsize(str(job["archive_path"]))
-        for _, job in retained
-        if os.path.isfile(str(job["archive_path"]))
+        os.path.getsize(str(result["archive_path"]))
+        for _, result, _ in retained
+        if os.path.isfile(str(result["archive_path"]))
     )
-    for job_id, job in retained:
+    for op_id, result, _ in retained:
         if retained_bytes + archive_bytes <= EXPORT_MAX_RETAINED_ARCHIVE_BYTES:
             break
-        path = str(job["archive_path"])
+        path = str(result["archive_path"])
         if os.path.isfile(path):
             retained_bytes -= os.path.getsize(path)
-        _delete_archive(_export_jobs.pop(job_id))
+        _discard_export(op_id, result)
 
 
 def _unique_archive_path(path: str, used_paths: set[str]) -> str:
@@ -493,9 +520,9 @@ def _unique_archive_path(path: str, used_paths: set[str]) -> str:
 
 
 def _cleanup_export_archives() -> None:
-    with _export_jobs_lock:
-        for job in _export_jobs.values():
-            _delete_archive(job)
+    with _export_archive_lock:
+        for _, result, _ in _retained_archives():
+            _delete_archive(result)
 
 
 atexit.register(_cleanup_export_archives)
@@ -683,34 +710,22 @@ def init_app(app: Flask) -> None:
         filename = f"{project_name}_{suffix}_export.zip"
 
         if body.get("async") is True:
-            if not _export_capacity.acquire(blocking=False):
+            active_exports = sum(
+                1 for operation in registry.active() if operation.get("kind") == KIND_EXPORT
+            )
+            if active_exports >= EXPORT_MAX_ACTIVE_JOBS:
                 response = make_response({"error": "Export queue is full; retry later"}, 503)
                 response.headers["Retry-After"] = "5"
                 return response
 
-            job_id = str(uuid.uuid4())
-            with _export_jobs_lock:
-                _prune_export_jobs()
-                _export_jobs[job_id] = {
-                    "status": "running",
-                    "current": 0,
-                    "total": len(scopes) * len(selections),
-                    "progress": "Queued",
-                    "logs": [],
-                    "error": None,
-                    "filename": filename,
-                }
+            op_id = f"export:{uuid.uuid4()}"
 
             @copy_current_request_context
-            def generate_archive() -> None:
+            def generate_archive(ctx: JobContext) -> None:
                 def update_progress(current: int, total: int, element_name: str) -> None:
                     message = f"Generating {current} of {total} element: {element_name}"
-                    with _export_jobs_lock:
-                        job = _export_jobs[job_id]
-                        job.update({"current": current, "total": total, "progress": message})
-                        logs = job["logs"]
-                        assert isinstance(logs, list)
-                        logs.append(message)
+                    ctx.report(current, total, message)
+                    ctx.log(message)
 
                 archive_path: str | None = None
                 try:
@@ -719,49 +734,37 @@ def init_app(app: Flask) -> None:
                     ) as archive:
                         archive_path = archive.name
                         _build_export_archive(app, scopes, selections, cast(BinaryIO, archive), update_progress)
-                    with _export_jobs_lock:
-                        _prune_export_jobs()
+                    with _export_archive_lock:
+                        _prune_export_archives()
                         _reserve_retained_archive(os.path.getsize(archive_path))
-                        _export_jobs[job_id].update({
-                            "status": "done",
-                            "progress": "Export ready",
+                        ctx.message("Export ready")
+                        ctx.set_result({
                             "archive_path": archive_path,
-                            "finished_at": time.monotonic(),
+                            "filename": filename,
+                            "download_ready": True,
                         })
                     archive_path = None
-                except (ExportGenerationError, FileNotFoundError) as exc:
-                    message = str(exc)
-                    if isinstance(exc, FileNotFoundError):
-                        message = "Required conversion tool was not found"
-                    with _export_jobs_lock:
-                        _export_jobs[job_id].update({
-                            "status": "error",
-                            "error": message,
-                            "progress": "Export failed",
-                            "finished_at": time.monotonic(),
-                        })
+                except ExportGenerationError as exc:
+                    raise RuntimeError(str(exc)) from exc
+                except FileNotFoundError as exc:
+                    raise RuntimeError("Required conversion tool was not found") from exc
                 except Exception:
-                    app.logger.exception("Export job %s failed", job_id)
-                    with _export_jobs_lock:
-                        _export_jobs[job_id].update({
-                            "status": "error",
-                            "error": "Export generation failed",
-                            "progress": "Export failed",
-                            "finished_at": time.monotonic(),
-                        })
+                    app.logger.exception("Export operation %s failed", op_id)
+                    raise RuntimeError("Export generation failed")
                 finally:
                     if archive_path is not None:
                         _delete_archive({"archive_path": archive_path})
 
-            try:
-                future = _export_executor.submit(generate_archive)
-            except RuntimeError:
-                with _export_jobs_lock:
-                    del _export_jobs[job_id]
-                _export_capacity.release()
-                return {"error": "Export service is unavailable"}, 503
-            future.add_done_callback(lambda _future: _export_capacity.release())
-            return {"job_id": job_id}, 202
+            registry.create(
+                op_id=op_id,
+                kind=KIND_EXPORT,
+                source="documents",
+                label=f"Export {project.name}",
+                lane=LANE_EXPORT,
+                scope={"project_id": str(project_uuid), "project_name": project.name},
+            )
+            operation_queue.submit(op_id, LANE_EXPORT, generate_archive, JobContext(op_id))
+            return {"op_id": op_id}, 202
 
         if not _sync_export_capacity.acquire(blocking=False):
             response = make_response({"error": "Export service is busy; retry later"}, 503)
@@ -786,33 +789,26 @@ def init_app(app: Flask) -> None:
             download_name=filename,
         )
 
-    @app.route('/api/documents/export/<job_id>', methods=['GET'])
-    def export_status(job_id: str) -> ResponseReturnValue:
-        with _export_jobs_lock:
-            _prune_export_jobs()
-            job = _export_jobs.get(job_id)
-            if job is None:
+    @app.route('/api/documents/export/<op_id>/download', methods=['GET'])
+    def download_export(op_id: str) -> ResponseReturnValue:
+        with _export_archive_lock:
+            _prune_export_archives()
+            operation = registry.get(op_id)
+            if operation is None or operation.get("kind") != KIND_EXPORT:
                 return {"error": "Export job not found"}, 404
-            return {key: value for key, value in job.items() if key not in {"archive", "filename", "finished_at"}}
-
-    @app.route('/api/documents/export/<job_id>/download', methods=['GET'])
-    def download_export(job_id: str) -> ResponseReturnValue:
-        with _export_jobs_lock:
-            _prune_export_jobs()
-            job = _export_jobs.get(job_id)
-            if job is None:
-                return {"error": "Export job not found"}, 404
-            if job["status"] != "done" or "archive_path" not in job:
+            result = operation.get("result")
+            if not isinstance(result, dict):
                 return {"error": "Export is not ready"}, 409
-            archive_path = job["archive_path"]
-            if not isinstance(archive_path, str):
-                return {"error": "Export archive is invalid"}, 500
+            archive_path = result.get("archive_path")
+            if operation.get("status") != STATUS_DONE or not isinstance(archive_path, str):
+                return {"error": "Export is not ready"}, 409
             try:
                 archive = open(archive_path, "rb")
             except FileNotFoundError:
-                _delete_archive(_export_jobs.pop(job_id))
+                _discard_export(op_id, result)
                 return {"error": "Export archive is no longer available"}, 410
-            filename = str(_export_jobs.pop(job_id)["filename"])
+            filename = str(result.get("filename"))
+            registry.remove(op_id)
             os.remove(archive_path)
         return send_file(archive, mimetype="application/zip", as_attachment=True, download_name=filename)
 

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -6,7 +6,6 @@ import json
 import uuid
 import time
 import tempfile
-import threading
 import tarfile
 import subprocess
 import shutil
@@ -24,6 +23,9 @@ from ..controllers import (
     ScanController,
     SBOMDocumentController,
 )
+from ..controllers.job_context import JobContext
+from ..controllers.operation_queue import queue as operation_queue
+from ..controllers.operation_registry import KIND_UPLOAD, LANE_UPLOAD, registry
 from ..extensions import db, batch_session
 from ..models.scan import Scan as ScanModel
 from ..models.project import Project
@@ -49,22 +51,7 @@ class _CrudController(Protocol[_C]):
         ...
 
 
-# Tracks in-progress SBOM uploads: upload_id → {status, message, ts}
-_upload_status: dict[str, dict] = {}
-_UPLOAD_STATUS_TTL = 3600  # seconds – entries older than this are pruned
 _REFRESH_SOURCES = set(REFRESH_SOURCES)
-
-
-def _prune_upload_status() -> None:
-    """Remove completed/errored entries older than _UPLOAD_STATUS_TTL."""
-    now = time.time()
-    stale = [
-        uid for uid, info in _upload_status.items()
-        if info.get("status") in ("done", "error")
-        and now - info.get("ts", 0) > _UPLOAD_STATUS_TTL
-    ]
-    for uid in stale:
-        _upload_status.pop(uid, None)
 
 
 def _retry_on_lock(fn: Callable[[], T], max_retries: int = 5, delay: float = 0.5) -> T:
@@ -168,74 +155,62 @@ def _extract_spdx_archive(archive_path: str, filename: str) -> list[tuple[str, s
 
 
 def _process_sbom_background(
-    app: Flask, upload_id: str, file_paths: list[str],
+    ctx: JobContext, file_paths: list[str],
     scan_id: uuid.UUID, variant_id: uuid.UUID, refresh_sources: set[str] | None = None,
 ) -> None:
-    """Run SBOM parsing in a background thread for one or more files."""
+    """Parse uploaded SBOM files and run the selected enrichment refreshes."""
     if refresh_sources is None:
         refresh_sources = {"epss"}
-    with app.app_context():
-        try:
-            _upload_status[upload_id] = {"status": "processing", "message": "Parsing SBOM file(s)..."}
+    try:
+        ctx.report(0, 3, "Parsing SBOM file(s)…")
 
-            from ..bin.cmd_process import read_inputs, populate_observations
+        from ..bin.cmd_process import read_inputs, populate_observations
 
-            controllers = ControllersCache()
-            vulnCtrl = controllers.vulnerabilities
-            assessCtrl = controllers.assessments
-            assessCtrl.current_variant_id = variant_id
+        controllers = ControllersCache()
+        vulnCtrl = controllers.vulnerabilities
+        assessCtrl = controllers.assessments
+        assessCtrl.current_variant_id = variant_id
 
-            with batch_session():
-                vulnCtrl.use_savepoints = False
-                assessCtrl.use_savepoints = False
-                read_inputs(controllers, scan_id=scan_id)
-                verbose("settings/upload: Finished reading inputs")
+        with batch_session():
+            vulnCtrl.use_savepoints = False
+            assessCtrl.use_savepoints = False
+            read_inputs(controllers, scan_id=scan_id)
+            verbose("settings/upload: Finished reading inputs")
 
-            verbose("settings/upload: DB commit done")
+        verbose("settings/upload: DB commit done")
+        ctx.report(1, 3, "Recording observations…")
 
-            # Populate observations table
-            scan = ScanModel.get_by_id(scan_id) if isinstance(scan_id, uuid.UUID) \
-                else ScanModel.get_by_id(uuid.UUID(str(scan_id)))
-            populate_observations(scan, vulnCtrl, log_prefix="settings/upload")
+        scan = ScanModel.get_by_id(scan_id) if isinstance(scan_id, uuid.UUID) \
+            else ScanModel.get_by_id(uuid.UUID(str(scan_id)))
+        populate_observations(scan, vulnCtrl, log_prefix="settings/upload")
 
-            def update_refresh_status(label: str, _step: int, _total: int) -> None:
-                _upload_status[upload_id] = {
-                    "status": "processing",
-                    "message": f"Refreshing {label} data...",
-                }
+        def update_refresh_status(label: str, step: int, total: int) -> None:
+            ctx.report(2, 3, f"Refreshing {label} data… ({step}/{total})")
 
-            failed_sources = refresh_vulnerability_sources(
-                controllers,
-                vulnCtrl._encountered_this_run,
-                refresh_sources,
-                update_refresh_status,
-            )
+        failed_sources = refresh_vulnerability_sources(
+            controllers,
+            vulnCtrl._encountered_this_run,
+            refresh_sources,
+            update_refresh_status,
+        )
 
-            done_message = "SBOM imported successfully."
-            if failed_sources:
-                unique_failed = list(dict.fromkeys(failed_sources))
-                done_message += f" ({', '.join(unique_failed)} refresh failed; check server logs.)"
+        done_message = "SBOM imported successfully."
+        if failed_sources:
+            unique_failed = list(dict.fromkeys(failed_sources))
+            done_message += f" ({', '.join(unique_failed)} refresh failed; check server logs.)"
 
-            _upload_status[upload_id] = {
-                "status": "done",
-                "message": done_message,
-                "ts": time.time(),
-            }
+        ctx.report(3, 3, done_message)
+        ctx.log(done_message)
 
-        except Exception as e:
-            verbose(f"settings/upload: SBOM import failed: {e}")
-            _upload_status[upload_id] = {
-                "status": "error",
-                "message": "SBOM import failed. Check server logs for details.",
-                "ts": time.time(),
-            }
-        finally:
-            # Clean up the temporary files
-            for fp in file_paths:
-                try:
-                    os.unlink(fp)
-                except OSError:
-                    pass
+    except Exception as e:
+        verbose(f"settings/upload: SBOM import failed: {e}")
+        raise RuntimeError("SBOM import failed. Check server logs for details.")
+    finally:
+        for fp in file_paths:
+            try:
+                os.unlink(fp)
+            except OSError:
+                pass
 
 
 def init_app(app: Flask) -> None:
@@ -1230,37 +1205,31 @@ def init_app(app: Flask) -> None:
             SBOMDocumentController.create(tmp_path, filename, scan.id, format=fmt)
             tmp_paths.append(tmp_path)
 
-        _prune_upload_status()
-
         upload_id = str(uuid.uuid4())
-        _upload_status[upload_id] = {"status": "processing", "message": "Starting..."}
-
-        # Process in background
-        threading.Thread(
-            target=_process_sbom_background,
-            args=(app, upload_id, tmp_paths, scan.id, variant.id, refresh_sources),
-            name=f"sbom-upload-{upload_id}",
-            daemon=True,
-        ).start()
+        op_id = f"upload:{upload_id}"
+        registry.create(
+            op_id=op_id,
+            kind=KIND_UPLOAD,
+            source="sbom",
+            label="SBOM import",
+            lane=LANE_UPLOAD,
+            scope={
+                "variant_id": str(variant.id),
+                "variant_name": variant.name,
+                "project_id": str(variant.project_id),
+            },
+        )
+        ctx = JobContext(op_id)
+        operation_queue.submit(
+            op_id, LANE_UPLOAD,
+            lambda job_ctx: _process_sbom_background(
+                job_ctx, tmp_paths, scan.id, variant.id, refresh_sources
+            ),
+            ctx,
+        )
 
         return jsonify({
-            "upload_id": upload_id,
+            "op_id": op_id,
             "scan_id": str(scan.id),
             "message": "Upload accepted. Processing started.",
         }), 202
-
-    # ------------------------------------------------------------------
-    # Upload SBOM status
-    # ------------------------------------------------------------------
-    @app.route('/api/sbom/upload/<upload_id>/status')
-    def upload_sbom_status(upload_id: str) -> ResponseReturnValue:
-        """Return the processing status of an asynchronous SBOM upload.
-
-        OpenAPI:
-        response 200 JsonObject Upload progress payload.
-        response 404 Error Unknown upload identifier.
-        """
-        status = _upload_status.get(upload_id)
-        if status is None:
-            return jsonify({"error": "Unknown upload ID."}), 404
-        return jsonify(status)

--- a/tests/webapp_tests/test_get_endpoints.py
+++ b/tests/webapp_tests/test_get_endpoints.py
@@ -396,7 +396,21 @@ def test_export_documents_disambiguates_colliding_archive_paths(app, client):
         assert archive.namelist() == ["default/summary.adoc", "default/summary_2.adoc"]
 
 
+def _wait_for_operation(op_id, timeout=5):
+    from src.controllers.operation_registry import ACTIVE_STATUSES, registry
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        operation = registry.get(op_id)
+        if operation is not None and operation["status"] not in ACTIVE_STATUSES:
+            return operation
+        time.sleep(0.01)
+    raise AssertionError(f"operation {op_id} did not finish within {timeout}s")
+
+
 def test_export_documents_async_progress_and_download(client):
+    from src.controllers.operation_registry import registry
+
     response = client.post("/api/documents/export", json={
         "project_id": "11111111-1111-1111-1111-111111111111",
         "mode": "consolidated",
@@ -405,38 +419,78 @@ def test_export_documents_async_progress_and_download(client):
     })
 
     assert response.status_code == 202
-    job_id = response.get_json()["job_id"]
-    deadline = time.monotonic() + 5
-    while time.monotonic() < deadline:
-        status = client.get(f"/api/documents/export/{job_id}").get_json()
-        if status["status"] != "running":
-            break
-        time.sleep(0.01)
+    op_id = response.get_json()["op_id"]
+    assert op_id.startswith("export:")
 
-    assert status["status"] == "done"
-    assert status["current"] == status["total"] == 1
-    assert status["logs"] == ["Generating 1 of 1 element: summary.adoc (adoc)"]
+    operation = _wait_for_operation(op_id)
+    assert operation["status"] == "done"
+    assert operation["kind"] == "export"
+    assert operation["lane"] == "export"
+    assert operation["progress"]["current"] == operation["progress"]["total"] == 1
+    assert operation["logs"] == ["Generating 1 of 1 element: summary.adoc (adoc)"]
 
-    from src.routes.documents import _export_jobs, _export_jobs_lock
-    with _export_jobs_lock:
-        archive_path = str(_export_jobs[job_id]["archive_path"])
+    assert operation["result"]["download_ready"] is True
+    assert operation["result"]["filename"].endswith("_consolidated_export.zip")
+    archive_path = str(operation["result"]["archive_path"])
     assert os.path.isfile(archive_path)
 
-    download = client.get(f"/api/documents/export/{job_id}/download")
+    download = client.get(f"/api/documents/export/{op_id}/download")
     assert download.status_code == 200
     assert download.mimetype == "application/zip"
     with zipfile.ZipFile(io.BytesIO(download.data)) as archive:
         assert archive.namelist() == ["summary.adoc"]
     assert not os.path.exists(archive_path)
-    assert client.get(f"/api/documents/export/{job_id}").status_code == 404
+    assert registry.get(op_id) is None
+    assert client.get(f"/api/documents/export/{op_id}/download").status_code == 404
+
+
+def test_export_download_rejects_operation_that_is_not_ready(client):
+    from src.controllers.operation_registry import KIND_EXPORT, LANE_EXPORT, registry
+
+    op_id = "export:not-ready"
+    registry.create(
+        op_id=op_id, kind=KIND_EXPORT, source="documents",
+        label="Export demo", lane=LANE_EXPORT,
+    )
+    try:
+        response = client.get(f"/api/documents/export/{op_id}/download")
+        assert response.status_code == 409
+        assert response.get_json() == {"error": "Export is not ready"}
+    finally:
+        registry.update(op_id, status="cancelled")
+        registry.remove(op_id)
+
+
+def test_export_download_reports_a_vanished_archive(client, tmp_path):
+    from src.controllers.operation_registry import KIND_EXPORT, LANE_EXPORT, registry
+
+    op_id = "export:vanished"
+    registry.create(
+        op_id=op_id, kind=KIND_EXPORT, source="documents",
+        label="Export demo", lane=LANE_EXPORT,
+    )
+    registry.update(op_id, status="done", result={
+        "archive_path": str(tmp_path / "gone.zip"),
+        "filename": "gone.zip",
+        "download_ready": True,
+    })
+
+    response = client.get(f"/api/documents/export/{op_id}/download")
+    assert response.status_code == 410
+    assert response.get_json() == {"error": "Export archive is no longer available"}
+    assert registry.get(op_id) is None
 
 
 def test_export_documents_rejects_when_async_queue_is_full(client):
-    from src.routes.documents import EXPORT_MAX_QUEUED_JOBS, EXPORT_MAX_WORKERS, _export_capacity
+    from src.routes.documents import EXPORT_MAX_ACTIVE_JOBS
+    from src.controllers.operation_registry import KIND_EXPORT, LANE_EXPORT, registry
 
-    capacity = EXPORT_MAX_WORKERS + EXPORT_MAX_QUEUED_JOBS
-    for _ in range(capacity):
-        assert _export_capacity.acquire(blocking=False)
+    op_ids = [f"export:saturate-{index}" for index in range(EXPORT_MAX_ACTIVE_JOBS)]
+    for op_id in op_ids:
+        registry.create(
+            op_id=op_id, kind=KIND_EXPORT, source="documents",
+            label="Export demo", lane=LANE_EXPORT,
+        )
     try:
         response = client.post("/api/documents/export", json={
             "project_id": "11111111-1111-1111-1111-111111111111",
@@ -445,8 +499,9 @@ def test_export_documents_rejects_when_async_queue_is_full(client):
             "documents": [{"name": "summary.adoc", "extension": "adoc"}],
         })
     finally:
-        for _ in range(capacity):
-            _export_capacity.release()
+        for op_id in op_ids:
+            registry.update(op_id, status="cancelled")
+            registry.remove(op_id)
 
     assert response.status_code == 503
     assert response.headers["Retry-After"] == "5"
@@ -474,20 +529,52 @@ def test_export_documents_rejects_when_sync_capacity_is_full(client):
 
 def test_export_retention_evicts_oldest_archive(monkeypatch, tmp_path):
     from src.routes import documents
+    from src.controllers.operation_registry import KIND_EXPORT, LANE_EXPORT, registry
 
     old_archive = tmp_path / "old.zip"
     old_archive.write_bytes(b"1234")
-    job_id = "retention-test-job"
-    with documents._export_jobs_lock:
-        documents._export_jobs[job_id] = {
-            "archive_path": str(old_archive),
-            "finished_at": 1.0,
-        }
+    op_id = "export:retention-test"
+    registry.create(
+        op_id=op_id, kind=KIND_EXPORT, source="documents",
+        label="Export demo", lane=LANE_EXPORT,
+    )
+    registry.update(op_id, status="done", result={
+        "archive_path": str(old_archive),
+        "filename": "old.zip",
+        "download_ready": True,
+    })
+
+    with documents._export_archive_lock:
         monkeypatch.setattr(documents, "EXPORT_MAX_RETAINED_ARCHIVE_BYTES", 5)
         documents._reserve_retained_archive(3)
 
-    assert job_id not in documents._export_jobs
+    assert registry.get(op_id) is None
     assert not old_archive.exists()
+
+
+def test_export_retention_prunes_archives_past_the_ttl(monkeypatch, tmp_path):
+    from src.routes import documents
+    from src.controllers.operation_registry import KIND_EXPORT, LANE_EXPORT, registry
+
+    stale_archive = tmp_path / "stale.zip"
+    stale_archive.write_bytes(b"1234")
+    op_id = "export:ttl-test"
+    registry.create(
+        op_id=op_id, kind=KIND_EXPORT, source="documents",
+        label="Export demo", lane=LANE_EXPORT,
+    )
+    registry.update(op_id, status="done", result={
+        "archive_path": str(stale_archive),
+        "filename": "stale.zip",
+        "download_ready": True,
+    })
+
+    with documents._export_archive_lock:
+        monkeypatch.setattr(documents, "EXPORT_JOB_TTL_SECONDS", -1)
+        documents._prune_export_archives()
+
+    assert registry.get(op_id) is None
+    assert not stale_archive.exists()
 
 
 def test_export_missing_tool_does_not_disclose_server_path(monkeypatch, client):

--- a/tests/webapp_tests/test_settings_endpoints.py
+++ b/tests/webapp_tests/test_settings_endpoints.py
@@ -8,6 +8,7 @@
 import io
 import json
 import os
+import tempfile
 import uuid
 import tarfile
 import pytest
@@ -15,6 +16,13 @@ from unittest.mock import patch, MagicMock
 from werkzeug.datastructures import MultiDict
 
 from src.bin.webapp import create_app
+from src.controllers.job_context import JobContext
+from src.controllers.operation_registry import (
+    KIND_UPLOAD,
+    LANE_UPLOAD,
+    STATUS_QUEUED,
+    registry,
+)
 from . import write_demo_files, setup_demo_db
 
 
@@ -56,6 +64,79 @@ def app(init_files):
 @pytest.fixture()
 def client(app):
     return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Operations live in a process-wide registry; keep tests independent."""
+    registry.clear()
+    yield
+    registry.clear()
+
+
+@pytest.fixture()
+def queued_import():
+    """Run the queued SBOM import inline and record the arguments it got.
+
+    The endpoint hands a closure to the operation queue instead of starting a
+    thread, so the refresh-source selection is only observable by executing
+    that closure against a recording stand-in for the import body.
+    """
+    calls = []
+
+    def recorder(ctx, file_paths, scan_id, variant_id, refresh_sources=None):
+        calls.append({
+            "ctx": ctx,
+            "file_paths": list(file_paths),
+            "scan_id": scan_id,
+            "variant_id": variant_id,
+            "refresh_sources": refresh_sources,
+        })
+
+    def run_inline(op_id, lane, runner, ctx):
+        submissions.append({"op_id": op_id, "lane": lane, "ctx": ctx})
+        runner(ctx)
+
+    submissions = []
+    with patch("src.routes.settings._process_sbom_background", recorder), \
+            patch("src.routes.settings.operation_queue.submit", run_inline):
+        yield {"calls": calls, "submissions": submissions}
+
+    for call in calls:
+        for path in call["file_paths"]:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+
+@pytest.fixture()
+def upload_temp_files(monkeypatch):
+    """Record every temp file the upload endpoint creates for an SBOM input."""
+    created = []
+    real_mkstemp = tempfile.mkstemp
+
+    def recording_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        if str(kwargs.get("prefix", "")).startswith("vulnscout_"):
+            created.append(path)
+        return fd, path
+
+    monkeypatch.setattr("src.routes.settings.tempfile.mkstemp", recording_mkstemp)
+    return created
+
+
+def _register_upload_operation(op_id="upload:direct-test", scope=None):
+    """Register an upload operation and return a context bound to it."""
+    registry.create(
+        op_id=op_id,
+        kind=KIND_UPLOAD,
+        source="sbom",
+        label="SBOM import",
+        lane=LANE_UPLOAD,
+        scope=scope,
+    )
+    return JobContext(op_id)
 
 
 def _get_project_id(client, name="demo"):
@@ -549,10 +630,8 @@ def _make_spdx_tar_archive(member_name="archive.spdx.json", package_name="archiv
 class TestSBOMUpload:
     """Tests for POST /api/sbom/upload (multi-file support)."""
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_single_file(self, mock_thread, client):
-        """Single file upload returns 202 with upload_id and scan_id."""
-        mock_thread.return_value = MagicMock()
+    def test_upload_single_file(self, queued_import, client):
+        """Single file upload returns 202 with op_id and scan_id."""
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
 
@@ -566,14 +645,12 @@ class TestSBOMUpload:
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 202
         body = resp.get_json()
-        assert "upload_id" in body
+        assert body["op_id"].startswith("upload:")
         assert "scan_id" in body
-        mock_thread.return_value.start.assert_called_once()
-        assert mock_thread.call_args.kwargs["args"][-1] == {"epss", "euvd"}
+        assert len(queued_import["calls"]) == 1
+        assert queued_import["calls"][0]["refresh_sources"] == {"epss", "euvd"}
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_defaults_to_epss_refresh(self, mock_thread, client):
-        mock_thread.return_value = MagicMock()
+    def test_upload_defaults_to_epss_refresh(self, queued_import, client):
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
         data = {
@@ -585,7 +662,7 @@ class TestSBOMUpload:
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
 
         assert resp.status_code == 202
-        assert mock_thread.call_args.kwargs["args"][-1] == {"epss"}
+        assert queued_import["calls"][0]["refresh_sources"] == {"epss"}
 
     def test_upload_rejects_unknown_refresh_source(self, client):
         pid = _get_project_id(client)
@@ -602,10 +679,8 @@ class TestSBOMUpload:
         assert resp.status_code == 400
         assert "Unknown refresh source" in resp.get_json()["error"]
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_none_sentinel_disables_all_refresh(self, mock_thread, client):
+    def test_upload_none_sentinel_disables_all_refresh(self, queued_import, client):
         """The 'none' sentinel must not fall back to the epss default."""
-        mock_thread.return_value = MagicMock()
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
         data = {
@@ -618,7 +693,7 @@ class TestSBOMUpload:
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
 
         assert resp.status_code == 202
-        assert mock_thread.call_args.kwargs["args"][-1] == set()
+        assert queued_import["calls"][0]["refresh_sources"] == set()
 
     def test_upload_rejects_none_mixed_with_other_sources(self, client):
         pid = _get_project_id(client)
@@ -635,10 +710,8 @@ class TestSBOMUpload:
         assert resp.status_code == 400
         assert "Unknown refresh source" in resp.get_json()["error"]
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_multiple_files(self, mock_thread, client):
+    def test_upload_multiple_files(self, queued_import, client):
         """Multiple files upload creates one scan with multiple SBOM documents."""
-        mock_thread.return_value = MagicMock()
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
 
@@ -654,14 +727,13 @@ class TestSBOMUpload:
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 202
         body = resp.get_json()
-        assert "upload_id" in body
+        assert body["op_id"].startswith("upload:")
         assert "scan_id" in body
-        mock_thread.return_value.start.assert_called_once()
+        assert len(queued_import["calls"]) == 1
+        assert len(queued_import["calls"][0]["file_paths"]) == 2
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_multiple_files_same_scan(self, mock_thread, client, app):
+    def test_upload_multiple_files_same_scan(self, queued_import, client, app):
         """All uploaded files belong to the same scan."""
-        mock_thread.return_value = MagicMock()
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
 
@@ -755,10 +827,8 @@ class TestSBOMUpload:
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 400
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_invalid_json_file(self, mock_thread, client):
+    def test_upload_invalid_json_file(self, queued_import, client):
         """Non-JSON file should return 400."""
-        mock_thread.return_value = MagicMock()
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
         data = {
@@ -769,11 +839,10 @@ class TestSBOMUpload:
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 400
         assert "Could not parse" in resp.get_json()["error"]
+        assert queued_import["calls"] == []
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_tar_archive_is_extracted(self, mock_thread, client):
+    def test_upload_tar_archive_is_extracted(self, queued_import, client):
         """A tar archive containing SPDX JSON files is accepted and extracted."""
-        mock_thread.return_value = MagicMock()
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
 
@@ -784,13 +853,12 @@ class TestSBOMUpload:
         }
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 202
-        assert "upload_id" in resp.get_json()
-        mock_thread.return_value.start.assert_called_once()
+        assert resp.get_json()["op_id"].startswith("upload:")
+        assert len(queued_import["calls"]) == 1
+        assert len(queued_import["calls"][0]["file_paths"]) == 1
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_empty_tar_archive_rejected(self, mock_thread, client):
+    def test_upload_empty_tar_archive_rejected(self, queued_import, client):
         """A tar archive without SPDX JSON files is rejected."""
-        mock_thread.return_value = MagicMock()
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
 
@@ -807,12 +875,11 @@ class TestSBOMUpload:
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 400
         assert "No .spdx.json files" in resp.get_json()["error"]
+        assert queued_import["calls"] == []
 
-    @patch("src.routes.settings.threading.Thread")
     @patch("src.routes.settings.subprocess.run")
-    def test_upload_tar_zst_archive_is_extracted(self, mock_run, mock_thread, client):
+    def test_upload_tar_zst_archive_is_extracted(self, mock_run, queued_import, client):
         """A .tar.zst archive is decompressed and extracted like a normal tar."""
-        mock_thread.return_value = MagicMock()
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
 
@@ -840,19 +907,19 @@ class TestSBOMUpload:
         }
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 202
-        mock_thread.return_value.start.assert_called_once()
+        assert len(queued_import["calls"]) == 1
 
 
-class TestUploadStatus:
+class TestUploadOperationVisibility:
+    """The per-upload status endpoint was replaced by the operation stream."""
 
-    def test_status_unknown_id(self, client):
+    def test_retired_status_endpoint_is_gone(self, client):
         resp = client.get(f"/api/sbom/upload/{uuid.uuid4()}/status")
         assert resp.status_code == 404
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_status_after_upload(self, mock_thread, client):
-        """After upload the status endpoint returns 'processing'."""
-        mock_thread.return_value = MagicMock()
+    def test_upload_is_registered_as_an_operation(self, queued_import, client):
+        """After upload the import is visible as an operation, which is what
+        /api/events/stream serves to the browser."""
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
         content = _make_spdx_json()
@@ -862,39 +929,22 @@ class TestUploadStatus:
             "files": (io.BytesIO(content), "sbom.spdx.json"),
         }
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
-        upload_id = resp.get_json()["upload_id"]
+        op_id = resp.get_json()["op_id"]
 
-        status_resp = client.get(f"/api/sbom/upload/{upload_id}/status")
-        assert status_resp.status_code == 200
-        assert status_resp.get_json()["status"] == "processing"
-
-
-class TestUploadHelpers:
-
-    def test_prune_upload_status_removes_stale_entries(self):
-        from src.routes.settings import _prune_upload_status, _upload_status, _UPLOAD_STATUS_TTL
-
-        original = dict(_upload_status)
-        try:
-            now = 10_000.0
-            _upload_status.clear()
-            _upload_status.update({
-                "keep": {"status": "processing", "ts": now},
-                "done-old": {"status": "done", "ts": now - _UPLOAD_STATUS_TTL - 1},
-                "error-old": {"status": "error", "ts": now - _UPLOAD_STATUS_TTL - 1},
-                "done-fresh": {"status": "done", "ts": now},
-            })
-
-            with patch("src.routes.settings.time.time", return_value=now):
-                _prune_upload_status()
-
-            assert "keep" in _upload_status
-            assert "done-fresh" in _upload_status
-            assert "done-old" not in _upload_status
-            assert "error-old" not in _upload_status
-        finally:
-            _upload_status.clear()
-            _upload_status.update(original)
+        operation = registry.get(op_id)
+        assert operation is not None
+        assert operation["kind"] == KIND_UPLOAD
+        assert operation["source"] == "sbom"
+        assert operation["lane"] == LANE_UPLOAD
+        assert operation["label"] == "SBOM import"
+        assert operation["status"] == STATUS_QUEUED
+        assert operation["scope"] == {
+            "variant_id": vid,
+            "variant_name": "default",
+            "project_id": pid,
+        }
+        assert queued_import["submissions"][0]["lane"] == LANE_UPLOAD
+        assert queued_import["submissions"][0]["op_id"] == op_id
 
 
 # ---------------------------------------------------------------------------
@@ -930,12 +980,19 @@ class TestDetectFormat:
 
     def test_yocto_vex_via_cpes(self):
         from src.routes.settings import _detect_format
-        data = {"package": [{"name": "openssl", "cpes": ["cpe:2.3:a:openssl:openssl:3.0.2:*:*:*:*:*:*:*"], "issue": []}]}
+        data = {"package": [{
+            "name": "openssl",
+            "cpes": ["cpe:2.3:a:openssl:openssl:3.0.2:*:*:*:*:*:*:*"],
+            "issue": [],
+        }]}
         assert _detect_format("vex.json", data) == "yocto_vex"
 
     def test_yocto_vex_via_patch_file(self):
         from src.routes.settings import _detect_format
-        data = {"package": [{"name": "openssl", "issue": [{"id": "CVE-2022-0778", "patch-file": "/patches/fix.patch"}]}]}
+        data = {"package": [{
+            "name": "openssl",
+            "issue": [{"id": "CVE-2022-0778", "patch-file": "/patches/fix.patch"}],
+        }]}
         assert _detect_format("vex.json", data) == "yocto_vex"
 
     def test_yocto_vex_via_detail(self):
@@ -1051,11 +1108,9 @@ class TestUploadContentType:
 class TestProcessSBOMBackground:
     """Test the background SBOM processing function directly."""
 
-    def test_process_sets_done_status(self, app, monkeypatch):
-        """Processing an SPDX SBOM file sets status to 'done'."""
-        from src.routes.settings import (
-            _process_sbom_background, _upload_status,
-        )
+    def test_process_reports_the_done_message(self, app, monkeypatch):
+        """Processing an SPDX SBOM file ends on the final progress step."""
+        from src.routes.settings import _process_sbom_background
         from src.extensions import db
         from src.models.project import Project
         from src.models.variant import Variant
@@ -1070,7 +1125,6 @@ class TestProcessSBOMBackground:
             scan = Scan.create("", variant.id)
 
             # Write a minimal SPDX JSON to a temp file
-            import tempfile
             sbom_data = {
                 "spdxVersion": "SPDX-2.3",
                 "SPDXID": "SPDXRef-DOCUMENT",
@@ -1089,12 +1143,6 @@ class TestProcessSBOMBackground:
                 json.dump(sbom_data, f)
             os.close(fd)
 
-            SBOMDocument(
-                path=tmp_path,
-                source_name="test.spdx.json",
-                format="spdx",
-                scan_id=scan.id,
-            )
             db.session.add(
                 SBOMDocument(
                     path=tmp_path,
@@ -1105,42 +1153,56 @@ class TestProcessSBOMBackground:
             )
             db.session.commit()
 
-            upload_id = "bg-test-1"
-            _process_sbom_background(
-                app, upload_id, [tmp_path], scan.id, variant.id
-            )
+            ctx = _register_upload_operation("upload:bg-test-1")
+            _process_sbom_background(ctx, [tmp_path], scan.id, variant.id)
+            ctx.flush()
 
-            assert _upload_status[upload_id]["status"] == "done"
+            operation = registry.get("upload:bg-test-1")
+            assert operation["progress"] == {
+                "current": 3, "total": 3, "message": "SBOM imported successfully.",
+            }
+            assert operation["logs"][-1] == "SBOM imported successfully."
+            assert not os.path.exists(tmp_path)
 
-    def test_process_error_sets_error_status(self, app):
-        """Processing with an invalid file path sets status to 'error'."""
-        from src.routes.settings import (
-            _process_sbom_background, _upload_status,
-        )
+    def test_process_unparsable_file_raises_and_cleans_up(self, app):
+        """A document that cannot be parsed surfaces as a RuntimeError."""
+        from src.routes.settings import _process_sbom_background
         from src.extensions import db
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
+        from src.models.sbom_document import SBOMDocument
 
         with app.app_context():
             project = Project.create("BgErrProject")
             variant = Variant.create("BgErrVariant", project.id)
             scan = Scan.create("", variant.id)
 
-            # No SBOM documents registered — parser should fail
-            upload_id = "bg-test-err"
-            _process_sbom_background(
-                app, upload_id, ["/nonexistent/file.json"],
-                scan.id, variant.id
+            fd, broken_path = tempfile.mkstemp(suffix=".spdx.json")
+            with open(broken_path, "w") as f:
+                f.write("this is not JSON")
+            os.close(fd)
+
+            db.session.add(
+                SBOMDocument(
+                    path=broken_path,
+                    source_name="broken.spdx.json",
+                    format="spdx",
+                    scan_id=scan.id,
+                )
             )
+            db.session.commit()
 
-            status = _upload_status[upload_id]
-            # Should either succeed (no docs to parse) or fail gracefully
-            assert status["status"] in ("done", "error")
+            ctx = _register_upload_operation("upload:bg-test-err")
+            with pytest.raises(RuntimeError) as excinfo:
+                _process_sbom_background(ctx, [broken_path], scan.id, variant.id)
 
-    def test_process_read_inputs_failure_sets_error_status(self, app, monkeypatch, tmp_path):
-        """A processing failure inside read_inputs is converted to an error status."""
-        from src.routes.settings import _process_sbom_background, _upload_status
+            assert str(excinfo.value) == "SBOM import failed. Check server logs for details."
+            assert not os.path.exists(broken_path)
+
+    def test_process_read_inputs_failure_raises_and_cleans_up(self, app, monkeypatch, tmp_path):
+        """A processing failure inside read_inputs is converted to a RuntimeError."""
+        from src.routes.settings import _process_sbom_background
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
@@ -1158,10 +1220,12 @@ class TestProcessSBOMBackground:
                 lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
             )
 
-            upload_id = "bg-test-read-inputs-fail"
-            _process_sbom_background(app, upload_id, [str(sbom_path)], scan.id, variant.id)
+            ctx = _register_upload_operation("upload:bg-test-read-inputs-fail")
+            with pytest.raises(RuntimeError) as excinfo:
+                _process_sbom_background(ctx, [str(sbom_path)], scan.id, variant.id)
 
-            assert _upload_status[upload_id]["status"] == "error"
+            assert str(excinfo.value) == "SBOM import failed. Check server logs for details."
+            assert not sbom_path.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -2319,7 +2383,7 @@ class TestCopyAssessmentsMatchModes:
 
 class TestSBOMUploadEdgeCases:
 
-    def test_upload_corrupt_archive_returns_400(self, client):
+    def test_upload_corrupt_archive_returns_400(self, upload_temp_files, client):
         """A file with a .tar extension that is not a valid tar archive triggers a 400."""
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
@@ -2332,11 +2396,11 @@ class TestSBOMUploadEdgeCases:
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 400
         assert "Could not extract archive" in resp.get_json()["error"]
+        assert upload_temp_files
+        assert not any(os.path.exists(path) for path in upload_temp_files)
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_unknown_format_json_returns_400(self, mock_thread, client):
+    def test_upload_unknown_format_json_returns_400(self, upload_temp_files, queued_import, client):
         """Valid JSON that does not match any known SBOM format is rejected."""
-        mock_thread.return_value = MagicMock()
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
         unknown = json.dumps({"totally": "unrecognized", "structure": True}).encode()
@@ -2348,11 +2412,13 @@ class TestSBOMUploadEdgeCases:
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 400
         assert "Unrecognized SBOM format" in resp.get_json()["error"]
+        assert queued_import["calls"] == []
+        assert not any(os.path.exists(path) for path in upload_temp_files)
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_second_file_error_cleans_up_first_file(self, mock_thread, client):
+    def test_upload_second_file_error_cleans_up_first_file(
+        self, upload_temp_files, queued_import, client,
+    ):
         """When the second uploaded file is invalid, temp files from the first are cleaned up."""
-        mock_thread.return_value = MagicMock()
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
         data = MultiDict([
@@ -2364,11 +2430,12 @@ class TestSBOMUploadEdgeCases:
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 400
         assert "Could not parse" in resp.get_json()["error"]
+        assert queued_import["calls"] == []
+        assert len(upload_temp_files) == 2
+        assert not any(os.path.exists(path) for path in upload_temp_files)
 
-    @patch("src.routes.settings.threading.Thread")
-    def test_upload_file_with_empty_filename_skipped(self, mock_thread, client):
+    def test_upload_file_with_empty_filename_skipped(self, queued_import, client):
         """A file entry with an empty filename is skipped; the valid file still processes."""
-        mock_thread.return_value = MagicMock()
         pid = _get_project_id(client)
         vid = _get_variant_id(client, pid)
         data = MultiDict([
@@ -2379,7 +2446,8 @@ class TestSBOMUploadEdgeCases:
         ])
         resp = client.post("/api/sbom/upload", data=data, content_type="multipart/form-data")
         assert resp.status_code == 202
-        mock_thread.return_value.start.assert_called_once()
+        assert len(queued_import["calls"]) == 1
+        assert len(queued_import["calls"][0]["file_paths"]) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -2389,9 +2457,8 @@ class TestSBOMUploadEdgeCases:
 class TestProcessSBOMBackgroundEpss:
 
     def test_epss_failure_is_swallowed_and_processing_completes(self, app, monkeypatch):
-        """A post_treatment (EPSS) exception is caught; final status is still 'done'."""
-        import tempfile as _tempfile
-        from src.routes.settings import _process_sbom_background, _upload_status
+        """A post_treatment (EPSS) exception is caught; the import still completes."""
+        from src.routes.settings import _process_sbom_background
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
@@ -2409,10 +2476,14 @@ class TestProcessSBOMBackgroundEpss:
             variant = Variant.create("EpssFailVariant", project.id)
             scan = Scan.create("", variant.id)
 
-            upload_id = "epss-coverage-test"
-            _process_sbom_background(app, upload_id, [], scan.id, variant.id)
+            ctx = _register_upload_operation("upload:epss-coverage-test")
+            _process_sbom_background(ctx, [], scan.id, variant.id)
+            ctx.flush()
 
-            assert _upload_status[upload_id]["status"] == "done"
+            operation = registry.get("upload:epss-coverage-test")
+            assert operation["progress"] == {
+                "current": 3, "total": 3, "message": "SBOM imported successfully.",
+            }
 
 
 # ---------------------------------------------------------------------------
@@ -2421,9 +2492,9 @@ class TestProcessSBOMBackgroundEpss:
 
 class TestProcessSBOMBackgroundRefreshIsolation:
 
-    def test_provider_reported_failure_is_in_upload_status(self, app, monkeypatch):
+    def test_provider_reported_failure_reaches_the_operation(self, app, monkeypatch):
         """A provider that swallows a lookup failure still marks its refresh incomplete."""
-        from src.routes.settings import _process_sbom_background, _upload_status
+        from src.routes.settings import _process_sbom_background
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
@@ -2450,17 +2521,18 @@ class TestProcessSBOMBackgroundRefreshIsolation:
             variant = Variant.create("ProviderResultVariant", project.id)
             scan = Scan.create("", variant.id)
 
-            upload_id = "provider-result-failure-test"
-            _process_sbom_background(app, upload_id, [], scan.id, variant.id, {"nvd"})
+            ctx = _register_upload_operation("upload:provider-result-failure-test")
+            _process_sbom_background(ctx, [], scan.id, variant.id, {"nvd"})
+            ctx.flush()
 
-            status = _upload_status[upload_id]
-            assert status["status"] == "done"
-            assert "NVD refresh failed" in status["message"]
+            operation = registry.get("upload:provider-result-failure-test")
+            assert "NVD refresh failed" in operation["progress"]["message"]
+            assert any("NVD refresh failed" in line for line in operation["logs"])
 
     def test_one_source_failure_does_not_block_the_others(self, app, monkeypatch):
         """A failure in one selected refresh source must not prevent the
         remaining selected sources from running."""
-        from src.routes.settings import _process_sbom_background, _upload_status
+        from src.routes.settings import _process_sbom_background
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
@@ -2497,19 +2569,18 @@ class TestProcessSBOMBackgroundRefreshIsolation:
             variant = Variant.create("PartialFailVariant", project.id)
             scan = Scan.create("", variant.id)
 
-            upload_id = "partial-fail-test"
-            _process_sbom_background(
-                app, upload_id, [], scan.id, variant.id, {"epss", "nvd"},
-            )
+            ctx = _register_upload_operation("upload:partial-fail-test")
+            _process_sbom_background(ctx, [], scan.id, variant.id, {"epss", "nvd"})
+            ctx.flush()
 
             assert called == ["epss", "nvd"]
-            status = _upload_status[upload_id]
-            assert status["status"] == "done"
-            assert "EPSS refresh failed" in status["message"]
+            operation = registry.get("upload:partial-fail-test")
+            assert "EPSS refresh failed" in operation["progress"]["message"]
+            assert any("EPSS refresh failed" in line for line in operation["logs"])
 
     def test_no_arg_defaults_to_epss(self, app, monkeypatch):
         """Callers that omit refresh_sources keep the historical epss-only default."""
-        from src.routes.settings import _process_sbom_background, _upload_status
+        from src.routes.settings import _process_sbom_background
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
@@ -2518,12 +2589,27 @@ class TestProcessSBOMBackgroundRefreshIsolation:
         monkeypatch.setattr("src.bin.cmd_process.read_inputs", lambda *a, **k: None)
         monkeypatch.setattr("src.bin.cmd_process.populate_observations", lambda *a, **k: None)
 
+        selected: list[set[str]] = []
+
+        def recording_refresh(controllers, vulnerability_ids, refresh_sources, on_source_start=None):
+            selected.append(set(refresh_sources))
+            return []
+
+        monkeypatch.setattr(
+            "src.routes.settings.refresh_vulnerability_sources", recording_refresh,
+        )
+
         with app.app_context():
             project = Project.create("NoArgDefaultProject")
             variant = Variant.create("NoArgDefaultVariant", project.id)
             scan = Scan.create("", variant.id)
 
-            upload_id = "no-arg-default-test"
-            _process_sbom_background(app, upload_id, [], scan.id, variant.id)
+            ctx = _register_upload_operation("upload:no-arg-default-test")
+            _process_sbom_background(ctx, [], scan.id, variant.id)
+            ctx.flush()
 
-            assert _upload_status[upload_id]["status"] == "done"
+            assert selected == [{"epss"}]
+            operation = registry.get("upload:no-arg-default-test")
+            assert operation["progress"] == {
+                "current": 3, "total": 3, "message": "SBOM imported successfully.",
+            }


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR 4 of 6 — split out of #529.** Review and merge in order; each PR targets the one before it.
>
> 1. #548 — operation queue core, scan/refresh jobs extracted → base `staging`
> 2. #549 — queue REST API and SSE event stream → base `#548`
> 3. #550 — delete the 21 legacy polling endpoints → base `#549`
> 4. **#551 — route exports and uploads through the queue → base `#550` ← you are here**
> 5. #552 — frontend SSE operation store, queue rendered from it → base `#551`
> 6. #553 — migrate remaining frontend workflows, delete the polling client → base `#552`
>
> The tip of the stack (#553) is commit-identical to #529, which stays open untouched as the integration reference.

---

## Fixes # by moving the last two ad-hoc progress mechanisms onto the queue

### Changes proposed in this pull request:

* Move document export off `_export_jobs` and onto the queue's `export` lane in `routes/documents.py`, so export progress arrives on the same event stream as everything else.
* Move SBOM/CVE upload off `_upload_status` and onto the queue's `upload` lane in `routes/settings.py`.
* Update the affected endpoint tests to assert against operation state instead of the removed job dictionaries.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

`make test` in `tests/` should pass. Triggering an export or an upload should now produce an operation on `GET /api/events/stream` with the correct lane, and two exports requested at once should run concurrently while a third waits.

### Additional notes

With this PR the backend has a single progress mechanism; the remaining stack is entirely frontend.

### Related Issue

No linked issue.

## Pull Request Checklist

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers
