### PR TITLE
feat(operations): add the frontend SSE operation store and render the queue from it

### DIFF
--- a/frontend/src/components/OperationQueueModal.tsx
+++ b/frontend/src/components/OperationQueueModal.tsx
@@ -1,35 +1,101 @@
-import { useEffect, useRef, useSyncExternalStore } from "react";
+/**
+ * The operation queue window.
+ *
+ * Subscribes to the single event stream instead of the six separate stores the
+ * polling implementation needed.
+ */
+
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBug, faShieldHalved, faLeaf, faCrosshairs, faXmark, faArrowsRotate, faFileExport } from "@fortawesome/free-solid-svg-icons";
+import {
+    faArrowsRotate, faBug, faCrosshairs, faFileExport, faFileImport,
+    faLeaf, faSeedling, faShieldHalved, faXmark,
+} from "@fortawesome/free-solid-svg-icons";
+import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import OperationQueuePanel from "./OperationQueuePanel";
-import { subscribe as grypeSubscribe, getSnapshot as grypeGetSnapshot, dismiss as grypeDismiss } from "../handlers/grypeScanState";
-import { subscribe as nvdSubscribe, getSnapshot as nvdGetSnapshot, dismiss as nvdDismiss } from "../handlers/nvdScanState";
-import { subscribe as osvSubscribe, getSnapshot as osvGetSnapshot, dismiss as osvDismiss } from "../handlers/osvScanState";
-import { subscribe as sccSubscribe, getSnapshot as sccGetSnapshot, dismiss as sccDismiss } from "../handlers/sccScanState";
-import { subscribeToRefreshQueue, getRefreshQueueSnapshot, dismissRefreshQueueEntry } from "../handlers/activeScanQueue";
-import type { RefreshType } from "../handlers/activeScanQueue";
-import { subscribe as exportSubscribe, getSnapshot as exportGetSnapshot, dismiss as exportDismiss } from "../handlers/exportQueue";
+import Operations from "../handlers/operations";
+import { getConnectionState, getSnapshot, subscribe } from "../handlers/operationStore";
+import type { Operation } from "../types/operation";
+import { isActive } from "../types/operation";
 
 type Props = {
     isOpen: boolean;
     onClose: () => void;
 };
 
