### PR TITLE
feat(operations): expose the queue API and the SSE event stream

### DIFF
--- a/src/bin/cmd_process.py
+++ b/src/bin/cmd_process.py
@@ -67,9 +67,10 @@ def _ts_key(ts) -> str:
         return str(ts)
 
 
-def post_treatment(controllers: ControllersCache, documents=None):
+def post_treatment(controllers: ControllersCache, documents=None, reporter=None):
     """Enrich vulnerabilities with EPSS scores."""
-    return controllers.vulnerabilities.fetch_epss_scores()
+    from ..controllers.progress_reporter import NULL_REPORTER
+    return controllers.vulnerabilities.fetch_epss_scores(reporter or NULL_REPORTER)
 
 
 REFRESH_SOURCES = ("epss", "nvd", "euvd", "ghsa")

--- a/src/bin/webapp.py
+++ b/src/bin/webapp.py
@@ -8,8 +8,10 @@
 from ..helpers.add_middleware import FlaskWithMiddleware as Flask
 from ..helpers.env_vars import get_bool_env
 from ..extensions import db, migrate, setup_write_serialization
+from ..controllers.operation_queue import queue as operation_queue
 from ..routes import init_app
 from ..routes.documents import MAX_ASSET_UPLOAD_BYTES
+from ..routes.events import STREAM_PATH
 from .. import models  # noqa: F401
 from .merger_ci import init_app as init_merger_cli, post_treatment
 import sys
@@ -28,26 +30,34 @@ DEFAULT_BACKGROUND_TASK_DELAY = 120.0
 
 
 def _launch_enrichment(app):
-    """Spawn background thread for EPSS enrichment.
+    """Queue boot EPSS enrichment so its progress reaches the event stream."""
+    from ..controllers.job_context import JobContext
+    from ..controllers.operation_queue import queue
+    from ..controllers.operation_registry import (
+        KIND_ENRICHMENT, LANE_PIPELINE, registry,
+    )
 
-    Runs in its own thread so it doesn't block Flask request handlers
-    (WAL journal mode allows concurrent reads).
-    """
-    def _enrich_epss():
-        with app.app_context():
-            # Disable autoflush: without this, every SELECT triggers a flush
-            # which acquires the write-lock and holds it across the slow HTTP
-            # calls until the next explicit commit().  With autoflush=False
-            # the lock is only held during commit() itself (milliseconds).
-            db.session.autoflush = False
-            try:
-                from ..controllers import ControllersCache
-                controllers = ControllersCache()
-                post_treatment(controllers)
-            except Exception as e:
-                print(f"[enrichment/epss] {e}", flush=True)
+    op_id = "enrichment:boot"
+    if registry.has_active(op_id):
+        return
 
-    threading.Thread(target=_enrich_epss, name="enrichment-epss", daemon=True).start()
+    def _enrich_epss(ctx):
+        # Disable autoflush: without this, every SELECT triggers a flush which
+        # acquires the write-lock and holds it across the slow HTTP calls until
+        # the next explicit commit(). With autoflush=False the lock is only
+        # held during commit() itself (milliseconds).
+        db.session.autoflush = False
+        from ..controllers import ControllersCache
+        post_treatment(ControllersCache(), reporter=ctx)
+
+    registry.create(
+        op_id=op_id,
+        kind=KIND_ENRICHMENT,
+        source="epss",
+        label="EPSS enrichment",
+        lane=LANE_PIPELINE,
+    )
+    queue.submit(op_id, LANE_PIPELINE, _enrich_epss, JobContext(op_id))
 
 
 def _warm_scan_list_cache(app):
@@ -238,12 +248,18 @@ def create_app():
 
     @app.middleware("/api")
     def fail_scan_not_finished(*args, **kw):
-        if request.path in {"/api", "/api/openapi", "/api/openapi.json", "/api/openapi/ui"}:
+        # The event stream is exempt like /api/scan/status: the UI opens it
+        # during boot import so it can render enrichment progress live.
+        if request.path in {
+            "/api", "/api/openapi", "/api/openapi.json", "/api/openapi/ui",
+            STREAM_PATH,
+        }:
             return None
         if not is_scan_finished():
             return {"error": "Scan not finished"}, 503
 
     init_app(app)
+    operation_queue.init_app(app)
     init_merger_cli(app)
     return app
 

--- a/src/controllers/event_bus.py
+++ b/src/controllers/event_bus.py
@@ -1,0 +1,156 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""In-process publish/subscribe bus backing the SSE event stream.
+
+Publishers (scan threads, refresh trackers, the operation watcher) call
+:meth:`EventBus.publish`.  Every connected SSE client owns one
+:class:`Subscription` and drains its queue.
+
+State is process-local: a multi-worker deployment would need a shared
+transport (Redis, database polling) before a single stream could serve
+events produced by another worker.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from collections import deque
+from typing import Any, Deque, Iterator, List, Optional, Set
+
+# Events kept for reconnecting clients that send ``Last-Event-ID``.
+DEFAULT_REPLAY_BUFFER = 512
+
+# Per-client backlog. A client slower than this is dropped and must resync
+# from a fresh snapshot rather than stalling the publisher.
+DEFAULT_CLIENT_BACKLOG = 256
+
+
+class Subscription:
+    """A single client's view of the bus."""
+
+    def __init__(self, bus: "EventBus", backlog: int) -> None:
+        self._bus = bus
+        self._queue: queue.Queue[Optional[dict]] = queue.Queue(maxsize=backlog)
+        self.overflowed = False
+        self.closed = False
+
+    def _offer(self, event: dict) -> None:
+        try:
+            self._queue.put_nowait(event)
+        except queue.Full:
+            self.overflowed = True
+
+    def close(self) -> None:
+        self._bus.unsubscribe(self)
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            pass
+
+    def drain(self, timeout: float) -> List[dict]:
+        """Block up to *timeout* seconds for events, then take what is queued.
+
+        Returns an empty list when the timeout expires with nothing pending,
+        which is the caller's cue to emit a heartbeat.
+        """
+        events: List[dict] = []
+        try:
+            first = self._queue.get(timeout=timeout)
+        except queue.Empty:
+            return events
+        if first is None:
+            self.closed = True
+            return events
+        events.append(first)
+        while True:
+            try:
+                nxt = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if nxt is None:
+                self.closed = True
+                break
+            events.append(nxt)
+        return events
+
+    def __enter__(self) -> "Subscription":
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.close()
+
+
+class EventBus:
+    """Thread-safe fan-out with a bounded replay buffer."""
+
+    def __init__(
+        self,
+        replay_size: int = DEFAULT_REPLAY_BUFFER,
+        client_backlog: int = DEFAULT_CLIENT_BACKLOG,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._subscribers: Set[Subscription] = set()
+        self._replay: Deque[dict] = deque(maxlen=replay_size)
+        self._client_backlog = client_backlog
+        self._seq = 0
+
+    @property
+    def seq(self) -> int:
+        with self._lock:
+            return self._seq
+
+    def subscriber_count(self) -> int:
+        with self._lock:
+            return len(self._subscribers)
+
+    def publish(self, event_type: str, data: dict) -> dict:
+        """Stamp *data* with a monotonic sequence id and fan it out."""
+        with self._lock:
+            self._seq += 1
+            event = {"seq": self._seq, "event": event_type, "data": data}
+            self._replay.append(event)
+            targets = list(self._subscribers)
+        for sub in targets:
+            sub._offer(event)
+        return event
+
+    def subscribe(self) -> Subscription:
+        sub = Subscription(self, self._client_backlog)
+        with self._lock:
+            self._subscribers.add(sub)
+        return sub
+
+    def unsubscribe(self, sub: Subscription) -> None:
+        with self._lock:
+            self._subscribers.discard(sub)
+
+    def close_all(self) -> None:
+        """Signal every stream to terminate so clients reconnect."""
+        with self._lock:
+            targets = list(self._subscribers)
+            self._subscribers.clear()
+        for sub in targets:
+            try:
+                sub._queue.put_nowait(None)
+            except queue.Full:
+                pass
+
+    def replay_since(self, last_seq: int) -> Optional[Iterator[dict]]:
+        """Return buffered events after *last_seq*.
+
+        ``None`` means the gap is too large to bridge and the client must
+        restart from a snapshot.
+        """
+        with self._lock:
+            if not self._replay:
+                return iter(()) if last_seq == self._seq else None
+            oldest = self._replay[0]["seq"]
+            if last_seq < oldest - 1 or last_seq > self._seq:
+                return None
+            return iter([e for e in self._replay if e["seq"] > last_seq])
+
+
+# Single bus shared by every stream in this process.
+operation_events = EventBus()

--- a/src/controllers/job_context.py
+++ b/src/controllers/job_context.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Reporting handle passed to every queued job.
+
+A job body never touches the registry or the event bus directly; it calls
+``report`` / ``log`` / ``is_cancelled`` on its context.  The context
+coalesces updates so a scan emitting thousands of log lines produces a
+bounded number of SSE frames.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+from .operation_registry import registry
+
+# Minimum spacing between published updates for a single operation.
+FLUSH_INTERVAL_SECONDS = 0.25
+
+
+class CancelledError(Exception):
+    """Raised by :meth:`JobContext.check_cancelled` when a stop was requested."""
+
+
+class JobContext:
+    """Progress channel and cancellation signal for one operation."""
+
+    def __init__(self, op_id: str, options: Optional[Dict[str, Any]] = None) -> None:
+        self.op_id = op_id
+        self.options: Dict[str, Any] = options or {}
+        self._lock = threading.Lock()
+        self._cancel = threading.Event()
+        self._pending_logs: List[str] = []
+        self._pending_progress: Optional[Dict[str, Any]] = None
+        self._current = 0
+        self._total = 0
+        self._last_flush = 0.0
+        self._on_cancel: Optional[Callable[[], None]] = None
+
+    # ------------------------------------------------------------------
+    # Cancellation
+    # ------------------------------------------------------------------
+
+    def request_cancel(self) -> None:
+        with self._lock:
+            on_cancel = self._on_cancel
+        self._cancel.set()
+        if on_cancel is not None:
+            on_cancel()
+
+    def set_cancel_hook(self, hook: Optional[Callable[[], None]]) -> None:
+        """Register a callback that aborts blocking work (e.g. kills a subprocess)."""
+        with self._lock:
+            self._on_cancel = hook
+
+    def is_cancelled(self) -> bool:
+        return self._cancel.is_set()
+
+    def check_cancelled(self) -> None:
+        if self._cancel.is_set():
+            raise CancelledError()
+
+    # ------------------------------------------------------------------
+    # Progress reporting
+    # ------------------------------------------------------------------
+
+    def report(self, current: int, total: int, message: str) -> None:
+        with self._lock:
+            self._current = current
+            self._total = total
+            self._pending_progress = {
+                "current": current,
+                "total": total,
+                "message": message,
+            }
+        self._maybe_flush()
+
+    def message(self, message: str) -> None:
+        """Update the status line while keeping the current counters."""
+        with self._lock:
+            self._pending_progress = {
+                "current": self._current,
+                "total": self._total,
+                "message": message,
+            }
+        self._maybe_flush()
+
+    def log(self, line: str) -> None:
+        with self._lock:
+            self._pending_logs.append(line)
+        self._maybe_flush()
+
+    def set_result(self, result: Dict[str, Any]) -> None:
+        self.flush()
+        registry.update(self.op_id, result=result)
+
+    def _maybe_flush(self) -> None:
+        now = time.monotonic()
+        with self._lock:
+            if now - self._last_flush < FLUSH_INTERVAL_SECONDS:
+                return
+            self._last_flush = now
+        self.flush()
+
+    def flush(self) -> None:
+        """Publish everything buffered so far."""
+        with self._lock:
+            logs = self._pending_logs
+            progress = self._pending_progress
+            self._pending_logs = []
+            self._pending_progress = None
+        if not logs and progress is None:
+            return
+        patch: Dict[str, Any] = {}
+        if progress is not None:
+            patch["progress"] = progress
+        if logs:
+            patch["append_logs"] = logs
+        registry.update(self.op_id, **patch)

--- a/src/controllers/operation_queue.py
+++ b/src/controllers/operation_queue.py
@@ -1,0 +1,238 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Server-side execution queue for every long-running operation.
+
+Three lanes reproduce the concurrency the frontend used to enforce by hand:
+
+``pipeline``
+    Scans and vulnerability refreshes, strictly serial.  Grype shells out to
+    ``flask export`` and sbom-cve-check holds a file lock on the engine, so
+    only one may run at a time; refreshes were likewise gated behind a
+    "wait for active scans" barrier in the browser.
+
+``export``
+    Document exports, two at a time, matching the previous
+    ``ThreadPoolExecutor(max_workers=2)``.
+
+``upload``
+    SBOM imports, one thread each, unbounded.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from dataclasses import dataclass
+from typing import Callable, Deque, Dict, List, Optional
+
+from flask import Flask
+
+from .job_context import CancelledError, JobContext
+from .operation_registry import (
+    LANE_EXPORT,
+    LANE_PIPELINE,
+    LANE_UPLOAD,
+    STATUS_CANCELLED,
+    STATUS_DONE,
+    STATUS_ERROR,
+    STATUS_RUNNING,
+    registry,
+)
+
+JobRunner = Callable[[JobContext], None]
+
+
+@dataclass
+class _Job:
+    op_id: str
+    lane: str
+    ctx: JobContext
+    runner: JobRunner
+
+
+class _Lane:
+    """One execution lane with a fixed worker count, or a thread per job."""
+
+    def __init__(self, name: str, workers: Optional[int]) -> None:
+        self.name = name
+        self.workers = workers
+        self._lock = threading.Lock()
+        self._wake = threading.Condition(self._lock)
+        self._pending: Deque[_Job] = deque()
+        self._running: Dict[str, _Job] = {}
+        self._started = False
+
+    def start(self, execute: Callable[[_Job], None]) -> None:
+        if self.workers is None or self._started:
+            return
+        self._started = True
+        for index in range(self.workers):
+            thread = threading.Thread(
+                target=self._worker_loop,
+                args=(execute,),
+                name=f"operations-{self.name}-{index}",
+                daemon=True,
+            )
+            thread.start()
+
+    def submit(self, job: _Job, execute: Callable[[_Job], None]) -> None:
+        if self.workers is None:
+            with self._lock:
+                self._running[job.op_id] = job
+            threading.Thread(
+                target=execute,
+                args=(job,),
+                name=f"operations-{self.name}-{job.op_id}",
+                daemon=True,
+            ).start()
+            return
+        with self._wake:
+            self._pending.append(job)
+            self._wake.notify()
+
+    def _worker_loop(self, execute: Callable[[_Job], None]) -> None:
+        while True:
+            with self._wake:
+                while not self._pending:
+                    self._wake.wait()
+                job = self._pending.popleft()
+                self._running[job.op_id] = job
+            execute(job)
+
+    def finish(self, op_id: str) -> None:
+        with self._lock:
+            self._running.pop(op_id, None)
+
+    def take_pending(self, op_id: str) -> Optional[_Job]:
+        """Remove a not-yet-started job so it can be cancelled without running."""
+        with self._lock:
+            for job in self._pending:
+                if job.op_id == op_id:
+                    self._pending.remove(job)
+                    return job
+        return None
+
+    def running_job(self, op_id: str) -> Optional[_Job]:
+        with self._lock:
+            return self._running.get(op_id)
+
+    def pending_ids(self) -> List[str]:
+        with self._lock:
+            return [job.op_id for job in self._pending]
+
+
+class OperationQueue:
+    """Dispatches queued operations onto their lane and records the outcome."""
+
+    def __init__(self) -> None:
+        self._app: Optional[Flask] = None
+        self._lanes = {
+            LANE_PIPELINE: _Lane(LANE_PIPELINE, 1),
+            LANE_EXPORT: _Lane(LANE_EXPORT, 2),
+            LANE_UPLOAD: _Lane(LANE_UPLOAD, None),
+        }
+
+    def init_app(self, app: Flask) -> None:
+        self._app = app
+        for lane in self._lanes.values():
+            lane.start(self._execute)
+
+    def submit(self, op_id: str, lane: str, runner: JobRunner, ctx: JobContext) -> None:
+        """Queue an already-registered operation for execution."""
+        target = self._lanes[lane]
+        target.submit(_Job(op_id=op_id, lane=lane, ctx=ctx, runner=runner), self._execute)
+
+    def cancel(self, op_id: str) -> bool:
+        """Cancel a queued or running operation.
+
+        Queued work is dropped without ever starting; running work gets a
+        cooperative stop signal that the job body polls.
+        """
+        operation = registry.get(op_id)
+        if operation is None or not operation.get("cancellable", False):
+            return False
+
+        for lane in self._lanes.values():
+            pending = lane.take_pending(op_id)
+            if pending is not None:
+                pending.ctx.request_cancel()
+                registry.update(
+                    op_id,
+                    status=STATUS_CANCELLED,
+                    progress={"current": 0, "total": 0, "message": "Cancelled before start"},
+                )
+                return True
+            running = lane.running_job(op_id)
+            if running is not None:
+                running.ctx.request_cancel()
+                registry.update(op_id, append_logs=["Cancellation requested"])
+                return True
+        return False
+
+    def cancel_queue(self, queue_id: str) -> int:
+        """Cancel every still-active operation belonging to a batch."""
+        targets = [
+            operation["op_id"]
+            for operation in registry.active()
+            if operation.get("queue_id") == queue_id
+        ]
+        return sum(1 for op_id in targets if self.cancel(op_id))
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def _execute(self, job: _Job) -> None:
+        try:
+            if job.ctx.is_cancelled():
+                registry.update(
+                    job.op_id,
+                    status=STATUS_CANCELLED,
+                    progress={"current": 0, "total": 0, "message": "Cancelled before start"},
+                )
+                return
+            registry.update(
+                job.op_id,
+                status=STATUS_RUNNING,
+                progress={"current": 0, "total": 0, "message": "Starting"},
+            )
+            self._run_body(job)
+        finally:
+            self._lanes[job.lane].finish(job.op_id)
+
+    def _run_body(self, job: _Job) -> None:
+        assert self._app is not None, "OperationQueue.init_app() was never called"
+        try:
+            with self._app.app_context():
+                job.runner(job.ctx)
+        except CancelledError:
+            job.ctx.flush()
+            registry.update(
+                job.op_id,
+                status=STATUS_CANCELLED,
+                progress={"current": 0, "total": 0, "message": "Cancelled"},
+                append_logs=["Operation cancelled"],
+            )
+        except Exception as error:  # noqa: BLE001 - surfaced to the client verbatim
+            job.ctx.flush()
+            message = str(error)[:500] or error.__class__.__name__
+            registry.update(
+                job.op_id,
+                status=STATUS_ERROR,
+                error=message,
+                append_logs=[f"ERROR: {message}"],
+            )
+        else:
+            job.ctx.flush()
+            if job.ctx.is_cancelled():
+                registry.update(
+                    job.op_id,
+                    status=STATUS_CANCELLED,
+                    progress={"current": 0, "total": 0, "message": "Cancelled"},
+                )
+            else:
+                registry.update(job.op_id, status=STATUS_DONE)
+
+
+queue = OperationQueue()

--- a/src/controllers/operation_registry.py
+++ b/src/controllers/operation_registry.py
@@ -1,0 +1,201 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Single in-memory store for every long-running operation.
+
+Scans, vulnerability refreshes, SBOM uploads, document exports and boot
+enrichment all normalise to one :class:`Operation` shape here.  Every
+mutation publishes to :data:`~src.controllers.event_bus.operation_events`,
+which is what the ``/api/events/stream`` SSE endpoint serves.
+
+State is process-local, matching the shipped single-process deployment.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .event_bus import operation_events
+
+# Terminal operations stay visible this long so a reconnecting client still
+# sees the outcome of work that finished while it was away.
+TERMINAL_TTL_SECONDS = 3600
+
+# Per-operation log cap; scans can emit thousands of lines.
+MAX_LOGS = 500
+
+KIND_SCAN = "scan"
+KIND_REFRESH = "refresh"
+KIND_UPLOAD = "upload"
+KIND_EXPORT = "export"
+KIND_ENRICHMENT = "enrichment"
+
+LANE_PIPELINE = "pipeline"
+LANE_EXPORT = "export"
+LANE_UPLOAD = "upload"
+
+STATUS_QUEUED = "queued"
+STATUS_RUNNING = "running"
+STATUS_DONE = "done"
+STATUS_ERROR = "error"
+STATUS_CANCELLED = "cancelled"
+
+TERMINAL_STATUSES = frozenset({STATUS_DONE, STATUS_ERROR, STATUS_CANCELLED})
+ACTIVE_STATUSES = frozenset({STATUS_QUEUED, STATUS_RUNNING})
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class OperationRegistry:
+    """Thread-safe operation table with change publication."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._operations: Dict[str, dict] = {}
+        self._finished_at: Dict[str, float] = {}
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def create(
+        self,
+        op_id: str,
+        kind: str,
+        source: str,
+        label: str,
+        lane: str,
+        scope: Optional[dict] = None,
+        queue_id: Optional[str] = None,
+        position: Optional[int] = None,
+        options: Optional[dict] = None,
+        cancellable: bool = False,
+    ) -> dict:
+        """Register a new operation in ``queued`` state and publish it."""
+        operation: Dict[str, Any] = {
+            "op_id": op_id,
+            "kind": kind,
+            "source": source,
+            "label": label,
+            "lane": lane,
+            "scope": scope,
+            "status": STATUS_QUEUED,
+            "progress": {"current": 0, "total": 0, "message": "Queued"},
+            "logs": [],
+            "error": None,
+            "queue_id": queue_id,
+            "position": position,
+            "options": options or {},
+            "cancellable": cancellable,
+            "created_at": _now(),
+            "started_at": None,
+            "finished_at": None,
+            "result": None,
+        }
+        with self._lock:
+            self._operations[op_id] = operation
+            self._finished_at.pop(op_id, None)
+            snapshot = dict(operation)
+        operation_events.publish("operation", snapshot)
+        return snapshot
+
+    def update(self, op_id: str, **patch: Any) -> Optional[dict]:
+        """Apply *patch* to an operation and publish the new state.
+
+        ``append_logs`` is handled specially: the given lines are appended to
+        the existing log list rather than replacing it.
+        """
+        append_logs = patch.pop("append_logs", None)
+        with self._lock:
+            operation = self._operations.get(op_id)
+            if operation is None:
+                return None
+            operation.update(patch)
+            if append_logs:
+                logs = operation["logs"]
+                logs.extend(append_logs)
+                if len(logs) > MAX_LOGS:
+                    del logs[: len(logs) - MAX_LOGS]
+            status = operation["status"]
+            if status == STATUS_RUNNING and operation["started_at"] is None:
+                operation["started_at"] = _now()
+            if status in TERMINAL_STATUSES:
+                if operation["finished_at"] is None:
+                    operation["finished_at"] = _now()
+                self._finished_at[op_id] = time.monotonic()
+            snapshot = dict(operation)
+            snapshot["logs"] = list(operation["logs"])
+        operation_events.publish("operation", snapshot)
+        return snapshot
+
+    def remove(self, op_id: str) -> bool:
+        """Drop a terminal operation and tell clients to forget it."""
+        with self._lock:
+            operation = self._operations.get(op_id)
+            if operation is None or operation["status"] not in TERMINAL_STATUSES:
+                return False
+            del self._operations[op_id]
+            self._finished_at.pop(op_id, None)
+        operation_events.publish("operation_removed", {"op_id": op_id})
+        return True
+
+    def prune(self) -> None:
+        """Drop terminal operations older than :data:`TERMINAL_TTL_SECONDS`."""
+        cutoff = time.monotonic() - TERMINAL_TTL_SECONDS
+        with self._lock:
+            expired = [op_id for op_id, at in self._finished_at.items() if at < cutoff]
+            for op_id in expired:
+                self._operations.pop(op_id, None)
+                self._finished_at.pop(op_id, None)
+        for op_id in expired:
+            operation_events.publish("operation_removed", {"op_id": op_id})
+
+    def clear(self) -> None:
+        """Drop every operation. Used by tests to isolate cases."""
+        with self._lock:
+            self._operations.clear()
+            self._finished_at.clear()
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def get(self, op_id: str) -> Optional[dict]:
+        with self._lock:
+            operation = self._operations.get(op_id)
+            if operation is None:
+                return None
+            snapshot = dict(operation)
+            snapshot["logs"] = list(operation["logs"])
+            return snapshot
+
+    def snapshot(self) -> List[dict]:
+        with self._lock:
+            result = []
+            for operation in self._operations.values():
+                entry = dict(operation)
+                entry["logs"] = list(operation["logs"])
+                result.append(entry)
+        result.sort(key=lambda item: (item["created_at"], item["op_id"]))
+        return result
+
+    def active(self) -> List[dict]:
+        return [op for op in self.snapshot() if op["status"] in ACTIVE_STATUSES]
+
+    def has_active(self, op_id: str) -> bool:
+        with self._lock:
+            operation = self._operations.get(op_id)
+            return operation is not None and operation["status"] in ACTIVE_STATUSES
+
+
+def new_queue_id() -> str:
+    return f"q-{uuid.uuid4()}"
+
+
+registry = OperationRegistry()

--- a/src/controllers/progress_reporter.py
+++ b/src/controllers/progress_reporter.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Progress sink for enrichment code that may or may not run as a queued operation.
+
+Boot enrichment and SBOM-upload enrichment pass a
+:class:`~src.controllers.job_context.JobContext`, so their progress reaches the
+SSE stream. The CLI passes nothing and the calls become no-ops.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ProgressReporter(Protocol):
+    def report(self, current: int, total: int, message: str) -> None:
+        ...
+
+    def log(self, line: str) -> None:
+        ...
+
+    def is_cancelled(self) -> bool:
+        ...
+
+
+class NullReporter:
+    """Discards everything; used when enrichment runs outside the queue."""
+
+    def report(self, current: int, total: int, message: str) -> None:
+        return None
+
+    def log(self, line: str) -> None:
+        return None
+
+    def is_cancelled(self) -> bool:
+        return False
+
+
+NULL_REPORTER: ProgressReporter = NullReporter()

--- a/src/controllers/refresh_jobs.py
+++ b/src/controllers/refresh_jobs.py
@@ -1,0 +1,444 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Vulnerability refresh job bodies executed by the operation queue.
+
+NVD, EPSS, GHSA and ENISA EUVD each run on the ``pipeline`` lane so they never
+overlap a scan, reproducing the barrier the frontend used to enforce.
+"""
+
+from __future__ import annotations
+
+import datetime
+import decimal
+import os
+import re
+import time
+import urllib.error
+import uuid
+from typing import Dict, List, Optional, Set, Tuple
+
+from ..extensions import db
+from ..helpers.active_scans import active_package_ids_for_scans, active_scan_ids_for_variant
+from ..models import Finding, Observation, Scan, Vulnerability
+from .epss_db import EPSS_DB
+from .euvd_db import EUVD_DB
+from .job_context import JobContext
+from .nvd_apply import apply_cvss_update, apply_nvd_update
+from .nvd_db import NVD_DB
+from .nvd_extract import extract_cve_details
+from .operation_registry import STATUS_CANCELLED, STATUS_ERROR, registry
+from .scc_engine import get_cve_json, get_engine as _get_scc_engine
+from .vulnerabilities import VulnerabilitiesController
+
+EPSS_BATCH_SIZE = 100
+NVD_COMMIT_EVERY = 50
+# Cap prevents burning NVD API rate-limit quota (6 s/CVE without a key).
+MAX_CVE_IDS = 1000
+CVE_RE = re.compile(r'^CVE-\d{4}-\d{4,}$')
+MAX_GHSA_IDS = 500
+GHSA_RE = re.compile(r'^GHSA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$')
+GHSA_COMMIT_EVERY = 20
+GHSA_SLEEP_INTERVAL = 1.0
+# EUVD annotates from cached ENISA dumps with no per-CVE network call, so it
+# commits in larger batches than the network-bound refreshes.
+EUVD_COMMIT_EVERY = 200
+# Kept under SQLite's 999 bound-parameter limit so the "which of these exist?"
+# intersection stays an indexed ``WHERE id IN (...)`` bounded by request size.
+DB_LOOKUP_CHUNK = 500
+
+
+def _nvd_sleep_interval() -> float:
+    """Seconds between NVD REST calls: 6 s without an API key, 0.6 s with one."""
+    return 0.6 if os.getenv("NVD_API_KEY") else 6.0
+
+
+def _safe_commit(label: str) -> None:
+    """Commit, rolling back on failure, then expunge so the identity map stays bounded."""
+    try:
+        db.session.commit()
+    except Exception as exc:
+        print(f"[{label}] commit error: {exc}", flush=True)
+        db.session.rollback()
+    finally:
+        db.session.expunge_all()
+
+
+def normalise_cve_ids(raw_ids: object) -> List[str]:
+    if not isinstance(raw_ids, list):
+        return []
+    candidates = [c.strip().upper() for c in raw_ids if isinstance(c, str) and c.strip()]
+    return [c for c in dict.fromkeys(candidates) if CVE_RE.match(c)]
+
+
+def normalise_ghsa_ids(raw_ids: object) -> List[str]:
+    if not isinstance(raw_ids, list):
+        return []
+    candidates = [c.strip().upper() for c in raw_ids if isinstance(c, str) and c.strip()]
+    return [c for c in dict.fromkeys(candidates) if GHSA_RE.match(c)]
+
+
+def known_cve_ids(cve_ids: List[str]) -> List[str]:
+    """Intersect *cve_ids* with the database in request-bounded chunks."""
+    known: Set[str] = set()
+    for start in range(0, len(cve_ids), DB_LOOKUP_CHUNK):
+        chunk = cve_ids[start:start + DB_LOOKUP_CHUNK]
+        rows = db.session.query(Vulnerability.id).filter(Vulnerability.id.in_(chunk)).all()
+        known.update(row[0] for row in rows)
+    return [cve_id for cve_id in cve_ids if cve_id in known]
+
+
+def _scoped_vulnerability_ids(variant_ids: List[str]) -> Set[str]:
+    """Return vulnerability IDs visible in the active scans for the variants."""
+    scan_ids = [
+        scan_id
+        for variant_id in variant_ids
+        for scan_id in active_scan_ids_for_variant(uuid.UUID(variant_id))
+    ]
+    if not scan_ids:
+        return set()
+
+    package_ids = active_package_ids_for_scans(scan_ids)
+    query = (
+        db.select(Vulnerability.id)
+        .join(Finding, Vulnerability.id == Finding.vulnerability_id)
+        .join(Observation, Finding.id == Observation.finding_id)
+        .join(Scan, Observation.scan_id == Scan.id)
+        .where(Observation.scan_id.in_(scan_ids))
+    )
+    if package_ids:
+        query = query.where(db.or_(
+            Scan.scan_type.is_(None),
+            Scan.scan_type == "sbom",
+            Finding.package_id.in_(package_ids),
+        ))
+    return set(db.session.execute(query.distinct()).scalars().all())
+
+
+def run_deferred_refresh(ctx: JobContext) -> None:
+    """Resolve a wizard refresh target after its preceding scans have finished."""
+    ctx.check_cancelled()
+    operation = registry.get(ctx.op_id)
+    if operation is not None and operation.get("queue_id") is not None:
+        preceding_scans = [
+            candidate for candidate in registry.snapshot()
+            if candidate.get("queue_id") == operation["queue_id"]
+            and candidate.get("kind") == "scan"
+            and candidate.get("position", 0) < operation.get("position", 0)
+        ]
+        if any(scan.get("status") in {STATUS_ERROR, STATUS_CANCELLED} for scan in preceding_scans):
+            ctx.report(0, 0, "Skipped because an earlier scan did not complete")
+            return
+
+    source = str(ctx.options["source"])
+    existing_ids = set(ctx.options.get("exclude_ids", []))
+    scoped_ids = _scoped_vulnerability_ids(list(ctx.options["variant_ids"]))
+    if source == "ghsa":
+        ids = normalise_ghsa_ids(sorted(scoped_ids - existing_ids))
+    else:
+        ids = normalise_cve_ids(sorted(scoped_ids - existing_ids))
+        if source == "epss":
+            ids = known_cve_ids(ids)
+        if source == "nvd" and ctx.options.get("mode") == "api" and len(ids) > MAX_CVE_IDS:
+            raise RuntimeError(
+                f"nvd refresh accepts at most {MAX_CVE_IDS} identifiers in api mode"
+            )
+
+    if not ids:
+        ctx.report(0, 0, "No newly discovered vulnerabilities to refresh")
+        return
+
+    ctx.options["ids"] = ids
+    REFRESH_JOBS[source](ctx)
+
+
+# ---------------------------------------------------------------------------
+# NVD
+# ---------------------------------------------------------------------------
+
+def _refresh_nvd_record(cve_id: str, mode: str, nvd: Optional[NVD_DB]) -> None:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    if mode == "api" and nvd is not None:
+        status_code, payload = nvd.api_get_cve(cve_id, max_retries=2)
+        if status_code != 200 or not payload.get("vulnerabilities"):
+            print(f"[bulk NVD refresh] {cve_id}: status={status_code}, skipping", flush=True)
+            return
+        details = NVD_DB.extract_cve_details(payload["vulnerabilities"][0]["cve"])
+    else:
+        cve_obj = get_cve_json(cve_id)
+        if cve_obj is None:
+            print(
+                f"[bulk NVD refresh] {cve_id}: not found in local NVD database, skipping",
+                flush=True,
+            )
+            return
+        details = extract_cve_details(cve_obj)
+
+    record = db.session.get(Vulnerability, cve_id)
+    if record is not None:
+        apply_nvd_update(record, details, now)
+        apply_cvss_update(record, details, db)
+
+
+def run_nvd_refresh(ctx: JobContext) -> None:
+    """Refresh NVD/CVSS metadata from the local FKIE database or the REST API."""
+    cve_ids: List[str] = list(ctx.options["ids"])
+    mode = ctx.options.get("mode", "local")
+    total = len(cve_ids)
+    ctx.report(0, total, f"Starting bulk NVD refresh: 0/{total}")
+
+    nvd: Optional[NVD_DB] = None
+    sleep_between = 0.0
+    if mode == "api":
+        sleep_between = _nvd_sleep_interval()
+        nvd = NVD_DB(nvd_api_key=os.getenv("NVD_API_KEY"))
+    else:
+        # Pre-warm the shared engine once so per-CVE lookups reuse the cache.
+        try:
+            _get_scc_engine(progress=lambda message: ctx.report(0, total, message))
+        except Exception as exc:
+            raise RuntimeError(f"Failed to load local NVD database: {exc}")
+
+    done = 0
+    for cve_id in cve_ids:
+        if ctx.is_cancelled():
+            _safe_commit("bulk NVD refresh cancel")
+            ctx.check_cancelled()
+        try:
+            _refresh_nvd_record(cve_id, mode, nvd)
+        except Exception as exc:
+            print(f"[bulk NVD refresh] error for {cve_id}: {exc}", flush=True)
+
+        done += 1
+        ctx.report(done, total, f"NVD refresh: {done}/{total} ({cve_id})")
+        if done % NVD_COMMIT_EVERY == 0:
+            _safe_commit("bulk NVD refresh")
+        if mode == "api" and done < total:
+            time.sleep(sleep_between)
+
+    _safe_commit("bulk NVD refresh final")
+    ctx.report(total, total, "NVD refresh complete")
+
+
+# ---------------------------------------------------------------------------
+# EPSS
+# ---------------------------------------------------------------------------
+
+def _apply_epss_score(cve_id: str, score: object, now: datetime.datetime) -> None:
+    record = db.session.get(Vulnerability, cve_id)
+    if record is None:
+        return
+    new_score = decimal.Decimal(str(score))
+    updates: dict = {
+        "epss_score": new_score,
+        "epss_fetched_at": now,
+        "commit": False,
+    }
+    if record.epss_score is None or record.epss_score != new_score:
+        updates["epss_data_updated_at"] = now
+    record.update_record(**updates)
+
+
+def run_epss_refresh(ctx: JobContext) -> None:
+    """Refresh EPSS scores in batches of :data:`EPSS_BATCH_SIZE`."""
+    cve_ids: List[str] = list(ctx.options["ids"])
+    total = len(cve_ids)
+    ctx.report(0, total, f"Starting bulk EPSS refresh: 0/{total}")
+
+    epss = EPSS_DB()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    processed = 0
+
+    for start in range(0, total, EPSS_BATCH_SIZE):
+        chunk = cve_ids[start:start + EPSS_BATCH_SIZE]
+        if ctx.is_cancelled():
+            _safe_commit("bulk EPSS refresh cancel")
+            ctx.check_cancelled()
+
+        try:
+            results = epss.api_get_epss_batch(chunk)
+        except Exception as exc:
+            print(f"[bulk EPSS refresh] batch error: {exc}", flush=True)
+            processed += len(chunk)
+            ctx.report(processed, total, f"EPSS refresh: {processed}/{total}")
+            continue
+
+        for cve_id in chunk:
+            result = results.get(cve_id)
+            if result:
+                try:
+                    _apply_epss_score(cve_id, result["score"], now)
+                except Exception as exc:
+                    print(f"[bulk EPSS refresh] error updating {cve_id}: {exc}", flush=True)
+            processed += 1
+
+        _safe_commit("bulk EPSS refresh")
+        ctx.report(processed, total, f"EPSS refresh: {processed}/{total}")
+
+    ctx.report(total, total, "EPSS refresh complete")
+
+
+# ---------------------------------------------------------------------------
+# GHSA
+# ---------------------------------------------------------------------------
+
+def _apply_ghsa_published(ghsa_id: str, now: datetime.datetime) -> None:
+    published_at = VulnerabilitiesController._fetch_ghsa_published(ghsa_id)
+    if not published_at:
+        return
+    record = db.session.get(Vulnerability, ghsa_id)
+    if record is None:
+        return
+    try:
+        publish_date = datetime.date.fromisoformat(str(published_at)[:10])
+    except ValueError:
+        publish_date = None
+
+    updates: dict = {"ghsa_fetched_at": now, "commit": False}
+    if publish_date is not None:
+        updates["publish_date"] = publish_date
+        if record.publish_date != publish_date:
+            updates["ghsa_data_updated_at"] = now
+    record.update_record(**updates)
+
+
+def run_ghsa_refresh(ctx: JobContext) -> None:
+    """Fetch GHSA publication dates, honouring GitHub's rate limit."""
+    ghsa_ids: List[str] = list(ctx.options["ids"])
+    total = len(ghsa_ids)
+    ctx.report(0, total, f"Starting bulk GHSA refresh: 0/{total}")
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    done = 0
+    failed = 0
+
+    for ghsa_id in ghsa_ids:
+        if ctx.is_cancelled():
+            _safe_commit("bulk GHSA refresh cancel")
+            ctx.check_cancelled()
+
+        try:
+            _apply_ghsa_published(ghsa_id, now)
+        except urllib.error.HTTPError as exc:
+            if exc.code in (403, 429):
+                _safe_commit("bulk GHSA refresh rate-limited")
+                raise RuntimeError(
+                    f"GitHub rate limit reached after {done} IDs (HTTP {exc.code})."
+                    " Set GITHUB_TOKEN env var to increase quota."
+                )
+            print(f"[bulk GHSA refresh] error for {ghsa_id}: {exc}", flush=True)
+            failed += 1
+        except Exception as exc:
+            print(f"[bulk GHSA refresh] error for {ghsa_id}: {exc}", flush=True)
+            failed += 1
+
+        done += 1
+        ctx.report(done, total, f"GHSA refresh: {done}/{total} ({ghsa_id})")
+        if done % GHSA_COMMIT_EVERY == 0:
+            _safe_commit("bulk GHSA refresh")
+        if done < total:
+            time.sleep(GHSA_SLEEP_INTERVAL)
+
+    _safe_commit("bulk GHSA refresh final")
+    summary = (
+        f"GHSA refresh complete ({total} IDs, {failed} failed)"
+        if failed else "GHSA refresh complete"
+    )
+    ctx.report(total, total, summary)
+
+
+# ---------------------------------------------------------------------------
+# ENISA EUVD
+# ---------------------------------------------------------------------------
+
+def _apply_euvd(
+    cve_id: str,
+    full_map: Dict[str, str],
+    kev_map: Dict[str, dict],
+    now: datetime.datetime,
+) -> Tuple[bool, bool]:
+    """Annotate one CVE. Returns ``(matched_an_euvd_id, known_exploited)``."""
+    record = db.session.get(Vulnerability, cve_id)
+    if record is None:
+        return False, False
+
+    kev = kev_map.get(cve_id)
+    euvd_id = full_map.get(cve_id) or (kev["euvd_id"] if kev else None)
+
+    if euvd_id:
+        known_exploited = kev is not None
+        record.update_record(
+            euvd_id=euvd_id,
+            euvd_known_exploited=known_exploited,
+            euvd_kev_sources=(kev.get("sources") or []) if kev else [],
+            euvd_date_added=kev.get("date_added") if kev else None,
+            euvd_fetched_at=now,
+            euvd_data_updated_at=now,
+            commit=False,
+        )
+        return True, known_exploited
+
+    had_euvd_data = (
+        record.euvd_id is not None
+        or record.euvd_known_exploited
+        or record.euvd_kev_sources
+        or record.euvd_date_added is not None
+    )
+    if had_euvd_data:
+        record.euvd_id = None
+        record.euvd_known_exploited = False
+        record.euvd_kev_sources = []
+        record.euvd_date_added = None
+        record.update_record(euvd_fetched_at=now, euvd_data_updated_at=now, commit=False)
+    else:
+        record.update_record(euvd_fetched_at=now, commit=False)
+    return False, False
+
+
+def run_euvd_refresh(ctx: JobContext) -> None:
+    """Annotate CVEs from the cached ENISA EUVD mapping and EU KEV dump."""
+    cve_ids: List[str] = list(ctx.options["ids"])
+    total = len(cve_ids)
+    ctx.report(0, total, "Loading ENISA EUVD CVE mapping…")
+
+    euvd = EUVD_DB()
+    full_map = euvd.get_full_mapping()
+    if not full_map:
+        raise RuntimeError("ENISA EUVD CVE mapping unavailable or empty")
+    kev_map = euvd.get_mapping()
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    done = 0
+    matched = 0
+    kev_matched = 0
+
+    for cve_id in cve_ids:
+        if ctx.is_cancelled():
+            _safe_commit("bulk EUVD refresh cancel")
+            ctx.check_cancelled()
+
+        matched_euvd, known_exploited = _apply_euvd(cve_id, full_map, kev_map, now)
+        if matched_euvd:
+            matched += 1
+        if known_exploited:
+            kev_matched += 1
+
+        done += 1
+        ctx.report(done, total, f"EUVD refresh: {done}/{total}")
+        if done % EUVD_COMMIT_EVERY == 0:
+            _safe_commit("bulk EUVD refresh")
+
+    _safe_commit("bulk EUVD refresh final")
+    ctx.report(
+        total, total,
+        f"EUVD enrichment complete ({matched}/{total} matched, "
+        f"{kev_matched} known exploitable)",
+    )
+
+
+REFRESH_JOBS = {
+    "nvd": run_nvd_refresh,
+    "epss": run_epss_refresh,
+    "ghsa": run_ghsa_refresh,
+    "euvd": run_euvd_refresh,
+}

--- a/src/controllers/scan_jobs.py
+++ b/src/controllers/scan_jobs.py
@@ -1,0 +1,755 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Scan job bodies executed by the operation queue.
+
+Each ``run_*_scan`` runs inside an application context on the ``pipeline``
+lane and reports through its :class:`~src.controllers.job_context.JobContext`.
+Raising propagates to the queue, which records the operation as failed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import uuid as uuid_module
+from typing import Callable, Dict, List, Sequence, Set, Tuple
+
+from ..extensions import db
+from ..helpers.scan_filters import is_kernel_package_name
+from ..models.finding import Finding
+from ..models.package import Package
+from ..models.project import Project
+from ..models.sbom_document import SBOMDocument
+from ..models.sbom_package import SBOMPackage
+from ..models.scan import Scan
+from ..models.variant import Variant
+from ..routes._scan_helpers import (
+    create_observation_and_assessment,
+    resolve_active_packages,
+)
+from ..views.grype_vulns import GrypeVulns
+from .job_context import JobContext
+
+GRYPE_EXPORT_TIMEOUT = 120
+GRYPE_SCAN_TIMEOUT = 600
+GRYPE_MERGE_TIMEOUT = 120
+GRYPE_PROCESS_TIMEOUT = 300
+
+FLASK_APP = "src.bin.webapp"
+EMPTY_DESCRIPTION = "empty description"
+RESOLVING_PACKAGES = "Resolving active packages…"
+
+
+def _preview(identifiers: Sequence[str], limit: int = 10) -> str:
+    ellipsis = "…" if len(identifiers) > limit else ""
+    return f"{', '.join(identifiers[:limit])}{ellipsis}"
+
+
+def _engine_progress(ctx: JobContext) -> Callable[[str], None]:
+    """Surface advisory-database sync messages as both status line and log."""
+    def report(message: str) -> None:
+        ctx.message(message)
+        ctx.log(message)
+    return report
+
+
+def _variant_uuid(ctx: JobContext) -> uuid_module.UUID:
+    return uuid_module.UUID(str(ctx.options["variant_id"]))
+
+
+def _exclude_kernel(ctx: JobContext) -> bool:
+    return bool(ctx.options.get("exclude_kernel", True))
+
+
+def _active_packages(ctx: JobContext) -> Sequence[Package]:
+    packages, error = resolve_active_packages(
+        _variant_uuid(ctx), exclude_kernel=_exclude_kernel(ctx)
+    )
+    if error:
+        raise RuntimeError(error)
+    return packages
+
+
+def _detect_memory_ceiling() -> int:
+    """Bytes of memory available, from cgroup v2, cgroup v1, then /proc."""
+    sources = (
+        ("/sys/fs/cgroup/memory.max", lambda value: int(value) > 0),
+        # cgroup v1 uses PAGE_COUNTER_MAX as the "unconstrained" sentinel.
+        (
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+            lambda value: 0 < int(value) < 9223372036854771712,
+        ),
+    )
+    for path, accept in sources:
+        try:
+            with open(path) as handle:
+                value = handle.read().strip()
+        except OSError:
+            continue
+        if value.isdigit() and accept(value):
+            return int(value)
+
+    try:
+        with open("/proc/meminfo") as handle:
+            for line in handle:
+                if line.startswith("MemTotal:"):
+                    return int(line.split()[1]) * 1024
+    except OSError:
+        pass
+    return 0
+
+
+def _resolve_grype_memlimit() -> str | None:
+    """Translate ``GRYPE_MEMLIMIT`` into a ``GOMEMLIMIT`` value.
+
+    ``off``/``0``/``disabled`` means no limit, an explicit value is passed
+    through verbatim, and an unset value auto-detects ~80 % of the cgroup or
+    ``/proc/meminfo`` ceiling.
+    """
+    raw = os.environ.get("GRYPE_MEMLIMIT", "").strip()
+
+    if raw.lower() in ("off", "0", "disabled"):
+        return None
+    if raw:
+        return raw
+
+    mem_bytes = _detect_memory_ceiling()
+    return str(mem_bytes * 80 // 100) if mem_bytes > 0 else None
+
+
+# ---------------------------------------------------------------------------
+# Grype
+# ---------------------------------------------------------------------------
+
+def _variant_sbom_packages(variant_uuid: uuid_module.UUID) -> Set[Tuple[str, str]]:
+    """Name/version pairs from the variant's latest SBOM scan."""
+    sbom_scan_id = db.session.execute(
+        db.select(Scan.id)
+        .where(Scan.variant_id == variant_uuid)
+        .where(db.or_(Scan.scan_type == "sbom", Scan.scan_type.is_(None)))
+        .order_by(Scan.timestamp.desc())
+        .limit(1)
+    ).scalar()
+    if sbom_scan_id is None:
+        return set()
+    rows = db.session.execute(
+        db.select(Package.name, Package.version)
+        .join(SBOMPackage, SBOMPackage.package_id == Package.id)
+        .join(SBOMDocument, SBOMPackage.sbom_document_id == SBOMDocument.id)
+        .where(SBOMDocument.scan_id == sbom_scan_id)
+    ).all()
+    return {(row[0], row[1]) for row in rows}
+
+
+def _deduplicate_cyclonedx(
+    ctx: JobContext, export_path: str, exclude_kernel: bool
+) -> None:
+    """Collapse supplier-duplicated components before handing the SBOM to Grype.
+
+    The export emits one row per package, so a package appears several times
+    when it differs only by supplier. Keying on the raw name@version is
+    deliberate: normalising would over-collapse genuinely distinct packages.
+    """
+    with open(export_path, "r") as handle:
+        data = json.load(handle)
+
+    components = data.get("components", [])
+    original_count = len(components)
+    kept: List[dict] = []
+    kept_refs: Set[str] = set()
+    seen: Set[Tuple[str, str]] = set()
+    kernel_dropped = 0
+
+    for component in components:
+        name = component.get("name", "")
+        version = component.get("version", "")
+        if exclude_kernel and is_kernel_package_name(name):
+            kernel_dropped += 1
+            continue
+        if (name, version) in seen:
+            continue
+        seen.add((name, version))
+        kept.append(component)
+        ref = component.get("bom-ref")
+        if ref:
+            kept_refs.add(ref)
+
+    data["components"] = kept
+    if isinstance(data.get("dependencies"), list):
+        data["dependencies"] = [
+            dep for dep in data["dependencies"] if dep.get("ref") in kept_refs
+        ]
+    with open(export_path, "w") as handle:
+        json.dump(data, handle)
+
+    suffix = f" ({kernel_dropped} kernel modules excluded)" if kernel_dropped else ""
+    ctx.log(f"[1/4] De-duplicated components: {len(kept)}/{original_count} kept{suffix}")
+
+
+def _filter_grype_matches(
+    ctx: JobContext, results_path: str, sbom_packages: Set[Tuple[str, str]]
+) -> None:
+    """Drop matches for artifacts Grype synthesised outside the variant SBOM."""
+    with open(results_path, "r") as handle:
+        data = json.load(handle)
+
+    matches = data.get("matches", [])
+    kept = []
+    for match in matches:
+        artifact = match.get("artifact", {})
+        name = GrypeVulns._normalize_artifact_name(
+            artifact.get("name", ""), artifact.get("purl")
+        )
+        if (name, artifact.get("version", "")) in sbom_packages:
+            kept.append(match)
+    data["matches"] = kept
+    with open(results_path, "w") as handle:
+        json.dump(data, handle)
+
+    ctx.log(
+        f"[2/4] Filtered: {len(kept)}/{len(matches)} matches kept "
+        f"(variant SBOM packages only)"
+    )
+
+
+def _run_cancellable(
+    ctx: JobContext, command: List[str], cwd: str, timeout: int, **kwargs
+) -> None:
+    """Run a subprocess that a cancel request can terminate."""
+    process = subprocess.Popen(
+        command, cwd=cwd, text=True,
+        stdout=kwargs.pop("stdout", subprocess.PIPE),
+        stderr=subprocess.PIPE, **kwargs,
+    )
+    ctx.set_cancel_hook(process.terminate)
+    try:
+        _, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.communicate()
+        raise
+    finally:
+        ctx.set_cancel_hook(None)
+    ctx.check_cancelled()
+    if process.returncode != 0:
+        detail = (stderr or "")[:500] or f"exit code {process.returncode}"
+        raise RuntimeError(f"Command failed: {detail}")
+
+
+def run_grype_scan(ctx: JobContext) -> None:
+    """Export the variant as CycloneDX, run Grype on it, merge the results."""
+    if shutil.which("grype") is None:
+        raise RuntimeError("grype binary not found on this system")
+
+    variant_uuid = _variant_uuid(ctx)
+    variant = db.session.get(Variant, variant_uuid)
+    if variant is None:
+        raise RuntimeError("Variant not found")
+    project = db.session.get(Project, variant.project_id)
+    project_name = project.name if project else "unknown"
+    vid_str = str(variant_uuid)
+
+    sbom_packages = _variant_sbom_packages(variant_uuid)
+    exclude_kernel = _exclude_kernel(ctx)
+    base_dir = os.environ.get(
+        "BASE_DIR",
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    )
+
+    def _run(command: List[str], timeout: int, **kwargs) -> None:
+        _run_cancellable(ctx, command, base_dir, timeout, **kwargs)
+
+    grype_tmp = tempfile.mkdtemp(prefix="vulnscout_grype_")
+    try:
+        ctx.report(0, 4, "1/4 Exporting CycloneDX")
+        ctx.log("[1/4] Exporting variant packages as CycloneDX…")
+        _run(
+            ["flask", "--app", FLASK_APP, "export", "--format", "cdx16",
+             "--output-dir", grype_tmp, "--variant-id", vid_str],
+            GRYPE_EXPORT_TIMEOUT,
+        )
+        ctx.report(1, 4, "1/4 Exporting CycloneDX")
+
+        exported_cdx = os.path.join(grype_tmp, "sbom_cyclonedx_v1_6.cdx.json")
+        if not os.path.isfile(exported_cdx):
+            raise RuntimeError("CycloneDX export produced no file")
+        ctx.log("[1/4] CycloneDX export complete")
+
+        if sbom_packages:
+            _deduplicate_cyclonedx(ctx, exported_cdx, exclude_kernel)
+
+        ctx.check_cancelled()
+        ctx.report(1, 4, "2/4 Running Grype")
+        ctx.log("[2/4] Running Grype vulnerability scanner…")
+        grype_out = os.path.join(grype_tmp, "grype_results.grype.json")
+        grype_env = os.environ.copy()
+        memlimit = _resolve_grype_memlimit()
+        if memlimit is not None:
+            grype_env["GOMEMLIMIT"] = memlimit
+            ctx.log(f"[2/4] Grype memory limit (GOMEMLIMIT): {memlimit}")
+        with open(grype_out, "w") as handle:
+            _run(
+                ["grype", "--add-cpes-if-none", f"sbom:{exported_cdx}", "-o", "json"],
+                GRYPE_SCAN_TIMEOUT, stdout=handle, env=grype_env,
+            )
+        ctx.report(2, 4, "2/4 Running Grype")
+
+        if not os.path.isfile(grype_out) or os.path.getsize(grype_out) == 0:
+            raise RuntimeError("Grype produced no output")
+        ctx.log("[2/4] Grype scan complete")
+
+        if sbom_packages:
+            _filter_grype_matches(ctx, grype_out, sbom_packages)
+
+        ctx.check_cancelled()
+        ctx.report(2, 4, "3/4 Merging results")
+        ctx.log("[3/4] Merging Grype results into database…")
+        _run(
+            ["flask", "--app", FLASK_APP, "merge", "--project", project_name,
+             "--variant", variant.name, "--grype", grype_out],
+            GRYPE_MERGE_TIMEOUT,
+        )
+        ctx.report(3, 4, "3/4 Merging results")
+        ctx.log("[3/4] Merge complete")
+
+        ctx.check_cancelled()
+        ctx.report(3, 4, "4/4 Processing")
+        ctx.log("[4/4] Processing scan results…")
+        _run(["flask", "--app", FLASK_APP, "process"], GRYPE_PROCESS_TIMEOUT)
+
+        ctx.report(4, 4, "Scan complete")
+        ctx.log("✓ Grype scan complete")
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("Grype scan timed out")
+    finally:
+        shutil.rmtree(grype_tmp, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# NVD
+# ---------------------------------------------------------------------------
+
+def _run_nvd_scan_local(ctx: JobContext, packages: List[Package]) -> None:
+    from ..bin.cmd_vuln_scan import _SccBulkWriter
+    from .scc_engine import get_engine
+
+    variant_uuid = _variant_uuid(ctx)
+    ctx.log("Loading local NVD advisory database…")
+    try:
+        engine = get_engine(progress=_engine_progress(ctx))
+    except Exception as error:
+        raise RuntimeError(f"Failed to load local NVD database: {error}")
+
+    scan = Scan.create(
+        description=EMPTY_DESCRIPTION, variant_id=variant_uuid,
+        scan_type="tool", scan_source="nvd",
+    )
+    total = len(packages)
+    writer = _SccBulkWriter(scan.id, variant_uuid, packages)
+    seen_keys: set = set()
+
+    for index, package in enumerate(packages, 1):
+        ctx.check_cancelled()
+        ctx.report(index, total, f"{index}/{total} packages")
+        try:
+            for computed, status in engine.applicable_vulns(package):
+                writer.add(package, computed, status, seen_keys)
+        except Exception as error:
+            ctx.log(f"[{index}/{total}] ERROR {package.name}: {str(error)[:200]}")
+
+    writer.flush()
+    found = len(seen_keys)
+    ctx.report(total, total, f"Found {found} CVEs across {total} packages")
+    ctx.log(f"✓ Scan complete — found {found} unique CVEs across {total} packages")
+
+
+def _query_cpe(ctx: JobContext, nvd, cpe_name: str) -> List[dict] | None:
+    """Return NVD records for *cpe_name*, or ``None`` when the query failed."""
+    parts = cpe_name.split(":")
+    has_wildcards = len(parts) >= 6 and (
+        parts[2] == "*" or parts[3] == "*" or parts[5] == "*"
+    )
+    try:
+        return nvd.api_get_cves_by_cpe(
+            cpe_name, results_per_page=100, use_virtual_match=has_wildcards
+        )
+    except Exception as error:
+        ctx.log(f"ERROR {cpe_name}: {str(error)[:200]}")
+        return None
+
+
+def _collect_cpes(packages: List[Package]) -> Dict[str, List[Package]]:
+    """Index packages by the CPEs that carry a concrete version field."""
+    cpe_to_packages: Dict[str, List[Package]] = {}
+    for package in packages:
+        for cpe in (package.cpe or []):
+            parts = cpe.split(":")
+            if len(parts) >= 6 and parts[4] != "*":
+                cpe_to_packages.setdefault(cpe, []).append(package)
+    return cpe_to_packages
+
+
+def _persist_nvd_records(
+    nvd_vulns: List[dict],
+    matched: List[Package],
+    scan: Scan,
+    variant_uuid: uuid_module.UUID,
+    observation_pairs: Set[Tuple[uuid_module.UUID, uuid_module.UUID]],
+    assessed_findings: Set[Tuple[uuid_module.UUID, uuid_module.UUID]],
+) -> Set[str]:
+    from .nvd_db import NVD_DB
+    from .nvd_persist import persist_nvd_cve
+
+    recorded: Set[str] = set()
+    for nvd_vuln in nvd_vulns:
+        cve = nvd_vuln.get("cve", {})
+        cve_id = cve.get("id", "")
+        if not cve_id:
+            continue
+        recorded.add(cve_id)
+        persist_nvd_cve(cve_id, NVD_DB.extract_cve_details(cve))
+        for package in matched:
+            finding = Finding.get_or_create(package.id, cve_id)
+            create_observation_and_assessment(
+                finding, scan, variant_uuid, "nvd",
+                observation_pairs, assessed_findings,
+            )
+    return recorded
+
+
+def _run_nvd_scan_api(ctx: JobContext, packages: List[Package]) -> None:
+    from .nvd_db import NVD_DB
+
+    variant_uuid = _variant_uuid(ctx)
+    nvd = NVD_DB(nvd_api_key=os.getenv("NVD_API_KEY"))
+    cpe_to_packages = _collect_cpes(packages)
+
+    if not cpe_to_packages:
+        raise RuntimeError("No packages with valid CPE identifiers")
+
+    total = len(cpe_to_packages)
+    ctx.log(f"Found {len(packages)} packages with {total} unique CPEs to query")
+
+    scan = Scan.create(
+        description=EMPTY_DESCRIPTION, variant_id=variant_uuid,
+        scan_type="tool", scan_source="nvd",
+    )
+    cves_found: Set[str] = set()
+    observation_pairs: Set[Tuple[uuid_module.UUID, uuid_module.UUID]] = set()
+    assessed_findings: Set[Tuple[uuid_module.UUID, uuid_module.UUID]] = set()
+
+    for index, (cpe_name, matched) in enumerate(cpe_to_packages.items(), 1):
+        ctx.check_cancelled()
+        ctx.report(index - 1, total, f"{index}/{total} CPEs")
+        ctx.log(f"[{index}/{total}] Querying {cpe_name}…")
+        nvd_vulns = _query_cpe(ctx, nvd, cpe_name)
+        ctx.report(index, total, f"{index}/{total} CPEs")
+        if nvd_vulns is None:
+            continue
+
+        cve_ids = [
+            vuln.get("cve", {}).get("id", "")
+            for vuln in nvd_vulns
+            if vuln.get("cve", {}).get("id")
+        ]
+        if cve_ids:
+            ctx.log(
+                f"[{index}/{total}] {cpe_name} → {len(cve_ids)} CVE(s): "
+                f"{_preview(cve_ids)}"
+            )
+        else:
+            ctx.log(f"[{index}/{total}] {cpe_name} → no CVEs")
+
+        cves_found |= _persist_nvd_records(
+            nvd_vulns, matched, scan, variant_uuid,
+            observation_pairs, assessed_findings,
+        )
+
+    db.session.commit()
+    ctx.report(total, total, f"Found {len(cves_found)} CVEs across {total} CPEs")
+    ctx.log(
+        f"✓ Scan complete — found {len(cves_found)} unique CVEs across {total} CPEs"
+    )
+
+
+def run_nvd_scan(ctx: JobContext) -> None:
+    """Match package CPEs against NVD, locally or through the REST API."""
+    from .scc_engine import serialized_engine_operation
+
+    @serialized_engine_operation
+    def _scan() -> None:
+        try:
+            ctx.log(RESOLVING_PACKAGES)
+            packages = list(_active_packages(ctx))
+            if ctx.options.get("mode") == "api":
+                _run_nvd_scan_api(ctx, packages)
+            else:
+                _run_nvd_scan_local(ctx, packages)
+        except Exception:
+            db.session.rollback()
+            raise
+
+    _scan()
+
+
+# ---------------------------------------------------------------------------
+# OSV
+# ---------------------------------------------------------------------------
+
+def _collect_purls(
+    packages: List[Package],
+) -> Tuple[Dict[str, List[Package]], Set[uuid_module.UUID]]:
+    """Index packages by PURL.
+
+    A package may carry several PURLs (generic plus ecosystem-specific); all
+    of them are queried so ecosystem-only advisories are not missed.
+    """
+    purl_to_packages: Dict[str, List[Package]] = {}
+    packages_with_purls: Set[uuid_module.UUID] = set()
+    for package in packages:
+        for purl in (package.purl or []):
+            purl_str = str(purl).strip()
+            if purl_str.startswith("pkg:"):
+                purl_to_packages.setdefault(purl_str, []).append(package)
+                packages_with_purls.add(package.id)
+    return purl_to_packages, packages_with_purls
+
+
+def _persist_osv_vulnerability(
+    osv_vuln: dict,
+    matched: List[Package],
+    scan: Scan,
+    variant_uuid: uuid_module.UUID,
+    observation_pairs: Set[Tuple[uuid_module.UUID, uuid_module.UUID]],
+    assessed_findings: Set[Tuple[uuid_module.UUID, uuid_module.UUID]],
+) -> str | None:
+    """Record one OSV advisory and its CVE aliases against every matched package."""
+    from ..models.vulnerability import Vulnerability as VulnModel
+
+    vuln_id = osv_vuln.get("id", "")
+    if not vuln_id:
+        return None
+
+    aliases = [
+        alias for alias in osv_vuln.get("aliases", []) if alias.startswith("CVE-")
+    ]
+    description = osv_vuln.get("summary") or osv_vuln.get("details")
+    links = [
+        ref.get("url") for ref in osv_vuln.get("references", []) if ref.get("url")
+    ] or None
+
+    for identifier in [vuln_id] + aliases:
+        existing = db.session.get(VulnModel, identifier.upper())
+        if existing is None:
+            existing = VulnModel.create_record(
+                id=identifier, description=description, links=links
+            )
+            existing.add_found_by("osv")
+        else:
+            existing.add_found_by("osv")
+            if not existing.description and description:
+                existing.update_record(description=description, commit=False)
+
+        for package in matched:
+            finding = Finding.get_or_create(package.id, identifier)
+            create_observation_and_assessment(
+                finding, scan, variant_uuid, "osv",
+                observation_pairs, assessed_findings,
+            )
+    return vuln_id
+
+
+def run_osv_scan(ctx: JobContext) -> None:
+    """Query OSV.dev for every PURL carried by the variant's packages."""
+    from .osv_client import OSVClient
+
+    variant_uuid = _variant_uuid(ctx)
+    try:
+        osv = OSVClient()
+
+        ctx.log(RESOLVING_PACKAGES)
+        packages = list(_active_packages(ctx))
+        purl_to_packages, packages_with_purls = _collect_purls(packages)
+
+        if not purl_to_packages:
+            raise RuntimeError("No packages with valid PURL identifiers")
+
+        total = len(purl_to_packages)
+        ctx.log(
+            f"Found {len(packages)} packages, {len(packages_with_purls)} with "
+            f"PURL identifiers ({total} unique PURLs to query)"
+        )
+
+        scan = Scan.create(
+            description=EMPTY_DESCRIPTION, variant_id=variant_uuid,
+            scan_type="tool", scan_source="osv",
+        )
+        vulns_found: Set[str] = set()
+        observation_pairs: Set[Tuple[uuid_module.UUID, uuid_module.UUID]] = set()
+        assessed_findings: Set[Tuple[uuid_module.UUID, uuid_module.UUID]] = set()
+
+        for index, (purl_str, matched) in enumerate(purl_to_packages.items(), 1):
+            ctx.check_cancelled()
+            ctx.report(index - 1, total, f"{index}/{total} PURLs")
+            ctx.log(f"[{index}/{total}] Querying {purl_str}…")
+            try:
+                osv_vulns = osv.query_by_purl(purl_str)
+            except Exception as error:
+                ctx.log(f"[{index}/{total}] ERROR {purl_str}: {str(error)[:200]}")
+                ctx.report(index, total, f"{index}/{total} PURLs")
+                continue
+
+            vuln_ids = [vuln.get("id", "") for vuln in osv_vulns if vuln.get("id")]
+            if vuln_ids:
+                ctx.log(
+                    f"[{index}/{total}] {purl_str} → {len(vuln_ids)} vuln(s): "
+                    f"{_preview(vuln_ids)}"
+                )
+            else:
+                ctx.log(f"[{index}/{total}] {purl_str} → no vulnerabilities")
+            ctx.report(index, total, f"{index}/{total} PURLs")
+
+            for osv_vuln in osv_vulns:
+                recorded = _persist_osv_vulnerability(
+                    osv_vuln, matched, scan, variant_uuid,
+                    observation_pairs, assessed_findings,
+                )
+                if recorded:
+                    vulns_found.add(recorded)
+
+        db.session.commit()
+        ctx.report(
+            total, total,
+            f"Found {len(vulns_found)} vulnerabilities across {total} PURLs",
+        )
+        ctx.log(
+            f"✓ Scan complete — found {len(vulns_found)} unique vulnerabilities "
+            f"across {total} PURLs ({len(packages_with_purls)} packages)"
+        )
+    except Exception:
+        db.session.rollback()
+        raise
+
+
+# ---------------------------------------------------------------------------
+# sbom-cve-check
+# ---------------------------------------------------------------------------
+
+class _SccLogForwarder(logging.Handler):
+    """Pipes sbom_cve_check library logs into the operation's log stream."""
+
+    def __init__(self, ctx: JobContext) -> None:
+        super().__init__(logging.INFO)
+        self._ctx = ctx
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self._ctx.log(self.format(record))
+
+
+def _load_scc_engine(ctx: JobContext):
+    """Load the shared advisory index, forwarding library logs to the client."""
+    from .scc_engine import get_engine
+
+    forwarder = _SccLogForwarder(ctx)
+    forwarder.setFormatter(logging.Formatter("%(message)s"))
+    scc_logger = logging.getLogger("sbom_cve_check")
+    scc_logger.addHandler(forwarder)
+    previous_level = scc_logger.level
+    scc_logger.setLevel(logging.INFO)
+    ctx.log("Loading CVE databases — this might take several minutes on first run…")
+    try:
+        return get_engine(progress=_engine_progress(ctx))
+    except Exception as error:
+        raise RuntimeError(f"Failed to load CVE databases: {str(error)[:300]}")
+    finally:
+        scc_logger.removeHandler(forwarder)
+        scc_logger.setLevel(previous_level)
+
+
+def _scan_package_with_engine(
+    ctx: JobContext, engine, writer, package: Package, index: int, total: int
+) -> None:
+    label = f"{package.name}@{package.version}" if package.name else str(package.id)
+    ctx.report(index - 1, total, f"{index}/{total} packages")
+
+    persisted: List[str] = []
+    seen_keys: Set[Tuple[uuid_module.UUID, str]] = set()
+    try:
+        for computed, status in engine.applicable_vulns(package):
+            cve_id = writer.add(package, computed, status, seen_keys)
+            if cve_id is not None:
+                persisted.append(cve_id)
+    except Exception as error:
+        ctx.log(f"[{index}/{total}] ERROR {label}: {str(error)[:200]}")
+        ctx.report(index, total, f"{index}/{total} packages")
+        return
+
+    if persisted:
+        ctx.log(
+            f"[{index}/{total}] {label} → {len(persisted)} vuln(s): "
+            f"{_preview(persisted)}"
+        )
+    else:
+        ctx.log(f"[{index}/{total}] {label} → no vulnerabilities")
+    ctx.report(index, total, f"{index}/{total} packages")
+
+
+def run_scc_scan(ctx: JobContext) -> None:
+    """Match packages against the local NVD-FKIE and CVEList databases."""
+    from ..bin.cmd_vuln_scan import _SccBulkWriter
+    from .scc_engine import serialized_engine_operation
+
+    variant_uuid = _variant_uuid(ctx)
+
+    @serialized_engine_operation
+    def _scan() -> None:
+        try:
+            ctx.log(RESOLVING_PACKAGES)
+            packages = list(_active_packages(ctx))
+            total = len(packages)
+            ctx.report(0, total, f"0/{total} packages")
+            ctx.log(f"Resolved {total} active packages")
+
+            engine = _load_scc_engine(ctx)
+            ctx.log("Index ready — scanning packages")
+
+            scan = Scan.create(
+                description=EMPTY_DESCRIPTION, variant_id=variant_uuid,
+                scan_type="tool", scan_source="scc",
+            )
+            writer = _SccBulkWriter(scan.id, variant_uuid, packages)
+
+            for index, package in enumerate(packages, 1):
+                ctx.check_cancelled()
+                _scan_package_with_engine(ctx, engine, writer, package, index, total)
+                # Bulk-insert in chunks to bound transaction size.
+                writer.maybe_flush()
+
+            writer.flush()
+            found = len(writer.cves_found)
+            ctx.report(
+                total, total,
+                f"Found {found} vulnerabilities across {total} packages",
+            )
+            ctx.log(
+                f"✓ Scan complete — found {found} unique vulnerabilities "
+                f"across {total} packages"
+            )
+        except Exception:
+            db.session.rollback()
+            raise
+
+    _scan()
+
+
+SCAN_JOBS = {
+    "grype": run_grype_scan,
+    "nvd": run_nvd_scan,
+    "osv": run_osv_scan,
+    "scc": run_scc_scan,
+}

--- a/src/controllers/vulnerabilities.py
+++ b/src/controllers/vulnerabilities.py
@@ -20,6 +20,7 @@ from ..controllers.scc_engine import get_cve_json
 from ..controllers.nvd_extract import api_weaknesses_to_list_str, api_references_filter_patches
 from ..helpers.verbose import verbose
 from ._base import to_dict_with_fallback
+from .progress_reporter import NULL_REPORTER, ProgressReporter
 from ..models.cvss import CVSS
 from ..models.metrics import Metrics as MetricsModel
 from ..extensions import db
@@ -345,8 +346,7 @@ class VulnerabilitiesController:
             return True
         return False
 
-    def fetch_epss_scores(self) -> EnrichmentResult:
-        from ..controllers.epss_progress import EPSSProgressTracker
+    def fetch_epss_scores(self, reporter: ProgressReporter = NULL_REPORTER) -> EnrichmentResult:
         start_time = time.time()
         nb_vuln = 0
         failed = 0
@@ -377,9 +377,7 @@ class VulnerabilitiesController:
             msg += f" ({', '.join(extra)})"
         print(msg, flush=True)
 
-        tracker = EPSSProgressTracker
-        tracker.start("epss_enrichment")
-        tracker.update("epss_enrichment", 0, total, f"EPSS enrichment: 0/{total}")
+        reporter.report(0, total, f"EPSS enrichment: 0/{total}")
 
         # Batch in chunks of 100 (FIRST.org API limit).
         # DB commits happen every 500 CVEs to minimise write-transaction overhead.
@@ -396,7 +394,7 @@ class VulnerabilitiesController:
                 verbose(f"[fetch_epss_scores batch {chunk_idx}] {e}")
                 failed += len(chunk)
                 processed += len(chunk)
-                tracker.update("epss_enrichment", processed, total, f"EPSS enrichment: {processed}/{total}")
+                reporter.report(processed, total, f"EPSS enrichment: {processed}/{total}")
                 continue
 
             for cve_id in chunk:
@@ -421,7 +419,7 @@ class VulnerabilitiesController:
                     verbose(f"[fetch_epss_scores {cve_id!r}] {e}")
                     failed += 1
             processed += len(chunk)
-            tracker.update("epss_enrichment", processed, total, f"EPSS enrichment: {processed}/{total}")
+            reporter.report(processed, total, f"EPSS enrichment: {processed}/{total}")
             # Commit once every 500 CVEs processed.
             if processed % DB_COMMIT_EVERY < BATCH_SIZE:
                 _batch_commit(processed, total, "EPSS")
@@ -434,7 +432,6 @@ class VulnerabilitiesController:
             db.session.rollback()
             failed += 1
 
-        tracker.complete()
         print(f"=== EPSS: done — enriched {nb_vuln}/{total} CVEs in {time.time() - start_time:.1f}s.", flush=True)
         return EnrichmentResult(successful=nb_vuln, failed=failed)
 
@@ -558,7 +555,7 @@ class VulnerabilitiesController:
                     except Exception:
                         pass
 
-    def fetch_nvd_data(self) -> EnrichmentResult:
+    def fetch_nvd_data(self, reporter: ProgressReporter = NULL_REPORTER) -> EnrichmentResult:
         """Fetch NVD data (published date, weaknesses, versions_data, patch_url) for all vulnerabilities.
 
         CVE-prefixed IDs are looked up via the NVD API. GHSA-prefixed IDs use
@@ -566,11 +563,8 @@ class VulnerabilitiesController:
         the in-memory vulnerability objects and persisted to the main DB.
         All per-CVE failures are logged and silently skipped so that a single
         unreachable CVE never aborts the whole enrichment run.
-        Progress is reported via the NVDProgressTracker singleton so that
-        /api/nvd/progress reflects the live enrichment state.
         """
         from concurrent.futures import ThreadPoolExecutor, as_completed
-        from ..controllers.nvd_progress import NVDProgressTracker
 
         start_time = time.time()
         nb_vuln = 0
@@ -587,8 +581,7 @@ class VulnerabilitiesController:
         total = len(nvd_vulns) + len(ghsa_vulns)
         msg = f"=== NVD: starting enrichment — {len(nvd_vulns)} CVEs + {len(ghsa_vulns)} GHSAs"
         print(msg, flush=True)
-        tracker = NVDProgressTracker
-        tracker.start("nvd_enrichment")
+        reporter.report(0, total, f"NVD enrichment: 0/{total}")
 
         # NVD lookups via local FKIE database
         DB_COMMIT_EVERY = 100
@@ -651,7 +644,7 @@ class VulnerabilitiesController:
                 verbose(f"[fetch_nvd_data {vuln.id!r}] {e}")
                 failed += 1
             done += 1
-            tracker.update("nvd_enrichment", done, total, f"NVD enrichment: {done}/{total} ({vuln.id})")
+            reporter.report(done, total, f"NVD enrichment: {done}/{total} ({vuln.id})")
             if done % DB_COMMIT_EVERY == 0:
                 _batch_commit(done, total, "NVD")
 
@@ -687,7 +680,7 @@ class VulnerabilitiesController:
                         print(f"Error for {vid}: {e}")
                         failed += 1
                     done += 1
-                    tracker.update("nvd_enrichment", done, total, f"NVD enrichment: {done}/{total} ({vid})")
+                    reporter.report(done, total, f"NVD enrichment: {done}/{total} ({vid})")
 
         # Final commit for any remaining deferred NVD/GHSA updates.
         try:
@@ -696,7 +689,6 @@ class VulnerabilitiesController:
             verbose(f"[fetch_nvd_data final commit] {e}")
             db.session.rollback()
             failed += 1
-        tracker.complete()
         print(
             f"=== NVD: done — enriched {nb_vuln}/{total} vulnerabilities in {time.time() - start_time:.1f}s.",
             flush=True,

--- a/src/helpers/openapi.py
+++ b/src/helpers/openapi.py
@@ -22,6 +22,7 @@ _SCAN_EXEMPT_PATHS = {
     "/api/openapi/ui",
     "/api/scan/status",
     "/api/version",
+    "/api/events/stream",
 }
 
 

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,19 +1,15 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
-from .bulk_refresh import init_app as init_bulk_refresh_app
 from .packages import init_app as init_pkg_app
 from .vulnerabilities import init_app as init_vuln_app
 from .assessments import init_app as init_assess_app
 from .documents import init_app as init_doc_app
-from .nvd_progress import init_app as init_nvd_progress_app
-from .epss_progress import init_app as init_epss_progress_app
-from .ghsa_progress import init_app as init_ghsa_progress_app
-from .euvd_progress import init_app as init_euvd_progress_app
+from .events import init_app as init_events_app
+from .operations import init_app as init_operations_app
 from .project import init_app as init_project_app
 from .variant import init_app as init_variant_app
 from .scans import init_app as init_scans_app
-from .scan_triggers import init_app as init_scan_triggers_app
 from .config import init_app as init_config_app
 from .settings import init_app as init_settings_app
 from .openapi import init_app as init_openapi_app
@@ -26,15 +22,11 @@ def init_app(app):
     init_vuln_app(app)
     init_assess_app(app)
     init_doc_app(app)
-    init_nvd_progress_app(app)
-    init_epss_progress_app(app)
-    init_ghsa_progress_app(app)
-    init_euvd_progress_app(app)
+    init_events_app(app)
+    init_operations_app(app)
     init_project_app(app)
     init_variant_app(app)
     init_scans_app(app)
-    init_scan_triggers_app(app)
-    init_bulk_refresh_app(app)
     init_config_app(app)
     init_settings_app(app)
     init_context_app(app)

--- a/src/routes/events.py
+++ b/src/routes/events.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Server-sent event stream carrying every operation update.
+
+One connection replaces the per-scan, per-refresh, upload and export polling
+loops the frontend used to run. A new connection starts with a full snapshot;
+a reconnecting client that sends a usable ``Last-Event-ID`` receives the
+buffered deltas it missed instead, and falls back to a fresh snapshot when the
+gap is too wide to replay.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Iterator, Optional
+
+from flask import Flask, Response, jsonify, request, stream_with_context
+from flask.typing import ResponseReturnValue
+
+from ..controllers.event_bus import operation_events
+from ..controllers.operation_registry import registry
+
+STREAM_PATH = "/api/events/stream"
+
+# Long enough to stay cheap, short enough that proxies and load balancers do
+# not treat an idle stream as dead.
+HEARTBEAT_SECONDS = 15.0
+
+DEFAULT_MAX_STREAMS = 32
+
+_active_streams = 0
+_streams_lock = threading.Lock()
+
+
+def _max_streams() -> int:
+    """Cap concurrent streams; each one occupies a server thread."""
+    try:
+        return max(1, int(os.environ.get("VULNSCOUT_SSE_MAX_STREAMS", DEFAULT_MAX_STREAMS)))
+    except ValueError:
+        return DEFAULT_MAX_STREAMS
+
+
+def _acquire_slot() -> bool:
+    global _active_streams
+    with _streams_lock:
+        if _active_streams >= _max_streams():
+            return False
+        _active_streams += 1
+        return True
+
+
+def _release_slot() -> None:
+    global _active_streams
+    with _streams_lock:
+        _active_streams = max(0, _active_streams - 1)
+
+
+def _frame(event_type: str, data: dict, seq: Optional[int] = None) -> str:
+    lines = []
+    if seq is not None:
+        lines.append(f"id: {seq}")
+    lines.append(f"event: {event_type}")
+    lines.append(f"data: {json.dumps(data, default=str)}")
+    return "\n".join(lines) + "\n\n"
+
+
+def _snapshot_frame() -> tuple[str, int]:
+    seq = operation_events.seq
+    return _frame("snapshot", {"seq": seq, "operations": registry.snapshot()}), seq
+
+
+def _parse_last_event_id() -> Optional[int]:
+    raw = request.headers.get("Last-Event-ID") or request.args.get("last_event_id")
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _stream(last_event_id: Optional[int]) -> Iterator[str]:
+    # Subscribe before snapshotting so nothing published in between is lost;
+    # overlapping events are filtered by sequence below.
+    subscription = operation_events.subscribe()
+    try:
+        highest_sent = 0
+        replay = (
+            operation_events.replay_since(last_event_id)
+            if last_event_id is not None else None
+        )
+        if replay is not None:
+            highest_sent = last_event_id or 0
+            for event in replay:
+                yield _frame(event["event"], event["data"], event["seq"])
+                highest_sent = max(highest_sent, event["seq"])
+        else:
+            # No usable history: the client rebuilds from a full snapshot.
+            frame, highest_sent = _snapshot_frame()
+            yield frame
+
+        while True:
+            events = subscription.drain(HEARTBEAT_SECONDS)
+            if subscription.closed:
+                yield _frame("bye", {"reason": "server shutdown"})
+                return
+            if subscription.overflowed:
+                subscription.overflowed = False
+                frame, highest_sent = _snapshot_frame()
+                yield frame
+                continue
+            if not events:
+                yield _frame("heartbeat", {"seq": highest_sent})
+                continue
+            for event in events:
+                if event["seq"] <= highest_sent:
+                    continue
+                yield _frame(event["event"], event["data"], event["seq"])
+                highest_sent = event["seq"]
+    finally:
+        subscription.close()
+        _release_slot()
+
+
+def init_app(app: Flask) -> None:
+
+    @app.route(STREAM_PATH)
+    def operation_event_stream() -> ResponseReturnValue:
+        """Stream every operation update over a single connection.
+
+        Frames are ``snapshot`` (full state, sent first), ``operation`` and
+        ``operation_removed`` deltas, ``heartbeat`` every 15 seconds, and
+        ``bye`` on shutdown. Reconnecting clients that send ``Last-Event-ID``
+        are replayed from the buffer, or resnapshotted when the gap is too wide.
+
+        OpenAPI:
+        header Last-Event-ID string optional Resume from this sequence number.
+        response 200 string Server-sent event stream.
+        response 503 Error Too many concurrent streams.
+        """
+        if not _acquire_slot():
+            return jsonify({"error": "Too many concurrent event streams"}), 503
+
+        response = Response(
+            stream_with_context(_stream(_parse_last_event_id())),
+            mimetype="text/event-stream",
+        )
+        response.headers["Cache-Control"] = "no-cache, no-transform"
+        response.headers["Connection"] = "keep-alive"
+        # Tells nginx and friends to forward frames instead of buffering them.
+        response.headers["X-Accel-Buffering"] = "no"
+        return response

--- a/src/routes/operations.py
+++ b/src/routes/operations.py
@@ -1,0 +1,412 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Unified operation queue API.
+
+One endpoint enqueues any mix of scans and vulnerability refreshes; progress is
+delivered exclusively through ``/api/events/stream``.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid as uuid_module
+from typing import Dict, List, Tuple
+
+from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
+
+from ..controllers.job_context import JobContext
+from ..controllers.operation_queue import queue
+from ..controllers.operation_registry import (
+    KIND_REFRESH,
+    KIND_SCAN,
+    LANE_PIPELINE,
+    new_queue_id,
+    registry,
+)
+from ..controllers.refresh_jobs import (
+    MAX_CVE_IDS,
+    MAX_GHSA_IDS,
+    REFRESH_JOBS,
+    known_cve_ids,
+    normalise_cve_ids,
+    normalise_ghsa_ids,
+    run_deferred_refresh,
+)
+from ..controllers.scan_jobs import SCAN_JOBS
+from ..controllers.variants import VariantController
+
+SCAN_LABELS = {
+    "grype": "Grype",
+    "nvd": "NVD CPE",
+    "osv": "OSV PURL",
+    "scc": "sbom-cve-check",
+}
+
+REFRESH_LABELS = {
+    "nvd": "NVD",
+    "epss": "EPSS",
+    "ghsa": "GHSA",
+    "euvd": "ENISA EUVD",
+}
+
+# The order the frontend used to enforce by awaiting each manager in turn.
+SCAN_ORDER = ["grype", "nvd", "osv", "scc"]
+REFRESH_ORDER = ["nvd", "epss", "ghsa", "euvd"]
+
+VALID_MODES = ("local", "api")
+
+# Serialises the conflict check and the registry writes so two simultaneous
+# requests cannot both pass the check and double-submit the same operation.
+_enqueue_lock = threading.Lock()
+
+
+def scan_op_id(source: str, variant_id: str) -> str:
+    return f"scan:{source}:{variant_id}"
+
+
+def refresh_op_id(source: str) -> str:
+    return f"refresh:{source}"
+
+
+class _PlanError(Exception):
+    """Rejects a batch before anything is queued."""
+
+    def __init__(self, message: str, status: int = 400) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status = status
+
+
+def _job_options(job: dict) -> dict:
+    options = job.get("options")
+    if options is None:
+        return {}
+    if not isinstance(options, dict):
+        raise _PlanError("options must be an object")
+    return options
+
+
+def _mode_option(options: dict) -> str:
+    mode = options.get("mode", "local")
+    if mode not in VALID_MODES:
+        raise _PlanError(f"Unsupported mode: {mode}")
+    return mode
+
+
+def _bool_option(options: dict, key: str, default: bool) -> bool:
+    value = options.get(key, default)
+    if not isinstance(value, bool):
+        raise _PlanError(f"{key} must be a boolean")
+    return value
+
+
+def _plan_scan_job(job: dict) -> List[dict]:
+    source = job.get("source")
+    if source not in SCAN_JOBS:
+        raise _PlanError(f"Unknown scan source: {source}")
+
+    variant_ids = job.get("variant_ids") or []
+    if not isinstance(variant_ids, list) or not variant_ids:
+        raise _PlanError(f"{source} scan requires a non-empty variant_ids list")
+
+    options = _job_options(job)
+    mode = _mode_option(options)
+    exclude_kernel = _bool_option(options, "exclude_kernel", True)
+    planned: List[dict] = []
+    for raw_id in variant_ids:
+        try:
+            variant_uuid = uuid_module.UUID(str(raw_id))
+        except (ValueError, AttributeError):
+            raise _PlanError(f"Invalid variant id: {raw_id}")
+        variant = VariantController.get(variant_uuid)
+        if variant is None:
+            raise _PlanError(f"Variant not found: {raw_id}", status=404)
+
+        planned.append({
+            "op_id": scan_op_id(source, str(variant_uuid)),
+            "kind": KIND_SCAN,
+            "source": source,
+            "label": SCAN_LABELS[source],
+            "lane": LANE_PIPELINE,
+            "scope": {
+                "variant_id": str(variant_uuid),
+                "variant_name": variant.name,
+                "project_id": str(variant.project_id),
+            },
+            "options": {
+                "variant_id": str(variant_uuid),
+                "exclude_kernel": exclude_kernel,
+                "mode": mode,
+            },
+            "runner": SCAN_JOBS[source],
+        })
+    return planned
+
+
+def _deferred_refresh_options(source: str, job: dict, mode: str) -> dict:
+    if job.get("ids") is not None:
+        raise _PlanError("refresh jobs cannot specify both ids and variant_ids")
+    raw_variant_ids = job.get("variant_ids")
+    if not isinstance(raw_variant_ids, list) or not raw_variant_ids:
+        raise _PlanError(f"{source} deferred refresh requires variant_ids")
+
+    variant_ids: List[str] = []
+    for raw_id in raw_variant_ids:
+        try:
+            variant_uuid = uuid_module.UUID(str(raw_id))
+        except (ValueError, AttributeError):
+            raise _PlanError(f"Invalid variant id: {raw_id}")
+        if VariantController.get(variant_uuid) is None:
+            raise _PlanError(f"Variant not found: {raw_id}", status=404)
+        variant_ids.append(str(variant_uuid))
+
+    exclude_ids = (
+        normalise_ghsa_ids(job.get("exclude_ids", []))
+        if source == "ghsa"
+        else normalise_cve_ids(job.get("exclude_ids", []))
+    )
+    return {
+        "ids": [],
+        "mode": mode,
+        "source": source,
+        "variant_ids": variant_ids,
+        "exclude_ids": exclude_ids,
+    }
+
+
+def _explicit_refresh_options(source: str, job: dict, mode: str) -> dict:
+    if source == "ghsa":
+        ids = normalise_ghsa_ids(job.get("ids"))
+        if not ids:
+            raise _PlanError("ghsa refresh requires valid GHSA identifiers")
+        if len(ids) > MAX_GHSA_IDS:
+            raise _PlanError(f"ghsa refresh accepts at most {MAX_GHSA_IDS} identifiers")
+        return {"ids": ids, "mode": mode}
+
+    ids = normalise_cve_ids(job.get("ids"))
+    if not ids:
+        raise _PlanError(f"{source} refresh requires valid CVE identifiers")
+    if source == "nvd" and mode == "api" and len(ids) > MAX_CVE_IDS:
+        raise _PlanError(
+            f"nvd refresh accepts at most {MAX_CVE_IDS} identifiers in api mode"
+        )
+    if source == "epss":
+        ids = known_cve_ids(ids)
+        if not ids:
+            raise _PlanError("epss refresh requires at least one known CVE identifier")
+    return {"ids": ids, "mode": mode}
+
+
+def _plan_refresh_job(job: dict) -> List[dict]:
+    source = job.get("source")
+    if source not in REFRESH_JOBS:
+        raise _PlanError(f"Unknown refresh source: {source}")
+
+    options = _job_options(job)
+    mode = _mode_option(options)
+    deferred = job.get("variant_ids") is not None
+    job_options = (
+        _deferred_refresh_options(source, job, mode)
+        if deferred
+        else _explicit_refresh_options(source, job, mode)
+    )
+
+    return [{
+        "op_id": refresh_op_id(source),
+        "kind": KIND_REFRESH,
+        "source": source,
+        "label": REFRESH_LABELS[source],
+        "lane": LANE_PIPELINE,
+        "scope": None,
+        "options": job_options,
+        "runner": run_deferred_refresh if deferred else REFRESH_JOBS[source],
+    }]
+
+
+def _plan(jobs: List[dict]) -> List[dict]:
+    """Expand the requested jobs into individual operations, in execution order."""
+    scans: Dict[str, List[dict]] = {}
+    refreshes: Dict[str, List[dict]] = {}
+
+    for job in jobs:
+        if not isinstance(job, dict):
+            raise _PlanError("Each job must be an object")
+        kind = job.get("kind")
+        if kind == KIND_SCAN:
+            scans.setdefault(str(job.get("source")), []).extend(_plan_scan_job(job))
+        elif kind == KIND_REFRESH:
+            refreshes.setdefault(str(job.get("source")), []).extend(_plan_refresh_job(job))
+        else:
+            raise _PlanError(f"Unsupported job kind: {kind}")
+
+    planned: List[dict] = []
+    for source in SCAN_ORDER:
+        planned.extend(scans.get(source, []))
+    for source in REFRESH_ORDER:
+        planned.extend(refreshes.get(source, []))
+    return planned
+
+
+def _conflicts(planned: List[dict]) -> List[str]:
+    return [item["op_id"] for item in planned if registry.has_active(item["op_id"])]
+
+
+def _duplicates(planned: List[dict]) -> List[str]:
+    seen: set = set()
+    duplicated: List[str] = []
+    for item in planned:
+        if item["op_id"] in seen:
+            duplicated.append(item["op_id"])
+        seen.add(item["op_id"])
+    return duplicated
+
+
+class _ConflictError(Exception):
+    """Raised when a requested operation is already queued or running."""
+
+    def __init__(self, operations: List[str]) -> None:
+        super().__init__("conflicting operations")
+        self.operations = operations
+
+
+def _enqueue(planned: List[dict]) -> Tuple[str, List[dict]]:
+    queue_id = new_queue_id()
+    created: List[dict] = []
+    for position, item in enumerate(planned, 1):
+        operation = registry.create(
+            op_id=item["op_id"],
+            kind=item["kind"],
+            source=item["source"],
+            label=item["label"],
+            lane=item["lane"],
+            scope=item["scope"],
+            queue_id=queue_id,
+            position=position,
+            options=item["options"],
+            cancellable=True,
+        )
+        created.append(operation)
+        queue.submit(
+            op_id=item["op_id"],
+            lane=item["lane"],
+            runner=item["runner"],
+            ctx=JobContext(item["op_id"], item["options"]),
+        )
+    return queue_id, created
+
+
+def _enqueue_exclusively(planned: List[dict]) -> Tuple[str, List[dict]]:
+    """Conflict check and registry writes under one lock, so concurrent
+    requests cannot both pass the check and double-submit an operation."""
+    with _enqueue_lock:
+        conflicting = _conflicts(planned)
+        if conflicting:
+            raise _ConflictError(conflicting)
+        return _enqueue(planned)
+
+
+def _cancel_operation_response(op_id: str) -> ResponseReturnValue:
+    operation = registry.get(op_id)
+    if operation is not None and not operation.get("cancellable", False):
+        return jsonify({"error": "This operation does not support cancellation"}), 409
+    if queue.cancel(op_id):
+        return jsonify({"status": "cancelling", "op_id": op_id}), 200
+    return jsonify({"error": "No active operation with that id"}), 404
+
+
+def init_app(app: Flask) -> None:
+
+    @app.route('/api/operations', methods=['POST'])
+    def enqueue_operations() -> ResponseReturnValue:
+        """Queue a batch of scans and vulnerability refreshes.
+
+        Body: ``{"jobs": [{"kind": "scan", "source": "grype",
+        "variant_ids": [...], "options": {...}}, ...]}``
+
+        Scans run before refreshes and each family keeps its canonical order, so
+        one request reproduces the whole pipeline. Progress is published on
+        ``/api/events/stream``; there is no status endpoint to poll.
+
+        OpenAPI:
+        body JsonObject optional Batch of jobs to queue.
+        response 202 JsonObject Queue accepted with the created operations.
+        response 400 Error Invalid job specification.
+        response 404 Error Referenced variant not found.
+        response 409 Error One of the requested operations is already active.
+        """
+        body = request.get_json(force=True, silent=True) or {}
+        jobs = body.get("jobs")
+        if not isinstance(jobs, list) or not jobs:
+            return jsonify({"error": "jobs must be a non-empty list"}), 400
+
+        try:
+            planned = _plan(jobs)
+        except _PlanError as error:
+            return jsonify({"error": error.message}), error.status
+
+        if not planned:
+            return jsonify({"error": "jobs produced no operations"}), 400
+
+        duplicated = _duplicates(planned)
+        if duplicated:
+            return jsonify({
+                "error": "jobs contain duplicate operations",
+                "operations": duplicated,
+            }), 400
+
+        try:
+            queue_id, created = _enqueue_exclusively(planned)
+        except _ConflictError as conflict:
+            return jsonify({
+                "error": "Some requested operations are already queued or running",
+                "operations": conflict.operations,
+            }), 409
+        return jsonify({"queue_id": queue_id, "operations": created}), 202
+
+    @app.route('/api/operations', methods=['GET'])
+    def list_operations() -> ResponseReturnValue:
+        """Return every tracked operation.
+
+        The SSE stream sends the same payload as its first frame; this endpoint
+        exists for clients that cannot hold a stream open and for diagnostics.
+
+        OpenAPI:
+        response 200 JsonObject Current operation snapshot.
+        """
+        return jsonify({"operations": registry.snapshot()})
+
+    @app.route('/api/operations/<path:op_id>/cancel', methods=['POST'])
+    def cancel_operation(op_id: str) -> ResponseReturnValue:
+        """Cancel a queued or running operation.
+
+        Queued work is dropped without starting; running work receives a
+        cooperative stop signal that its job body honours at the next checkpoint.
+
+        OpenAPI:
+        response 200 JsonObject Cancellation accepted.
+        response 404 Error No such active operation.
+        """
+        return _cancel_operation_response(op_id)
+
+    @app.route('/api/operations/queue/<queue_id>/cancel', methods=['POST'])
+    def cancel_operation_queue(queue_id: str) -> ResponseReturnValue:
+        """Cancel every still-active operation in a batch.
+
+        OpenAPI:
+        response 200 JsonObject Number of operations cancelled.
+        """
+        return jsonify({"cancelled": queue.cancel_queue(queue_id)}), 200
+
+    @app.route('/api/operations/<path:op_id>', methods=['DELETE'])
+    def dismiss_operation(op_id: str) -> ResponseReturnValue:
+        """Forget a finished operation so it disappears from every client.
+
+        OpenAPI:
+        response 200 JsonObject Operation dismissed.
+        response 409 Error Operation is still active.
+        """
+        if registry.remove(op_id):
+            return jsonify({"status": "dismissed", "op_id": op_id}), 200
+        return jsonify({"error": "Operation is unknown or still active"}), 409

--- a/tests/unit_tests/test_operation_primitives.py
+++ b/tests/unit_tests/test_operation_primitives.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Edge-case coverage for operation registry and event transport primitives."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+from src.controllers.event_bus import EventBus
+from src.controllers import operation_queue as queue_mod
+from src.controllers.operation_queue import OperationQueue
+from src.controllers.operation_registry import LANE_PIPELINE, STATUS_DONE, OperationRegistry
+
+
+def test_event_bus_replay_close_and_backlog_paths():
+    bus = EventBus(replay_size=2, client_backlog=1)
+    sub = bus.subscribe()
+    bus.publish("operation", {"id": "one"})
+    bus.publish("operation", {"id": "two"})
+    assert sub.drain(timeout=0) == [{"seq": 1, "event": "operation", "data": {"id": "one"}}]
+
+    assert list(bus.replay_since(1))[0]["seq"] == 2
+    assert bus.replay_since(-1) is None
+    assert bus.replay_since(3) is None
+
+    bus.close_all()
+    assert sub.drain(timeout=0) == []
+    assert sub.closed
+
+    empty = EventBus()
+    assert list(empty.replay_since(0)) == []
+    assert empty.replay_since(1) is None
+
+    draining = EventBus(client_backlog=2).subscribe()
+    draining._queue.put_nowait({"seq": 1})
+    draining._queue.put_nowait(None)
+    assert draining.drain(timeout=0) == [{"seq": 1}]
+    assert draining.closed
+
+    multiple = EventBus(client_backlog=2).subscribe()
+    multiple._queue.put_nowait({"seq": 1})
+    multiple._queue.put_nowait({"seq": 2})
+    assert multiple.drain(timeout=0) == [{"seq": 1}, {"seq": 2}]
+
+    full = EventBus(client_backlog=1).subscribe()
+    full._queue.put_nowait({"seq": 1})
+    full.close()
+    assert full.overflowed is False
+
+    with EventBus().subscribe() as scoped:
+        assert scoped.closed is False
+
+
+def test_registry_prunes_logs_and_expired_operations(monkeypatch):
+    registry = OperationRegistry()
+    published = []
+    monkeypatch.setattr("src.controllers.operation_registry.operation_events.publish", lambda *args: published.append(args))
+    assert registry.update("missing", status=STATUS_DONE) is None
+    registry.create("scan:test", "scan", "nvd", "NVD", LANE_PIPELINE)
+    registry.update("scan:test", append_logs=[str(index) for index in range(600)])
+    assert len(registry.get("scan:test")["logs"]) == 500
+
+    registry.update("scan:test", status=STATUS_DONE)
+    monkeypatch.setattr(time, "monotonic", lambda: 10_000_000)
+    registry.prune()
+    assert registry.get("scan:test") is None
+    assert published[-1][0] == "operation_removed"
+
+
+def test_upload_lane_pending_ids_and_pre_cancelled_execution(monkeypatch):
+    executed = []
+
+    class InlineThread:
+        def __init__(self, target, args, **_kwargs):
+            self._target = target
+            self._args = args
+
+        def start(self):
+            self._target(*self._args)
+
+    monkeypatch.setattr(queue_mod.threading, "Thread", InlineThread)
+    lane = queue_mod._Lane("upload", None)
+    upload = queue_mod._Job("upload:one", "upload", SimpleNamespace(), lambda _ctx: None)
+    lane.submit(upload, lambda job: executed.append(job.op_id))
+    assert executed == ["upload:one"]
+
+    pending_lane = queue_mod._Lane("pending", 1)
+    pending_lane.submit(upload, lambda _job: None)
+    assert pending_lane.pending_ids() == ["upload:one"]
+
+    registry = OperationRegistry()
+    monkeypatch.setattr(queue_mod, "registry", registry)
+    registry.create("scan:cancelled", "scan", "nvd", "NVD", LANE_PIPELINE)
+    operation_queue = OperationQueue()
+    operation_queue._execute(queue_mod._Job(
+        "scan:cancelled",
+        LANE_PIPELINE,
+        SimpleNamespace(is_cancelled=lambda: True),
+        lambda _ctx: None,
+    ))
+    assert registry.get("scan:cancelled")["status"] == "cancelled"

--- a/tests/unit_tests/test_refresh_jobs.py
+++ b/tests/unit_tests/test_refresh_jobs.py
@@ -1,0 +1,347 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Direct coverage for refresh jobs executed by the operation queue."""
+
+from __future__ import annotations
+
+import datetime
+import decimal
+import urllib.error
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.controllers import refresh_jobs as jobs
+
+
+def job_context(ids, **options):
+    return SimpleNamespace(
+        options={"ids": ids, **options},
+        report=MagicMock(),
+        is_cancelled=lambda: False,
+        check_cancelled=MagicMock(),
+    )
+
+
+def test_normalisers_sleep_interval_and_safe_commit(monkeypatch):
+    assert jobs.normalise_cve_ids([" cve-2024-0001 ", "CVE-2024-0001", 2, "bad"]) == ["CVE-2024-0001"]
+    assert jobs.normalise_ghsa_ids([" ghsa-abcd-1234-5678 ", "GHSA-ABCD-1234-5678", "bad"]) == ["GHSA-ABCD-1234-5678"]
+    assert jobs.normalise_cve_ids("CVE-2024-1") == []
+    assert jobs.normalise_ghsa_ids("GHSA-ABCD-1234-5678") == []
+
+    monkeypatch.delenv("NVD_API_KEY", raising=False)
+    assert jobs._nvd_sleep_interval() == 6.0
+    monkeypatch.setenv("NVD_API_KEY", "key")
+    assert jobs._nvd_sleep_interval() == 0.6
+
+    session = MagicMock()
+    monkeypatch.setattr(jobs.db, "session", session)
+    jobs._safe_commit("success")
+    session.commit.assert_called_once()
+    session.expunge_all.assert_called_once()
+
+    session.reset_mock()
+    session.commit.side_effect = RuntimeError("database unavailable")
+    jobs._safe_commit("failure")
+    session.rollback.assert_called_once()
+    session.expunge_all.assert_called_once()
+
+
+def test_known_ids_and_refresh_helper_edge_cases(monkeypatch):
+    class Query:
+        def filter(self, _condition):
+            return self
+
+        def all(self):
+            return [("CVE-2024-0001",)]
+
+    monkeypatch.setattr(jobs, "DB_LOOKUP_CHUNK", 1)
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(query=lambda _column: Query()))
+    assert jobs.known_cve_ids(["CVE-2024-0001", "CVE-2024-0002"]) == ["CVE-2024-0001"]
+
+    record = object()
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(get=MagicMock(return_value=record)))
+    monkeypatch.setattr(jobs, "get_cve_json", lambda _cve_id: {"id": "CVE-2024-0001"})
+    monkeypatch.setattr(jobs, "extract_cve_details", lambda _payload: {"id": "CVE-2024-0001"})
+    apply_nvd = MagicMock()
+    monkeypatch.setattr(jobs, "apply_nvd_update", apply_nvd)
+    monkeypatch.setattr(jobs, "apply_cvss_update", MagicMock())
+    jobs._refresh_nvd_record("CVE-2024-0001", "local", None)
+    apply_nvd.assert_called_once()
+
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(get=MagicMock(return_value=None)))
+    jobs._apply_epss_score("CVE-2024-0001", "0.1", datetime.datetime.now(datetime.timezone.utc))
+
+
+def test_deferred_refresh_resolves_new_ids_when_it_starts(monkeypatch):
+    ctx = job_context(
+        [], source="epss", variant_ids=["variant-a"],
+        exclude_ids=["CVE-2024-0001"],
+    )
+    ctx.op_id = "refresh:epss"
+    monkeypatch.setattr(jobs.registry, "get", lambda _op_id: None)
+    monkeypatch.setattr(
+        jobs, "_scoped_vulnerability_ids",
+        lambda _variant_ids: {"CVE-2024-0001", "CVE-2024-0002"},
+    )
+    monkeypatch.setattr(jobs, "known_cve_ids", lambda ids: ids)
+    runner = MagicMock()
+    monkeypatch.setitem(jobs.REFRESH_JOBS, "epss", runner)
+
+    jobs.run_deferred_refresh(ctx)
+
+    assert ctx.options["ids"] == ["CVE-2024-0002"]
+    runner.assert_called_once_with(ctx)
+
+
+def test_deferred_refresh_skips_after_failed_scan(monkeypatch):
+    ctx = job_context([], source="epss", variant_ids=["variant-a"], exclude_ids=[])
+    ctx.op_id = "refresh:epss"
+    monkeypatch.setattr(
+        jobs.registry, "get",
+        lambda _op_id: {"queue_id": "q-1", "position": 2},
+    )
+    monkeypatch.setattr(
+        jobs.registry, "snapshot",
+        lambda: [{"queue_id": "q-1", "position": 1, "kind": "scan", "status": "error"}],
+    )
+    resolve = MagicMock()
+    monkeypatch.setattr(jobs, "_scoped_vulnerability_ids", resolve)
+
+    jobs.run_deferred_refresh(ctx)
+
+    resolve.assert_not_called()
+    ctx.report.assert_called_once_with(0, 0, "Skipped because an earlier scan did not complete")
+
+
+def test_refresh_nvd_record_api_and_local_paths(monkeypatch):
+    record = object()
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(get=MagicMock(return_value=record)))
+    apply_nvd = MagicMock()
+    apply_cvss = MagicMock()
+    monkeypatch.setattr(jobs, "apply_nvd_update", apply_nvd)
+    monkeypatch.setattr(jobs, "apply_cvss_update", apply_cvss)
+
+    client = MagicMock()
+    client.api_get_cve.return_value = (200, {"vulnerabilities": [{"cve": {"id": "CVE-2024-1"}}]})
+    monkeypatch.setattr(jobs.NVD_DB, "extract_cve_details", MagicMock(return_value={"id": "CVE-2024-1"}))
+    jobs._refresh_nvd_record("CVE-2024-1", "api", client)
+    apply_nvd.assert_called_once()
+    apply_cvss.assert_called_once()
+
+    apply_nvd.reset_mock()
+    client.api_get_cve.return_value = (404, {})
+    jobs._refresh_nvd_record("CVE-2024-2", "api", client)
+    apply_nvd.assert_not_called()
+
+    monkeypatch.setattr(jobs, "get_cve_json", lambda _cve_id: None)
+    jobs._refresh_nvd_record("CVE-2024-3", "local", None)
+    apply_nvd.assert_not_called()
+
+
+def test_run_nvd_refresh_api_and_local_setup_failure(monkeypatch):
+    ctx = job_context(["CVE-2024-1", "CVE-2024-2"], mode="api")
+    client = MagicMock()
+    monkeypatch.setattr(jobs, "NVD_DB", lambda **_kwargs: client)
+    monkeypatch.setattr(jobs, "_nvd_sleep_interval", lambda: 0.0)
+    refreshed = MagicMock()
+    monkeypatch.setattr(jobs, "_refresh_nvd_record", refreshed)
+    committed = MagicMock()
+    monkeypatch.setattr(jobs, "_safe_commit", committed)
+    slept = MagicMock()
+    monkeypatch.setattr(jobs.time, "sleep", slept)
+
+    jobs.run_nvd_refresh(ctx)
+    assert refreshed.call_count == 2
+    slept.assert_called_once_with(0.0)
+    assert committed.call_count == 1
+    assert ctx.report.call_args_list[-1].args[-1] == "NVD refresh complete"
+
+    monkeypatch.setattr(jobs, "_get_scc_engine", MagicMock(side_effect=ValueError("missing")))
+    with pytest.raises(RuntimeError, match="Failed to load local NVD database"):
+        jobs.run_nvd_refresh(job_context(["CVE-2024-1"]))
+
+
+def test_nvd_refresh_handles_item_errors_periodic_commits_and_cancellation(monkeypatch):
+    monkeypatch.setattr(jobs, "NVD_DB", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr(jobs, "_nvd_sleep_interval", lambda: 0.0)
+    monkeypatch.setattr(jobs, "_refresh_nvd_record", MagicMock(side_effect=ValueError("bad record")))
+    committed = MagicMock()
+    monkeypatch.setattr(jobs, "_safe_commit", committed)
+    monkeypatch.setattr(jobs, "NVD_COMMIT_EVERY", 1)
+    jobs.run_nvd_refresh(job_context(["CVE-2024-0001"], mode="api"))
+    assert committed.call_count == 2
+
+    ctx = job_context(["CVE-2024-0001"], mode="api")
+    ctx.is_cancelled = lambda: True
+    ctx.check_cancelled.side_effect = RuntimeError("cancelled")
+    with pytest.raises(RuntimeError, match="cancelled"):
+        jobs.run_nvd_refresh(ctx)
+
+
+def test_apply_and_run_epss_refresh(monkeypatch):
+    record = MagicMock(epss_score=None)
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(get=MagicMock(return_value=record)))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    jobs._apply_epss_score("CVE-2024-1", "0.42", now)
+    assert record.update_record.call_args.kwargs["epss_score"] == decimal.Decimal("0.42")
+    assert record.update_record.call_args.kwargs["epss_data_updated_at"] == now
+
+    record.reset_mock()
+    record.epss_score = decimal.Decimal("0.42")
+    jobs._apply_epss_score("CVE-2024-1", "0.42", now)
+    assert "epss_data_updated_at" not in record.update_record.call_args.kwargs
+
+    client = MagicMock()
+    client.api_get_epss_batch.side_effect = [{"CVE-2024-1": {"score": "0.5"}}, RuntimeError("offline")]
+    monkeypatch.setattr(jobs, "EPSS_DB", lambda: client)
+    applied = MagicMock()
+    monkeypatch.setattr(jobs, "_apply_epss_score", applied)
+    committed = MagicMock()
+    monkeypatch.setattr(jobs, "_safe_commit", committed)
+    monkeypatch.setattr(jobs, "EPSS_BATCH_SIZE", 1)
+    ctx = job_context(["CVE-2024-1", "CVE-2024-2"])
+    jobs.run_epss_refresh(ctx)
+    applied.assert_called_once()
+    assert committed.call_count == 1
+    assert ctx.report.call_args_list[-1].args[-1] == "EPSS refresh complete"
+
+
+def test_epss_refresh_handles_update_errors_and_cancellation(monkeypatch):
+    client = MagicMock()
+    client.api_get_epss_batch.return_value = {"CVE-2024-0001": {"score": "0.5"}}
+    monkeypatch.setattr(jobs, "EPSS_DB", lambda: client)
+    monkeypatch.setattr(jobs, "_apply_epss_score", MagicMock(side_effect=ValueError("bad score")))
+    monkeypatch.setattr(jobs, "_safe_commit", MagicMock())
+    jobs.run_epss_refresh(job_context(["CVE-2024-0001"]))
+
+    ctx = job_context(["CVE-2024-0001"])
+    ctx.is_cancelled = lambda: True
+    ctx.check_cancelled.side_effect = RuntimeError("cancelled")
+    with pytest.raises(RuntimeError, match="cancelled"):
+        jobs.run_epss_refresh(ctx)
+
+
+def test_apply_and_run_ghsa_refresh(monkeypatch):
+    record = MagicMock(publish_date=None)
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(get=MagicMock(return_value=record)))
+    monkeypatch.setattr(jobs.VulnerabilitiesController, "_fetch_ghsa_published", lambda _id: "2024-01-02T00:00:00Z")
+    now = datetime.datetime.now(datetime.timezone.utc)
+    jobs._apply_ghsa_published("GHSA-ABCD-1234", now)
+    assert record.update_record.call_args.kwargs["publish_date"] == datetime.date(2024, 1, 2)
+
+    monkeypatch.setattr(jobs, "_apply_ghsa_published", MagicMock(side_effect=[None, ValueError("bad")]))
+    monkeypatch.setattr(jobs, "_safe_commit", MagicMock())
+    monkeypatch.setattr(jobs.time, "sleep", MagicMock())
+    ctx = job_context(["GHSA-ABCD-1234", "GHSA-ABCD-5678"])
+    jobs.run_ghsa_refresh(ctx)
+    assert "1 failed" in ctx.report.call_args_list[-1].args[-1]
+
+    error = urllib.error.HTTPError("url", 429, "rate limited", {}, None)
+    monkeypatch.setattr(jobs, "_apply_ghsa_published", MagicMock(side_effect=error))
+    with pytest.raises(RuntimeError, match="rate limit"):
+        jobs.run_ghsa_refresh(job_context(["GHSA-ABCD-1234"]))
+
+
+def test_ghsa_helper_handles_missing_invalid_and_absent_records(monkeypatch):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    monkeypatch.setattr(jobs.VulnerabilitiesController, "_fetch_ghsa_published", lambda _id: None)
+    jobs._apply_ghsa_published("GHSA-ABCD-1234-5678", now)
+
+    record = MagicMock(publish_date=None)
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(get=MagicMock(return_value=record)))
+    monkeypatch.setattr(jobs.VulnerabilitiesController, "_fetch_ghsa_published", lambda _id: "not-a-date")
+    jobs._apply_ghsa_published("GHSA-ABCD-1234-5678", now)
+    assert record.update_record.call_args.kwargs == {"ghsa_fetched_at": now, "commit": False}
+
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(get=MagicMock(return_value=None)))
+    monkeypatch.setattr(jobs.VulnerabilitiesController, "_fetch_ghsa_published", lambda _id: "2024-01-02")
+    jobs._apply_ghsa_published("GHSA-ABCD-1234-5678", now)
+
+
+def test_ghsa_refresh_handles_http_error_periodic_commit_and_cancellation(monkeypatch):
+    error = urllib.error.HTTPError("url", 500, "server error", {}, None)
+    monkeypatch.setattr(jobs, "_apply_ghsa_published", MagicMock(side_effect=error))
+    committed = MagicMock()
+    monkeypatch.setattr(jobs, "_safe_commit", committed)
+    monkeypatch.setattr(jobs.time, "sleep", MagicMock())
+    monkeypatch.setattr(jobs, "GHSA_COMMIT_EVERY", 1)
+    jobs.run_ghsa_refresh(job_context(["GHSA-ABCD-1234-5678"]))
+    assert committed.call_count == 2
+
+    ctx = job_context(["GHSA-ABCD-1234-5678"])
+    ctx.is_cancelled = lambda: True
+    ctx.check_cancelled.side_effect = RuntimeError("cancelled")
+    with pytest.raises(RuntimeError, match="cancelled"):
+        jobs.run_ghsa_refresh(ctx)
+
+
+def test_apply_and_run_euvd_refresh(monkeypatch):
+    record = MagicMock(
+        euvd_id=None,
+        euvd_known_exploited=False,
+        euvd_kev_sources=[],
+        euvd_date_added=None,
+    )
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(get=MagicMock(return_value=record)))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    assert jobs._apply_euvd("CVE-2024-1", {"CVE-2024-1": "EUVD-1"}, {"CVE-2024-1": {"sources": ["kev"], "date_added": "2024-01-01"}}, now) == (True, True)
+    assert record.update_record.call_args.kwargs["euvd_id"] == "EUVD-1"
+
+    record.reset_mock()
+    assert jobs._apply_euvd("CVE-2024-1", {}, {}, now) == (False, False)
+    assert record.update_record.call_args.kwargs["euvd_fetched_at"] == now
+
+    client = MagicMock()
+    client.get_full_mapping.return_value = {"CVE-2024-1": "EUVD-1"}
+    client.get_mapping.return_value = {}
+    monkeypatch.setattr(jobs, "EUVD_DB", lambda: client)
+    monkeypatch.setattr(jobs, "_apply_euvd", MagicMock(side_effect=[(True, False), (False, False)]))
+    monkeypatch.setattr(jobs, "_safe_commit", MagicMock())
+    ctx = job_context(["CVE-2024-1", "CVE-2024-2"])
+    jobs.run_euvd_refresh(ctx)
+    assert "1/2 matched" in ctx.report.call_args_list[-1].args[-1]
+
+    client.get_full_mapping.return_value = {}
+    with pytest.raises(RuntimeError, match="mapping unavailable"):
+        jobs.run_euvd_refresh(job_context(["CVE-2024-1"]))
+
+
+def test_euvd_helper_handles_missing_and_stale_records(monkeypatch):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(get=MagicMock(return_value=None)))
+    assert jobs._apply_euvd("CVE-2024-0001", {}, {}, now) == (False, False)
+
+    record = MagicMock(
+        euvd_id="EUVD-1",
+        euvd_known_exploited=True,
+        euvd_kev_sources=["kev"],
+        euvd_date_added="2024-01-01",
+    )
+    monkeypatch.setattr(jobs.db, "session", SimpleNamespace(get=MagicMock(return_value=record)))
+    assert jobs._apply_euvd("CVE-2024-0001", {}, {}, now) == (False, False)
+    assert record.euvd_id is None
+    assert record.euvd_known_exploited is False
+
+
+def test_euvd_refresh_counts_exploitation_and_honours_cancellation(monkeypatch):
+    client = MagicMock()
+    client.get_full_mapping.return_value = {"CVE-2024-0001": "EUVD-1"}
+    client.get_mapping.return_value = {}
+    monkeypatch.setattr(jobs, "EUVD_DB", lambda: client)
+    monkeypatch.setattr(jobs, "_apply_euvd", MagicMock(return_value=(True, True)))
+    committed = MagicMock()
+    monkeypatch.setattr(jobs, "_safe_commit", committed)
+    monkeypatch.setattr(jobs, "EUVD_COMMIT_EVERY", 1)
+    ctx = job_context(["CVE-2024-0001"])
+    jobs.run_euvd_refresh(ctx)
+    assert "1 known exploitable" in ctx.report.call_args_list[-1].args[-1]
+    assert committed.call_count == 2
+
+    ctx = job_context(["CVE-2024-0001"])
+    ctx.is_cancelled = lambda: True
+    ctx.check_cancelled.side_effect = RuntimeError("cancelled")
+    with pytest.raises(RuntimeError, match="cancelled"):
+        jobs.run_euvd_refresh(ctx)

--- a/tests/unit_tests/test_webapp_coverage_boost.py
+++ b/tests/unit_tests/test_webapp_coverage_boost.py
@@ -9,6 +9,10 @@ import pytest
 from flask import Flask
 
 from src.bin import webapp as webapp_mod
+from src.controllers import operation_queue as operation_queue_mod
+from src.controllers.operation_registry import (
+    KIND_ENRICHMENT, LANE_PIPELINE, registry,
+)
 
 
 class _InlineThread:
@@ -23,42 +27,85 @@ class _InlineThread:
         self._target()
 
 
-def test_launch_enrichment_executes_epss(monkeypatch):
-    calls: list[str] = []
+@pytest.fixture()
+def captured_submissions(monkeypatch):
+    """Record what ``_launch_enrichment`` hands to the operation queue."""
+    registry.clear()
+    submissions: list[dict] = []
 
-    fake_session = SimpleNamespace(autoflush=True)
-    fake_db = SimpleNamespace(session=fake_session)
+    def _submit(op_id, lane, runner, ctx):
+        submissions.append(
+            {"op_id": op_id, "lane": lane, "runner": runner, "ctx": ctx}
+        )
 
-    def _record_post_treatment(_controllers):
-        calls.append("epss")
+    monkeypatch.setattr(operation_queue_mod.queue, "submit", _submit)
+    yield submissions
+    registry.clear()
 
-    monkeypatch.setattr(webapp_mod, "db", fake_db)
-    monkeypatch.setattr(webapp_mod.threading, "Thread", _InlineThread)
-    monkeypatch.setattr(webapp_mod, "post_treatment", _record_post_treatment)
 
+def test_boot_enrichment_is_registered_as_a_pipeline_operation(
+    captured_submissions,
+):
+    webapp_mod._launch_enrichment(Flask(__name__))
+
+    operation = registry.get("enrichment:boot")
+    assert operation is not None
+    assert operation["kind"] == KIND_ENRICHMENT
+    assert operation["source"] == "epss"
+    assert operation["lane"] == LANE_PIPELINE
+
+    assert len(captured_submissions) == 1
+    submission = captured_submissions[0]
+    assert submission["op_id"] == "enrichment:boot"
+    assert submission["lane"] == LANE_PIPELINE
+    assert submission["ctx"].op_id == "enrichment:boot"
+
+
+def test_boot_enrichment_is_not_queued_twice(captured_submissions):
     app = Flask(__name__)
     webapp_mod._launch_enrichment(app)
+    webapp_mod._launch_enrichment(app)
+
+    assert len(captured_submissions) == 1
+
+
+def test_boot_enrichment_runs_post_treatment_with_a_reporter(
+    captured_submissions, monkeypatch
+):
+    fake_session = SimpleNamespace(autoflush=True)
+    monkeypatch.setattr(webapp_mod, "db", SimpleNamespace(session=fake_session))
+
+    reporters: list[object] = []
+    monkeypatch.setattr(
+        webapp_mod, "post_treatment",
+        lambda _controllers, reporter=None: reporters.append(reporter),
+    )
+
+    webapp_mod._launch_enrichment(Flask(__name__))
+    submission = captured_submissions[0]
+    submission["runner"](submission["ctx"])
 
     assert fake_session.autoflush is False
-    assert "epss" in calls
+    assert reporters == [submission["ctx"]]
 
 
-def test_launch_enrichment_catches_and_logs_failures(monkeypatch, capsys):
-    fake_session = SimpleNamespace(autoflush=True)
-    fake_db = SimpleNamespace(session=fake_session)
+def test_boot_enrichment_failure_reaches_the_queue(
+    captured_submissions, monkeypatch
+):
+    """The runner raises so the queue can mark the operation as failed."""
+    monkeypatch.setattr(
+        webapp_mod, "db", SimpleNamespace(session=SimpleNamespace(autoflush=True))
+    )
 
-    def _raise_in_post_treatment(_controllers):
+    def _raise(_controllers, reporter=None):
         raise RuntimeError("epss failure")
 
-    monkeypatch.setattr(webapp_mod, "db", fake_db)
-    monkeypatch.setattr(webapp_mod.threading, "Thread", _InlineThread)
-    monkeypatch.setattr(webapp_mod, "post_treatment", _raise_in_post_treatment)
+    monkeypatch.setattr(webapp_mod, "post_treatment", _raise)
 
-    app = Flask(__name__)
-    webapp_mod._launch_enrichment(app)
-
-    out = capsys.readouterr().out
-    assert "[enrichment/epss]" in out
+    webapp_mod._launch_enrichment(Flask(__name__))
+    submission = captured_submissions[0]
+    with pytest.raises(RuntimeError, match="epss failure"):
+        submission["runner"](submission["ctx"])
 
 
 def test_create_app_schedules_background_tasks_when_scan_finished(monkeypatch, tmp_path):

--- a/tests/webapp_tests/test_event_stream.py
+++ b/tests/webapp_tests/test_event_stream.py
@@ -1,0 +1,277 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""The single SSE stream that replaced every status and progress endpoint."""
+
+import json
+import os
+
+import pytest
+
+from src.bin.webapp import create_app
+from src.controllers.event_bus import operation_events
+from src.controllers.operation_registry import (
+    LANE_PIPELINE,
+    STATUS_DONE,
+    registry,
+)
+from src.routes import events as events_module
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    registry.clear()
+    yield
+    registry.clear()
+
+
+@pytest.fixture(autouse=True)
+def fast_heartbeat(monkeypatch):
+    """Keep the idle timeout short so tests never wait 15 seconds."""
+    monkeypatch.setattr(events_module, "HEARTBEAT_SECONDS", 0.05)
+
+
+@pytest.fixture()
+def open_stream(client):
+    """Open streams and guarantee they are closed, freeing their slot."""
+    readers = []
+
+    def _open(**kwargs):
+        response = client.get("/api/events/stream", **kwargs)
+        reader = _Reader(response)
+        readers.append(reader)
+        return reader
+
+    yield _open
+    for reader in readers:
+        reader.close()
+
+
+class _Reader:
+    """Pulls SSE frames off a streaming response.
+
+    Reading is synchronous: the shortened heartbeat guarantees the generator
+    yields something within milliseconds, so no worker thread is needed.
+    """
+
+    def __init__(self, response):
+        self.response = response
+        self._iterator = iter(response.response)
+
+    def next_frame(self):
+        chunk = next(self._iterator)
+        return parse_frame(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+    def next_frame_of(self, event_type, max_skips=50):
+        for _ in range(max_skips):
+            frame = self.next_frame()
+            if frame["event"] == event_type:
+                return frame
+        raise AssertionError(f"no {event_type!r} frame arrived")
+
+    def close(self):
+        self.response.close()
+
+
+def parse_frame(raw):
+    parsed = {"id": None, "event": None, "data": None}
+    for line in raw.strip().splitlines():
+        key, _, value = line.partition(": ")
+        if key == "id":
+            parsed["id"] = int(value)
+        elif key == "event":
+            parsed["event"] = value
+        elif key == "data":
+            parsed["data"] = json.loads(value)
+    return parsed
+
+
+def _create(op_id, status=None):
+    operation = registry.create(
+        op_id=op_id, kind="scan", source="grype", label="Grype", lane=LANE_PIPELINE
+    )
+    if status is not None:
+        operation = registry.update(op_id, status=status)
+    return operation
+
+
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+def test_stream_declares_the_sse_content_type_and_disables_buffering(client):
+    response = client.get("/api/events/stream")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("text/event-stream")
+    assert response.headers["X-Accel-Buffering"] == "no"
+    assert "no-cache" in response.headers["Cache-Control"]
+    response.close()
+
+
+def test_stream_is_reachable_before_the_boot_import_finishes(app, tmp_path):
+    """The UI opens the stream while /api is still gated, like /api/scan/status."""
+    unfinished = tmp_path / "unfinished.txt"
+    unfinished.write_text("3 still importing")
+    app.config["SCAN_FILE"] = str(unfinished)
+    app._INT_SCAN_FINISHED = False
+
+    client = app.test_client()
+    assert client.get("/api/packages").status_code == 503
+
+    response = client.get("/api/events/stream")
+    assert response.status_code == 200
+    response.close()
+
+
+# ---------------------------------------------------------------------------
+# Snapshot first
+# ---------------------------------------------------------------------------
+
+def test_first_frame_is_a_full_snapshot(open_stream):
+    _create("scan:grype:v1")
+    _create("refresh:epss")
+
+    frame = open_stream().next_frame()
+
+    assert frame["event"] == "snapshot"
+    assert sorted(op["op_id"] for op in frame["data"]["operations"]) == [
+        "refresh:epss", "scan:grype:v1",
+    ]
+
+
+def test_snapshot_carries_progress_and_logs_so_a_reload_restores_everything(open_stream):
+    _create("scan:grype:v1")
+    registry.update(
+        "scan:grype:v1",
+        status="running",
+        progress={"current": 7, "total": 20, "message": "7/20 packages"},
+        append_logs=["Resolving active packages…"],
+    )
+
+    operations = open_stream().next_frame_of("snapshot")["data"]["operations"]
+
+    assert operations[0]["progress"] == {
+        "current": 7, "total": 20, "message": "7/20 packages",
+    }
+    assert operations[0]["logs"] == ["Resolving active packages…"]
+
+
+def test_queued_operations_survive_a_reload(open_stream):
+    """The old per-variant status endpoints could only restore running scans."""
+    _create("scan:grype:v1")
+
+    operations = open_stream().next_frame_of("snapshot")["data"]["operations"]
+
+    assert [op["status"] for op in operations] == ["queued"]
+
+
+# ---------------------------------------------------------------------------
+# Deltas
+# ---------------------------------------------------------------------------
+
+def test_updates_arrive_as_operation_deltas(open_stream):
+    reader = open_stream()
+    reader.next_frame_of("snapshot")
+
+    _create("scan:grype:v1")
+    frame = reader.next_frame_of("operation")
+
+    assert frame["data"]["op_id"] == "scan:grype:v1"
+    assert frame["id"] is not None
+
+
+def test_dismissal_is_broadcast_so_every_client_forgets_the_operation(open_stream):
+    _create("scan:grype:v1", status=STATUS_DONE)
+
+    reader = open_stream()
+    reader.next_frame_of("snapshot")
+
+    registry.remove("scan:grype:v1")
+    frame = reader.next_frame_of("operation_removed")
+
+    assert frame["data"] == {"op_id": "scan:grype:v1"}
+
+
+def test_idle_stream_emits_heartbeats(open_stream):
+    reader = open_stream()
+    reader.next_frame_of("snapshot")
+
+    assert reader.next_frame_of("heartbeat")["event"] == "heartbeat"
+
+
+# ---------------------------------------------------------------------------
+# Reconnection
+# ---------------------------------------------------------------------------
+
+def test_reconnect_with_last_event_id_replays_instead_of_resnapshotting(open_stream):
+    _create("scan:grype:v1")
+    baseline = operation_events.seq
+    registry.update("scan:grype:v1", status=STATUS_DONE)
+
+    frame = open_stream(headers={"Last-Event-ID": str(baseline)}).next_frame()
+
+    assert frame["event"] == "operation"
+    assert frame["data"]["status"] == STATUS_DONE
+
+
+def test_reconnect_resnapshots_when_the_gap_is_too_wide(open_stream):
+    _create("scan:grype:v1")
+
+    # A sequence far beyond anything published cannot be bridged from the buffer.
+    frame = open_stream(headers={"Last-Event-ID": "999999999"}).next_frame()
+
+    assert frame["event"] == "snapshot"
+
+
+def test_unparsable_last_event_id_falls_back_to_a_snapshot(open_stream):
+    frame = open_stream(headers={"Last-Event-ID": "garbage"}).next_frame()
+
+    assert frame["event"] == "snapshot"
+
+
+# ---------------------------------------------------------------------------
+# Capacity
+# ---------------------------------------------------------------------------
+
+def test_stream_count_is_capped_because_each_one_holds_a_thread(client, open_stream, monkeypatch):
+    monkeypatch.setenv("VULNSCOUT_SSE_MAX_STREAMS", "1")
+
+    assert open_stream().response.status_code == 200
+
+    refused = client.get("/api/events/stream")
+    assert refused.status_code == 503
+    assert "Too many concurrent event streams" in refused.get_json()["error"]
+
+
+def test_client_disconnect_releases_the_subscription_and_the_stream_slot(open_stream):
+    subscribers_before = operation_events.subscriber_count()
+    streams_before = events_module._active_streams
+
+    reader = open_stream()
+    reader.next_frame_of("snapshot")
+    assert operation_events.subscriber_count() == subscribers_before + 1
+    assert events_module._active_streams == streams_before + 1
+
+    # Closing the response finalizes the generator, as a client abort does.
+    reader.close()
+
+    assert operation_events.subscriber_count() == subscribers_before
+    assert events_module._active_streams == streams_before

--- a/tests/webapp_tests/test_operation_queue.py
+++ b/tests/webapp_tests/test_operation_queue.py
@@ -1,0 +1,342 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""Operation registry, queue lanes and cancellation semantics."""
+
+import os
+import threading
+import time
+
+import pytest
+
+from src.bin.webapp import create_app
+from src.controllers.event_bus import EventBus
+from src.controllers.job_context import CancelledError, JobContext
+from src.controllers.operation_queue import OperationQueue
+from src.controllers.operation_registry import (
+    LANE_EXPORT,
+    LANE_PIPELINE,
+    STATUS_CANCELLED,
+    STATUS_DONE,
+    STATUS_ERROR,
+    STATUS_QUEUED,
+    STATUS_RUNNING,
+    registry,
+)
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    registry.clear()
+    yield
+    registry.clear()
+
+
+@pytest.fixture
+def op_queue(app):
+    queue = OperationQueue()
+    queue.init_app(app)
+    return queue
+
+
+def _create(op_id, lane=LANE_PIPELINE, queue_id=None, position=None):
+    return registry.create(
+        op_id=op_id, kind="scan", source="grype", label="Grype",
+        lane=lane, queue_id=queue_id, position=position, cancellable=True,
+    )
+
+
+def _wait_for(op_id, status, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        operation = registry.get(op_id)
+        if operation is not None and operation["status"] == status:
+            return operation
+        time.sleep(0.01)
+    actual = registry.get(op_id)
+    raise AssertionError(
+        f"{op_id} never reached {status}; last state="
+        f"{actual['status'] if actual else 'missing'}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+def test_create_publishes_queued_operation():
+    operation = _create("scan:grype:v1")
+    assert operation["status"] == STATUS_QUEUED
+    assert registry.has_active("scan:grype:v1")
+    assert [op["op_id"] for op in registry.snapshot()] == ["scan:grype:v1"]
+
+
+def test_update_appends_logs_without_replacing_them():
+    _create("scan:grype:v1")
+    registry.update("scan:grype:v1", append_logs=["first"])
+    registry.update("scan:grype:v1", append_logs=["second", "third"])
+    assert registry.get("scan:grype:v1")["logs"] == ["first", "second", "third"]
+
+
+def test_terminal_status_stamps_finished_at_once():
+    _create("scan:grype:v1")
+    registry.update("scan:grype:v1", status=STATUS_DONE)
+    first = registry.get("scan:grype:v1")["finished_at"]
+    registry.update("scan:grype:v1", append_logs=["late"])
+    assert registry.get("scan:grype:v1")["finished_at"] == first
+
+
+def test_remove_only_drops_terminal_operations():
+    _create("scan:grype:v1")
+    assert registry.remove("scan:grype:v1") is False
+    registry.update("scan:grype:v1", status=STATUS_DONE)
+    assert registry.remove("scan:grype:v1") is True
+    assert registry.get("scan:grype:v1") is None
+
+
+# ---------------------------------------------------------------------------
+# Queue lanes
+# ---------------------------------------------------------------------------
+
+def test_pipeline_lane_runs_operations_serially_in_submission_order(op_queue):
+    order = []
+    running = []
+    overlap = threading.Event()
+
+    def make_runner(name):
+        def runner(ctx):
+            running.append(name)
+            if len(running) > 1:
+                overlap.set()
+            order.append(name)
+            time.sleep(0.05)
+            running.remove(name)
+        return runner
+
+    for name in ("a", "b", "c"):
+        _create(f"scan:grype:{name}")
+        op_queue.submit(
+            f"scan:grype:{name}", LANE_PIPELINE, make_runner(name),
+            JobContext(f"scan:grype:{name}"),
+        )
+
+    for name in ("a", "b", "c"):
+        _wait_for(f"scan:grype:{name}", STATUS_DONE)
+
+    assert order == ["a", "b", "c"]
+    assert not overlap.is_set(), "pipeline lane ran two operations at once"
+
+
+def test_export_lane_runs_two_operations_concurrently(op_queue):
+    both_started = threading.Barrier(2, timeout=5)
+
+    def runner(ctx):
+        both_started.wait()
+
+    for name in ("x", "y"):
+        _create(f"export:{name}", lane=LANE_EXPORT)
+        op_queue.submit(
+            f"export:{name}", LANE_EXPORT, runner, JobContext(f"export:{name}")
+        )
+
+    # The barrier only releases if both operations are in flight together.
+    for name in ("x", "y"):
+        _wait_for(f"export:{name}", STATUS_DONE)
+
+
+def test_failing_job_records_the_error(op_queue):
+    def runner(ctx):
+        raise RuntimeError("grype binary not found on this system")
+
+    _create("scan:grype:v1")
+    op_queue.submit("scan:grype:v1", LANE_PIPELINE, runner, JobContext("scan:grype:v1"))
+
+    operation = _wait_for("scan:grype:v1", STATUS_ERROR)
+    assert operation["error"] == "grype binary not found on this system"
+    assert operation["logs"][-1].startswith("ERROR:")
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+def test_cancelling_a_queued_operation_prevents_it_from_running(op_queue):
+    release = threading.Event()
+    ran = []
+
+    def blocker(ctx):
+        release.wait(timeout=5)
+
+    def should_not_run(ctx):
+        ran.append(True)
+
+    _create("scan:grype:first")
+    op_queue.submit("scan:grype:first", LANE_PIPELINE, blocker, JobContext("scan:grype:first"))
+    _wait_for("scan:grype:first", STATUS_RUNNING)
+
+    _create("scan:grype:second")
+    op_queue.submit(
+        "scan:grype:second", LANE_PIPELINE, should_not_run, JobContext("scan:grype:second")
+    )
+
+    assert op_queue.cancel("scan:grype:second") is True
+    assert registry.get("scan:grype:second")["status"] == STATUS_CANCELLED
+
+    release.set()
+    _wait_for("scan:grype:first", STATUS_DONE)
+    assert ran == [], "a cancelled queued operation still executed"
+
+
+def test_cancelling_a_running_operation_reaches_cancelled(op_queue):
+    started = threading.Event()
+
+    def runner(ctx):
+        started.set()
+        for _ in range(500):
+            ctx.check_cancelled()
+            time.sleep(0.01)
+
+    _create("scan:grype:v1")
+    op_queue.submit("scan:grype:v1", LANE_PIPELINE, runner, JobContext("scan:grype:v1"))
+    assert started.wait(timeout=5)
+
+    assert op_queue.cancel("scan:grype:v1") is True
+    _wait_for("scan:grype:v1", STATUS_CANCELLED)
+
+
+def test_cancel_queue_stops_every_operation_in_the_batch(op_queue):
+    release = threading.Event()
+
+    def blocker(ctx):
+        release.wait(timeout=5)
+
+    _create("scan:grype:a", queue_id="q-1", position=1)
+    op_queue.submit("scan:grype:a", LANE_PIPELINE, blocker, JobContext("scan:grype:a"))
+    _wait_for("scan:grype:a", STATUS_RUNNING)
+
+    for index, name in enumerate(("b", "c"), 2):
+        _create(f"scan:grype:{name}", queue_id="q-1", position=index)
+        op_queue.submit(
+            f"scan:grype:{name}", LANE_PIPELINE, blocker, JobContext(f"scan:grype:{name}")
+        )
+
+    assert op_queue.cancel_queue("q-1") == 3
+    release.set()
+    for name in ("b", "c"):
+        assert registry.get(f"scan:grype:{name}")["status"] == STATUS_CANCELLED
+
+
+def test_cancel_returns_false_for_unknown_operation(op_queue):
+    assert op_queue.cancel("scan:grype:missing") is False
+
+
+# ---------------------------------------------------------------------------
+# Job context
+# ---------------------------------------------------------------------------
+
+def test_check_cancelled_raises_after_request():
+    ctx = JobContext("scan:grype:v1")
+    ctx.check_cancelled()
+    ctx.request_cancel()
+    with pytest.raises(CancelledError):
+        ctx.check_cancelled()
+
+
+def test_cancel_hook_fires_so_blocking_work_can_abort():
+    ctx = JobContext("scan:grype:v1")
+    aborted = threading.Event()
+    ctx.set_cancel_hook(aborted.set)
+    ctx.request_cancel()
+    assert aborted.is_set()
+
+
+def test_flush_publishes_buffered_progress_and_logs():
+    _create("scan:grype:v1")
+    ctx = JobContext("scan:grype:v1")
+    ctx.report(3, 10, "3/10 packages")
+    ctx.log("scanning")
+    ctx.flush()
+
+    operation = registry.get("scan:grype:v1")
+    assert operation["progress"] == {"current": 3, "total": 10, "message": "3/10 packages"}
+    assert operation["logs"] == ["scanning"]
+
+
+def test_message_keeps_the_last_reported_counters():
+    _create("scan:grype:v1")
+    ctx = JobContext("scan:grype:v1")
+    ctx.report(4, 9, "4/9 packages")
+    ctx.flush()
+    ctx.message("Syncing advisory database")
+    ctx.flush()
+
+    progress = registry.get("scan:grype:v1")["progress"]
+    assert progress == {
+        "current": 4, "total": 9, "message": "Syncing advisory database",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Event bus
+# ---------------------------------------------------------------------------
+
+def test_publish_assigns_monotonic_sequence_numbers():
+    bus = EventBus()
+    first = bus.publish("operation", {"op_id": "a"})
+    second = bus.publish("operation", {"op_id": "b"})
+    assert (first["seq"], second["seq"]) == (1, 2)
+    assert bus.seq == 2
+
+
+def test_subscriber_receives_events_published_after_subscribing():
+    bus = EventBus()
+    subscription = bus.subscribe()
+    bus.publish("operation", {"op_id": "a"})
+    events = subscription.drain(timeout=1)
+    assert [event["data"]["op_id"] for event in events] == ["a"]
+    subscription.close()
+
+
+def test_replay_returns_events_after_the_given_sequence():
+    bus = EventBus()
+    for name in ("a", "b", "c"):
+        bus.publish("operation", {"op_id": name})
+    replayed = list(bus.replay_since(1))
+    assert [event["data"]["op_id"] for event in replayed] == ["b", "c"]
+
+
+def test_replay_returns_none_when_the_gap_is_too_wide():
+    bus = EventBus(replay_size=2)
+    for name in ("a", "b", "c", "d"):
+        bus.publish("operation", {"op_id": name})
+    assert bus.replay_since(1) is None
+
+
+def test_slow_subscriber_overflows_instead_of_blocking_the_publisher():
+    bus = EventBus(client_backlog=2)
+    subscription = bus.subscribe()
+    for index in range(5):
+        bus.publish("operation", {"op_id": str(index)})
+    assert subscription.overflowed is True
+    subscription.close()
+
+
+def test_close_all_signals_every_subscriber():
+    bus = EventBus()
+    subscription = bus.subscribe()
+    bus.close_all()
+    subscription.drain(timeout=1)
+    assert subscription.closed is True

--- a/tests/webapp_tests/test_operations_api.py
+++ b/tests/webapp_tests/test_operations_api.py
@@ -1,0 +1,380 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+
+"""The unified enqueue API that replaced the eight trigger endpoints."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.bin.webapp import create_app
+from src.extensions import db as _db
+from src.controllers.operation_registry import STATUS_DONE, registry
+
+
+def _build_db(app):
+    from src.models.package import Package
+    from src.models.project import Project
+    from src.models.sbom_document import SBOMDocument
+    from src.models.sbom_package import SBOMPackage
+    from src.models.scan import Scan
+    from src.models.variant import Variant
+    from src.models.vulnerability import Vulnerability
+
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+
+        project = Project.create("OpsProject")
+        first = Variant.create("alpha", project.id)
+        second = Variant.create("beta", project.id)
+
+        scan = Scan.create("initial scan", first.id, scan_type="sbom")
+        package = Package.find_or_create(
+            "openssl", "1.1.1",
+            cpe=["cpe:2.3:a:openssl:openssl:1.1.1:*:*:*:*:*:*:*"],
+            purl=["pkg:generic/openssl/openssl@1.1.1"],
+        )
+        Vulnerability.create_record(id="CVE-2024-1111", description="known")
+        _db.session.commit()
+
+        sbom = SBOMDocument.create("/test/sbom.json", "spdx", scan.id)
+        SBOMPackage.create(sbom.id, package.id)
+        _db.session.commit()
+
+        return {
+            "project_id": str(project.id),
+            "variant_a": str(first.id),
+            "variant_b": str(second.id),
+        }
+
+
+@pytest.fixture()
+def app(tmp_path):
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({"TESTING": True, "SCAN_FILE": str(scan_file)})
+        application._test_ids = _build_db(application)
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def ids(app):
+    return app._test_ids
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    registry.clear()
+    yield
+    registry.clear()
+
+
+@pytest.fixture(autouse=True)
+def never_execute():
+    """Keep enqueue tests about planning, not about running real scanners."""
+    with patch("src.controllers.operation_queue.OperationQueue.submit"):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Planning and ordering
+# ---------------------------------------------------------------------------
+
+def test_one_request_queues_scans_then_refreshes_in_canonical_order(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "refresh", "source": "epss", "ids": ["CVE-2024-1111"]},
+        {"kind": "scan", "source": "scc", "variant_ids": [ids["variant_a"]]},
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+        {"kind": "refresh", "source": "nvd", "ids": ["CVE-2024-1111"]},
+    ]})
+
+    assert response.status_code == 202
+    assert [op["op_id"] for op in response.get_json()["operations"]] == [
+        f"scan:grype:{ids['variant_a']}",
+        f"scan:scc:{ids['variant_a']}",
+        "refresh:nvd",
+        "refresh:epss",
+    ]
+
+
+def test_a_scan_expands_to_one_operation_per_variant(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype",
+         "variant_ids": [ids["variant_a"], ids["variant_b"]]},
+    ]})
+
+    operations = response.get_json()["operations"]
+    assert [op["position"] for op in operations] == [1, 2]
+    assert [op["scope"]["variant_name"] for op in operations] == ["alpha", "beta"]
+
+
+def test_every_operation_in_a_batch_shares_one_queue_id(client, ids):
+    payload = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+        {"kind": "refresh", "source": "epss", "ids": ["CVE-2024-1111"]},
+    ]}).get_json()
+
+    queue_ids = {op["queue_id"] for op in payload["operations"]}
+    assert queue_ids == {payload["queue_id"]}
+
+
+def test_deferred_refresh_is_reserved_with_its_scan_batch(client, ids):
+    payload = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+        {"kind": "refresh", "source": "epss", "variant_ids": [ids["variant_a"]],
+         "exclude_ids": ["CVE-2024-1111"]},
+    ]}).get_json()
+
+    assert [operation["op_id"] for operation in payload["operations"]] == [
+        f"scan:grype:{ids['variant_a']}",
+        "refresh:epss",
+    ]
+    refresh = payload["operations"][1]
+    assert refresh["queue_id"] == payload["queue_id"]
+    assert refresh["options"]["variant_ids"] == [ids["variant_a"]]
+    assert refresh["options"]["exclude_ids"] == ["CVE-2024-1111"]
+    assert refresh["cancellable"] is True
+
+
+def test_scan_options_are_carried_onto_the_operation(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "nvd", "variant_ids": [ids["variant_a"]],
+         "options": {"exclude_kernel": False, "mode": "api"}},
+    ]})
+
+    options = response.get_json()["operations"][0]["options"]
+    assert options["exclude_kernel"] is False
+    assert options["mode"] == "api"
+
+
+def test_operations_start_queued_so_the_ui_can_show_the_whole_batch(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype",
+         "variant_ids": [ids["variant_a"], ids["variant_b"]]},
+    ]})
+
+    assert {op["status"] for op in response.get_json()["operations"]} == {"queued"}
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_empty_job_list_is_rejected(client):
+    assert client.post("/api/operations", json={"jobs": []}).status_code == 400
+
+
+def test_unknown_scan_source_is_rejected(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "nessus", "variant_ids": [ids["variant_a"]]},
+    ]})
+    assert response.status_code == 400
+    assert "nessus" in response.get_json()["error"]
+
+
+def test_malformed_variant_id_is_rejected(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": ["not-a-uuid"]},
+    ]})
+    assert response.status_code == 400
+
+
+def test_unknown_variant_returns_404(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype",
+         "variant_ids": ["11111111-1111-1111-1111-111111111111"]},
+    ]})
+    assert response.status_code == 404
+
+
+def test_refresh_without_valid_identifiers_is_rejected(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "refresh", "source": "nvd", "ids": ["not-a-cve"]},
+    ]})
+    assert response.status_code == 400
+
+
+def test_epss_refresh_requires_at_least_one_known_cve(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "refresh", "source": "epss", "ids": ["CVE-2000-9999"]},
+    ]})
+    assert response.status_code == 400
+
+
+def test_ghsa_refresh_rejects_cve_identifiers(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "refresh", "source": "ghsa", "ids": ["CVE-2024-1111"]},
+    ]})
+    assert response.status_code == 400
+
+
+def test_nothing_is_queued_when_planning_fails(client, ids):
+    client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+        {"kind": "scan", "source": "grype", "variant_ids": ["not-a-uuid"]},
+    ]})
+    assert registry.snapshot() == []
+
+
+def test_the_same_operation_twice_in_one_batch_is_rejected(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+    ]})
+    assert response.status_code == 400
+    assert response.get_json()["operations"] == [f"scan:grype:{ids['variant_a']}"]
+
+
+def test_relaunching_an_active_operation_conflicts(client, ids):
+    job = {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]}
+    assert client.post("/api/operations", json={"jobs": [job]}).status_code == 202
+
+    response = client.post("/api/operations", json={"jobs": [job]})
+    assert response.status_code == 409
+    assert response.get_json()["operations"] == [f"scan:grype:{ids['variant_a']}"]
+
+
+def test_a_finished_operation_can_be_relaunched(client, ids):
+    job = {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]}
+    client.post("/api/operations", json={"jobs": [job]})
+    registry.update(f"scan:grype:{ids['variant_a']}", status=STATUS_DONE)
+
+    assert client.post("/api/operations", json={"jobs": [job]}).status_code == 202
+
+
+def test_non_object_options_are_rejected(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]],
+         "options": "exclude_kernel"},
+    ]})
+    assert response.status_code == 400
+    assert "options must be an object" in response.get_json()["error"]
+
+
+def test_unknown_mode_is_rejected(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "nvd", "variant_ids": [ids["variant_a"]],
+         "options": {"mode": "turbo"}},
+    ]})
+    assert response.status_code == 400
+    assert "Unsupported mode" in response.get_json()["error"]
+
+
+def test_string_exclude_kernel_is_rejected_instead_of_truthy_coerced(client, ids):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]],
+         "options": {"exclude_kernel": "false"}},
+    ]})
+    assert response.status_code == 400
+    assert "exclude_kernel must be a boolean" in response.get_json()["error"]
+
+
+def test_refresh_with_unknown_mode_is_rejected(client):
+    response = client.post("/api/operations", json={"jobs": [
+        {"kind": "refresh", "source": "nvd", "ids": ["CVE-2024-1111"],
+         "options": {"mode": "remote"}},
+    ]})
+    assert response.status_code == 400
+    assert "Unsupported mode" in response.get_json()["error"]
+
+
+def test_concurrent_requests_for_the_same_operation_yield_one_winner(app):
+    """The conflict check and the registry writes happen under one lock."""
+    import threading
+
+    # An nvd refresh plans without touching the database, so every thread
+    # reaches the enqueue step and the race is purely about the lock.
+    job = {"kind": "refresh", "source": "nvd", "ids": ["CVE-2024-1111"]}
+    attempts = 8
+    barrier = threading.Barrier(attempts)
+    statuses = []
+    statuses_lock = threading.Lock()
+
+    def submit():
+        thread_client = app.test_client()
+        barrier.wait()
+        response = thread_client.post("/api/operations", json={"jobs": [job]})
+        with statuses_lock:
+            statuses.append(response.status_code)
+
+    threads = [threading.Thread(target=submit) for _ in range(attempts)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(statuses) == [202] + [409] * (attempts - 1)
+    assert len(registry.snapshot()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Snapshot, cancel, dismiss
+# ---------------------------------------------------------------------------
+
+def test_snapshot_endpoint_mirrors_the_stream(client, ids):
+    client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+    ]})
+
+    payload = client.get("/api/operations").get_json()
+    assert [op["op_id"] for op in payload["operations"]] == [
+        f"scan:grype:{ids['variant_a']}"
+    ]
+
+
+def test_cancelling_an_unknown_operation_returns_404(client):
+    assert client.post("/api/operations/scan:grype:nope/cancel").status_code == 404
+
+
+def test_cancelling_an_unsupported_operation_returns_409(client):
+    registry.create(
+        op_id="upload:active", kind="upload", source="sbom", label="SBOM import",
+        lane="upload",
+    )
+
+    response = client.post("/api/operations/upload:active/cancel")
+
+    assert response.status_code == 409
+    assert "does not support cancellation" in response.get_json()["error"]
+
+
+def test_cancelling_a_batch_reports_how_many_stopped(client, ids):
+    payload = client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype",
+         "variant_ids": [ids["variant_a"], ids["variant_b"]]},
+    ]}).get_json()
+
+    response = client.post(f"/api/operations/queue/{payload['queue_id']}/cancel")
+    assert response.status_code == 200
+
+
+def test_dismiss_removes_a_finished_operation(client, ids):
+    client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+    ]})
+    op_id = f"scan:grype:{ids['variant_a']}"
+    registry.update(op_id, status=STATUS_DONE)
+
+    assert client.delete(f"/api/operations/{op_id}").status_code == 200
+    assert registry.get(op_id) is None
+
+
+def test_dismiss_refuses_while_the_operation_is_active(client, ids):
+    client.post("/api/operations", json={"jobs": [
+        {"kind": "scan", "source": "grype", "variant_ids": [ids["variant_a"]]},
+    ]})
+
+    response = client.delete(f"/api/operations/scan:grype:{ids['variant_a']}")
+    assert response.status_code == 409

--- a/tests/webapp_tests/test_sbom_cve_check_scan.py
+++ b/tests/webapp_tests/test_sbom_cve_check_scan.py
@@ -1,38 +1,28 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
-"""Tests for the sbom-cve-check scan trigger and status endpoints.
+"""sbom-cve-check scan behaviour, exercised through ``run_scc_scan``.
 
-Covers routes/scan_triggers.py lines 744-900, 905.
+The job reports through its :class:`JobContext`, so progress and log
+assertions read the operation back from the registry.  Failures are raised
+rather than recorded by the job itself; the queue is what turns them into an
+``error`` operation.
 """
 
-import json
 import os
-import uuid
 import pytest
 from unittest.mock import patch, MagicMock
 
 from src.bin.webapp import create_app
+from src.controllers.job_context import JobContext
+from src.controllers.operation_registry import KIND_SCAN, LANE_PIPELINE, registry
+from src.controllers.scan_jobs import run_scc_scan
 from src.extensions import db as _db
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def _sync_thread_patch():
-    """Run background scan threads synchronously in tests."""
-    return patch(
-        "threading.Thread",
-        side_effect=lambda **kwargs: type(
-            "SyncThread", (), {
-                "_target": kwargs.get("target"),
-                "start": lambda self: kwargs.get("target")(),
-                "daemon": True,
-            }
-        )(),
-    )
-
 
 class _SimpleComputed:
     """Minimal stand-in for sbom_cve_check ComputedVulnInfo."""
@@ -43,6 +33,26 @@ class _SimpleComputed:
     external_refs = []
     cvss_metrics = []
     vex_assessment = None
+
+
+def _context(variant_id, **options):
+    """Register an operation and return the context its job would receive."""
+    op_id = f"scan:scc:{variant_id}"
+    registry.create(
+        op_id=op_id, kind=KIND_SCAN, source="scc",
+        label="sbom-cve-check scan", lane=LANE_PIPELINE,
+    )
+    return JobContext(op_id, {"variant_id": variant_id, **options})
+
+
+def _run(app, ctx):
+    """Run the job the way the queue does, then publish what it buffered."""
+    with app.app_context():
+        try:
+            run_scc_scan(ctx)
+        finally:
+            ctx.flush()
+    return registry.get(ctx.op_id)
 
 
 # ---------------------------------------------------------------------------
@@ -95,224 +105,118 @@ def app(tmp_path):
 
 
 @pytest.fixture()
-def client(app):
-    return app.test_client()
-
-
-@pytest.fixture()
 def ids(app):
     return app._test_ids
 
 
-# ---------------------------------------------------------------------------
-# sbom-cve-check scan — status route (line 905)
-# ---------------------------------------------------------------------------
-
-class TestSbomCveCheckScanStatus:
-    def test_idle_when_never_started(self, client):
-        """Covers line 905: return scan_status_response(...)"""
-        fake_id = str(uuid.uuid4())
-        resp = client.get(f"/api/variants/{fake_id}/sbom-cve-check-scan/status")
-        assert resp.status_code == 200
-        data = json.loads(resp.data)
-        assert data["status"] == "idle"
-
-    def test_invalid_variant_id_status(self, client):
-        resp = client.get("/api/variants/not-a-uuid/sbom-cve-check-scan/status")
-        assert resp.status_code == 400
-
-    @patch("threading.Thread")
-    def test_running_after_trigger(self, mock_thread, client, ids):
-        mock_t = MagicMock()
-        mock_thread.return_value = mock_t
-        with patch("src.controllers.scc_engine.get_engine"):
-            client.post(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan")
-        resp = client.get(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan/status")
-        assert resp.status_code == 200
-        data = json.loads(resp.data)
-        assert data["status"] == "running"
+@pytest.fixture(autouse=True)
+def clean_registry():
+    registry.clear()
+    yield
+    registry.clear()
 
 
 # ---------------------------------------------------------------------------
-# sbom-cve-check scan — trigger route (lines 744-755+)
+# sbom-cve-check scan job
 # ---------------------------------------------------------------------------
 
-class TestTriggerSbomCveCheckScan:
-    def test_invalid_variant_id(self, client):
-        resp = client.post("/api/variants/not-a-uuid/sbom-cve-check-scan")
-        assert resp.status_code == 400
-        assert b"Invalid variant id" in resp.data
-
-    def test_variant_not_found(self, client):
-        fake_id = str(uuid.uuid4())
-        resp = client.post(f"/api/variants/{fake_id}/sbom-cve-check-scan")
-        assert resp.status_code == 404
-        assert b"Variant not found" in resp.data
-
-    @patch("threading.Thread")
-    def test_scan_starts_successfully(self, mock_thread, client, ids):
-        """Covers lines 749-755: vid_str, init_progress, thread creation."""
-        mock_t = MagicMock()
-        mock_thread.return_value = mock_t
-        with patch("src.controllers.scc_engine.get_engine"):
-            resp = client.post(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan")
-        assert resp.status_code == 202
-        data = json.loads(resp.data)
-        assert data["status"] == "started"
-        assert data["variant_id"] == ids["variant_id"]
-        mock_t.start.assert_called_once()
-
-    @patch("threading.Thread")
-    def test_scan_already_running(self, mock_thread, client, ids):
-        """Covers the 409 already-in-progress branch."""
-        mock_t = MagicMock()
-        mock_thread.return_value = mock_t
-        with patch("src.controllers.scc_engine.get_engine"):
-            resp1 = client.post(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan")
-            assert resp1.status_code == 202
-            resp2 = client.post(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan")
-            assert resp2.status_code == 409
-            assert b"already in progress" in resp2.data
-
-    def test_scan_engine_failure(self, client, ids):
-        """Covers lines ~808-812: get_engine() raises → set_error + early return."""
+class TestSbomCveCheckScan:
+    def test_unavailable_advisory_databases_fail_the_scan(self, app, ids):
+        """A database that cannot be loaded aborts the scan with its cause."""
+        ctx = _context(ids["variant_id"])
         with patch("src.controllers.scc_engine.get_engine",
                    side_effect=RuntimeError("engine unavailable")):
-            with _sync_thread_patch():
-                resp = client.post(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan")
-        assert resp.status_code == 202
+            with pytest.raises(RuntimeError, match="Failed to load CVE databases"):
+                _run(app, ctx)
 
-        resp_s = client.get(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "engine unavailable" in data.get("error", "") or any(
-            "Failed to load CVE databases" in log
-            for log in data.get("logs", [])
-        )
+        logs = registry.get(ctx.op_id)["logs"]
+        assert any("Loading CVE databases" in line for line in logs)
 
-    def test_scan_empty_results(self, client, ids):
-        """Covers most of _do_sbom_cve_check_scan with an engine that returns no vulns.
+    def test_package_without_matches_is_reported_as_clean(self, app, ids):
+        """A package the engine returns nothing for is logged as clean."""
+        engine = MagicMock()
+        engine.applicable_vulns.return_value = iter([])
 
-        This covers the happy path including:
-        - _SccLogForwarder class definition and usage
-        - logger level manipulation
-        - scan + writer creation
-        - per-package loop with 'no vulnerabilities' log
-        - writer.flush() call
-        - done state update
-        """
-        mock_engine = MagicMock()
-        mock_engine.applicable_vulns.return_value = iter([])
+        ctx = _context(ids["variant_id"])
+        with patch("src.controllers.scc_engine.get_engine", return_value=engine):
+            operation = _run(app, ctx)
 
-        with patch("src.controllers.scc_engine.get_engine", return_value=mock_engine):
-            with _sync_thread_patch():
-                resp = client.post(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan")
-        assert resp.status_code == 202
+        assert operation["error"] is None
+        assert any("no vulnerabilities" in line for line in operation["logs"])
+        assert operation["progress"]["message"].startswith("Found 0 vulnerabilities")
 
-        resp_s = client.get(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "done"
-        assert any("no vulnerabilities" in log for log in data.get("logs", []))
+    def test_matched_vulnerabilities_are_listed_in_the_log(self, app, ids):
+        """Persisted CVE identifiers appear in the per-package log line."""
+        engine = MagicMock()
+        engine.applicable_vulns.return_value = iter([(_SimpleComputed(), "affected")])
 
-    def test_scan_with_vulnerabilities_found(self, client, ids):
-        """Covers the 'has vulns' log path when persisted_ids is non-empty."""
-        computed = _SimpleComputed()
-        mock_engine = MagicMock()
-        mock_engine.applicable_vulns.return_value = iter([(computed, "affected")])
+        ctx = _context(ids["variant_id"])
+        with patch("src.controllers.scc_engine.get_engine", return_value=engine):
+            operation = _run(app, ctx)
 
-        with patch("src.controllers.scc_engine.get_engine", return_value=mock_engine):
-            with _sync_thread_patch():
-                resp = client.post(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan")
-        assert resp.status_code == 202
+        assert operation["error"] is None
+        assert any("CVE-2024-SCCTEST-01" in line for line in operation["logs"])
 
-        resp_s = client.get(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "done"
-        # The log should mention the CVE found
-        all_logs = " ".join(data.get("logs", []))
-        assert "CVE-2024-SCCTEST-01" in all_logs or "vuln" in all_logs.lower()
+    def test_package_level_failure_is_logged_and_scan_continues(self, app, ids):
+        """One unscannable package does not abort the whole run."""
+        engine = MagicMock()
+        engine.applicable_vulns.side_effect = RuntimeError("pkg scan failed")
 
-    def test_scan_per_package_exception(self, client, ids):
-        """Covers the except block inside the per-package loop."""
-        mock_engine = MagicMock()
-        mock_engine.applicable_vulns.side_effect = RuntimeError("pkg scan failed")
+        ctx = _context(ids["variant_id"])
+        with patch("src.controllers.scc_engine.get_engine", return_value=engine):
+            operation = _run(app, ctx)
 
-        with patch("src.controllers.scc_engine.get_engine", return_value=mock_engine):
-            with _sync_thread_patch():
-                resp = client.post(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan")
-        assert resp.status_code == 202
+        assert operation["error"] is None
+        assert any("ERROR" in line for line in operation["logs"])
+        assert any("pkg scan failed" in line for line in operation["logs"])
 
-        resp_s = client.get(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan/status")
-        data = json.loads(resp_s.data)
-        # Status should be done (the outer try/except completes) or error
-        assert data["status"] in ("done", "error")
-        all_logs = " ".join(data.get("logs", []))
-        assert "ERROR" in all_logs or "pkg scan failed" in all_logs
-
-    def test_scan_no_sbom_scan_for_variant(self, app, client):
-        """Line 772: pkg_err → early return when variant has no SBOM scan.
-
-        Creates a fresh variant with only a 'tool' scan — so
-        active_sbom_scan_ids_for_variant returns empty, pkg_err=True.
-        """
+    def test_variant_without_sbom_scan_fails(self, app):
+        """A variant holding only tool scans has no package set to scan."""
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
+
         with app.app_context():
             project = Project.create("NoSbomProj")
             variant = Variant.create("NoSbomVariant", project.id)
             # Only a tool scan — NOT an sbom scan
             Scan.create("tool only", variant.id, scan_type="tool")
-            from src.extensions import db as _db
             _db.session.commit()
             vid = str(variant.id)
 
+        ctx = _context(vid)
         with patch("src.controllers.scc_engine.get_engine"):
-            with _sync_thread_patch():
-                resp = client.post(f"/api/variants/{vid}/sbom-cve-check-scan")
-        assert resp.status_code == 202
+            with pytest.raises(RuntimeError, match="No SBOM scan found"):
+                _run(app, ctx)
 
-        resp_s = client.get(f"/api/variants/{vid}/sbom-cve-check-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "SBOM" in data.get("error", "") or "packages" in data.get("error", "").lower()
-
-    def test_scan_scc_log_forwarded_to_progress(self, client, ids):
-        """Line 792: _SccLogForwarder.emit is exercised when sbom_cve_check logs."""
-        mock_engine = MagicMock()
-        mock_engine.applicable_vulns.return_value = iter([])
+    def test_engine_library_output_reaches_the_operation_log(self, app, ids):
+        """Both ``sbom_cve_check`` logging and git sync progress are forwarded."""
+        engine = MagicMock()
+        engine.applicable_vulns.return_value = iter([])
 
         def _engine_that_logs(progress=None):
             import logging
             logging.getLogger("sbom_cve_check").info("test-forwarder-msg")
             progress("Synchronizing nvd-fkie: Receiving objects: 50%")
-            return mock_engine
+            return engine
 
-        with patch("src.controllers.scc_engine.get_engine", side_effect=_engine_that_logs):
-            with _sync_thread_patch():
-                resp = client.post(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan")
-        assert resp.status_code == 202
+        ctx = _context(ids["variant_id"])
+        with patch("src.controllers.scc_engine.get_engine",
+                   side_effect=_engine_that_logs):
+            operation = _run(app, ctx)
 
-        resp_s = client.get(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "done"
-        all_logs = " ".join(data.get("logs", []))
-        assert "test-forwarder-msg" in all_logs
-        assert "Synchronizing nvd-fkie: Receiving objects: 50%" in all_logs
+        assert operation["error"] is None
+        assert "test-forwarder-msg" in operation["logs"]
+        assert "Synchronizing nvd-fkie: Receiving objects: 50%" in operation["logs"]
 
-    def test_scan_outer_exception_handler(self, client, ids):
-        """Lines 889-891: outer except block when Scan.create raises unexpectedly."""
-        mock_engine = MagicMock()
-        mock_engine.applicable_vulns.return_value = iter([])
+    def test_unexpected_persistence_failure_fails_the_scan(self, app, ids):
+        """A crash while recording the scan propagates instead of being swallowed."""
+        engine = MagicMock()
+        engine.applicable_vulns.return_value = iter([])
 
-        with patch("src.controllers.scc_engine.get_engine", return_value=mock_engine):
-            with patch("src.routes.scan_triggers.Scan.create",
+        ctx = _context(ids["variant_id"])
+        with patch("src.controllers.scc_engine.get_engine", return_value=engine):
+            with patch("src.controllers.scan_jobs.Scan.create",
                        side_effect=RuntimeError("db crashed unexpectedly")):
-                with _sync_thread_patch():
-                    resp = client.post(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan")
-        assert resp.status_code == 202
-
-        resp_s = client.get(f"/api/variants/{ids['variant_id']}/sbom-cve-check-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "db crashed" in data.get("error", "")
+                with pytest.raises(RuntimeError, match="db crashed unexpectedly"):
+                    _run(app, ctx)

--- a/tests/webapp_tests/test_scan_advanced.py
+++ b/tests/webapp_tests/test_scan_advanced.py
@@ -1,15 +1,24 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
-"""Tests for _run_grype_scan inner logic, tool-scan diffs, and
-newly-detected computation in scan list serialisation."""
+"""Tests for the Grype scan job, tool-scan diffs, and newly-detected
+computation in scan list serialisation."""
 
 import json
 import os
+import subprocess
 import pytest
 from unittest.mock import patch, MagicMock
 
 from src.bin.webapp import create_app
+from src.controllers.job_context import JobContext
+from src.controllers.operation_registry import KIND_SCAN, LANE_PIPELINE, registry
+from src.controllers.scan_jobs import (
+    _resolve_grype_memlimit,
+    run_grype_scan,
+    run_nvd_scan,
+    run_osv_scan,
+)
 from src.extensions import db as _db
 
 
@@ -128,6 +137,13 @@ def client(app):
 @pytest.fixture()
 def ids(app):
     return app._test_ids
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    registry.clear()
+    yield
+    registry.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -292,25 +308,76 @@ class TestGlobalResultToolScanSources:
 
 
 # ---------------------------------------------------------------------------
-# _run_grype_scan logic (covers lines 845-916 via subprocess mocking)
+# Scan jobs — shared harness
 # ---------------------------------------------------------------------------
 
-def _make_sync_thread_patch():
-    """Return a context-manager patch that makes Thread.start() synchronous."""
-    return patch(
-        "threading.Thread",
-        side_effect=lambda **kwargs: type(
-            "SyncThread", (), {
-                "_target": kwargs.get("target"),
-                "start": lambda self: kwargs.get("target")(),
-                "daemon": True,
-            }
-        )(),
+def _context(source, variant_id, **options):
+    """Register an operation and return the context its job would receive."""
+    op_id = f"scan:{source}:{variant_id}"
+    registry.create(
+        op_id=op_id, kind=KIND_SCAN, source=source,
+        label=f"{source} scan", lane=LANE_PIPELINE,
     )
+    return JobContext(op_id, {"variant_id": variant_id, **options})
 
 
-class TestRunGrypeScan:
-    """Test the _run_grype_scan inner function with mocked subprocesses."""
+def _run_job(application, runner, ctx):
+    """Run a scan job the way the queue does, then publish what it buffered."""
+    with application.app_context():
+        try:
+            runner(ctx)
+        finally:
+            ctx.flush()
+    return registry.get(ctx.op_id)
+
+
+class _FakeProcess:
+    """Subprocess handle whose outcome the calling test decides."""
+
+    def __init__(self, returncode=0, stderr="", times_out=False):
+        self.returncode = returncode
+        self._stderr = stderr
+        self._times_out = times_out
+        self.killed = False
+
+    def communicate(self, timeout=None):
+        if self._times_out:
+            self._times_out = False
+            raise subprocess.TimeoutExpired(cmd="flask", timeout=timeout)
+        return "", self._stderr
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        self.killed = True
+
+
+def _grype_pipeline(export_payload=None, grype_output='{"matches": []}'):
+    """Popen side effect writing the artifacts each pipeline step expects.
+
+    Passing ``None`` for either payload simulates a step that reports success
+    while producing nothing.
+    """
+    def _spawn(command, **kwargs):
+        if "export" in command:
+            if export_payload is not None:
+                out_dir = command[command.index("--output-dir") + 1]
+                target = os.path.join(out_dir, "sbom_cyclonedx_v1_6.cdx.json")
+                with open(target, "w") as handle:
+                    json.dump(export_payload, handle)
+        elif "grype" in command and grype_output is not None:
+            kwargs["stdout"].write(grype_output)
+        return _FakeProcess()
+    return _spawn
+
+
+# ---------------------------------------------------------------------------
+# Grype scan job
+# ---------------------------------------------------------------------------
+
+class TestGrypeScanJob:
+    """The Grype pipeline: CycloneDX export, scan, merge, process."""
 
     @pytest.fixture()
     def grype_app(self, tmp_path):
@@ -351,212 +418,113 @@ class TestRunGrypeScan:
         finally:
             os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
 
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/grype")
-    def test_grype_scan_success(
-        self, mock_which, mock_sp_run, grype_app, tmp_path
+    def test_successful_pipeline_reports_four_completed_steps(
+        self, which, popen, grype_app
     ):
-        """Grype scan completes when subprocess calls succeed."""
-        # Make subprocess.run create the expected files
-        def subprocess_side_effect(*args, **kwargs):
-            cmd = args[0] if args else kwargs.get("args", [])
-            if isinstance(cmd, list) and "export" in cmd:
-                # Simulate export creating the CDX file
-                out_dir = cmd[cmd.index("--output-dir") + 1]
-                cdx_path = os.path.join(
-                    out_dir, "sbom_cyclonedx_v1_6.cdx.json"
-                )
-                with open(cdx_path, "w") as f:
-                    f.write("{}")
-            elif isinstance(cmd, list) and "grype" in cmd:
-                # grype writes to stdout which is redirected to a file
-                stdout_file = kwargs.get("stdout")
-                if stdout_file and hasattr(stdout_file, "write"):
-                    stdout_file.write('{"matches": []}')
-            return MagicMock(returncode=0)
+        """Every stage runs and the operation ends on the final step."""
+        popen.side_effect = _grype_pipeline(export_payload={})
 
-        mock_sp_run.side_effect = subprocess_side_effect
-        client = grype_app.test_client()
-        vid = grype_app._test_ids["variant_id"]
+        ctx = _context("grype", grype_app._test_ids["variant_id"])
+        operation = _run_job(grype_app, run_grype_scan, ctx)
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/grype-scan")
-        assert resp.status_code == 202
+        assert operation["error"] is None
+        assert operation["progress"] == {
+            "current": 4, "total": 4, "message": "Scan complete",
+        }
+        assert any("\u2713" in line for line in operation["logs"])
 
-        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "done"
-        assert data["error"] is None
-        assert data["progress"] == "Scan complete"
-        assert data["total"] == 4
-        assert data["done_count"] == 4
-        assert any("\u2713" in line for line in data["logs"])
-
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/grype")
-    def test_grype_scan_export_no_file(
-        self, mock_which, mock_sp_run, grype_app
+    def test_missing_cyclonedx_export_fails_the_scan(
+        self, which, popen, grype_app
     ):
-        """Grype scan errors when export produces no CDX file."""
-        mock_sp_run.return_value = MagicMock(returncode=0)
-        client = grype_app.test_client()
-        vid = grype_app._test_ids["variant_id"]
+        """A silent export failure is caught before Grype is invoked."""
+        popen.side_effect = _grype_pipeline(export_payload=None)
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/grype-scan")
-        assert resp.status_code == 202
+        ctx = _context("grype", grype_app._test_ids["variant_id"])
+        with pytest.raises(RuntimeError, match="CycloneDX export produced no file"):
+            _run_job(grype_app, run_grype_scan, ctx)
 
-        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "CycloneDX export produced no file" in data["error"]
-        assert any("ERROR" in line for line in data.get("logs", []))
-
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/grype")
-    def test_grype_scan_timeout(
-        self, mock_which, mock_sp_run, grype_app
-    ):
-        """Grype scan handles timeout."""
-        import subprocess
-        mock_sp_run.side_effect = subprocess.TimeoutExpired(
-            cmd="flask export", timeout=120
-        )
-        client = grype_app.test_client()
-        vid = grype_app._test_ids["variant_id"]
+    def test_subprocess_timeout_fails_the_scan(self, which, popen, grype_app):
+        popen.return_value = _FakeProcess(times_out=True)
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/grype-scan")
-        assert resp.status_code == 202
+        ctx = _context("grype", grype_app._test_ids["variant_id"])
+        with pytest.raises(RuntimeError, match="Grype scan timed out"):
+            _run_job(grype_app, run_grype_scan, ctx)
 
-        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "timed out" in data["error"]
-        assert any("ERROR" in line for line in data.get("logs", []))
-
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/grype")
-    def test_grype_scan_command_failure(
-        self, mock_which, mock_sp_run, grype_app
+    def test_failing_subprocess_surfaces_its_stderr(
+        self, which, popen, grype_app
     ):
-        """Grype scan handles CalledProcessError."""
-        import subprocess
-        mock_sp_run.side_effect = subprocess.CalledProcessError(
-            returncode=1, cmd="flask export", stderr="something failed"
-        )
-        client = grype_app.test_client()
-        vid = grype_app._test_ids["variant_id"]
+        popen.return_value = _FakeProcess(returncode=1, stderr="something failed")
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/grype-scan")
-        assert resp.status_code == 202
+        ctx = _context("grype", grype_app._test_ids["variant_id"])
+        with pytest.raises(RuntimeError, match="Command failed: something failed"):
+            _run_job(grype_app, run_grype_scan, ctx)
 
-        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "Command failed" in data["error"]
-        assert any("ERROR" in line for line in data.get("logs", []))
-
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/grype")
-    def test_grype_scan_generic_exception(
-        self, mock_which, mock_sp_run, grype_app
+    def test_unexpected_spawn_failure_fails_the_scan(
+        self, which, popen, grype_app
     ):
-        """Grype scan handles unexpected exceptions."""
-        mock_sp_run.side_effect = RuntimeError("unexpected")
-        client = grype_app.test_client()
-        vid = grype_app._test_ids["variant_id"]
+        popen.side_effect = RuntimeError("unexpected")
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/grype-scan")
-        assert resp.status_code == 202
+        ctx = _context("grype", grype_app._test_ids["variant_id"])
+        with pytest.raises(RuntimeError, match="unexpected"):
+            _run_job(grype_app, run_grype_scan, ctx)
 
-        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "unexpected" in data["error"]
-        assert any("ERROR" in line for line in data.get("logs", []))
-
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/grype")
-    def test_grype_scan_grype_no_output(
-        self, mock_which, mock_sp_run, grype_app, tmp_path
-    ):
-        """Grype scan errors when grype produces an empty output file."""
-        def subprocess_side_effect(*args, **kwargs):
-            cmd = args[0] if args else kwargs.get("args", [])
-            if isinstance(cmd, list) and "export" in cmd:
-                out_dir = cmd[cmd.index("--output-dir") + 1]
-                cdx_path = os.path.join(
-                    out_dir, "sbom_cyclonedx_v1_6.cdx.json"
-                )
-                with open(cdx_path, "w") as f:
-                    f.write("{}")
-            # grype call — don't write anything to stdout
-            return MagicMock(returncode=0)
+    def test_empty_grype_output_fails_the_scan(self, which, popen, grype_app):
+        """Grype exiting cleanly with no findings file is still a failure."""
+        popen.side_effect = _grype_pipeline(export_payload={}, grype_output=None)
 
-        mock_sp_run.side_effect = subprocess_side_effect
-        client = grype_app.test_client()
-        vid = grype_app._test_ids["variant_id"]
-
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/grype-scan")
-        assert resp.status_code == 202
-
-        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "Grype produced no output" in data["error"]
-        assert any("ERROR" in line for line in data.get("logs", []))
+        ctx = _context("grype", grype_app._test_ids["variant_id"])
+        with pytest.raises(RuntimeError, match="Grype produced no output"):
+            _run_job(grype_app, run_grype_scan, ctx)
 
 
 # ---------------------------------------------------------------------------
-# NVD / OSV scans with two scan types → break at line 1008/1280
+# NVD / OSV scans on a variant carrying both SBOM and tool scans
 # ---------------------------------------------------------------------------
 
-class TestNvdScanWithToolAndSbom:
-    """NVD scan on a variant that has both sbom and tool scans
-    (triggers the ``break`` at line 1008)."""
+class TestNvdScanWithToolAndSbomScans:
+    """The scanned package set comes from the SBOM scan, not the tool scans."""
 
     @patch("src.controllers.nvd_db.NVD_DB")
-    def test_nvd_scans_variant_two_types(self, MockNvdDb, app, client, ids):
-        mock_nvd = MagicMock()
-        MockNvdDb.return_value = mock_nvd
-        mock_nvd.api_get_cves_by_cpe.return_value = []
+    def test_nvd_scan_completes_on_a_variant_holding_both_scan_types(
+        self, MockNvdDb, app, ids
+    ):
+        nvd = MagicMock()
+        MockNvdDb.return_value = nvd
+        nvd.api_get_cves_by_cpe.return_value = []
 
-        with _make_sync_thread_patch():
-            resp = client.post(
-                f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api"
-            )
-        assert resp.status_code == 202
+        ctx = _context("nvd", ids["variant_id"], mode="api")
+        operation = _run_job(app, run_nvd_scan, ctx)
 
-        resp_s = client.get(
-            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
-        )
-        data = json.loads(resp_s.data)
-        assert data["status"] == "done"
+        assert operation["error"] is None
+        assert "0 CVEs" in operation["progress"]["message"]
 
 
-class TestOsvScanWithToolAndSbom:
-    """OSV scan on a variant that has both sbom and tool scans
-    (triggers the ``break`` at line 1280)."""
+class TestOsvScanWithToolAndSbomScans:
+    """The scanned package set comes from the SBOM scan, not the tool scans."""
 
     @patch("src.controllers.osv_client.OSVClient.query_by_purl")
-    def test_osv_scans_variant_two_types(self, mock_query, app, client, ids):
-        mock_query.return_value = []
+    def test_osv_scan_completes_on_a_variant_holding_both_scan_types(
+        self, query, app, ids
+    ):
+        query.return_value = []
 
-        with _make_sync_thread_patch():
-            resp = client.post(
-                f"/api/variants/{ids['variant_id']}/osv-scan"
-            )
-        assert resp.status_code == 202
+        ctx = _context("osv", ids["variant_id"])
+        operation = _run_job(app, run_osv_scan, ctx)
 
-        resp_s = client.get(
-            f"/api/variants/{ids['variant_id']}/osv-scan/status"
-        )
-        data = json.loads(resp_s.data)
-        assert data["status"] == "done"
+        assert operation["error"] is None
+        assert "0 vulnerabilities" in operation["progress"]["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -575,34 +543,28 @@ class TestResolveGrypeMemlimit:
 
     def test_explicit_value_returned_verbatim(self):
         """An explicit GRYPE_MEMLIMIT value is forwarded to GOMEMLIMIT as-is."""
-        from src.routes.scan_triggers import _resolve_grype_memlimit
         os.environ["GRYPE_MEMLIMIT"] = "24GiB"
         assert _resolve_grype_memlimit() == "24GiB"
 
     def test_explicit_bytes_returned_verbatim(self):
         """A plain-integer GRYPE_MEMLIMIT is forwarded unchanged."""
-        from src.routes.scan_triggers import _resolve_grype_memlimit
         os.environ["GRYPE_MEMLIMIT"] = "6442450944"
         assert _resolve_grype_memlimit() == "6442450944"
 
     def test_off_returns_none(self):
-        from src.routes.scan_triggers import _resolve_grype_memlimit
         os.environ["GRYPE_MEMLIMIT"] = "off"
         assert _resolve_grype_memlimit() is None
 
     def test_zero_returns_none(self):
-        from src.routes.scan_triggers import _resolve_grype_memlimit
         os.environ["GRYPE_MEMLIMIT"] = "0"
         assert _resolve_grype_memlimit() is None
 
     def test_disabled_returns_none(self):
-        from src.routes.scan_triggers import _resolve_grype_memlimit
         os.environ["GRYPE_MEMLIMIT"] = "disabled"
         assert _resolve_grype_memlimit() is None
 
     def test_auto_mode_uses_proc_meminfo(self, tmp_path):
         """Auto mode reads /proc/meminfo and returns ~80 % as bytes."""
-        from src.routes.scan_triggers import _resolve_grype_memlimit
         import builtins as _builtins
         fake_meminfo = tmp_path / "meminfo"
         # 8 GiB = 8388608 kB
@@ -622,7 +584,6 @@ class TestResolveGrypeMemlimit:
 
     def test_auto_mode_returns_integer_string(self, tmp_path):
         """Auto mode result is a plain integer string (valid GOMEMLIMIT)."""
-        from src.routes.scan_triggers import _resolve_grype_memlimit
         import builtins as _builtins
         fake_meminfo = tmp_path / "meminfo"
         fake_meminfo.write_text("MemTotal:        4194304 kB\n")
@@ -644,7 +605,7 @@ class TestResolveGrypeMemlimit:
 # ---------------------------------------------------------------------------
 
 class TestGrypeScanMemlimit:
-    """Assert that _run_grype_scan passes GOMEMLIMIT to the grype subprocess."""
+    """The Grype subprocess is the only one that receives GOMEMLIMIT."""
 
     @pytest.fixture()
     def grype_app_ml(self, tmp_path):
@@ -676,164 +637,107 @@ class TestGrypeScanMemlimit:
             os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
             os.environ.pop("GRYPE_MEMLIMIT", None)
 
-    def _subprocess_side_effect(self, grype_tmp):
-        """Return a side_effect that creates the expected CDX export file."""
-        def _side_effect(*args, **kwargs):
-            cmd = args[0] if args else kwargs.get("args", [])
-            if isinstance(cmd, list) and "export" in cmd:
-                out_dir = cmd[cmd.index("--output-dir") + 1]
-                import json as _json
-                cdx_path = os.path.join(out_dir, "sbom_cyclonedx_v1_6.cdx.json")
-                with open(cdx_path, "w") as f:
-                    _json.dump({"components": []}, f)
-            elif isinstance(cmd, list) and "grype" in cmd:
-                stdout_file = kwargs.get("stdout")
-                if stdout_file and hasattr(stdout_file, "write"):
-                    stdout_file.write('{"matches": []}')
-            return MagicMock(returncode=0)
-        return _side_effect
+    @staticmethod
+    def _call_for(popen, executable):
+        return next(
+            (call for call in popen.call_args_list
+             if isinstance(call.args[0], list) and executable in call.args[0]),
+            None,
+        )
 
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/grype")
     def test_explicit_grype_memlimit_sets_gomemlimit(
-        self, mock_which, mock_sp_run, grype_app_ml, tmp_path
+        self, which, popen, grype_app_ml
     ):
-        """When GRYPE_MEMLIMIT is set, grype subprocess receives GOMEMLIMIT."""
+        """When GRYPE_MEMLIMIT is set, the Grype subprocess receives GOMEMLIMIT."""
         os.environ["GRYPE_MEMLIMIT"] = "8GiB"
-        mock_sp_run.side_effect = self._subprocess_side_effect(tmp_path)
-        client = grype_app_ml.test_client()
-        vid = grype_app_ml._test_ids["variant_id"]
+        popen.side_effect = _grype_pipeline(export_payload={"components": []})
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/grype-scan")
-        assert resp.status_code == 202
+        ctx = _context("grype", grype_app_ml._test_ids["variant_id"])
+        _run_job(grype_app_ml, run_grype_scan, ctx)
 
-        # Find the grype subprocess call (the one whose cmd contains "grype")
-        grype_call = next(
-            (c for c in mock_sp_run.call_args_list
-             if isinstance(c.args[0], list) and "grype" in c.args[0]),
-            None,
-        )
+        grype_call = self._call_for(popen, "grype")
         assert grype_call is not None, "grype subprocess was never called"
-        env_passed = grype_call.kwargs.get("env", {})
-        assert env_passed.get("GOMEMLIMIT") == "8GiB"
+        assert grype_call.kwargs.get("env", {}).get("GOMEMLIMIT") == "8GiB"
 
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/grype")
     def test_off_grype_memlimit_does_not_set_gomemlimit(
-        self, mock_which, mock_sp_run, grype_app_ml, tmp_path
+        self, which, popen, grype_app_ml
     ):
-        """When GRYPE_MEMLIMIT=off, grype subprocess should NOT have GOMEMLIMIT."""
+        """When GRYPE_MEMLIMIT=off, the Grype subprocess has no GOMEMLIMIT."""
         os.environ["GRYPE_MEMLIMIT"] = "off"
-        mock_sp_run.side_effect = self._subprocess_side_effect(tmp_path)
-        client = grype_app_ml.test_client()
-        vid = grype_app_ml._test_ids["variant_id"]
+        popen.side_effect = _grype_pipeline(export_payload={"components": []})
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/grype-scan")
-        assert resp.status_code == 202
+        ctx = _context("grype", grype_app_ml._test_ids["variant_id"])
+        _run_job(grype_app_ml, run_grype_scan, ctx)
 
-        grype_call = next(
-            (c for c in mock_sp_run.call_args_list
-             if isinstance(c.args[0], list) and "grype" in c.args[0]),
-            None,
-        )
+        grype_call = self._call_for(popen, "grype")
         assert grype_call is not None, "grype subprocess was never called"
-        env_passed = grype_call.kwargs.get("env", {})
-        # GOMEMLIMIT must not be injected
-        assert "GOMEMLIMIT" not in env_passed
+        assert "GOMEMLIMIT" not in grype_call.kwargs.get("env", {})
 
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/grype")
     def test_flask_export_does_not_receive_gomemlimit(
-        self, mock_which, mock_sp_run, grype_app_ml, tmp_path
+        self, which, popen, grype_app_ml
     ):
-        """GOMEMLIMIT must only reach grype, not the flask export subprocess."""
+        """GOMEMLIMIT must only reach Grype, not the flask export subprocess."""
         os.environ["GRYPE_MEMLIMIT"] = "4GiB"
-        mock_sp_run.side_effect = self._subprocess_side_effect(tmp_path)
-        client = grype_app_ml.test_client()
-        vid = grype_app_ml._test_ids["variant_id"]
+        popen.side_effect = _grype_pipeline(export_payload={"components": []})
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/grype-scan")
-        assert resp.status_code == 202
+        ctx = _context("grype", grype_app_ml._test_ids["variant_id"])
+        _run_job(grype_app_ml, run_grype_scan, ctx)
 
-        export_call = next(
-            (c for c in mock_sp_run.call_args_list
-             if isinstance(c.args[0], list) and "export" in c.args[0]),
-            None,
-        )
+        export_call = self._call_for(popen, "export")
         assert export_call is not None, "flask export subprocess was never called"
-        # The export call should not have an env kwarg (inherits from process)
+        # The export call inherits the process environment untouched.
         export_env = export_call.kwargs.get("env")
         if export_env is not None:
             assert "GOMEMLIMIT" not in export_env
 
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/grype")
-    def test_memlimit_logged_in_scan_progress(
-        self, mock_which, mock_sp_run, grype_app_ml, tmp_path
+    def test_memlimit_is_recorded_in_the_operation_log(
+        self, which, popen, grype_app_ml
     ):
-        """Applied GOMEMLIMIT is recorded in the scan progress logs."""
+        """The applied GOMEMLIMIT is visible to whoever watches the scan."""
         os.environ["GRYPE_MEMLIMIT"] = "12GiB"
-        mock_sp_run.side_effect = self._subprocess_side_effect(tmp_path)
-        client = grype_app_ml.test_client()
-        vid = grype_app_ml._test_ids["variant_id"]
+        popen.side_effect = _grype_pipeline(export_payload={"components": []})
 
-        with _make_sync_thread_patch():
-            client.post(f"/api/variants/{vid}/grype-scan")
+        ctx = _context("grype", grype_app_ml._test_ids["variant_id"])
+        operation = _run_job(grype_app_ml, run_grype_scan, ctx)
 
-        resp_s = client.get(f"/api/variants/{vid}/grype-scan/status")
-        data = json.loads(resp_s.data)
         assert any("GOMEMLIMIT" in line and "12GiB" in line
-                   for line in data.get("logs", []))
+                   for line in operation["logs"])
 
 
 # ---------------------------------------------------------------------------
-# NVD / OSV scans outer exception handler (lines 1187-1189 / 1479-1481)
+# NVD / OSV scans propagate unexpected crashes
 # ---------------------------------------------------------------------------
 
-class TestNvdScanOuterException:
-    """NVD scan outer except catches unexpected crashes."""
+class TestNvdScanCrashPropagation:
+    """An unexpected crash surfaces instead of being swallowed."""
 
     @patch("src.controllers.nvd_db.NVD_DB")
-    def test_nvd_scan_outer_crash(self, MockNvdDb, app, client, ids):
-        """An exception in the NVD scan body is caught and reported."""
+    def test_nvd_scan_reraises_an_unexpected_crash(self, MockNvdDb, app, ids):
         MockNvdDb.side_effect = RuntimeError("crashed at construction")
 
-        with _make_sync_thread_patch():
-            resp = client.post(
-                f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api"
-            )
-        assert resp.status_code == 202
-
-        resp_s = client.get(
-            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
-        )
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "crashed at construction" in data["error"]
+        ctx = _context("nvd", ids["variant_id"], mode="api")
+        with pytest.raises(RuntimeError, match="crashed at construction"):
+            _run_job(app, run_nvd_scan, ctx)
 
 
-class TestOsvScanOuterException:
-    """OSV scan outer except catches unexpected crashes."""
+class TestOsvScanCrashPropagation:
+    """An unexpected crash surfaces instead of being swallowed."""
 
     @patch("src.controllers.osv_client.OSVClient")
-    def test_osv_scan_outer_crash(self, MockOsv, app, client, ids):
+    def test_osv_scan_reraises_an_unexpected_crash(self, MockOsv, app, ids):
         MockOsv.side_effect = RuntimeError("osv crash")
 
-        with _make_sync_thread_patch():
-            resp = client.post(
-                f"/api/variants/{ids['variant_id']}/osv-scan"
-            )
-        assert resp.status_code == 202
-
-        resp_s = client.get(
-            f"/api/variants/{ids['variant_id']}/osv-scan/status"
-        )
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "osv crash" in data["error"]
+        ctx = _context("osv", ids["variant_id"])
+        with pytest.raises(RuntimeError, match="osv crash"):
+            _run_job(app, run_osv_scan, ctx)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webapp_tests/test_scan_logic.py
+++ b/tests/webapp_tests/test_scan_logic.py
@@ -1,19 +1,23 @@
 # Copyright (C) 2026 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: GPL-3.0-only
 
-"""Tests exercising the NVD and OSV scan *logic* (``_do_nvd_scan`` / ``_do_osv_scan``).
+"""NVD and OSV scan behaviour, exercised through the queued job entry points.
 
-The inner helper functions are closures inside ``init_app``, so the cleanest
-way to test them is to let the trigger endpoint run the thread target
-synchronously (by making ``Thread.start()`` call ``target()`` immediately).
+``run_nvd_scan`` / ``run_osv_scan`` receive a :class:`JobContext` and report
+through it, so the assertions read the resulting operation straight from the
+registry instead of polling a status endpoint.  A job signals failure by
+raising, which is what the queue turns into an ``error`` operation.
 """
 
-import json
+import os
 import pytest
 from unittest.mock import patch, MagicMock
 
 from src.bin.webapp import create_app
+from src.controllers.job_context import JobContext
 from src.controllers.nvd_db import NVD_DB as _RealNvdDb
+from src.controllers.operation_registry import KIND_SCAN, LANE_PIPELINE, registry
+from src.controllers.scan_jobs import run_nvd_scan, run_osv_scan
 from src.extensions import db as _db
 
 
@@ -71,7 +75,6 @@ def _build_nvd_osv_db(app):
 
 @pytest.fixture()
 def app(tmp_path):
-    import os
     scan_file = tmp_path / "scan_status.txt"
     scan_file.write_text("__END_OF_SCAN_SCRIPT__")
     os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
@@ -86,217 +89,250 @@ def app(tmp_path):
 
 
 @pytest.fixture()
-def client(app):
-    return app.test_client()
-
-
-@pytest.fixture()
 def ids(app):
     return app._test_ids
 
 
-def _make_sync_thread_patch():
-    """Return a patch that makes Thread.start() run target synchronously."""
-    return patch(
-        "threading.Thread",
-        side_effect=lambda **kwargs: type(
-            "SyncThread", (), {
-                "_target": kwargs.get("target"),
-                "start": lambda self: kwargs.get("target")(),
-                "daemon": True,
-            }
-        )(),
+@pytest.fixture(autouse=True)
+def clean_registry():
+    registry.clear()
+    yield
+    registry.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _context(source, variant_id, **options):
+    """Register an operation and return the context its job would receive."""
+    op_id = f"scan:{source}:{variant_id}"
+    registry.create(
+        op_id=op_id, kind=KIND_SCAN, source=source,
+        label=f"{source} scan", lane=LANE_PIPELINE,
     )
+    return JobContext(op_id, {"variant_id": variant_id, **options})
+
+
+def _run(app, runner, ctx):
+    """Run a scan job the way the queue does, then publish what it buffered."""
+    with app.app_context():
+        try:
+            runner(ctx)
+        finally:
+            ctx.flush()
+    return registry.get(ctx.op_id)
 
 
 # ---------------------------------------------------------------------------
-# _do_nvd_scan — full logic
+# NVD scan
 # ---------------------------------------------------------------------------
 
-class TestDoNvdScan:
-    """Test the NVD scan logic end-to-end via synchronous thread execution."""
+class TestNvdScan:
+    """NVD scan against the REST API."""
 
     @patch("src.controllers.nvd_db.NVD_DB")
-    def test_nvd_scan_finds_cves(self, MockNvdDb, app, client, ids):
-        """Scan completes and creates findings for discovered CVEs."""
-        mock_nvd = MagicMock()
-        MockNvdDb.return_value = mock_nvd
+    def test_discovered_cves_are_persisted(self, MockNvdDb, app, ids):
+        """Every CVE returned for a CPE becomes a vulnerability record."""
+        nvd = MagicMock()
+        MockNvdDb.return_value = nvd
         MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
-        mock_nvd.api_get_cves_by_cpe.return_value = [
+        nvd.api_get_cves_by_cpe.return_value = [
             {"cve": {"id": "CVE-2023-0001"}},
             {"cve": {"id": "CVE-2023-0002"}},
         ]
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
-        assert resp.status_code == 202
+        ctx = _context("nvd", ids["variant_id"], mode="api")
+        operation = _run(app, run_nvd_scan, ctx)
 
-        # Check the scan status was set to done
-        resp_status = client.get(
-            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
-        )
-        data = json.loads(resp_status.data)
-        assert data["status"] == "done"
-        assert data["error"] is None
-        assert data["total"] >= 1
-        assert data["done_count"] >= 1
+        assert operation["error"] is None
+        assert operation["progress"]["total"] >= 1
+        assert operation["progress"]["current"] >= 1
 
-        # Verify CVEs were actually created in DB
         with app.app_context():
             from src.models.vulnerability import Vulnerability
-            v1 = _db.session.get(Vulnerability, "CVE-2023-0001")
-            v2 = _db.session.get(Vulnerability, "CVE-2023-0002")
-            assert v1 is not None
-            assert v2 is not None
+            assert _db.session.get(Vulnerability, "CVE-2023-0001") is not None
+            assert _db.session.get(Vulnerability, "CVE-2023-0002") is not None
 
     @patch("src.controllers.nvd_db.NVD_DB")
-    def test_nvd_scan_no_cves(self, MockNvdDb, app, client, ids):
-        """No CVEs found — scan completes successfully with 0 CVEs."""
-        mock_nvd = MagicMock()
-        MockNvdDb.return_value = mock_nvd
-        mock_nvd.api_get_cves_by_cpe.return_value = []
+    def test_scan_without_matches_reports_zero_cves(self, MockNvdDb, app, ids):
+        """A scan that matches nothing still completes and says so."""
+        nvd = MagicMock()
+        MockNvdDb.return_value = nvd
+        nvd.api_get_cves_by_cpe.return_value = []
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
-        assert resp.status_code == 202
+        ctx = _context("nvd", ids["variant_id"], mode="api")
+        operation = _run(app, run_nvd_scan, ctx)
 
-        resp_status = client.get(
-            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
-        )
-        data = json.loads(resp_status.data)
-        assert data["status"] == "done"
-        assert "0 CVEs" in data["progress"]
+        assert "0 CVEs" in operation["progress"]["message"]
 
     @patch("src.controllers.nvd_db.NVD_DB")
-    def test_nvd_scan_api_error_continues(self, MockNvdDb, app, client, ids):
-        """API error on one CPE doesn't crash the whole scan."""
-        mock_nvd = MagicMock()
-        MockNvdDb.return_value = mock_nvd
-        mock_nvd.api_get_cves_by_cpe.side_effect = Exception("NVD timeout")
+    def test_failed_cpe_query_is_logged_and_scan_continues(
+        self, MockNvdDb, app, ids
+    ):
+        """An API failure on one CPE is recorded without aborting the scan."""
+        nvd = MagicMock()
+        MockNvdDb.return_value = nvd
+        nvd.api_get_cves_by_cpe.side_effect = Exception("NVD timeout")
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
-        assert resp.status_code == 202
+        ctx = _context("nvd", ids["variant_id"], mode="api")
+        operation = _run(app, run_nvd_scan, ctx)
 
-        resp_status = client.get(
-            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
-        )
-        data = json.loads(resp_status.data)
-        # Should complete (done) — errors per CPE are logged but don't fail
-        assert data["status"] == "done"
-        any_error_log = any("ERROR" in log for log in data.get("logs", []))
-        assert any_error_log
+        assert any("ERROR" in line for line in operation["logs"])
+        assert any("NVD timeout" in line for line in operation["logs"])
+        assert "0 CVEs" in operation["progress"]["message"]
 
-    def test_nvd_scan_empty_variant(self, app, client, ids):
-        """Variant with no scans produces an error."""
-        with _make_sync_thread_patch():
-            resp = client.post(
-                f"/api/variants/{ids['variant_empty_id']}/nvd-scan"
+    def test_variant_without_sbom_scan_fails(self, app, ids):
+        """A variant that was never imported cannot be scanned."""
+        ctx = _context("nvd", ids["variant_empty_id"])
+        with pytest.raises(RuntimeError, match="No SBOM scan found"):
+            _run(app, run_nvd_scan, ctx)
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_known_vulnerability_is_not_duplicated(self, MockNvdDb, app, ids):
+        """Re-discovering a CVE reuses the existing record."""
+        from src.models.vulnerability import Vulnerability
+
+        with app.app_context():
+            Vulnerability.create_record(
+                id="CVE-2023-9876", description="pre-existing"
             )
-        assert resp.status_code == 202
+            _db.session.commit()
 
-        resp_status = client.get(
-            f"/api/variants/{ids['variant_empty_id']}/nvd-scan/status"
-        )
-        data = json.loads(resp_status.data)
-        assert data["status"] == "error"
-        assert "No SBOM scan found" in data["error"]
+        nvd = MagicMock()
+        MockNvdDb.return_value = nvd
+        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
+        nvd.api_get_cves_by_cpe.return_value = [{"cve": {"id": "CVE-2023-9876"}}]
+
+        ctx = _context("nvd", ids["variant_id"], mode="api")
+        operation = _run(app, run_nvd_scan, ctx)
+
+        assert operation["error"] is None
+        with app.app_context():
+            rows = _db.session.execute(
+                _db.select(Vulnerability).where(
+                    Vulnerability.id == "CVE-2023-9876"
+                )
+            ).scalars().all()
+            assert len(rows) == 1
+
+    @patch("src.controllers.nvd_db.NVD_DB")
+    def test_long_cve_list_is_truncated_in_the_log(self, MockNvdDb, app, ids):
+        """Only the first ten CVEs are listed, the rest become an ellipsis."""
+        nvd = MagicMock()
+        MockNvdDb.return_value = nvd
+        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
+        nvd.api_get_cves_by_cpe.return_value = [
+            {"cve": {"id": f"CVE-2023-{i:04d}"}} for i in range(15)
+        ]
+
+        ctx = _context("nvd", ids["variant_id"], mode="api")
+        operation = _run(app, run_nvd_scan, ctx)
+
+        listing = next(line for line in operation["logs"] if "CVE(s):" in line)
+        assert listing.count("CVE-2023-") == 10
+        assert listing.endswith("…")
 
 
 # ---------------------------------------------------------------------------
-# _do_osv_scan — full logic
+# OSV scan
 # ---------------------------------------------------------------------------
 
-class TestDoOsvScan:
-    """Test the OSV scan logic end-to-end via synchronous thread execution."""
+class TestOsvScan:
+    """OSV scan against osv.dev."""
 
     @patch("src.controllers.osv_client.OSVClient.query_by_purl")
-    def test_osv_scan_finds_vulns(self, mock_query, app, client, ids):
-        """Scan completes and creates findings for discovered vulns."""
-        mock_query.return_value = [
+    def test_advisory_and_its_cve_alias_are_persisted(self, query, app, ids):
+        """An advisory is recorded under its own id and under its aliases."""
+        query.return_value = [
             {"id": "GHSA-1234-5678", "aliases": ["CVE-2023-9999"]},
         ]
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
-        assert resp.status_code == 202
+        ctx = _context("osv", ids["variant_id"])
+        operation = _run(app, run_osv_scan, ctx)
 
-        resp_status = client.get(
-            f"/api/variants/{ids['variant_id']}/osv-scan/status"
-        )
-        data = json.loads(resp_status.data)
-        assert data["status"] == "done"
-        assert data["error"] is None
-        assert data["total"] >= 1
+        assert operation["error"] is None
+        assert operation["progress"]["total"] >= 1
 
-        # Verify vulns were created in DB
         with app.app_context():
             from src.models.vulnerability import Vulnerability
-            v1 = _db.session.get(Vulnerability, "GHSA-1234-5678")
-            assert v1 is not None
-            # CVE alias should also be created
-            v2 = _db.session.get(Vulnerability, "CVE-2023-9999")
-            assert v2 is not None
+            assert _db.session.get(Vulnerability, "GHSA-1234-5678") is not None
+            assert _db.session.get(Vulnerability, "CVE-2023-9999") is not None
 
     @patch("src.controllers.osv_client.OSVClient.query_by_purl")
-    def test_osv_scan_no_vulns(self, mock_query, app, client, ids):
-        """No vulns found — scan completes with 0."""
-        mock_query.return_value = []
+    def test_scan_without_matches_reports_zero_vulnerabilities(
+        self, query, app, ids
+    ):
+        query.return_value = []
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
-        assert resp.status_code == 202
+        ctx = _context("osv", ids["variant_id"])
+        operation = _run(app, run_osv_scan, ctx)
 
-        resp_status = client.get(
-            f"/api/variants/{ids['variant_id']}/osv-scan/status"
-        )
-        data = json.loads(resp_status.data)
-        assert data["status"] == "done"
-        assert "0 vulnerabilities" in data["progress"]
+        assert "0 vulnerabilities" in operation["progress"]["message"]
 
     @patch("src.controllers.osv_client.OSVClient.query_by_purl")
-    def test_osv_scan_api_error_continues(self, mock_query, app, client, ids):
-        """API error on one PURL doesn't crash the whole scan."""
-        mock_query.side_effect = Exception("OSV timeout")
+    def test_failed_purl_query_is_logged_and_scan_continues(
+        self, query, app, ids
+    ):
+        query.side_effect = Exception("OSV timeout")
 
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
-        assert resp.status_code == 202
+        ctx = _context("osv", ids["variant_id"])
+        operation = _run(app, run_osv_scan, ctx)
 
-        resp_status = client.get(
-            f"/api/variants/{ids['variant_id']}/osv-scan/status"
-        )
-        data = json.loads(resp_status.data)
-        assert data["status"] == "done"
-        any_error_log = any("ERROR" in log for log in data.get("logs", []))
-        assert any_error_log
+        assert any("ERROR" in line for line in operation["logs"])
+        assert any("OSV timeout" in line for line in operation["logs"])
+        assert "0 vulnerabilities" in operation["progress"]["message"]
 
-    def test_osv_scan_empty_variant(self, app, client, ids):
-        """Variant with no scans produces an error."""
-        with _make_sync_thread_patch():
-            resp = client.post(
-                f"/api/variants/{ids['variant_empty_id']}/osv-scan"
-            )
-        assert resp.status_code == 202
+    def test_variant_without_sbom_scan_fails(self, app, ids):
+        ctx = _context("osv", ids["variant_empty_id"])
+        with pytest.raises(RuntimeError, match="No SBOM scan found"):
+            _run(app, run_osv_scan, ctx)
 
-        resp_status = client.get(
-            f"/api/variants/{ids['variant_empty_id']}/osv-scan/status"
-        )
-        data = json.loads(resp_status.data)
-        assert data["status"] == "error"
-        assert "No SBOM scan found" in data["error"]
+    @patch("src.controllers.osv_client.OSVClient.query_by_purl")
+    def test_known_vulnerability_is_not_duplicated(self, query, app, ids):
+        from src.models.vulnerability import Vulnerability
+
+        with app.app_context():
+            Vulnerability.create_record(id="GHSA-0000-1111", description="pre")
+            _db.session.commit()
+
+        query.return_value = [{"id": "GHSA-0000-1111", "aliases": []}]
+
+        ctx = _context("osv", ids["variant_id"])
+        operation = _run(app, run_osv_scan, ctx)
+
+        assert operation["error"] is None
+        with app.app_context():
+            rows = _db.session.execute(
+                _db.select(Vulnerability).where(
+                    Vulnerability.id == "GHSA-0000-1111"
+                )
+            ).scalars().all()
+            assert len(rows) == 1
+
+    @patch("src.controllers.osv_client.OSVClient.query_by_purl")
+    def test_long_advisory_list_is_truncated_in_the_log(self, query, app, ids):
+        query.return_value = [
+            {"id": f"GHSA-{i:04d}", "aliases": []} for i in range(12)
+        ]
+
+        ctx = _context("osv", ids["variant_id"])
+        operation = _run(app, run_osv_scan, ctx)
+
+        listing = next(line for line in operation["logs"] if "vuln(s):" in line)
+        assert listing.count("GHSA-") == 10
+        assert listing.endswith("…")
 
 
 # ---------------------------------------------------------------------------
-# NVD scan — no valid CPEs edge case
+# NVD scan — no usable CPE identifiers
 # ---------------------------------------------------------------------------
 
 class TestNvdScanNoCpes:
-    """Test NVD scan when packages have no CPEs."""
+    """NVD needs a CPE carrying a concrete version field."""
 
     @pytest.fixture()
     def app_no_cpe(self, tmp_path):
-        import os
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
@@ -327,37 +363,27 @@ class TestNvdScanNoCpes:
                 sbom = SBOMDocument.create("/t/sbom.json", "spdx", scan.id)
                 SBOMPackage.create(sbom.id, pkg.id)
                 _db.session.commit()
-                application._test_ids = {
-                    "variant_id": str(variant.id),
-                }
+                application._test_ids = {"variant_id": str(variant.id)}
             yield application
         finally:
             os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
 
     @patch("src.controllers.nvd_db.NVD_DB")
-    def test_no_valid_cpes(self, MockNvdDb, app_no_cpe):
-        client = app_no_cpe.test_client()
-        vid = app_no_cpe._test_ids["variant_id"]
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/nvd-scan?mode=api")
-        assert resp.status_code == 202
-
-        resp_s = client.get(f"/api/variants/{vid}/nvd-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "No packages with valid CPE" in data["error"]
+    def test_wildcard_only_cpes_fail_the_scan(self, MockNvdDb, app_no_cpe):
+        ctx = _context("nvd", app_no_cpe._test_ids["variant_id"], mode="api")
+        with pytest.raises(RuntimeError, match="No packages with valid CPE"):
+            _run(app_no_cpe, run_nvd_scan, ctx)
 
 
 # ---------------------------------------------------------------------------
-# OSV scan — no valid PURLs edge case
+# OSV scan — no usable PURL identifiers
 # ---------------------------------------------------------------------------
 
 class TestOsvScanNoPurls:
-    """Test OSV scan when packages have no PURLs."""
+    """OSV needs at least one ``pkg:`` identifier."""
 
     @pytest.fixture()
     def app_no_purl(self, tmp_path):
-        import os
         from src.models.project import Project
         from src.models.variant import Variant
         from src.models.scan import Scan
@@ -384,254 +410,57 @@ class TestOsvScanNoPurls:
                 sbom = SBOMDocument.create("/t/sbom.json", "spdx", scan.id)
                 SBOMPackage.create(sbom.id, pkg.id)
                 _db.session.commit()
-                application._test_ids = {
-                    "variant_id": str(variant.id),
-                }
+                application._test_ids = {"variant_id": str(variant.id)}
             yield application
         finally:
             os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
 
-    def test_no_valid_purls(self, app_no_purl):
-        client = app_no_purl.test_client()
-        vid = app_no_purl._test_ids["variant_id"]
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/osv-scan")
-        assert resp.status_code == 202
-
-        resp_s = client.get(f"/api/variants/{vid}/osv-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "No packages with valid PURL" in data["error"]
+    def test_packages_without_purls_fail_the_scan(self, app_no_purl):
+        ctx = _context("osv", app_no_purl._test_ids["variant_id"])
+        with pytest.raises(RuntimeError, match="No packages with valid PURL"):
+            _run(app_no_purl, run_osv_scan, ctx)
 
 
 # ---------------------------------------------------------------------------
-# NVD scan — variant with no packages
+# Scans of a variant whose SBOM scan carries no packages
 # ---------------------------------------------------------------------------
 
-class TestNvdScanNoPackages:
-    """Test NVD scan when variant has scans but no packages."""
+@pytest.fixture()
+def app_no_packages(tmp_path):
+    from src.models.project import Project
+    from src.models.variant import Variant
+    from src.models.scan import Scan
 
-    @pytest.fixture()
-    def app_no_pkgs(self, tmp_path):
-        import os
-        from src.models.project import Project
-        from src.models.variant import Variant
-        from src.models.scan import Scan
-
-        scan_file = tmp_path / "scan_status.txt"
-        scan_file.write_text("__END_OF_SCAN_SCRIPT__")
-        os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-        try:
-            application = create_app()
-            application.config.update({
-                "TESTING": True, "SCAN_FILE": str(scan_file),
-            })
-            with application.app_context():
-                _db.drop_all()
-                _db.create_all()
-                project = Project.create("NoPkgProject")
-                variant = Variant.create("NoPkgVariant", project.id)
-                # Scan exists but has no SBOM documents → no packages
-                Scan.create("empty scan", variant.id)
-                _db.session.commit()
-                application._test_ids = {
-                    "variant_id": str(variant.id),
-                }
-            yield application
-        finally:
-            os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
-
-    @patch("src.controllers.nvd_db.NVD_DB")
-    def test_no_packages(self, MockNvdDb, app_no_pkgs):
-        client = app_no_pkgs.test_client()
-        vid = app_no_pkgs._test_ids["variant_id"]
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/nvd-scan?mode=api")
-        assert resp.status_code == 202
-
-        resp_s = client.get(f"/api/variants/{vid}/nvd-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "No packages found" in data["error"]
-
-
-# ---------------------------------------------------------------------------
-# OSV scan — variant with no packages
-# ---------------------------------------------------------------------------
-
-class TestOsvScanNoPackages:
-    """Test OSV scan when variant has scans but no packages."""
-
-    @pytest.fixture()
-    def app_no_pkgs(self, tmp_path):
-        import os
-        from src.models.project import Project
-        from src.models.variant import Variant
-        from src.models.scan import Scan
-
-        scan_file = tmp_path / "scan_status.txt"
-        scan_file.write_text("__END_OF_SCAN_SCRIPT__")
-        os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-        try:
-            application = create_app()
-            application.config.update({
-                "TESTING": True, "SCAN_FILE": str(scan_file),
-            })
-            with application.app_context():
-                _db.drop_all()
-                _db.create_all()
-                project = Project.create("NoPkgProject2")
-                variant = Variant.create("NoPkgVariant2", project.id)
-                Scan.create("empty scan", variant.id)
-                _db.session.commit()
-                application._test_ids = {
-                    "variant_id": str(variant.id),
-                }
-            yield application
-        finally:
-            os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
-
-    def test_no_packages(self, app_no_pkgs):
-        client = app_no_pkgs.test_client()
-        vid = app_no_pkgs._test_ids["variant_id"]
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{vid}/osv-scan")
-        assert resp.status_code == 202
-
-        resp_s = client.get(f"/api/variants/{vid}/osv-scan/status")
-        data = json.loads(resp_s.data)
-        assert data["status"] == "error"
-        assert "No packages found" in data["error"]
-
-
-# ---------------------------------------------------------------------------
-# NVD scan — existing vulnerability gets add_found_by("nvd")
-# ---------------------------------------------------------------------------
-
-class TestNvdScanExistingVuln:
-    """NVD scan with a pre-existing vulnerability still completes."""
-
-    @patch("src.controllers.nvd_db.NVD_DB")
-    def test_existing_vuln_no_duplicate(self, MockNvdDb, app, client, ids):
-        from src.models.vulnerability import Vulnerability
-
-        # Pre-create the vulnerability
-        with app.app_context():
-            Vulnerability.create_record(
-                id="CVE-2023-9876", description="pre-existing"
-            )
+    scan_file = tmp_path / "scan_status.txt"
+    scan_file.write_text("__END_OF_SCAN_SCRIPT__")
+    os.environ["FLASK_SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    try:
+        application = create_app()
+        application.config.update({
+            "TESTING": True, "SCAN_FILE": str(scan_file),
+        })
+        with application.app_context():
+            _db.drop_all()
+            _db.create_all()
+            project = Project.create("NoPkgProject")
+            variant = Variant.create("NoPkgVariant", project.id)
+            # Scan exists but has no SBOM documents → no packages
+            Scan.create("empty scan", variant.id)
             _db.session.commit()
-
-        mock_nvd = MagicMock()
-        MockNvdDb.return_value = mock_nvd
-        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
-        mock_nvd.api_get_cves_by_cpe.return_value = [
-            {"cve": {"id": "CVE-2023-9876"}},
-        ]
-
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
-        assert resp.status_code == 202
-
-        resp_s = client.get(
-            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
-        )
-        data = json.loads(resp_s.data)
-        assert data["status"] == "done"
-
-        # Vulnerability still exists and was not duplicated
-        with app.app_context():
-            v = _db.session.get(Vulnerability, "CVE-2023-9876")
-            assert v is not None
+            application._test_ids = {"variant_id": str(variant.id)}
+        yield application
+    finally:
+        os.environ.pop("FLASK_SQLALCHEMY_DATABASE_URI", None)
 
 
-# ---------------------------------------------------------------------------
-# OSV scan — existing vulnerability gets add_found_by("osv")
-# ---------------------------------------------------------------------------
-
-class TestOsvScanExistingVuln:
-    """OSV scan with a pre-existing vulnerability still completes."""
-
-    @patch("src.controllers.osv_client.OSVClient.query_by_purl")
-    def test_existing_vuln_no_duplicate(self, mock_query, app, client, ids):
-        from src.models.vulnerability import Vulnerability
-
-        with app.app_context():
-            Vulnerability.create_record(
-                id="GHSA-0000-1111", description="pre"
-            )
-            _db.session.commit()
-
-        mock_query.return_value = [
-            {"id": "GHSA-0000-1111", "aliases": []},
-        ]
-
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
-        assert resp.status_code == 202
-
-        resp_s = client.get(
-            f"/api/variants/{ids['variant_id']}/osv-scan/status"
-        )
-        data = json.loads(resp_s.data)
-        assert data["status"] == "done"
-
-        # Vulnerability still exists and was not duplicated
-        with app.app_context():
-            v = _db.session.get(Vulnerability, "GHSA-0000-1111")
-            assert v is not None
+@patch("src.controllers.nvd_db.NVD_DB")
+def test_nvd_scan_of_a_packageless_variant_fails(MockNvdDb, app_no_packages):
+    ctx = _context("nvd", app_no_packages._test_ids["variant_id"], mode="api")
+    with pytest.raises(RuntimeError, match="No packages found"):
+        _run(app_no_packages, run_nvd_scan, ctx)
 
 
-# ---------------------------------------------------------------------------
-# NVD scan — multiple CVEs returned (> 10 triggers ellipsis in log)
-# ---------------------------------------------------------------------------
-
-class TestNvdScanManyCves:
-    """NVD scan with >10 CVEs per CPE shows ellipsis in log."""
-
-    @patch("src.controllers.nvd_db.NVD_DB")
-    def test_many_cves_ellipsis(self, MockNvdDb, app, client, ids):
-        mock_nvd = MagicMock()
-        MockNvdDb.return_value = mock_nvd
-        MockNvdDb.extract_cve_details = _RealNvdDb.extract_cve_details
-        mock_nvd.api_get_cves_by_cpe.return_value = [
-            {"cve": {"id": f"CVE-2023-{i:04d}"}} for i in range(15)
-        ]
-
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/nvd-scan?mode=api")
-        assert resp.status_code == 202
-
-        resp_s = client.get(
-            f"/api/variants/{ids['variant_id']}/nvd-scan/status"
-        )
-        data = json.loads(resp_s.data)
-        assert data["status"] == "done"
-        log_text = "\n".join(data.get("logs", []))
-        assert "…" in log_text  # ellipsis for >10 CVEs
-
-
-# ---------------------------------------------------------------------------
-# OSV scan — multiple vulns returned (> 10 triggers ellipsis in log)
-# ---------------------------------------------------------------------------
-
-class TestOsvScanManyVulns:
-    """OSV scan with >10 vulns per PURL shows ellipsis in log."""
-
-    @patch("src.controllers.osv_client.OSVClient.query_by_purl")
-    def test_many_vulns_ellipsis(self, mock_query, app, client, ids):
-        mock_query.return_value = [
-            {"id": f"GHSA-{i:04d}", "aliases": []} for i in range(12)
-        ]
-
-        with _make_sync_thread_patch():
-            resp = client.post(f"/api/variants/{ids['variant_id']}/osv-scan")
-        assert resp.status_code == 202
-
-        resp_s = client.get(
-            f"/api/variants/{ids['variant_id']}/osv-scan/status"
-        )
-        data = json.loads(resp_s.data)
-        assert data["status"] == "done"
-        log_text = "\n".join(data.get("logs", []))
-        assert "…" in log_text
+def test_osv_scan_of_a_packageless_variant_fails(app_no_packages):
+    ctx = _context("osv", app_no_packages._test_ids["variant_id"])
+    with pytest.raises(RuntimeError, match="No packages found"):
+        _run(app_no_packages, run_osv_scan, ctx)


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR 2 of 6 — split out of #529.** Review and merge in order; each PR targets the one before it.
>
> 1. #548 — operation queue core, scan/refresh jobs extracted → base `staging`
> 2. **#549 — queue REST API and SSE event stream → base `#548` ← you are here**
> 3. #550 — delete the 21 legacy polling endpoints → base `#549`
> 4. #551 — route exports and uploads through the queue → base `#550`
> 5. #552 — frontend SSE operation store, queue rendered from it → base `#551`
> 6. #553 — migrate remaining frontend workflows, delete the polling client → base `#552`
>
> The tip of the stack (#553) is commit-identical to #529, which stays open untouched as the integration reference.

---

## Fixes # by putting one batch-submit endpoint and one event stream in front of the queue

### Changes proposed in this pull request:

* Add `GET /api/events/stream`, a single Server-Sent Events connection carrying every operation update: a full `snapshot` first, then `operation` / `operation_removed` deltas, a `heartbeat` every 15 s, and `bye` on shutdown. `Last-Event-ID` replays from a bounded buffer, or triggers a fresh snapshot when the gap is too wide.
* Add `POST /api/operations`, which accepts a whole batch of scans and refreshes in one request and expands it into individually tracked operations. Scans run before refreshes; each family keeps its canonical order (`grype → nvd → osv → scc`, then `nvd → epss → ghsa → euvd`).
* Add cooperative cancellation for scans, which previously had none — only the four bulk refreshes could be cancelled. A cancel request also terminates the Grype subprocess.
* Run three lanes reproducing the concurrency the frontend used to enforce by hand: `pipeline` (all scans and refreshes, strictly serial), `export` (two at a time), and `upload` (one thread each).
* Register the queue on the app in `bin/webapp.py` and surface the boot enrichment thread as a tracked operation — it previously reported nothing at all.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

The legacy polling endpoints are all still present and untouched in this layer, so the running app is unaffected. `curl -N http://localhost:7275/api/events/stream` should emit a `snapshot` immediately and a `heartbeat` every 15 s. `POST /api/operations` with a multi-scan batch should return one operation id per expanded operation, and those should appear on the stream in canonical order.

### Additional notes

Adding the new surface before removing the old one keeps this PR and the next one independently reviewable, and means the stack is never in a state where neither mechanism works.

### Related Issue

No linked issue.

## Pull Request Checklist

- [x] The code compiles and passes all tests
- [x] All new and existing tests are passing
- [x] Documentation has been updated (if applicable)
- [X] Code follows project style guidelines
- [X] No sensitive information is included
- [x] Linked relevant issues (if any)
- [x] Added necessary reviewers