-const grypeColors = { border: "border-purple-700/60", headerBg: "bg-purple-900/40", iconText: "text-purple-400", titleText: "text-purple-200", subtitleText: "text-purple-300/80", bar: "bg-purple-500" };
-const nvdColors = { border: "border-orange-700/60", headerBg: "bg-orange-900/40", iconText: "text-orange-400", titleText: "text-orange-200", subtitleText: "text-orange-300/80", bar: "bg-orange-500" };
-const osvColors = { border: "border-green-700/60", headerBg: "bg-green-900/40", iconText: "text-green-400", titleText: "text-green-200", subtitleText: "text-green-300/80", bar: "bg-green-500" };
-const sccColors = { border: "border-sky-700/60", headerBg: "bg-sky-900/40", iconText: "text-sky-400", titleText: "text-sky-200", subtitleText: "text-sky-300/80", bar: "bg-sky-500" };
-const refreshColors = { border: "border-cyan-700/60", headerBg: "bg-cyan-900/40", iconText: "text-cyan-400", titleText: "text-cyan-200", subtitleText: "text-cyan-300/80", bar: "bg-cyan-500" };
-const exportColors = { border: "border-teal-700/60", headerBg: "bg-teal-900/40", iconText: "text-teal-400", titleText: "text-teal-200", subtitleText: "text-teal-300/80", bar: "bg-teal-500" };
+type Appearance = { icon: IconDefinition; colors: Record<string, string> };
+
+const purple = { border: "border-purple-700/60", headerBg: "bg-purple-900/40", iconText: "text-purple-400", titleText: "text-purple-200", subtitleText: "text-purple-300/80", bar: "bg-purple-500" };
+const orange = { border: "border-orange-700/60", headerBg: "bg-orange-900/40", iconText: "text-orange-400", titleText: "text-orange-200", subtitleText: "text-orange-300/80", bar: "bg-orange-500" };
+const green = { border: "border-green-700/60", headerBg: "bg-green-900/40", iconText: "text-green-400", titleText: "text-green-200", subtitleText: "text-green-300/80", bar: "bg-green-500" };
+const sky = { border: "border-sky-700/60", headerBg: "bg-sky-900/40", iconText: "text-sky-400", titleText: "text-sky-200", subtitleText: "text-sky-300/80", bar: "bg-sky-500" };
+const cyan = { border: "border-cyan-700/60", headerBg: "bg-cyan-900/40", iconText: "text-cyan-400", titleText: "text-cyan-200", subtitleText: "text-cyan-300/80", bar: "bg-cyan-500" };
+const teal = { border: "border-teal-700/60", headerBg: "bg-teal-900/40", iconText: "text-teal-400", titleText: "text-teal-200", subtitleText: "text-teal-300/80", bar: "bg-teal-500" };
+const amber = { border: "border-amber-700/60", headerBg: "bg-amber-900/40", iconText: "text-amber-400", titleText: "text-amber-200", subtitleText: "text-amber-300/80", bar: "bg-amber-500" };
+
+const SCAN_APPEARANCE: Record<string, Appearance> = {
+    grype: { icon: faBug, colors: purple },
+    nvd: { icon: faShieldHalved, colors: orange },
+    osv: { icon: faLeaf, colors: green },
+    scc: { icon: faCrosshairs, colors: sky },
+};
+
+function appearanceFor(operation: Operation): Appearance {
+    if (operation.kind === "scan") {
+        return SCAN_APPEARANCE[operation.source] ?? { icon: faCrosshairs, colors: sky };
+    }
+    if (operation.kind === "refresh") return { icon: faArrowsRotate, colors: cyan };
+    if (operation.kind === "export") return { icon: faFileExport, colors: teal };
+    if (operation.kind === "upload") return { icon: faFileImport, colors: amber };
+    return { icon: faSeedling, colors: green };
+}
+
+/**
+ * " (variant 2 of 3)" for multi-variant scan batches.
+ *
+ * The backend numbers positions across the whole batch, so the index is
+ * recomputed within each scan source.
+ */
+function positionLabelFor(operation: Operation, all: readonly Operation[]): string {
+    if (operation.kind !== "scan" || operation.queue_id === null) return "";
+    const siblings = all.filter(
+        candidate => candidate.kind === "scan"
+            && candidate.source === operation.source
+            && candidate.queue_id === operation.queue_id,
+    );
+    if (siblings.length < 2) return "";
+    const index = siblings.findIndex(candidate => candidate.op_id === operation.op_id);
+    return ` (variant ${index + 1} of ${siblings.length})`;
+}
 
 function OperationQueueModal({ isOpen, onClose }: Readonly<Props>) {
     const overlayRef = useRef<HTMLDivElement>(null);
-    const grypeEntries = useSyncExternalStore(grypeSubscribe, grypeGetSnapshot);
-    const nvdEntries = useSyncExternalStore(nvdSubscribe, nvdGetSnapshot);
-    const osvEntries = useSyncExternalStore(osvSubscribe, osvGetSnapshot);
-    const sccEntries = useSyncExternalStore(sccSubscribe, sccGetSnapshot);
-    const refreshEntries = useSyncExternalStore(subscribeToRefreshQueue, getRefreshQueueSnapshot);
-    const exportEntries = useSyncExternalStore(exportSubscribe, exportGetSnapshot);
+    const operations = useSyncExternalStore(subscribe, getSnapshot);
+    const connection = useSyncExternalStore(subscribe, getConnectionState);
+    // Cancellations awaiting their terminal event, so the button cannot be spammed.
+    const [cancelRequested, setCancelRequested] = useState<Set<string>>(new Set());
+
+    useEffect(() => {
+        setCancelRequested(previous => {
+            const stillActive = [...previous].filter(opId => {
+                const operation = operations.find(candidate => candidate.op_id === opId);
+                return operation !== undefined && isActive(operation);
+            });
+            return stillActive.length === previous.size ? previous : new Set(stillActive);
+        });
+    }, [operations]);
+
+    const requestCancel = (opId: string) => {
+        setCancelRequested(previous => new Set(previous).add(opId));
+        const restore = () => setCancelRequested(previous => {
+            const next = new Set(previous);
+            next.delete(opId);
+            return next;
+        });
+        Operations.cancel(opId).then(cancelled => {
+            if (!cancelled) restore();
+        }).catch(restore);
+    };
 
     useEffect(() => {
         if (!isOpen) return;
@@ -42,8 +108,6 @@ function OperationQueueModal({ isOpen, onClose }: Readonly<Props>) {
     }, [isOpen, onClose]);
 
     if (!isOpen) return null;
-
-    const hasEntries = grypeEntries.length + nvdEntries.length + osvEntries.length + sccEntries.length + refreshEntries.length + exportEntries.length > 0;
 
     return (
         <div
@@ -71,27 +135,30 @@ function OperationQueueModal({ isOpen, onClose }: Readonly<Props>) {
                         <FontAwesomeIcon icon={faXmark} />
                     </button>
                 </div>
+                {connection === "reconnecting" && (
+                    <p role="status" className="border-b border-amber-700/60 bg-amber-900/30 px-4 py-2 text-xs text-amber-200">
+                        Reconnecting to the operation stream…
+                    </p>
+                )}
                 <div className="overflow-y-auto p-4">
-                    {hasEntries ? (
+                    {operations.length > 0 ? (
                         <div className="overflow-hidden rounded-lg border border-neutral-700 divide-y divide-neutral-700">
-                            {grypeEntries.map(entry => (
-                                <OperationQueuePanel key={`grype-${entry.variantId}`} entry={entry} label="Grype Scan" icon={faBug} colors={grypeColors} onDismiss={() => grypeDismiss(entry.variantId)} />
-                            ))}
-                            {nvdEntries.map(entry => (
-                                <OperationQueuePanel key={`nvd-${entry.variantId}`} entry={entry} label="NVD Scan" icon={faShieldHalved} colors={nvdColors} onDismiss={() => nvdDismiss(entry.variantId)} />
-                            ))}
-                            {osvEntries.map(entry => (
-                                <OperationQueuePanel key={`osv-${entry.variantId}`} entry={entry} label="OSV Scan" icon={faLeaf} colors={osvColors} onDismiss={() => osvDismiss(entry.variantId)} />
-                            ))}
-                            {sccEntries.map(entry => (
-                                <OperationQueuePanel key={`scc-${entry.variantId}`} entry={entry} label="sbom-cve-check Scan" icon={faCrosshairs} colors={sccColors} onDismiss={() => sccDismiss(entry.variantId)} />
-                            ))}
-                            {refreshEntries.map(entry => (
-                                <OperationQueuePanel key={entry.variantId} entry={entry} label="Vulnerability Data Refresh" icon={faArrowsRotate} colors={refreshColors} onDismiss={() => dismissRefreshQueueEntry(entry.variantId as RefreshType)} />
-                            ))}
-                            {exportEntries.map(entry => (
-                                <OperationQueuePanel key={entry.variantId} entry={entry} label="Export" icon={faFileExport} colors={exportColors} onDismiss={() => exportDismiss(entry.variantId)} />
-                            ))}
+                            {operations.map(operation => {
+                                const { icon, colors } = appearanceFor(operation);
+                                return (
+                                    <OperationQueuePanel
+                                        key={operation.op_id}
+                                        operation={operation}
+                                        icon={icon}
+                                        colors={colors as never}
+                                        positionLabel={positionLabelFor(operation, operations)}
+                                        onDismiss={() => void Operations.dismiss(operation.op_id)}
+                                        onCancel={operation.cancellable && isActive(operation) && !cancelRequested.has(operation.op_id)
+                                            ? () => requestCancel(operation.op_id)
+                                            : undefined}
+                                    />
+                                );
+                            })}
                         </div>
                     ) : (
                         <p className="py-8 text-center text-sm text-neutral-400">No operations to display.</p>

--- a/frontend/src/components/OperationQueuePanel.tsx
+++ b/frontend/src/components/OperationQueuePanel.tsx
@@ -1,47 +1,47 @@
 /**
- * OperationQueuePanel — reusable per-variant operation progress / log panel.
+ * One operation in the queue: collapsible card with progress bar and logs.
  *
- * Renders a collapsible card with:
- *  - coloured header showing scan type + variant name
- *  - progress bar
- *  - scrollable log box
- *  - dismiss button (when not running)
+ * Consumes the shared `Operation` shape, so scans, refreshes, uploads and
+ * exports all render through this single component.
  */
 
 import { useEffect, useId, useRef, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck, faChevronRight, faXmark } from "@fortawesome/free-solid-svg-icons";
+import { faBan, faCheck, faChevronRight, faXmark } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
-import type { ScanEntryState } from "../handlers/scanStateManager";
+import type { Operation } from "../types/operation";
+import { isActive, percentOf } from "../types/operation";
 
 type ColorScheme = {
-    border: string;   // e.g. "border-purple-700/60"
-    headerBg: string; // e.g. "bg-purple-900/40"
-    iconText: string; // e.g. "text-purple-400"
-    titleText: string; // e.g. "text-purple-200"
-    subtitleText: string; // e.g. "text-purple-300/80"
-    bar: string;      // e.g. "bg-purple-500"
+    border: string;
+    headerBg: string;
+    iconText: string;
+    titleText: string;
+    subtitleText: string;
+    bar: string;
 };
 
 type Props = {
-    entry: ScanEntryState;
-    label: string;        // e.g. "Grype Scan"
+    operation: Operation;
     icon: IconDefinition;
     colors: ColorScheme;
+    /** e.g. " (variant 2 of 3)" — the caller knows the batch grouping. */
+    positionLabel?: string;
     onDismiss: () => void;
+    onCancel?: () => void;
 };
 
-export default function OperationQueuePanel({ entry, label, icon, colors, onDismiss }: Props) {
-    const { status, variantName, variantPosition, variantCount, progress, logs, total, doneCount } = entry;
-    const pct = status === "done" ? 100 : total > 0 ? Math.max(0, Math.min(100, Math.round((doneCount / total) * 100))) : 0;
-    const hasProgressContent = logs.length > 0 || total > 0 || doneCount > 0;
-    const isActivelyScanning = status === "running" && hasProgressContent;
-    const expandsForStatus = isActivelyScanning || status === "error";
+export default function OperationQueuePanel({
+    operation, icon, colors, positionLabel = "", onDismiss, onCancel,
+}: Readonly<Props>) {
+    const { status, label, scope, progress, logs } = operation;
+    const pct = percentOf(operation);
+    const hasProgressContent = logs.length > 0 || progress.total > 0 || progress.current > 0;
+    const isActivelyRunning = status === "running" && hasProgressContent;
+    const expandsForStatus = isActivelyRunning || status === "error";
     const [isOpen, setIsOpen] = useState(expandsForStatus);
     const contentId = useId();
-    const variantProgress = variantPosition && variantCount && variantCount > 1
-        ? ` (variant ${variantPosition} of ${variantCount})`
-        : "";
+    const title = scope?.variant_name ?? label;
 
     const logBoxRef = useRef<HTMLDivElement>(null);
     useEffect(() => {
@@ -53,16 +53,15 @@ export default function OperationQueuePanel({ entry, label, icon, colors, onDism
         if (el) el.scrollTop = el.scrollHeight;
     }, [logs.length]);
 
-    const statusText =
-        status === "queued" || (status === "running" && !isActivelyScanning) ? "queued"
-            : isActivelyScanning ? "in progress"
-                : status === "error" ? "failed"
-                    : status === "cancelled" ? "cancelled"
-                    : "complete";
+    let statusText: string;
+    if (status === "queued" || (status === "running" && !isActivelyRunning)) statusText = "queued";
+    else if (isActivelyRunning) statusText = "in progress";
+    else if (status === "error") statusText = "failed";
+    else if (status === "cancelled") statusText = "cancelled";
+    else statusText = "complete";
 
     return (
         <section className="bg-neutral-900">
-            {/* Header */}
             <div className={`px-4 py-2 flex items-center gap-3 ${colors.headerBg}`}>
                 <button
                     type="button"
@@ -77,17 +76,28 @@ export default function OperationQueuePanel({ entry, label, icon, colors, onDism
                     />
                     <FontAwesomeIcon icon={icon} className={colors.iconText} />
                     <span className={`text-sm font-semibold ${colors.titleText}`}>
-                        {label} – {variantName} {statusText}{variantProgress}
+                        {label} – {title} {statusText}{positionLabel}
                     </span>
                     {status === "done" && (
                         <FontAwesomeIcon icon={faCheck} className="text-green-400" aria-label="Complete" />
                     )}
                     <span className={`text-xs ${colors.subtitleText} ml-auto`}>
-                        {progress ?? ""}
-                        {total > 0 && ` (${pct}%)`}
+                        {progress.message ?? ""}
+                        {progress.total > 0 && ` (${pct}%)`}
                     </span>
                 </button>
-                {status !== "running" && status !== "queued" && (
+                {isActive(operation) && onCancel && (
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        title="Cancel"
+                        aria-label={`Cancel ${label} – ${title}`}
+                        className="text-neutral-400 hover:text-red-400 transition-colors ml-1"
+                    >
+                        <FontAwesomeIcon icon={faBan} className="text-sm" />
+                    </button>
+                )}
+                {!isActive(operation) && (
                     <button
                         type="button"
                         onClick={onDismiss}
@@ -101,9 +111,8 @@ export default function OperationQueuePanel({ entry, label, icon, colors, onDism
 
             {isOpen && (
                 <div id={contentId}>
-                    {/* Progress bar */}
                     <div className="w-full h-2 bg-neutral-800">
-                        {!isActivelyScanning && status !== "done" && status !== "error" && status !== "cancelled" ? (
+                        {!isActivelyRunning && status !== "done" && status !== "error" && status !== "cancelled" ? (
                             <div className="h-full w-full bg-neutral-600 animate-pulse" />
                         ) : (
                             <div
@@ -116,25 +125,16 @@ export default function OperationQueuePanel({ entry, label, icon, colors, onDism
                         )}
                     </div>
 
-                    {/* Log box */}
                     <div
                         ref={logBoxRef}
                         className="max-h-52 overflow-y-auto px-4 py-2 font-mono text-xs text-neutral-300 space-y-0.5 scrollbar-thin scrollbar-thumb-neutral-700"
                     >
-                        {logs.map((line, i) => (
-                            <div
-                                key={i}
-                                className={
-                                    line.startsWith("[") && line.includes("ERROR")
-                                        ? "text-red-400"
-                                        : line.startsWith("✓")
-                                            ? "text-green-400 font-semibold"
-                                            : ""
-                                }
-                            >
-                                {line}
-                            </div>
-                        ))}
+                        {logs.map((line, i) => {
+                            let tone = "";
+                            if (line.includes("ERROR")) tone = "text-red-400";
+                            else if (line.startsWith("✓")) tone = "text-green-400 font-semibold";
+                            return <div key={i} className={tone}>{line}</div>;
+                        })}
                     </div>
                 </div>
             )}

--- a/frontend/src/handlers/operationStore.ts
+++ b/frontend/src/handlers/operationStore.ts
@@ -1,0 +1,295 @@
+/**
+ * Single source of truth for every long-running backend operation.
+ *
+ * One `EventSource` replaces the per-scan managers, the refresh queue, the
+ * upload poll and the export poll. The backend owns sequencing, so this module
+ * only mirrors what the stream reports and exposes it through the
+ * `useSyncExternalStore` contract.
+ */
+
+import type { Operation, OperationKind } from "../types/operation";
+import { isActive } from "../types/operation";
+
+const STREAM_PATH = "/api/events/stream";
+
+/** Backoff schedule for reconnects, in milliseconds. */
+const RECONNECT_DELAYS_MS = [500, 1000, 2000, 5000, 10000];
+
+export type ConnectionState = "idle" | "connecting" | "open" | "reconnecting";
+
+type SnapshotFrame = { seq: number; operations: Operation[] };
+type RemovedFrame = { op_id: string };
+
+let operations = new Map<string, Operation>();
+let snapshot: readonly Operation[] = [];
+let connection: ConnectionState = "idle";
+
+const listeners = new Set<() => void>();
+let source: EventSource | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectAttempt = 0;
+// Highest sequence seen, sent back on reconnect so the server replays the
+// missed deltas instead of resending a full snapshot.
+let lastEventId: number | null = null;
+
+/** Swappable so tests can drive the store without a live server. */
+let createEventSource: (url: string) => EventSource = url => new EventSource(url);
+
+const streamUrl = (): string => {
+    const base = import.meta.env.VITE_API_URL + STREAM_PATH;
+    return lastEventId === null ? base : `${base}?last_event_id=${lastEventId}`;
+};
+
+function emit() {
+    // Sorting by creation keeps the queue order stable across re-renders.
+    snapshot = [...operations.values()].sort((a, b) => {
+        if (a.created_at !== b.created_at) return a.created_at < b.created_at ? -1 : 1;
+        return a.op_id < b.op_id ? -1 : 1;
+    });
+    listeners.forEach(listener => listener());
+}
+
+function setConnection(next: ConnectionState) {
+    if (connection === next) return;
+    connection = next;
+    listeners.forEach(listener => listener());
+}
+
+function applySnapshot(frame: SnapshotFrame) {
+    operations = new Map(frame.operations.map(operation => [operation.op_id, operation]));
+    emit();
+}
+
+function applyOperation(operation: Operation) {
+    operations.set(operation.op_id, operation);
+    emit();
+}
+
+function applyRemoval(frame: RemovedFrame) {
+    if (operations.delete(frame.op_id)) emit();
+}
+
+function parse<T>(event: MessageEvent): T | null {
+    try {
+        return JSON.parse(event.data) as T;
+    } catch {
+        return null;
+    }
+}
+
+function trackEventId(event: MessageEvent) {
+    const id = Number.parseInt(event.lastEventId, 10);
+    if (!Number.isNaN(id)) lastEventId = id;
+}
+
+function scheduleReconnect() {
+    if (reconnectTimer !== null) return;
+    const delay = RECONNECT_DELAYS_MS[Math.min(reconnectAttempt, RECONNECT_DELAYS_MS.length - 1)];
+    reconnectAttempt += 1;
+    setConnection("reconnecting");
+    reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        openStream();
+    }, delay);
+}
+
+function openStream() {
+    if (source !== null) return;
+    setConnection(connection === "reconnecting" ? "reconnecting" : "connecting");
+
+    const stream = createEventSource(streamUrl());
+    source = stream;
+
+    stream.addEventListener("snapshot", event => {
+        reconnectAttempt = 0;
+        setConnection("open");
+        const frame = parse<SnapshotFrame>(event as MessageEvent);
+        if (frame) {
+            lastEventId = frame.seq;
+            applySnapshot(frame);
+        }
+    });
+
+    stream.addEventListener("operation", event => {
+        setConnection("open");
+        trackEventId(event as MessageEvent);
+        const operation = parse<Operation>(event as MessageEvent);
+        if (operation) applyOperation(operation);
+    });
+
+    stream.addEventListener("operation_removed", event => {
+        trackEventId(event as MessageEvent);
+        const frame = parse<RemovedFrame>(event as MessageEvent);
+        if (frame) applyRemoval(frame);
+    });
+
+    stream.addEventListener("heartbeat", () => {
+        reconnectAttempt = 0;
+        setConnection("open");
+    });
+
+    // The server is going away; reconnecting picks up a fresh snapshot.
+    stream.addEventListener("bye", () => {
+        closeStream();
+        scheduleReconnect();
+    });
+
+    stream.onerror = () => {
+        closeStream();
+        scheduleReconnect();
+    };
+}
+
+function closeStream() {
+    if (source === null) return;
+    source.close();
+    source = null;
+}
+
+/** Full teardown once nothing is listening: no stream, no pending reconnect. */
+function teardown() {
+    if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+    }
+    closeStream();
+    reconnectAttempt = 0;
+    connection = "idle";
+}
+
+// ---- useSyncExternalStore API ----
+
+export const subscribe = (listener: () => void): (() => void) => {
+    listeners.add(listener);
+    openStream();
+    return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) teardown();
+    };
+};
+
+export const getSnapshot = (): readonly Operation[] => snapshot;
+
+export const subscribeToConnection = subscribe;
+
+export const getConnectionState = (): ConnectionState => connection;
+
+// ---- selectors ----
+
+export const getOperation = (opId: string): Operation | undefined => operations.get(opId);
+
+export const selectByKind = (kind: OperationKind): Operation[] =>
+    snapshot.filter(operation => operation.kind === kind);
+
+export const selectBySource = (kind: OperationKind, source_: string): Operation[] =>
+    snapshot.filter(operation => operation.kind === kind && operation.source === source_);
+
+export const selectByQueue = (queueId: string): Operation[] =>
+    snapshot.filter(operation => operation.queue_id === queueId);
+
+export const hasActive = (kind?: OperationKind): boolean =>
+    snapshot.some(operation => isActive(operation) && (kind === undefined || operation.kind === kind));
+
+export const hasActiveSource = (kind: OperationKind, source_: string): boolean =>
+    snapshot.some(operation => isActive(operation) && operation.kind === kind && operation.source === source_);
+
+/** Resolves once no operation of *queueId* is queued or running. */
+export const waitForQueue = (queueId: string): Promise<Operation[]> =>
+    new Promise(resolve => {
+        const settled = () => {
+            const batch = selectByQueue(queueId);
+            // An empty batch means the snapshot has not caught up yet.
+            return batch.length > 0 && !batch.some(isActive) ? batch : null;
+        };
+
+        const immediate = settled();
+        if (immediate) {
+            resolve(immediate);
+            return;
+        }
+
+        const unsubscribe = subscribe(() => {
+            const batch = settled();
+            if (!batch) return;
+            unsubscribe();
+            resolve(batch);
+        });
+    });
+
+// ---- refresh progress adapter ----
+
+/**
+ * The legacy per-source progress shape the vulnerability table renders.
+ *
+ * Derived from the stream rather than fetched, so the four `/progress`
+ * endpoints are no longer needed.
+ */
+export type RefreshProgressView = {
+    in_progress: boolean;
+    phase: string;
+    current: number;
+    total: number;
+    message: string;
+    started_at?: string;
+};
+
+const IDLE_REFRESH: RefreshProgressView = {
+    in_progress: false,
+    phase: "idle",
+    current: 0,
+    total: 0,
+    message: "No update in progress",
+};
+
+const PHASE_BY_STATUS: Record<string, string> = {
+    queued: "queued",
+    running: "running",
+    done: "completed",
+    error: "error",
+    cancelled: "cancelled",
+};
+
+export const refreshProgressOf = (source: string): RefreshProgressView => {
+    const operation = operations.get(`refresh:${source}`);
+    if (!operation) return IDLE_REFRESH;
+    return {
+        in_progress: isActive(operation),
+        phase: PHASE_BY_STATUS[operation.status] ?? operation.status,
+        current: operation.progress.current,
+        total: operation.progress.total,
+        message: operation.progress.message,
+        started_at: operation.started_at ?? undefined,
+    };
+};
+
+export const refreshProgressPercentage = (progress: RefreshProgressView): number => {
+    if (!progress.in_progress || progress.total === 0) {
+        return progress.phase === "completed" ? 1 : 0;
+    }
+    return Math.min(progress.current / progress.total, 1);
+};
+
+// ---- test seams ----
+
+/** Replaces the EventSource factory. Returns a function restoring the default. */
+export const __setEventSourceFactory = (factory: (url: string) => EventSource): (() => void) => {
+    const previous = createEventSource;
+    createEventSource = factory;
+    return () => {
+        createEventSource = previous;
+    };
+};
+
+export const __reset = () => {
+    if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+    }
+    closeStream();
+    listeners.clear();
+    operations = new Map();
+    snapshot = [];
+    connection = "idle";
+    reconnectAttempt = 0;
+    lastEventId = null;
+};

--- a/frontend/src/handlers/operations.ts
+++ b/frontend/src/handlers/operations.ts
@@ -1,0 +1,115 @@
+/**
+ * HTTP client for the operation queue.
+ *
+ * Progress never comes back through these calls; it arrives on the event
+ * stream. These only enqueue, cancel and dismiss.
+ */
+
+import type { Operation, OperationJob, RefreshSource, ScanSource } from "../types/operation";
+
+export type EnqueueResult =
+    | { ok: true; queueId: string; operations: Operation[] }
+    | { ok: false; error: string; conflicts?: string[] };
+
+const api = (path: string) => import.meta.env.VITE_API_URL + path;
+
+async function errorFrom(response: Response): Promise<{ error: string; conflicts?: string[] }> {
+    const data = await response.json().catch(() => ({}));
+    return {
+        error: data?.error ?? `HTTP ${response.status}`,
+        conflicts: Array.isArray(data?.operations) ? data.operations : undefined,
+    };
+}
+
+class Operations {
+    /** Queue a batch. The backend orders scans before refreshes. */
+    static async enqueue(jobs: OperationJob[]): Promise<EnqueueResult> {
+        const response = await fetch(api("/api/operations"), {
+            method: "POST",
+            mode: "cors",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ jobs }),
+        });
+        if (response.status === 202) {
+            const data = await response.json();
+            return { ok: true, queueId: data.queue_id, operations: data.operations };
+        }
+        return { ok: false, ...(await errorFrom(response)) };
+    }
+
+    static scanJob(
+        source: ScanSource,
+        variantIds: string[],
+        options: { excludeKernel?: boolean; mode?: "local" | "api" } = {},
+    ): OperationJob {
+        return {
+            kind: "scan",
+            source,
+            variant_ids: variantIds,
+            options: {
+                exclude_kernel: options.excludeKernel ?? true,
+                mode: options.mode ?? "local",
+            },
+        };
+    }
+
+    static refreshJob(
+        source: RefreshSource,
+        ids: string[],
+        options: { mode?: "local" | "api" } = {},
+    ): OperationJob {
+        return { kind: "refresh", source, ids, options: { mode: options.mode ?? "local" } };
+    }
+
+    static deferredRefreshJob(
+        source: RefreshSource,
+        variantIds: string[],
+        excludeIds: string[],
+        options: { mode?: "local" | "api" } = {},
+    ): OperationJob {
+        return {
+            kind: "refresh",
+            source,
+            variant_ids: variantIds,
+            exclude_ids: excludeIds,
+            options: { mode: options.mode ?? "local" },
+        };
+    }
+
+    static async cancel(opId: string): Promise<boolean> {
+        const response = await fetch(api(`/api/operations/${encodeURIComponent(opId)}/cancel`), {
+            method: "POST",
+            mode: "cors",
+        });
+        return response.ok;
+    }
+
+    static async cancelQueue(queueId: string): Promise<number> {
+        const response = await fetch(api(`/api/operations/queue/${encodeURIComponent(queueId)}/cancel`), {
+            method: "POST",
+            mode: "cors",
+        });
+        if (!response.ok) return 0;
+        const data = await response.json().catch(() => ({}));
+        return data?.cancelled ?? 0;
+    }
+
+    /** Drop a finished operation so it disappears for every connected client. */
+    static async dismiss(opId: string): Promise<boolean> {
+        const response = await fetch(api(`/api/operations/${encodeURIComponent(opId)}`), {
+            method: "DELETE",
+            mode: "cors",
+        });
+        return response.ok;
+    }
+
+    /** Fallback snapshot for clients that cannot hold a stream open. */
+    static async list(): Promise<Operation[]> {
+        const response = await fetch(api("/api/operations"), { mode: "cors" });
+        if (!response.ok) return [];
+        const data = await response.json().catch(() => null);
+        return Array.isArray(data?.operations) ? data.operations : [];
+    }
+}
+
+export default Operations;

--- a/frontend/src/types/operation.ts
+++ b/frontend/src/types/operation.ts
@@ -1,0 +1,76 @@
+/**
+ * One shape for every long-running backend operation.
+ *
+ * Scans, vulnerability refreshes, SBOM uploads, document exports and boot
+ * enrichment all arrive on the same event stream in this form.
+ */
+
+export type OperationKind = "scan" | "refresh" | "upload" | "export" | "enrichment";
+
+export type OperationStatus = "queued" | "running" | "done" | "error" | "cancelled";
+
+export type OperationLane = "pipeline" | "export" | "upload";
+
+export type ScanSource = "grype" | "nvd" | "osv" | "scc";
+
+export type RefreshSource = "nvd" | "epss" | "ghsa" | "euvd";
+
+export type OperationScope = {
+    variant_id: string;
+    variant_name: string;
+    project_id: string;
+};
+
+export type OperationProgress = {
+    current: number;
+    total: number;
+    message: string;
+};
+
+export type Operation = {
+    op_id: string;
+    kind: OperationKind;
+    source: string;
+    label: string;
+    lane: OperationLane;
+    scope: OperationScope | null;
+    status: OperationStatus;
+    progress: OperationProgress;
+    logs: string[];
+    error: string | null;
+    queue_id: string | null;
+    position: number | null;
+    options: Record<string, unknown>;
+    cancellable: boolean;
+    created_at: string;
+    started_at: string | null;
+    finished_at: string | null;
+    result: Record<string, unknown> | null;
+};
+
+/** Whether the operation still has work ahead of it. */
+export const isActive = (operation: Operation): boolean =>
+    operation.status === "queued" || operation.status === "running";
+
+/** Whether the operation has settled and can be dismissed. */
+export const isTerminal = (operation: Operation): boolean => !isActive(operation);
+
+export const percentOf = (operation: Operation): number => {
+    if (operation.status === "done") return 100;
+    const { current, total } = operation.progress;
+    if (total <= 0) return 0;
+    return Math.max(0, Math.min(100, Math.round((current / total) * 100)));
+};
+
+/** A job as sent to `POST /api/operations`. */
+export type OperationJob = {
+    kind: "scan" | "refresh";
+    source: ScanSource | RefreshSource;
+    variant_ids?: string[];
+    ids?: string[];
+    exclude_ids?: string[];
+    options?: {
+        exclude_kernel?: boolean;
+        mode?: "local" | "api";
+    };
+};

--- a/frontend/tests/handlers/operationStore.test.ts
+++ b/frontend/tests/handlers/operationStore.test.ts
@@ -1,0 +1,574 @@
+/**
+ * The single event stream that replaced every polling loop.
+ *
+ * Drives the store through a stand-in EventSource so frames can be delivered
+ * deterministically.
+ */
+
+import Operations from "../../src/handlers/operations";
+import {
+    __reset,
+    __setEventSourceFactory,
+    getConnectionState,
+    getOperation,
+    getSnapshot,
+    hasActive,
+    hasActiveSource,
+    refreshProgressOf,
+    refreshProgressPercentage,
+    selectByKind,
+    selectByQueue,
+    subscribe,
+    waitForQueue,
+} from "../../src/handlers/operationStore";
+import type { RefreshProgressView } from "../../src/handlers/operationStore";
+import type { Operation } from "../../src/types/operation";
+
+class FakeEventSource {
+    static instances: FakeEventSource[] = [];
+
+    readonly url: string;
+    closed = false;
+    onerror: (() => void) | null = null;
+    private readonly handlers = new Map<string, Array<(event: MessageEvent) => void>>();
+
+    constructor(url: string) {
+        this.url = url;
+        FakeEventSource.instances.push(this);
+    }
+
+    addEventListener(type: string, handler: (event: MessageEvent) => void) {
+        const existing = this.handlers.get(type) ?? [];
+        existing.push(handler);
+        this.handlers.set(type, existing);
+    }
+
+    close() {
+        this.closed = true;
+    }
+
+    /** Deliver one SSE frame to the store. */
+    send(type: string, data: unknown, id?: number) {
+        const event = {
+            data: JSON.stringify(data),
+            lastEventId: id !== undefined ? String(id) : "",
+        } as MessageEvent;
+        (this.handlers.get(type) ?? []).forEach(handler => handler(event));
+    }
+
+    fail() {
+        this.onerror?.();
+    }
+
+    static latest(): FakeEventSource {
+        return FakeEventSource.instances[FakeEventSource.instances.length - 1];
+    }
+}
+
+const operation = (overrides: Partial<Operation> & { op_id: string }): Operation => ({
+    kind: "scan",
+    source: "grype",
+    label: "Grype",
+    lane: "pipeline",
+    scope: null,
+    status: "queued",
+    progress: { current: 0, total: 0, message: "Queued" },
+    logs: [],
+    error: null,
+    queue_id: null,
+    position: null,
+    options: {},
+    cancellable: true,
+    created_at: "2026-08-19T10:00:00+00:00",
+    started_at: null,
+    finished_at: null,
+    result: null,
+    ...overrides,
+});
+
+let restoreFactory: () => void;
+
+beforeEach(() => {
+    FakeEventSource.instances = [];
+    restoreFactory = __setEventSourceFactory(url => new FakeEventSource(url) as unknown as EventSource);
+});
+
+afterEach(() => {
+    __reset();
+    restoreFactory();
+    jest.restoreAllMocks();
+});
+
+/** Subscribing is what opens the connection. */
+function connect(): FakeEventSource {
+    subscribe(() => {});
+    return FakeEventSource.latest();
+}
+
+describe("connection", () => {
+    it("opens exactly one stream no matter how many components subscribe", () => {
+        subscribe(() => {});
+        subscribe(() => {});
+        subscribe(() => {});
+
+        expect(FakeEventSource.instances).toHaveLength(1);
+    });
+
+    it("reports the connection as open once the first frame arrives", () => {
+        const stream = connect();
+        expect(getConnectionState()).toBe("connecting");
+
+        stream.send("snapshot", { seq: 1, operations: [] });
+
+        expect(getConnectionState()).toBe("open");
+    });
+
+    it("reconnects after the stream errors", () => {
+        jest.useFakeTimers();
+        const stream = connect();
+        stream.send("snapshot", { seq: 1, operations: [] });
+
+        stream.fail();
+        expect(getConnectionState()).toBe("reconnecting");
+
+        jest.advanceTimersByTime(500);
+        expect(FakeEventSource.instances).toHaveLength(2);
+        jest.useRealTimers();
+    });
+
+    it("reconnects when the server says goodbye", () => {
+        jest.useFakeTimers();
+        const stream = connect();
+        stream.send("snapshot", { seq: 1, operations: [] });
+
+        stream.send("bye", { reason: "server shutdown" });
+
+        expect(stream.closed).toBe(true);
+        jest.advanceTimersByTime(500);
+        expect(FakeEventSource.instances).toHaveLength(2);
+        jest.useRealTimers();
+    });
+
+    it("treats a heartbeat as proof the connection is alive", () => {
+        const stream = connect();
+        stream.send("heartbeat", { seq: 4 });
+
+        expect(getConnectionState()).toBe("open");
+    });
+
+    it("closes the stream once the last subscriber leaves", () => {
+        const unsubscribeFirst = subscribe(() => {});
+        const unsubscribeSecond = subscribe(() => {});
+        const stream = FakeEventSource.latest();
+
+        unsubscribeFirst();
+        expect(stream.closed).toBe(false);
+
+        unsubscribeSecond();
+        expect(stream.closed).toBe(true);
+        expect(getConnectionState()).toBe("idle");
+    });
+
+    it("cancels a pending reconnect when the last subscriber leaves", () => {
+        jest.useFakeTimers();
+        const unsubscribe = subscribe(() => {});
+        FakeEventSource.latest().fail();
+
+        unsubscribe();
+        jest.advanceTimersByTime(60000);
+
+        expect(FakeEventSource.instances).toHaveLength(1);
+        expect(getConnectionState()).toBe("idle");
+        jest.useRealTimers();
+    });
+
+    it("resumes with the last seen event id so the server replays missed deltas", () => {
+        jest.useFakeTimers();
+        const stream = connect();
+        stream.send("snapshot", { seq: 3, operations: [] });
+        stream.send("operation", operation({ op_id: "scan:grype:v1" }), 7);
+
+        stream.fail();
+        jest.advanceTimersByTime(500);
+
+        expect(FakeEventSource.latest().url).toContain("last_event_id=7");
+        jest.useRealTimers();
+    });
+});
+
+describe("state from the stream", () => {
+    it("adopts the snapshot as the whole state", () => {
+        const stream = connect();
+
+        stream.send("snapshot", {
+            seq: 7,
+            operations: [
+                operation({ op_id: "scan:grype:v1" }),
+                operation({ op_id: "refresh:epss", kind: "refresh", source: "epss", label: "EPSS" }),
+            ],
+        });
+
+        expect(getSnapshot().map(item => item.op_id)).toEqual(["refresh:epss", "scan:grype:v1"]);
+    });
+
+    it("restores queued operations, which per-variant status endpoints could never do", () => {
+        const stream = connect();
+
+        stream.send("snapshot", {
+            seq: 1,
+            operations: [operation({ op_id: "scan:osv:v9", status: "queued" })],
+        });
+
+        expect(getOperation("scan:osv:v9")?.status).toBe("queued");
+    });
+
+    it("applies deltas on top of the snapshot", () => {
+        const stream = connect();
+        stream.send("snapshot", { seq: 1, operations: [operation({ op_id: "scan:grype:v1" })] });
+
+        stream.send("operation", operation({
+            op_id: "scan:grype:v1",
+            status: "running",
+            progress: { current: 3, total: 10, message: "3/10 packages" },
+        }));
+
+        expect(getOperation("scan:grype:v1")?.progress).toEqual({
+            current: 3, total: 10, message: "3/10 packages",
+        });
+    });
+
+    it("forgets an operation the server removed", () => {
+        const stream = connect();
+        stream.send("snapshot", { seq: 1, operations: [operation({ op_id: "scan:grype:v1", status: "done" })] });
+
+        stream.send("operation_removed", { op_id: "scan:grype:v1" });
+
+        expect(getOperation("scan:grype:v1")).toBeUndefined();
+        expect(getSnapshot()).toHaveLength(0);
+    });
+
+    it("keeps the remaining operations when one is removed", () => {
+        const stream = connect();
+        stream.send("snapshot", {
+            seq: 1,
+            operations: [
+                operation({ op_id: "scan:grype:v1", status: "done" }),
+                operation({ op_id: "scan:grype:v2", status: "running", created_at: "2026-08-19T10:00:01+00:00" }),
+            ],
+        });
+
+        stream.send("operation_removed", { op_id: "scan:grype:v1" });
+
+        expect(getSnapshot().map(item => item.op_id)).toEqual(["scan:grype:v2"]);
+    });
+
+    it("replaces state wholesale when a later snapshot arrives after a gap", () => {
+        const stream = connect();
+        stream.send("snapshot", { seq: 1, operations: [operation({ op_id: "scan:grype:v1" })] });
+
+        stream.send("snapshot", { seq: 90, operations: [operation({ op_id: "refresh:nvd", kind: "refresh" })] });
+
+        expect(getSnapshot().map(item => item.op_id)).toEqual(["refresh:nvd"]);
+    });
+
+    it("notifies subscribers when state changes", () => {
+        const listener = jest.fn();
+        subscribe(listener);
+        const stream = FakeEventSource.latest();
+
+        stream.send("snapshot", { seq: 1, operations: [operation({ op_id: "scan:grype:v1" })] });
+
+        expect(listener).toHaveBeenCalled();
+    });
+
+    it("stops notifying a subscriber that unsubscribed", () => {
+        const listener = jest.fn();
+        const unsubscribe = subscribe(listener);
+        const stream = FakeEventSource.latest();
+
+        stream.send("snapshot", { seq: 1, operations: [operation({ op_id: "scan:grype:v1" })] });
+        const callsWhileSubscribed = listener.mock.calls.length;
+        unsubscribe();
+        stream.send("operation", operation({ op_id: "scan:grype:v1", status: "running" }));
+
+        expect(callsWhileSubscribed).toBeGreaterThan(0);
+        expect(listener).toHaveBeenCalledTimes(callsWhileSubscribed);
+    });
+
+    it("keeps existing state when a frame payload cannot be parsed", () => {
+        const stream = connect();
+        stream.send("snapshot", { seq: 1, operations: [operation({ op_id: "scan:grype:v1" })] });
+
+        stream.send("operation", undefined);
+
+        expect(getSnapshot()).toHaveLength(1);
+    });
+});
+
+describe("selectors", () => {
+    const seed = (stream: FakeEventSource) => stream.send("snapshot", {
+        seq: 1,
+        operations: [
+            operation({ op_id: "scan:grype:v1", queue_id: "q-1", status: "running" }),
+            operation({ op_id: "scan:grype:v2", queue_id: "q-1", status: "queued" }),
+            operation({
+                op_id: "refresh:epss", kind: "refresh", source: "epss",
+                label: "EPSS", queue_id: "q-2", status: "done",
+            }),
+        ],
+    });
+
+    it("filters by kind", () => {
+        const stream = connect();
+        seed(stream);
+
+        expect(selectByKind("scan").map(item => item.op_id)).toEqual(["scan:grype:v1", "scan:grype:v2"]);
+    });
+
+    it("filters by batch", () => {
+        const stream = connect();
+        seed(stream);
+
+        expect(selectByQueue("q-1")).toHaveLength(2);
+    });
+
+    it("reports active work overall and per source", () => {
+        const stream = connect();
+        seed(stream);
+
+        expect(hasActive()).toBe(true);
+        expect(hasActive("scan")).toBe(true);
+        expect(hasActive("refresh")).toBe(false);
+        expect(hasActiveSource("scan", "grype")).toBe(true);
+        expect(hasActiveSource("refresh", "epss")).toBe(false);
+    });
+});
+
+describe("waitForQueue", () => {
+    it("resolves once every operation in the batch has settled", async () => {
+        const stream = connect();
+        stream.send("snapshot", {
+            seq: 1,
+            operations: [
+                operation({ op_id: "scan:grype:v1", queue_id: "q-1", status: "running" }),
+                operation({ op_id: "scan:nvd:v1", queue_id: "q-1", status: "queued", source: "nvd" }),
+            ],
+        });
+
+        const pending = waitForQueue("q-1");
+
+        stream.send("operation", operation({ op_id: "scan:grype:v1", queue_id: "q-1", status: "done" }));
+        stream.send("operation", operation({
+            op_id: "scan:nvd:v1", queue_id: "q-1", status: "done", source: "nvd",
+        }));
+
+        await expect(pending).resolves.toHaveLength(2);
+    });
+
+    it("resolves for a batch that had already finished", async () => {
+        const stream = connect();
+        stream.send("snapshot", {
+            seq: 1,
+            operations: [operation({ op_id: "scan:grype:v1", queue_id: "q-1", status: "done" })],
+        });
+
+        await expect(waitForQueue("q-1")).resolves.toHaveLength(1);
+    });
+
+    it("still resolves when the batch ends in failure", async () => {
+        const stream = connect();
+        stream.send("snapshot", {
+            seq: 1,
+            operations: [operation({ op_id: "scan:grype:v1", queue_id: "q-1", status: "running" })],
+        });
+
+        const pending = waitForQueue("q-1");
+        stream.send("operation", operation({
+            op_id: "scan:grype:v1", queue_id: "q-1", status: "error", error: "grype binary not found",
+        }));
+
+        await expect(pending).resolves.toHaveLength(1);
+    });
+});
+
+describe("refresh progress adapter", () => {
+    it("reports idle for a source that has never run", () => {
+        connect();
+
+        expect(refreshProgressOf("nvd")).toMatchObject({ in_progress: false, phase: "idle" });
+    });
+
+    it("derives the legacy progress shape from a running refresh", () => {
+        const stream = connect();
+        stream.send("snapshot", {
+            seq: 1,
+            operations: [operation({
+                op_id: "refresh:epss",
+                kind: "refresh",
+                source: "epss",
+                label: "EPSS",
+                status: "running",
+                started_at: "2026-08-19T10:01:00+00:00",
+                progress: { current: 40, total: 100, message: "EPSS refresh: 40/100" },
+            })],
+        });
+
+        expect(refreshProgressOf("epss")).toEqual({
+            in_progress: true,
+            phase: "running",
+            current: 40,
+            total: 100,
+            message: "EPSS refresh: 40/100",
+            started_at: "2026-08-19T10:01:00+00:00",
+        });
+    });
+
+    it("maps a finished refresh to the completed phase", () => {
+        const stream = connect();
+        stream.send("snapshot", {
+            seq: 1,
+            operations: [operation({
+                op_id: "refresh:ghsa", kind: "refresh", source: "ghsa", label: "GHSA", status: "done",
+            })],
+        });
+
+        expect(refreshProgressOf("ghsa")).toMatchObject({ in_progress: false, phase: "completed" });
+    });
+
+    it("keeps a cancelled refresh distinct from a completed one", () => {
+        const stream = connect();
+        stream.send("snapshot", {
+            seq: 1,
+            operations: [operation({
+                op_id: "refresh:nvd",
+                kind: "refresh",
+                source: "nvd",
+                label: "NVD",
+                status: "cancelled",
+                progress: { current: 1, total: 2, message: "Cancelled" },
+            })],
+        });
+
+        expect(refreshProgressOf("nvd")).toMatchObject({
+            in_progress: false,
+            phase: "cancelled",
+            current: 1,
+            total: 2,
+        });
+    });
+
+    it("maps a failed refresh to the error phase", () => {
+        const stream = connect();
+        stream.send("snapshot", {
+            seq: 1,
+            operations: [operation({
+                op_id: "refresh:euvd", kind: "refresh", source: "euvd", label: "EUVD",
+                status: "error", error: "EUVD unreachable",
+            })],
+        });
+
+        expect(refreshProgressOf("euvd")).toMatchObject({ in_progress: false, phase: "error" });
+    });
+});
+
+describe("refresh progress percentage", () => {
+    const view = (overrides: Partial<RefreshProgressView>): RefreshProgressView => ({
+        in_progress: false,
+        phase: "idle",
+        current: 0,
+        total: 0,
+        message: "",
+        ...overrides,
+    });
+
+    it("reports nothing done while idle", () => {
+        expect(refreshProgressPercentage(view({ phase: "idle" }))).toBe(0);
+    });
+
+    it("reports everything done once the phase is completed", () => {
+        expect(refreshProgressPercentage(view({ phase: "completed", current: 100, total: 100 }))).toBe(1);
+    });
+
+    it("reports nothing done while the total is still unknown", () => {
+        expect(refreshProgressPercentage(view({ in_progress: true, phase: "running" }))).toBe(0);
+    });
+
+    it("reports the ratio of processed items", () => {
+        expect(refreshProgressPercentage(view({ in_progress: true, phase: "running", current: 50, total: 100 }))).toBe(0.5);
+        expect(refreshProgressPercentage(view({ in_progress: true, phase: "running", current: 25, total: 100 }))).toBe(0.25);
+        expect(refreshProgressPercentage(view({ in_progress: true, phase: "running", current: 33, total: 100 }))).toBe(0.33);
+    });
+
+    it("never reports more than everything done", () => {
+        expect(refreshProgressPercentage(view({ in_progress: true, phase: "running", current: 120, total: 100 }))).toBe(1);
+        expect(refreshProgressPercentage(view({ in_progress: true, phase: "running", current: 100, total: 100 }))).toBe(1);
+    });
+});
+
+describe("enqueueing work", () => {
+    it("sends scans and refreshes as one batch", async () => {
+        const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+            status: 202,
+            json: async () => ({ queue_id: "q-9", operations: [] }),
+        } as Response);
+
+        const result = await Operations.enqueue([
+            Operations.scanJob("grype", ["v1", "v2"], { excludeKernel: false }),
+            Operations.refreshJob("epss", ["CVE-2024-1111"]),
+        ]);
+
+        expect(result).toEqual({ ok: true, queueId: "q-9", operations: [] });
+        const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+        expect(body.jobs[0]).toEqual({
+            kind: "scan",
+            source: "grype",
+            variant_ids: ["v1", "v2"],
+            options: { exclude_kernel: false, mode: "local" },
+        });
+        expect(body.jobs[1]).toEqual({
+            kind: "refresh",
+            source: "epss",
+            ids: ["CVE-2024-1111"],
+            options: { mode: "local" },
+        });
+    });
+
+    it("surfaces the conflicting operations when a batch is already running", async () => {
+        jest.spyOn(global, "fetch").mockResolvedValue({
+            status: 409,
+            json: async () => ({ error: "already queued", operations: ["scan:grype:v1"] }),
+        } as Response);
+
+        const result = await Operations.enqueue([Operations.scanJob("grype", ["v1"])]);
+
+        expect(result).toEqual({ ok: false, error: "already queued", conflicts: ["scan:grype:v1"] });
+    });
+
+    it("builds a deferred refresh target for an atomic scan batch", () => {
+        expect(Operations.deferredRefreshJob(
+            "epss", ["v1", "v2"], ["CVE-2024-1111"],
+        )).toEqual({
+            kind: "refresh",
+            source: "epss",
+            variant_ids: ["v1", "v2"],
+            exclude_ids: ["CVE-2024-1111"],
+            options: { mode: "local" },
+        });
+    });
+
+    it("cancels a single operation", async () => {
+        const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({ ok: true } as Response);
+
+        await Operations.cancel("scan:grype:v1");
+
+        expect(fetchSpy.mock.calls[0][0]).toContain("/api/operations/scan%3Agrype%3Av1/cancel");
+    });
+
+    it("dismisses a finished operation for every client", async () => {
+        const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({ ok: true } as Response);
+
+        await Operations.dismiss("scan:grype:v1");
+
+        expect(fetchSpy.mock.calls[0][1]).toMatchObject({ method: "DELETE" });
+    });
+});

--- a/frontend/tests/unit_tests/test_operation_queue_modal.tsx
+++ b/frontend/tests/unit_tests/test_operation_queue_modal.tsx
@@ -1,69 +1,108 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-jest.mock('../../src/handlers/activeScanQueue', () => ({
-    subscribeToRefreshQueue: () => () => undefined,
-    getRefreshQueueSnapshot: jest.fn(),
-    dismissRefreshQueueEntry: jest.fn(),
-}));
-jest.mock('../../src/handlers/grypeScanState', () => ({
-    subscribe: () => () => undefined,
-    getSnapshot: jest.fn(),
-    dismiss: jest.fn(),
-}));
-jest.mock('../../src/handlers/nvdScanState', () => ({
-    subscribe: () => () => undefined,
-    getSnapshot: jest.fn(),
-    dismiss: jest.fn(),
-}));
-jest.mock('../../src/handlers/osvScanState', () => ({
-    subscribe: () => () => undefined,
-    getSnapshot: jest.fn(),
-    dismiss: jest.fn(),
-}));
-jest.mock('../../src/handlers/sccScanState', () => ({
-    subscribe: () => () => undefined,
-    getSnapshot: jest.fn(),
-    dismiss: jest.fn(),
-}));
-jest.mock('../../src/handlers/exportQueue', () => ({
-    subscribe: () => () => undefined,
-    getSnapshot: jest.fn(),
-    dismiss: jest.fn(),
-}));
-
 import OperationQueueModal from '../../src/components/OperationQueueModal';
-import { dismissRefreshQueueEntry, getRefreshQueueSnapshot } from '../../src/handlers/activeScanQueue';
-import { dismiss as grypeDismiss, getSnapshot as grypeGetSnapshot } from '../../src/handlers/grypeScanState';
-import { dismiss as nvdDismiss, getSnapshot as nvdGetSnapshot } from '../../src/handlers/nvdScanState';
-import { dismiss as osvDismiss, getSnapshot as osvGetSnapshot } from '../../src/handlers/osvScanState';
-import { dismiss as sccDismiss, getSnapshot as sccGetSnapshot } from '../../src/handlers/sccScanState';
-import { dismiss as exportDismiss, getSnapshot as exportGetSnapshot } from '../../src/handlers/exportQueue';
+import Operations from '../../src/handlers/operations';
+import { __reset, __setEventSourceFactory } from '../../src/handlers/operationStore';
+import type { Operation } from '../../src/types/operation';
 
-const completedEntry = (variantId: string, variantName: string) => ({
-    variantId,
-    variantName,
-    status: 'done',
-    error: null,
-    progress: 'Complete',
+/** Stand-in for the browser EventSource so frames arrive deterministically. */
+class FakeEventSource {
+    static instances: FakeEventSource[] = [];
+
+    readonly url: string;
+    closed = false;
+    onerror: (() => void) | null = null;
+    private readonly handlers = new Map<string, Array<(event: MessageEvent) => void>>();
+
+    constructor(url: string) {
+        this.url = url;
+        FakeEventSource.instances.push(this);
+    }
+
+    addEventListener(type: string, handler: (event: MessageEvent) => void) {
+        const existing = this.handlers.get(type) ?? [];
+        existing.push(handler);
+        this.handlers.set(type, existing);
+    }
+
+    close() {
+        this.closed = true;
+    }
+
+    send(type: string, data: unknown) {
+        const event = { data: JSON.stringify(data) } as MessageEvent;
+        act(() => {
+            (this.handlers.get(type) ?? []).forEach(handler => handler(event));
+        });
+    }
+
+    fail() {
+        act(() => {
+            this.onerror?.();
+        });
+    }
+
+    static latest(): FakeEventSource {
+        return FakeEventSource.instances[FakeEventSource.instances.length - 1];
+    }
+}
+
+const operation = (overrides: Partial<Operation> & { op_id: string }): Operation => ({
+    kind: 'scan',
+    source: 'grype',
+    label: 'Grype Scan',
+    lane: 'pipeline',
+    scope: null,
+    status: 'queued',
+    progress: { current: 0, total: 0, message: 'Queued' },
     logs: [],
-    total: 1,
-    doneCount: 1,
+    error: null,
+    queue_id: null,
+    position: null,
+    options: {},
+    cancellable: true,
+    created_at: '2026-08-19T10:00:00+00:00',
+    started_at: null,
+    finished_at: null,
+    result: null,
+    ...overrides,
+});
+
+const completed = (opId: string, label: string, overrides: Partial<Operation> = {}): Operation => operation({
+    op_id: opId,
+    label,
+    status: 'done',
+    progress: { current: 1, total: 1, message: 'Complete' },
+    ...overrides,
 });
 
 describe('OperationQueueModal', () => {
+    let restoreFactory: () => void;
+
     beforeEach(() => {
-        jest.clearAllMocks();
-        [getRefreshQueueSnapshot, grypeGetSnapshot, nvdGetSnapshot, osvGetSnapshot, sccGetSnapshot, exportGetSnapshot]
-            .forEach(snapshot => (snapshot as jest.Mock).mockReturnValue([]));
+        FakeEventSource.instances = [];
+        restoreFactory = __setEventSourceFactory(url => new FakeEventSource(url) as unknown as EventSource);
     });
+
+    afterEach(() => {
+        __reset();
+        restoreFactory();
+        jest.restoreAllMocks();
+    });
+
+    /** Renders the modal and returns the stream it opened. */
+    const renderModal = (onClose = jest.fn()) => {
+        const view = render(<OperationQueueModal isOpen={true} onClose={onClose} />);
+        return { ...view, stream: FakeEventSource.latest(), onClose };
+    };
 
     it('closes from its close button, backdrop, and Escape key', () => {
         const onClose = jest.fn();
-        const { rerender } = render(<OperationQueueModal isOpen={true} onClose={onClose} />);
+        const { rerender } = renderModal(onClose);
 
         expect(screen.getByRole('dialog', { name: 'Operation queue' })).toBeInTheDocument();
-    expect(screen.getByText('This window can be safely closed. Track the operation queue in the navigation bar.')).toBeInTheDocument();
+        expect(screen.getByText('This window can be safely closed. Track the operation queue in the navigation bar.')).toBeInTheDocument();
         expect(screen.getByText('No operations to display.')).toBeInTheDocument();
 
         fireEvent.click(screen.getByRole('button', { name: 'Close operation queue' }));
@@ -76,14 +115,23 @@ describe('OperationQueueModal', () => {
     });
 
     it('renders each vulnerability refresh source as an independent collapse', () => {
-        (getRefreshQueueSnapshot as jest.Mock).mockReturnValue([
-            { variantId: 'nvd', variantName: 'NVD', status: 'queued', error: null, progress: 'Queued', logs: ['Waiting'], total: 0, doneCount: 0 },
-            { variantId: 'epss', variantName: 'EPSS', status: 'queued', error: null, progress: 'Queued', logs: ['Waiting'], total: 0, doneCount: 0 },
-        ]);
-        render(<OperationQueueModal isOpen={true} onClose={jest.fn()} />);
+        const { stream } = renderModal();
+        stream.send('snapshot', {
+            seq: 1,
+            operations: [
+                operation({
+                    op_id: 'refresh:nvd', kind: 'refresh', source: 'nvd', label: 'NVD refresh',
+                    logs: ['Waiting'], created_at: '2026-08-19T10:00:00+00:00',
+                }),
+                operation({
+                    op_id: 'refresh:epss', kind: 'refresh', source: 'epss', label: 'EPSS refresh',
+                    logs: ['Waiting'], created_at: '2026-08-19T10:00:01+00:00',
+                }),
+            ],
+        });
 
-        const nvdCollapse = screen.getByRole('button', { name: /vulnerability data refresh.*nvd queued/i });
-        const epssCollapse = screen.getByRole('button', { name: /vulnerability data refresh.*epss queued/i });
+        const nvdCollapse = screen.getByRole('button', { name: /nvd refresh.*queued/i });
+        const epssCollapse = screen.getByRole('button', { name: /epss refresh.*queued/i });
         expect(nvdCollapse).toHaveAttribute('aria-expanded', 'false');
         expect(epssCollapse).toHaveAttribute('aria-expanded', 'false');
 
@@ -92,22 +140,113 @@ describe('OperationQueueModal', () => {
         expect(epssCollapse).toHaveAttribute('aria-expanded', 'false');
     });
 
-    it('dismisses completed operations through their owning queues', () => {
-        (grypeGetSnapshot as jest.Mock).mockReturnValue([completedEntry('grype-id', 'Grype')]);
-        (nvdGetSnapshot as jest.Mock).mockReturnValue([completedEntry('nvd-id', 'NVD')]);
-        (osvGetSnapshot as jest.Mock).mockReturnValue([completedEntry('osv-id', 'OSV')]);
-        (sccGetSnapshot as jest.Mock).mockReturnValue([completedEntry('scc-id', 'SCC')]);
-        (getRefreshQueueSnapshot as jest.Mock).mockReturnValue([completedEntry('epss', 'EPSS')]);
-        (exportGetSnapshot as jest.Mock).mockReturnValue([completedEntry('export-id', 'Project export')]);
+    it('dismisses finished operations through the operation API', () => {
+        const dismiss = jest.spyOn(Operations, 'dismiss').mockResolvedValue(true);
+        const { stream } = renderModal();
+        stream.send('snapshot', {
+            seq: 1,
+            operations: [
+                completed('scan:grype:variant-1', 'Grype Scan', { created_at: '2026-08-19T10:00:00+00:00' }),
+                completed('scan:nvd:variant-1', 'NVD Scan', { source: 'nvd', created_at: '2026-08-19T10:00:01+00:00' }),
+                completed('scan:osv:variant-1', 'OSV Scan', { source: 'osv', created_at: '2026-08-19T10:00:02+00:00' }),
+                completed('scan:scc:variant-1', 'SCC Scan', { source: 'scc', created_at: '2026-08-19T10:00:03+00:00' }),
+                completed('refresh:epss', 'EPSS refresh', { kind: 'refresh', source: 'epss', created_at: '2026-08-19T10:00:04+00:00' }),
+                completed('export:doc-1', 'Project export', { kind: 'export', source: 'documents', lane: 'export', created_at: '2026-08-19T10:00:05+00:00' }),
+                completed('upload:sbom-1', 'SBOM import', { kind: 'upload', source: 'sbom', lane: 'upload', created_at: '2026-08-19T10:00:06+00:00' }),
+            ],
+        });
 
-        render(<OperationQueueModal isOpen={true} onClose={jest.fn()} />);
         screen.getAllByTitle('Close').forEach(button => fireEvent.click(button));
 
-        expect(grypeDismiss).toHaveBeenCalledWith('grype-id');
-        expect(nvdDismiss).toHaveBeenCalledWith('nvd-id');
-        expect(osvDismiss).toHaveBeenCalledWith('osv-id');
-        expect(sccDismiss).toHaveBeenCalledWith('scc-id');
-        expect(dismissRefreshQueueEntry).toHaveBeenCalledWith('epss');
-        expect(exportDismiss).toHaveBeenCalledWith('export-id');
+        expect(dismiss.mock.calls.map(([opId]) => opId)).toEqual([
+            'scan:grype:variant-1',
+            'scan:nvd:variant-1',
+            'scan:osv:variant-1',
+            'scan:scc:variant-1',
+            'refresh:epss',
+            'export:doc-1',
+            'upload:sbom-1',
+        ]);
+    });
+
+    it('cancels an operation that is still running', () => {
+        const cancel = jest.spyOn(Operations, 'cancel').mockResolvedValue(true);
+        const { stream } = renderModal();
+        stream.send('snapshot', {
+            seq: 1,
+            operations: [operation({
+                op_id: 'scan:grype:variant-1',
+                status: 'running',
+                scope: { variant_id: 'variant-1', variant_name: 'Variant 1', project_id: 'project-1' },
+                logs: ['Scanning'],
+            })],
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel Grype Scan – Variant 1' }));
+
+        expect(cancel).toHaveBeenCalledWith('scan:grype:variant-1');
+    });
+
+    it('does not offer cancellation for unsupported running operations', () => {
+        const { stream } = renderModal();
+        stream.send('snapshot', {
+            seq: 1,
+            operations: [
+                operation({
+                    op_id: 'upload:sbom-1', kind: 'upload', source: 'sbom', label: 'SBOM import',
+                    lane: 'upload', status: 'running', cancellable: false,
+                }),
+                operation({
+                    op_id: 'export:doc-1', kind: 'export', source: 'documents', label: 'Export docs',
+                    lane: 'export', status: 'running', cancellable: false,
+                }),
+            ],
+        });
+
+        expect(screen.queryByRole('button', { name: /cancel sbom import/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /cancel export docs/i })).not.toBeInTheDocument();
+    });
+
+    it('numbers the variants of a multi-variant scan batch', () => {
+        const { stream } = renderModal();
+        stream.send('snapshot', {
+            seq: 1,
+            operations: [
+                operation({
+                    op_id: 'scan:grype:variant-1', status: 'running', queue_id: 'q-1',
+                    scope: { variant_id: 'variant-1', variant_name: 'alpha', project_id: 'project-1' },
+                    logs: ['Scanning'], created_at: '2026-08-19T10:00:00+00:00',
+                }),
+                operation({
+                    op_id: 'scan:grype:variant-2', status: 'running', queue_id: 'q-1',
+                    scope: { variant_id: 'variant-2', variant_name: 'hyper-v', project_id: 'project-1' },
+                    logs: ['Scanning'], created_at: '2026-08-19T10:00:01+00:00',
+                }),
+                operation({
+                    op_id: 'scan:nvd:variant-1', source: 'nvd', label: 'NVD Scan', status: 'running', queue_id: 'q-1',
+                    scope: { variant_id: 'variant-1', variant_name: 'alpha', project_id: 'project-1' },
+                    logs: ['Scanning'], created_at: '2026-08-19T10:00:02+00:00',
+                }),
+            ],
+        });
+
+        expect(screen.getByText(/grype scan – hyper-v in progress \(variant 2 of 2\)/i)).toBeInTheDocument();
+        expect(screen.getByText(/nvd scan – alpha in progress/i)).toBeInTheDocument();
+        expect(screen.queryByText(/nvd scan – alpha in progress \(variant/i)).not.toBeInTheDocument();
+    });
+
+    it('warns that it is reconnecting when the stream drops', () => {
+        jest.useFakeTimers();
+        try {
+            const { stream } = renderModal();
+            stream.send('snapshot', { seq: 1, operations: [] });
+            expect(screen.queryByText(/reconnecting to the operation stream/i)).not.toBeInTheDocument();
+
+            stream.fail();
+
+            expect(screen.getByRole('status')).toHaveTextContent(/reconnecting to the operation stream/i);
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });

--- a/frontend/tests/unit_tests/test_operation_queue_panel.tsx
+++ b/frontend/tests/unit_tests/test_operation_queue_panel.tsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 
 import OperationQueuePanel from '../../src/components/OperationQueuePanel';
-import type { ScanEntryState } from '../../src/handlers/scanStateManager';
+import type { Operation, OperationStatus } from '../../src/types/operation';
 
 describe('OperationQueuePanel', () => {
     const colors = {
@@ -16,23 +16,39 @@ describe('OperationQueuePanel', () => {
         bar: 'bg-cyan-500',
     };
 
-    const makeEntry = (status: ScanEntryState['status'], overrides: Partial<ScanEntryState> = {}): ScanEntryState => ({
-        variantId: 'variant-1',
-        variantName: 'Variant 1',
+    const makeOperation = (status: OperationStatus, overrides: Partial<Operation> = {}): Operation => ({
+        op_id: 'scan:grype:variant-1',
+        kind: 'scan',
+        source: 'grype',
+        label: 'Grype Scan',
+        lane: 'pipeline',
+        scope: { variant_id: 'variant-1', variant_name: 'Variant 1', project_id: 'project-1' },
         status,
-        error: null,
-        progress: status === 'done' ? 'Done' : 'Running',
+        progress: {
+            current: status === 'done' ? 4 : 2,
+            total: 4,
+            message: status === 'done' ? 'Done' : 'Running',
+        },
         logs: [],
-        total: 4,
-        doneCount: status === 'done' ? 4 : 2,
+        error: null,
+        queue_id: null,
+        position: null,
+        options: {},
+        cancellable: true,
+        created_at: '2026-08-19T10:00:00+00:00',
+        started_at: null,
+        finished_at: null,
+        result: null,
         ...overrides,
     });
 
-    it('keeps a scan queued until progress content arrives', async () => {
+    it('keeps an operation collapsed until progress content arrives', async () => {
         const { rerender } = render(
             <OperationQueuePanel
-                entry={makeEntry('queued', { progress: 'Queued', logs: ['Waiting for previous scan to finish…'] })}
-                label="Grype Scan"
+                operation={makeOperation('queued', {
+                    progress: { current: 0, total: 0, message: 'Queued' },
+                    logs: ['Waiting for previous scan to finish…'],
+                })}
                 icon={faCircleInfo}
                 colors={colors}
                 onDismiss={jest.fn()}
@@ -46,8 +62,7 @@ describe('OperationQueuePanel', () => {
 
         rerender(
             <OperationQueuePanel
-                entry={makeEntry('running', { progress: 'starting', total: 0, doneCount: 0 })}
-                label="Grype Scan"
+                operation={makeOperation('running', { progress: { current: 0, total: 0, message: 'starting' } })}
                 icon={faCircleInfo}
                 colors={colors}
                 onDismiss={jest.fn()}
@@ -59,8 +74,10 @@ describe('OperationQueuePanel', () => {
 
         rerender(
             <OperationQueuePanel
-                entry={makeEntry('running', { progress: '1 / 4', logs: ['Scanning package metadata'] })}
-                label="Grype Scan"
+                operation={makeOperation('running', {
+                    progress: { current: 1, total: 4, message: '1 / 4' },
+                    logs: ['Scanning package metadata'],
+                })}
                 icon={faCircleInfo}
                 colors={colors}
                 onDismiss={jest.fn()}
@@ -75,8 +92,10 @@ describe('OperationQueuePanel', () => {
     it('shows the queued state without a dismiss button', () => {
         render(
             <OperationQueuePanel
-                entry={makeEntry('queued', { progress: 'Queued', logs: ['Waiting for previous scan to finish…'] })}
-                label="Grype Scan"
+                operation={makeOperation('queued', {
+                    progress: { current: 0, total: 0, message: 'Queued' },
+                    logs: ['Waiting for previous scan to finish…'],
+                })}
                 icon={faCircleInfo}
                 colors={colors}
                 onDismiss={jest.fn()}
@@ -91,14 +110,13 @@ describe('OperationQueuePanel', () => {
     it('shows the position for a multi-variant scan', () => {
         render(
             <OperationQueuePanel
-                entry={makeEntry('running', {
-                    variantName: 'hyper-v',
-                    variantPosition: 2,
-                    variantCount: 3,
+                operation={makeOperation('running', {
+                    label: 'sbom-cve-check Scan',
+                    scope: { variant_id: 'variant-2', variant_name: 'hyper-v', project_id: 'project-1' },
                 })}
-                label="sbom-cve-check Scan"
                 icon={faCircleInfo}
                 colors={colors}
+                positionLabel=" (variant 2 of 3)"
                 onDismiss={jest.fn()}
             />,
         );
@@ -109,8 +127,7 @@ describe('OperationQueuePanel', () => {
     it('omits the position for a single-variant scan', () => {
         render(
             <OperationQueuePanel
-                entry={makeEntry('running', { variantPosition: 1, variantCount: 1 })}
-                label="NVD Scan"
+                operation={makeOperation('running', { label: 'NVD Scan' })}
                 icon={faCircleInfo}
                 colors={colors}
                 onDismiss={jest.fn()}
@@ -121,17 +138,35 @@ describe('OperationQueuePanel', () => {
         expect(screen.queryByText(/variant 1 of 1/i)).not.toBeInTheDocument();
     });
 
-    it('renders running logs then collapses a completed scan with a success indicator', async () => {
+    it('falls back to the operation label when there is no variant scope', () => {
+        render(
+            <OperationQueuePanel
+                operation={makeOperation('running', {
+                    kind: 'refresh',
+                    label: 'EPSS refresh',
+                    scope: null,
+                    logs: ['Fetching scores'],
+                })}
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText(/epss refresh – epss refresh in progress/i)).toBeInTheDocument();
+    });
+
+    it('renders running logs then collapses a completed operation with a success indicator', async () => {
         const user = userEvent.setup();
         const onDismiss = jest.fn();
 
         const { rerender } = render(
             <OperationQueuePanel
-                entry={makeEntry('running', {
-                    progress: '2 / 4',
-                        logs: ['[ERROR] scanning', '✓ finished step'],
+                operation={makeOperation('running', {
+                    label: 'NVD Scan',
+                    progress: { current: 2, total: 4, message: '2 / 4' },
+                    logs: ['[ERROR] scanning', '✓ finished step'],
                 })}
-                label="NVD Scan"
                 icon={faCircleInfo}
                 colors={colors}
                 onDismiss={onDismiss}
@@ -139,17 +174,16 @@ describe('OperationQueuePanel', () => {
         );
 
         expect(screen.getByText(/nvd scan – variant 1 in progress/i)).toBeInTheDocument();
-        expect(screen.queryByText('Waiting for first results…')).not.toBeInTheDocument();
         expect(screen.getByText('[ERROR] scanning')).toHaveClass('text-red-400');
         expect(screen.getByText('✓ finished step')).toHaveClass('text-green-400', 'font-semibold');
 
         rerender(
             <OperationQueuePanel
-                entry={makeEntry('done', {
-                    progress: '4 / 4',
+                operation={makeOperation('done', {
+                    label: 'NVD Scan',
+                    progress: { current: 4, total: 4, message: '4 / 4' },
                     logs: ['✓ completed'],
                 })}
-                label="NVD Scan"
                 icon={faCircleInfo}
                 colors={colors}
                 onDismiss={onDismiss}
@@ -166,12 +200,34 @@ describe('OperationQueuePanel', () => {
         expect(screen.getByText(/nvd scan – variant 1 complete/i)).toBeInTheDocument();
     });
 
+    it('expands a failed operation and labels it as failed', () => {
+        render(
+            <OperationQueuePanel
+                operation={makeOperation('error', {
+                    label: 'NVD Scan',
+                    error: 'nvd api unreachable',
+                    logs: ['[ERROR] nvd api unreachable'],
+                })}
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByRole('button', { name: /nvd scan – variant 1 failed/i }))
+            .toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByText('[ERROR] nvd api unreachable')).toHaveClass('text-red-400');
+        expect(screen.queryByLabelText('Complete')).not.toBeInTheDocument();
+    });
+
     it('renders zero-total completion at 100% and clamps excessive progress', async () => {
         const user = userEvent.setup();
         const { container, rerender } = render(
             <OperationQueuePanel
-                entry={makeEntry('done', { total: 0, doneCount: 0 })}
-                label="NVD Scan"
+                operation={makeOperation('done', {
+                    label: 'NVD Scan',
+                    progress: { current: 0, total: 0, message: 'Done' },
+                })}
                 icon={faCircleInfo}
                 colors={colors}
                 onDismiss={jest.fn()}
@@ -182,8 +238,11 @@ describe('OperationQueuePanel', () => {
 
         rerender(
             <OperationQueuePanel
-                entry={makeEntry('running', { total: 2, doneCount: 3, logs: ['Finishing'] })}
-                label="NVD Scan"
+                operation={makeOperation('running', {
+                    label: 'NVD Scan',
+                    progress: { current: 3, total: 2, message: 'Finishing' },
+                    logs: ['Finishing'],
+                })}
                 icon={faCircleInfo}
                 colors={colors}
                 onDismiss={jest.fn()}
@@ -192,11 +251,30 @@ describe('OperationQueuePanel', () => {
         expect(container.querySelector('.bg-cyan-500')).toHaveStyle({ width: '100%' });
     });
 
+    it('shows the completion percentage next to the progress message', () => {
+        render(
+            <OperationQueuePanel
+                operation={makeOperation('running', {
+                    label: 'NVD Scan',
+                    progress: { current: 1, total: 4, message: '1 / 4' },
+                    logs: ['Working'],
+                })}
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText(/1 \/ 4 \(25%\)/)).toBeInTheDocument();
+    });
+
     it('labels cancellation without a success indicator', () => {
         render(
             <OperationQueuePanel
-                entry={makeEntry('cancelled', { progress: 'Cancelled', doneCount: 1, total: 4 })}
-                label="Vulnerability Data Refresh"
+                operation={makeOperation('cancelled', {
+                    label: 'Vulnerability Data Refresh',
+                    progress: { current: 1, total: 4, message: 'Cancelled' },
+                })}
                 icon={faCircleInfo}
                 colors={colors}
                 onDismiss={jest.fn()}
@@ -205,5 +283,47 @@ describe('OperationQueuePanel', () => {
 
         expect(screen.getByRole('button', { name: /vulnerability data refresh – variant 1 cancelled/i })).toBeInTheDocument();
         expect(screen.queryByLabelText('Complete')).not.toBeInTheDocument();
+    });
+
+    it('offers cancellation only while the operation is still active', async () => {
+        const user = userEvent.setup();
+        const onCancel = jest.fn();
+
+        const { rerender } = render(
+            <OperationQueuePanel
+                operation={makeOperation('queued', { progress: { current: 0, total: 0, message: 'Queued' } })}
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={jest.fn()}
+                onCancel={onCancel}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Cancel Grype Scan – Variant 1' }));
+        expect(onCancel).toHaveBeenCalledTimes(1);
+
+        rerender(
+            <OperationQueuePanel
+                operation={makeOperation('running', { logs: ['Scanning'] })}
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={jest.fn()}
+                onCancel={onCancel}
+            />,
+        );
+        expect(screen.getByRole('button', { name: 'Cancel Grype Scan – Variant 1' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+
+        rerender(
+            <OperationQueuePanel
+                operation={makeOperation('done')}
+                icon={faCircleInfo}
+                colors={colors}
+                onDismiss={jest.fn()}
+                onCancel={onCancel}
+            />,
+        );
+        expect(screen.queryByRole('button', { name: 'Cancel Grype Scan – Variant 1' })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR 5 of 6 — split out of #529.** Review and merge in order; each PR targets the one before it.
>
> 1. #548 — operation queue core, scan/refresh jobs extracted → base `staging`
> 2. #549 — queue REST API and SSE event stream → base `#548`
> 3. #550 — delete the 21 legacy polling endpoints → base `#549`
> 4. #551 — route exports and uploads through the queue → base `#550`
> 5. **#552 — frontend SSE operation store, queue rendered from it → base `#551` ← you are here**
> 6. #553 — migrate remaining frontend workflows, delete the polling client → base `#552`
>
> The tip of the stack (#553) is commit-identical to #529, which stays open untouched as the integration reference.

---

## Fixes # by giving the frontend one SSE-backed store to read operation state from

### Changes proposed in this pull request:

* Add `handlers/operationStore.ts`, a single subscribable store fed by one `EventSource` on `/api/events/stream`. It applies the initial `snapshot`, then `operation` / `operation_removed` deltas, tracks `Last-Event-ID` for replay, and reconnects with backoff.
* Add `handlers/operations.ts` (batch submit and cancel) and `types/operation.ts`.
* Render `OperationQueueModal` and `OperationQueuePanel` from store state instead of from locally reconstructed progress, so every tab shows the identical queue.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Open the app in two browser tabs and launch a scan. Both tabs should show the identical queue, including still-`queued` items after a reload. DevTools should show exactly one open `/api/events/stream` request.

The old polling handlers are still present in this layer and are removed in the next PR.

### Additional notes

Split from the migration PR so the new store can be reviewed on its own, before the diff that deletes the code it replaces.

### Related Issue

No linked issue.

## Pull Request Checklist

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers
